### PR TITLE
Regex escape quote

### DIFF
--- a/src/Behat/Behat/Definition/DefinitionDispatcher.php
+++ b/src/Behat/Behat/Definition/DefinitionDispatcher.php
@@ -105,15 +105,16 @@ class DefinitionDispatcher
         $regex = preg_replace('/([\[\]\(\)\\\^\$\.\|\?\*\+])/', '\\\\$1', $text);
         $regex = preg_replace(
             array(
-                '/\'([^\']*)\'/', '/\"([^\"]*)\"/',
-                '/(\d+)/'
+                '/\'([^\']*)\'/', '/\"([^\"]*)\"/', // Quoted strings
+                '/(\d+)/',                          // Numbers
             ),
             array(
                 "\'([^\']*)\'", "\"([^\"]*)\"",
-                "(\\d+)"
+                "(\\d+)",
             ),
             $regex, -1, $count
         );
+        $regex = preg_replace('/\'.*(?<!\')/', '\\\\$0', $regex); // Single quotes without matching pair (escape in resulting regex)
 
         $args = array("\$world");
         for ($i = 0; $i < $count; $i++) {


### PR DESCRIPTION
Escape unmatched single quotes in proposed regex.
Example: Given John's bag has color "blue"
will propose the properly escaped regex '/^John\'s bag has color "([^"]+)"$/'
