### PR TITLE
[Environment] No need to extend \stdClass

### DIFF
--- a/src/Behat/Behat/Environment/Environment.php
+++ b/src/Behat/Behat/Environment/Environment.php
@@ -15,7 +15,7 @@ namespace Behat\Behat\Environment;
  *
  * @author      Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class Environment extends \stdClass implements EnvironmentInterface
+class Environment implements EnvironmentInterface
 {
     /**
      * Environment parameters.


### PR DESCRIPTION
This is implicit for any user defined class
