### PR TITLE
Include header row in HTML formatter

### DIFF
--- a/features/html.feature
+++ b/features/html.feature
@@ -171,6 +171,9 @@ Feature: HTML Formatter
               #behat .scenario > ol li table.argument {
                   border:1px solid #d2d2d2;
               }
+              #behat .scenario > ol li table.argument thead td {
+                  font-weight: bold;
+              }
               #behat .scenario > ol li table.argument td {
                   padding:5px 10px;
                   background:#f3f3f3;

--- a/src/Behat/Behat/Formatter/HtmlFormatter.php
+++ b/src/Behat/Behat/Formatter/HtmlFormatter.php
@@ -303,13 +303,18 @@ class HtmlFormatter extends PrettyFormatter
     protected function printStepTableArgument(TableNode $table, $color = null)
     {
         $this->writeln('<table class="argument">');
-        $this->writeln('<tbody>');
 
+        $this->writeln('<thead>');
+        $headers = $table->getRow(0);
+        $this->printColorizedTableRow($headers, 'row');
+        $this->writeln('</thead>');
+
+        $this->writeln('<tbody>');
         foreach ($table->getHash() as $row) {
             $this->printColorizedTableRow($row, 'row');
         }
-
         $this->writeln('</tbody>');
+
         $this->writeln('</table>');
     }
 
@@ -526,6 +531,9 @@ class HtmlFormatter extends PrettyFormatter
         }
         #behat .scenario > ol li table.argument {
             border:1px solid #d2d2d2;
+        }
+        #behat .scenario > ol li table.argument thead td {
+            font-weight: bold;
         }
         #behat .scenario > ol li table.argument td {
             padding:5px 10px;


### PR DESCRIPTION
I noticed that the HTML formatter's table argument output was missing a header row.
