### PR TITLE
Fix typo on JUnit formatter when using Outlines

### DIFF
--- a/src/Behat/Behat/Formatter/JUnitFormatter.php
+++ b/src/Behat/Behat/Formatter/JUnitFormatter.php
@@ -145,9 +145,9 @@ class JUnitFormatter extends ConsoleFormatter
     /**
      * Listens to "outline.example.before" event.
      *
-     * @param   Behat\Behat\Event\OutlineExampelEvent   $event
+     * @param   Behat\Behat\Event\OutlineExampleEvent   $event
      */
-    public function beforeOutlineExample(OutlineExampelEvent $event)
+    public function beforeOutlineExample(OutlineExampleEvent $event)
     {
         $this->scenarioStartTime = microtime(true);
     }
@@ -155,11 +155,11 @@ class JUnitFormatter extends ConsoleFormatter
     /**
      * Listens to "outline.example.after" event.
      *
-     * @param   Behat\Behat\Event\OutlineExampelEvent   $event
+     * @param   Behat\Behat\Event\OutlineExampleEvent   $event
      *
      * @uses    printTestCase()
      */
-    public function afterOutlineExample(OutlineExampelEvent $event)
+    public function afterOutlineExample(OutlineExampleEvent $event)
     {
         $this->printTestCase($event->getOutline(), microtime(true) - $this->scenarioStartTime, $event);
     }


### PR DESCRIPTION
When using Behat with Scenario Outlines, the JUnitFormatter was throwing the error:
  [Behat\Behat\Exception\Error]  
  Error: Argument 1 passed to Behat\Behat\Formatter\JUnitFormatter::afterOutlineExample() must be an instance of Behat\Behat\Formatter\OutlineExampelEvent, instance of Behat\Behat\Event\OutlineExampleEvent given, called in /usr/share/php/behat/vendor/Symfony/Component/EventDispatcher/EventDispatcher.php on line 179 and defined  

This appears to just be a simple typo on OutlineExampelEvent instead of OutlineExampleEvent.
