### PR TITLE
Improvements and fixes to HTML outputter

### DIFF
--- a/features/html.feature
+++ b/features/html.feature
@@ -10,9 +10,7 @@ Feature: HTML Formatter
       require_once 'PHPUnit/Autoload.php';
       require_once 'PHPUnit/Framework/Assert/Functions.php';
       """
-
-  Scenario: Multiple parameters
-    Given a file named "features/steps/math.php" with:
+    And a file named "features/steps/math.php" with:
       """
       <?php
       $steps->Given('/I have entered (\d+)/', function($world, $num) {
@@ -31,7 +29,9 @@ Feature: HTML Formatter
             $world->value -= $num;
       });
       """
-    And a file named "features/World.feature" with:
+
+  Scenario: Multiple parameters
+    Given a file named "features/World.feature" with:
       """
       Feature: World consistency
         In order to maintain stable behaviors
@@ -348,4 +348,86 @@ Feature: HTML Formatter
           </div>
       </body>
       </html>
+      """
+
+  Scenario: Scenario outline examples table
+    Given a file named "features/World.feature" with:
+      """
+      Feature: World consistency
+        In order to maintain stable behaviors
+        As a features developer
+        I want, that "World" flushes between scenarios
+
+        Background:
+          Given I have entered 10
+
+        Scenario Outline: Adding
+          Then I must have 10
+          And I add the value <n>
+          Then I must have <total>
+
+          Examples:
+            | n  | total |
+            | 5  | 15    |
+            | 10 | 21    |
+      """
+    When I run "behat -f html"
+    And the output should contain:
+      """
+      <div class="scenario outline">
+      <h3>
+      <span class="keyword">Scenario Outline: </span>
+      <span class="title">Adding</span>
+      <span class="path">features/World.feature:9</span>
+      </h3>
+      <ol>
+      <li class="skipped">
+      <div class="step">
+      <span class="keyword">Then </span>
+      <span class="text">I must have <strong class="skipped_param">10</strong></span>
+      <span class="path">features/steps/math.php:9</span>
+      </div>
+      </li>
+      <li class="skipped">
+      <div class="step">
+      <span class="keyword">And </span>
+      <span class="text">I add the value <strong class="skipped_param"><n></strong></span>
+      <span class="path">features/steps/math.php:16</span>
+      </div>
+      </li>
+      <li class="skipped">
+      <div class="step">
+      <span class="keyword">Then </span>
+      <span class="text">I must have <strong class="skipped_param"><total></strong></span>
+      <span class="path">features/steps/math.php:9</span>
+      </div>
+      </li>
+      </ol>
+      <div class="examples">
+      <h4>Examples</h4>
+      <table>
+      <thead>
+      <tr class="skipped">
+      <td>n</td>
+      <td>total</td>
+      </tr>
+      </thead>
+      <tbody>
+      <tr class="passed">
+      <td>5</td>
+      <td>15</td>
+      </tr>
+      <tr class="failed">
+      <td>10</td>
+      <td>21</td>
+      </tr>
+      <tr class="failed exception">
+      <td colspan="2">
+      <pre class="backtrace">Failed asserting that &lt;integer:20&gt; is equal to &lt;string:21&gt;.</pre>
+      </td>
+      </tr>
+      </tbody>
+      </table>
+      </div>
+      </div>
       """

--- a/src/Behat/Behat/Formatter/HtmlFormatter.php
+++ b/src/Behat/Behat/Formatter/HtmlFormatter.php
@@ -196,6 +196,15 @@ class HtmlFormatter extends PrettyFormatter
     /**
      * {@inheritdoc}
      */
+    protected function printOutlineSteps(OutlineNode $outline)
+    {
+        parent::printOutlineSteps($outline);
+        $this->writeln('</ol>');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function printOutlineExamplesSectionHeader(TableNode $examples)
     {
         $this->writeln('<div class="examples">');
@@ -212,12 +221,26 @@ class HtmlFormatter extends PrettyFormatter
     /**
      * {@inheritdoc}
      */
+    protected function printOutlineExampleResult(TableNode $examples, $iteration, $result, $isSkipped)
+    {
+        $color  = $this->getResultColorCode($result);
+
+        $this->printColorizedTableRow($examples->getRow($iteration + 1), $color);
+        $this->printOutlineExampleResultExceptions($examples, $this->delayedStepEvents);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function printOutlineExampleResultExceptions(TableNode $examples, array $events)
     {
         $colCount = count($examples->getRow(0));
 
         foreach ($events as $event) {
-            $error = $this->relativizePathsInString($event->get('exception')->getMessage());
+            if (!($exception = $event->getException()))
+                continue;
+
+            $error = $this->relativizePathsInString($exception->getMessage());
 
             $this->writeln('<tr class="failed exception">');
             $this->writeln('<td colspan="' . $colCount . '">');

--- a/src/Behat/Behat/Formatter/PrettyFormatter.php
+++ b/src/Behat/Behat/Formatter/PrettyFormatter.php
@@ -532,8 +532,6 @@ class PrettyFormatter extends ProgressFormatter
         }
 
         $this->inOutlineSteps = false;
-
-        $this->writeln();
     }
 
     /**
@@ -545,6 +543,7 @@ class PrettyFormatter extends ProgressFormatter
      */
     protected function printOutlineExamplesSectionHeader(TableNode $examples)
     {
+        $this->writeln();
         $keyword = $examples->getKeyword();
         $this->writeln("    $keyword:");
 


### PR DESCRIPTION
The first commit includes a summary section at the bottom of the file.

The second fixes an issue in the output of scenario outline tables (including a new testcase for this).

I'm also considering doing some more stuff to take advantage of the features of HTML, including a table of contents at the top - this would be populated by outputting short lines of javascript after each scenario/feature. This would also allow hyperlinking directly to failing tests from the summary. Thoughts?
