### PR TITLE
Custom Error Level

### DIFF
--- a/src/Behat/Behat/Definition/Definition.php
+++ b/src/Behat/Behat/Definition/Definition.php
@@ -175,6 +175,9 @@ class Definition
      */
     public function errorHandler($code, $message, $file, $line)
     {
+        if ((error_reporting() & $code) == 0) {
+            return;
+        }
         throw new Error($code, $message, $file, $line);
     }
 


### PR DESCRIPTION
IMO behat should respect the error_reporting level already set by php.ini or in code.
