### PR TITLE
Don't throw exception where errors are suppressed

### DIFF
--- a/src/Behat/Behat/Definition/Annotation/Definition.php
+++ b/src/Behat/Behat/Definition/Annotation/Definition.php
@@ -124,6 +124,9 @@ abstract class Definition extends Annotation implements DefinitionInterface
      */
     public function errorHandler($code, $message, $file, $line)
     {
+        if (0 === error_reporting()) {
+            return; // error reporting turned off or more likely suppressed with @
+        }
         throw new ErrorException($code, $message, $file, $line);
     }
 

--- a/src/Behat/Behat/Hook/HookDispatcher.php
+++ b/src/Behat/Behat/Hook/HookDispatcher.php
@@ -228,6 +228,9 @@ class HookDispatcher implements EventSubscriberInterface
      */
     public function errorHandler($code, $message, $file, $line)
     {
+        if (0 === error_reporting()) {
+            return; // error reporting turned off or more likely suppresed with @
+        }
         throw new ErrorException($code, $message, $file, $line);
     }
 


### PR DESCRIPTION
I'm currently testing a REST API and using Guzzle in my definitions, unfortunately guzzle uses the @ operator to suppress warnings from the curl functions, but the @ operator doesn't work when you're using a custom error handler, so I'm get spurious error exceptions when running my test suites.

See http://www.php.net/manual/en/language.operators.errorcontrol.php#98895 for a better explanation.

Happy to write some tests if you need them, although I'm not quite sure how to write one...
