### PR TITLE
Parse error in ErrorException 

### DIFF
--- a/src/Behat/Behat/Exception/ErrorException.php
+++ b/src/Behat/Behat/Exception/ErrorException.php
@@ -42,6 +42,6 @@ class ErrorException extends BehaviorException
             $message,
             $file,
             $line
-        );
+        ));
     }
 }


### PR DESCRIPTION
when error should be displayed 
Parse error: syntax error, unexpected ';' in /home/wodor/wrk/www/motowypady/vendor/behat/behat/src/Behat/Behat/Exception/ErrorException.php on line 45
