### PR TITLE
Bugfix for HTML formatter's print media output in the case of collapsed examples table

### DIFF
--- a/src/Behat/Behat/Formatter/HtmlFormatter.php
+++ b/src/Behat/Behat/Formatter/HtmlFormatter.php
@@ -822,6 +822,7 @@ HTMLTPL;
         }
 
         #behat .jq-toggle > .scenario,
+        #behat .jq-toggle > .scenario .examples,
         #behat .jq-toggle > ol {
             display:block;
         }


### PR DESCRIPTION
Sorry, I overlooked the CSS for print media when working on #128
