### PR TITLE
Scenario outlines with failed steps do not expand in the HTML formatter's output

### DIFF
--- a/src/Behat/Behat/Formatter/HtmlFormatter.php
+++ b/src/Behat/Behat/Formatter/HtmlFormatter.php
@@ -891,7 +891,7 @@ HTMLTPL;
             $('#behat .summary .counters .scenarios .passed')
                 .addClass('switcher')
                 .click(function(){
-                    var $scenario = $('.feature .scenario:not(:has(li.failed, li.pending))');
+                    var $scenario = $('.feature .scenario:not(:has(.failed, .pending))');
                     var $feature  = $scenario.parent();
 
                     $('#behat_hide_all').click();
@@ -903,7 +903,7 @@ HTMLTPL;
             $('#behat .summary .counters .steps .passed')
                 .addClass('switcher')
                 .click(function(){
-                    var $scenario = $('.feature .scenario:has(li.passed)');
+                    var $scenario = $('.feature .scenario:has(.passed)');
                     var $feature  = $scenario.parent();
 
                     $('#behat_hide_all').click();
@@ -915,7 +915,7 @@ HTMLTPL;
             $('#behat .summary .counters .failed')
                 .addClass('switcher')
                 .click(function(){
-                    var $scenario = $('.feature .scenario:has(li.failed)');
+                    var $scenario = $('.feature .scenario:has(.failed)');
                     var $feature = $scenario.parent();
 
                     $('#behat_hide_all').click();
@@ -927,7 +927,7 @@ HTMLTPL;
             $('#behat .summary .counters .skipped')
                 .addClass('switcher')
                 .click(function(){
-                    var $scenario = $('.feature .scenario:has(li.skipped)');
+                    var $scenario = $('.feature .scenario:has(.skipped)');
                     var $feature = $scenario.parent();
 
                     $('#behat_hide_all').click();
@@ -939,7 +939,7 @@ HTMLTPL;
             $('#behat .summary .counters .pending')
                 .addClass('switcher')
                 .click(function(){
-                    var $scenario = $('.feature .scenario:has(li.pending)');
+                    var $scenario = $('.feature .scenario:has(.pending)');
                     var $feature = $scenario.parent();
 
                     $('#behat_hide_all').click();


### PR DESCRIPTION
If you have failed steps in a scenario outline (ie. rows in the examples table are colored red), then in the case of the HTML formatter's output you can not expand such a scenario outline by clicking one of the two appropriate counters in the summary at the very beginning of the HTML page (# of failed scenarios / # of failed steps).
