### PR TITLE
Expected PHPUnit failure messages in test suite do not match actual ones

### DIFF
--- a/features/annotations/html_format.feature
+++ b/features/annotations/html_format.feature
@@ -240,7 +240,7 @@ Feature: HTML Formatter
       </tr>
       <tr class="failed exception">
       <td colspan="2">
-      <pre class="backtrace">Failed asserting that &lt;integer:20&gt; is equal to &lt;string:21&gt;.</pre>
+      <pre class="backtrace">Failed asserting that 20 matches expected '21'.</pre>
       </td>
       </tr>
       </tbody>
@@ -357,7 +357,7 @@ Feature: HTML Formatter
       <span class="text">I must have <strong class="failed_param">21</strong></span>
       <span class="path">FeatureContext::iMustHave()</span>
       </div>
-      <pre class="backtrace">Failed asserting that &lt;integer:20&gt; is equal to &lt;string:21&gt;.</pre>
+      <pre class="backtrace">Failed asserting that 20 matches expected '21'.</pre>
       </li>
       </ol>
       </div>

--- a/features/closures/html.feature
+++ b/features/closures/html.feature
@@ -275,7 +275,7 @@ Feature: HTML Formatter
       </tr>
       <tr class="failed exception">
       <td colspan="2">
-      <pre class="backtrace">Failed asserting that &lt;integer:20&gt; is equal to &lt;string:21&gt;.</pre>
+      <pre class="backtrace">Failed asserting that 20 matches expected '21'.</pre>
       </td>
       </tr>
       </tbody>
@@ -392,7 +392,7 @@ Feature: HTML Formatter
       <span class="text">I must have <strong class="failed_param">21</strong></span>
       <span class="path">features/steps/math.php:7</span>
       </div>
-      <pre class="backtrace">Failed asserting that &lt;integer:20&gt; is equal to &lt;string:21&gt;.</pre>
+      <pre class="backtrace">Failed asserting that 20 matches expected '21'.</pre>
       </li>
       </ol>
       </div>


### PR DESCRIPTION
see https://github.com/Behat/Behat/pull/122#issuecomment-5384579 (PR #122)

Is it right now?

BTW: Have I ever mentioned that I dislike the use of Behat for Unit Testing of Behat itself? :) It is really awkward to change or debug the tests...
