### PR TITLE
Formatter patch

### DIFF
--- a/src/Behat/Behat/Console/Processor/FormatProcessor.php
+++ b/src/Behat/Behat/Console/Processor/FormatProcessor.php
@@ -165,7 +165,7 @@ class FormatProcessor extends Processor
     protected function loadCustomFormatters(FormatterManager $manager)
     {
         foreach ($this->container->getParameter('behat.formatter.classes') as $name => $class) {
-            $manager->addDispatcher(new FormatterDispatcher($name, $class));
+            $manager->addDispatcher(new FormatterDispatcher($class, $name));
         }
     }
 


### PR DESCRIPTION
Got an error with a custom formatter:

```
[ReflectionException]        
  Class name does not exist  
```

Problem is that the args were inverted.
