### PR TITLE
require_once instead of require for loading legacy definitions.

### DIFF
--- a/src/Behat/Behat/Definition/Loader/ClosuredDefinitionLoader.php
+++ b/src/Behat/Behat/Definition/Loader/ClosuredDefinitionLoader.php
@@ -46,7 +46,7 @@ class ClosuredDefinitionLoader implements DefinitionLoaderInterface
     {
         $steps = $this;
 
-        require($resource);
+        require_once($resource);
     }
 
     /**


### PR DESCRIPTION
When loading legacy files, some of the files might already be loaded.
