### PR TITLE
Wrong path on update to behat 2.4.1 on a Symfony2.1 project

### DIFF
--- a/bin/behat
+++ b/bin/behat
@@ -15,7 +15,7 @@ define('BEHAT_VERSION',      'DEV');
 
 if (is_dir($vendor = __DIR__.'/../vendor')) {
     require($vendor.'/autoload.php');
-} elseif (is_dir($vendor = __DIR__.'/../../../vendor')) {
+} elseif (is_dir($vendor = __DIR__.'/../../../../vendor')) {
     require($vendor.'/autoload.php');
 } else {
     die(


### PR DESCRIPTION
Hi, I updated today morning a symfony2.1 project throught composer and behat command stopped working. The behat command always returns the die sentence:

You must set up the project dependencies, run the following commands:
curl -s http://getcomposer.org/installer | php
php composer.phar install

I think the path to find autoload.php on a symfony2.1 project must be "**DIR**.'/../../../../vendor" instead "**DIR**.'/../../../vendor"

Thank you for this project!
