### PR TITLE
Adding a hook point to AnnotatedDefinitionProposal

### DIFF
--- a/src/Behat/Behat/Definition/Proposal/AnnotatedDefinitionProposal.php
+++ b/src/Behat/Behat/Definition/Proposal/AnnotatedDefinitionProposal.php
@@ -121,7 +121,14 @@ class AnnotatedDefinitionProposal implements DefinitionProposalInterface
             }
         }
 
-        $description = sprintf(<<<PHP
+        $description = $this->generateSnippet($regex, $methodName, $args);
+
+        return new DefinitionSnippet($step, $description);
+    }
+
+    protected function generateSnippet($regex, $methodName, array $args)
+    {
+        return sprintf(<<<PHP
     /**
      * @%s /^%s$/
      */
@@ -132,7 +139,5 @@ class AnnotatedDefinitionProposal implements DefinitionProposalInterface
 PHP
           , '%s', $regex, $methodName, implode(', ', $args)
         );
-
-        return new DefinitionSnippet($step, $description);
     }
 }


### PR DESCRIPTION
Hey guys!

Right now, if a group were to want to override the generated definitions and render them with different coding standards, it's not possible without overriding the whole AnnotatedDefinitionProposal::propose() method.

This adds a hook point so this is possible without much overriding.

Thanks!

This PR follows after #176
