### PR TITLE
Suggest behat/common-formatters extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "suggest": {
         "behat/symfony2-extension":  "for integration with Symfony2 web framework",
         "behat/yii-extension":       "for integration with Yii web framework",
-        "behat/mink-extension":      "for integration with Mink testing framework"
+        "behat/mink-extension":      "for integration with Mink testing framework",
+        "behat/common-formatters":   "extra formatters used commonly"
     },
 
     "autoload": {


### PR DESCRIPTION
As proposed (https://github.com/Behat/Behat/issues/134#issuecomment-5620069), I have recently revamped Behat/CommonFormatters as a behat extension. (Furthermore, I have set up the repository for Travis CI.) 

Thus, Behat/CommonFormatters can be used as a behat extension (behat/common-formatters). I have added it as a suggestion to behat's composer.json.
