### PR TITLE
Fixed extensions loading when they are declared using it's class path

### DIFF
--- a/src/Behat/Behat/Extension/ExtensionManager.php
+++ b/src/Behat/Behat/Extension/ExtensionManager.php
@@ -107,9 +107,9 @@ class ExtensionManager
         if (class_exists($id)) {
             $extension = new $id;
         } elseif (file_exists($this->basePath.DIRECTORY_SEPARATOR.$id)) {
-            $extension = require($this->basePath.DIRECTORY_SEPARATOR.$id);
+            require($this->basePath.DIRECTORY_SEPARATOR.$id);
         } else {
-            $extension = require($id);
+            require($id);
         }
 
         if (null === $extension) {


### PR DESCRIPTION
Hi,

The extensions manager allows extensions to be specified by it's class path (https://github.com/Behat/Behat/blob/master/src/Behat/Behat/Extension/ExtensionManager.php#L112) which is a good option for applications using behat as an external tool, but require() returns a boolean var so $extension it's currently useless, IMO a good approach could be to instantiate the extension inside initializeExtension() but there is no proper way from the behat side to guess the class name to instantiate so it could be delegated to the external extension file:

``` php
class MyExternalExtension extends Extension {
...
}
$extension = new MyExternalExtension()
```

An alternative from the behat side could be to guess the class name from the specified extension path:
/path/to/class/ClassToInstantiate.php
