### PR TITLE
Added branch alias 2.4-dev and bumped Symfony version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     "require": {
         "php":                           ">=5.3.1",
         "behat/gherkin":                 ">=2.2.4,<2.3.0-dev",
-        "symfony/console":               ">=2.0.0,<2.2.0-dev",
-        "symfony/config":                ">=2.0.0,<2.2.0-dev",
-        "symfony/dependency-injection":  ">=2.0.0,<2.2.0-dev",
-        "symfony/event-dispatcher":      ">=2.0.0,<2.2.0-dev",
-        "symfony/translation":           ">=2.0.0,<2.2.0-dev",
-        "symfony/yaml":                  ">=2.0.0,<2.2.0-dev",
-        "symfony/finder":                ">=2.0.0,<2.2.0-dev"
+        "symfony/console":               ">=2.0.0,<2.3.0-dev",
+        "symfony/config":                ">=2.0.0,<2.3.0-dev",
+        "symfony/dependency-injection":  ">=2.0.0,<2.3.0-dev",
+        "symfony/event-dispatcher":      ">=2.0.0,<2.3.0-dev",
+        "symfony/translation":           ">=2.0.0,<2.3.0-dev",
+        "symfony/yaml":                  ">=2.0.0,<2.3.0-dev",
+        "symfony/finder":                ">=2.0.0,<2.3.0-dev"
     },
 
     "suggest": {
@@ -37,5 +37,10 @@
         }
     },
 
-    "bin": ["bin/behat"]
+    "bin": ["bin/behat"],
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "2.4-dev"
+        }
+    }
 }


### PR DESCRIPTION
This should allow to install SymfonyExtension in Symfony 2.2. The Symfony version was updated (..<2.3-dev) in master branch but not in develop branch. This should be merged together with: https://github.com/Behat/Gherkin/pull/46. 
