### PR TITLE
Features without scenarios also should be printed

### DIFF
--- a/src/Behat/Behat/Tester/FeatureTester.php
+++ b/src/Behat/Behat/Tester/FeatureTester.php
@@ -67,34 +67,30 @@ class FeatureTester implements NodeVisitorInterface
     {
         $result = 0;
 
-
         $this->dispatcher->dispatch(
             'beforeFeature', new FeatureEvent($feature, $this->parameters)
         );
-
-        // If feature has scenarios - run them
-        if ($feature->hasScenarios()) {
-            foreach ($feature->getScenarios() as $scenario) {
-                if ($scenario instanceof OutlineNode) {
-                    $tester = $this->container->get('behat.tester.outline');
-                } elseif ($scenario instanceof ScenarioNode) {
-                    $tester = $this->container->get('behat.tester.scenario');
-                } else {
-                    throw new BehaviorException(
-                        'Unknown scenario type found: ' . get_class($scenario)
-                    );
-                }
-
-                $tester->setDryRun($this->dryRun);
-                $result = max($result, $scenario->accept($tester));
+        
+        // run each scenario in feature
+        foreach ($feature->getScenarios() as $scenario) {
+            if ($scenario instanceof OutlineNode) {
+                $tester = $this->container->get('behat.tester.outline');
+            } elseif ($scenario instanceof ScenarioNode) {
+                $tester = $this->container->get('behat.tester.scenario');
+            } else {
+                throw new BehaviorException(
+                    'Unknown scenario type found: ' . get_class($scenario)
+                );
             }
+
+            $tester->setDryRun($this->dryRun);
+            $result = max($result, $scenario->accept($tester));
         }
         
         $this->dispatcher->dispatch(
             'afterFeature', new FeatureEvent($feature, $this->parameters, $result)
         );
     
-
         return $result;
     }
 }


### PR DESCRIPTION
@everzet beforeFeature and afterFeature events should be called for all features as we spoke on twitter

thanks to this change I can list all features, even ones without scenarios

Also there is no longer need to check

``` php
if ($feature->hasScenarios()) {
```

because foreach won't run loop anyway

What you think?
