### PR TITLE
Prefer registered format dispatcher over autoloaded formatters

### DIFF
--- a/src/Behat/Behat/Formatter/FormatterManager.php
+++ b/src/Behat/Behat/Formatter/FormatterManager.php
@@ -70,10 +70,10 @@ class FormatterManager
      */
     public function initFormatter($name)
     {
-        if (class_exists($name)) {
-            $dispatcher = new FormatterDispatcher($name);
-        } elseif (isset($this->dispatchers[strtolower($name)])) {
+        if (isset($this->dispatchers[strtolower($name)])) {
             $dispatcher = $this->dispatchers[strtolower($name)];
+        } elseif (class_exists($name)) {
+            $dispatcher = new FormatterDispatcher($name);
         } else {
             throw new \RuntimeException("Unknown formatter: \"$name\". " .
                 'Available formatters are: ' . implode(', ', array_keys($this->dispatchers))


### PR DESCRIPTION
Fixes compatibility issues with certain autoloaders (Zend_Loader_Autoloader in particular)

The call to `class_exists()` falls back to the spl_autoloader unless passed with a second argument of `false`. This would be usual behaviour if the autoloader stack was full of PSR-0 style autoloaders.

In the case that my FeatureContext uses libraries that require alternative autoloaders (such as ZF1), calling `class_exists()` triggers an error:

```
PHP Warning:  include_once(pretty.php): failed to open stream: No such file or directory in /path/to/project/lib/Zend/Loader.php on line 146
```

![Screen Shot 2013-03-05 at 13 35 38](https://f.cloud.github.com/assets/200351/221402/9ee53458-8599-11e2-9599-3248ee7da9ee.png)

You could argue that the autoloader should handle this more gracefully, but the fact is that `pretty.php` will never and should never exist. It should invoke the formatter registered with the name `pretty` instead of expecting the autoloader to gracefully fail.

My solution moves the call to the autoloader into the `elseif` condition if the named formatter is not registered.

Thanks,
Andrew.
