### PR TITLE
Reverted part of Loader.php file because of issues with loading configuration

### DIFF
--- a/src/Behat/Behat/DependencyInjection/Configuration/Loader.php
+++ b/src/Behat/Behat/DependencyInjection/Configuration/Loader.php
@@ -106,12 +106,12 @@ class Loader
         $config   = Yaml::parse($configPath);
         $configs  = array();
 
-        // first load default profile from current config, but only if custom profile requested
-        if ('default' !== $profile && isset($config['default'])) {
+        // first load default profile from current config
+        if (isset($config['default'])) {
             $configs[] = $config['default'];
         }
 
-        // then recursively load profiles from imports
+        // then load profiles from import
         if (isset($config['imports']) && is_array($config['imports'])) {
             foreach ($config['imports'] as $path) {
                 foreach ($this->parseImport($basePath, $path, $profile) as $importConfig) {
@@ -121,7 +121,7 @@ class Loader
         }
 
         // then load specific profile from current config
-        if (isset($config[$profile])) {
+        if ('default' !== $profile && isset($config[$profile])) {
             $configs[] = $config[$profile];
             $this->profileFound = true;
         }


### PR DESCRIPTION
Hi. I reverted part of Loader.php from this commit:

```
https://github.com/nenadalm/Behat/blob/7f84418e43c2ee6e07b12dff0ff00d6d62a3f355/src/Behat/Behat/DependencyInjection/Configuration/Loader.php

```

because of problems with configuration.

We are using behat.yml

``` yml
default:
...
    extensions:
        Behat\MinkExtension\Extension:
            base_url: 'http://test.website.com/'
            default_session: goutte
            javascript_session: selenium2
            selenium: ~
            selenium2: ~
            goutte:
                guzzle_parameters:
                    redirect.disable: true
            browser_name: firefox
...
imports:
    - app/config/parameters_behat_test.yml
```

``` yml
default:   
    extensions:
        Behat\MinkExtension\Extension:
            base_url: 'http://test-something.website.com/'
```

and without change I sent `base_url: 'http://test.website.com/'` is used.
