### PR TITLE
Fixed unserialization for closure-style step definitions

### DIFF
--- a/src/Behat/Behat/Annotation/Annotation.php
+++ b/src/Behat/Behat/Annotation/Annotation.php
@@ -166,7 +166,7 @@ abstract class Annotation implements AnnotationInterface
      */
     public function __sleep() {
         $serializable = array();
-        foreach ( $this as $paramName => $paramValue ) {
+        foreach ($this as $paramName => $paramValue) {
             if (!is_string($paramValue) && !is_array($paramValue) && is_callable($paramValue)) {
                 continue;
             }


### PR DESCRIPTION
When you use Behat with Gearman extension, you might get "Serialization of 'Closure' is not allowed" exception in case if one of your steps is implemented like this: http://docs.behat.org/guides/5.closures.html

This happens, since German processes communicate between each other with serialized classes. When such serialization happens with a result of a step, defined in closure, you'll get a problem.
