### PR TITLE
changed required symfony/config version to 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php":                           ">=5.3.1",
         "behat/gherkin":                 "~2.2.9",
         "symfony/console":               "~2.0",
-        "symfony/config":                "~2.0",
+        "symfony/config":                "~2.2",
         "symfony/dependency-injection":  "~2.0",
         "symfony/event-dispatcher":      "~2.0",
         "symfony/translation":           "~2.0",


### PR DESCRIPTION
Behat uses 'XmlFileLoader' which requires symfony to load 'Symfony\Component\Config\Util\XmlUtils', which is only included since version 2.2
