### PR TITLE
Fix snippet generation when step contains percentage symbol

### DIFF
--- a/features/annotations/snippets_formatter.feature
+++ b/features/annotations/snippets_formatter.feature
@@ -119,6 +119,7 @@ Feature: Snippets format
           And 'another escaped' string
           And one 'more string'
           And one "more string"
+          And one percentage 10%
       """
 
   Scenario: Run feature with failing scenarios
@@ -193,6 +194,14 @@ Feature: Snippets format
            * @Given /^one "([^"]*)"$/
            */
           public function one2($arg1)
+          {
+              throw new PendingException();
+          }
+
+          /**
+           * @Given /^one percentage (\d+)%$/
+           */
+          public function onePercentage($arg1)
           {
               throw new PendingException();
           }

--- a/src/Behat/Behat/Definition/DefinitionSnippet.php
+++ b/src/Behat/Behat/Definition/DefinitionSnippet.php
@@ -84,7 +84,7 @@ class DefinitionSnippet
      */
     public function getSnippet()
     {
-        return sprintf($this->template, $this->type);
+        return sprintf(preg_replace('/%(?!s)/', '%%', $this->template), $this->type);
     }
 
     /**


### PR DESCRIPTION
Otherwise the following undefined step 

``` gherkin
Given 1% of scenarios' steps contains a percentage symbol
```

will throw the following exception:

```
[ErrorException]
Warning: sprintf(): Too few arguments in
vendor/behat/behat/src/Behat/Behat/Definition/DefinitionSnippet.php line 88
```

and 

``` gherkin
Given we are the 1%
```

will throw

```
[ErrorException]

Warning: sprintf(): Argument number must be greater than zero in
vendor/behat/behat/src/Behat/Behat/Definition/DefinitionSnippet.php line 87
```

because the `%` symbol isn't escaped.
