### PR TITLE
fix result_types.feature failing on php5.5

### DIFF
--- a/features/closures/result_types.feature
+++ b/features/closures/result_types.feature
@@ -225,7 +225,7 @@ Feature: Different result types
       """
       <?php
       $steps->Given('/^I have throwed (\d+)\$ into machine$/', function($world, $money) {
-          $world->money += $money;
+          $world->money = isset($world->money) ? ($world->money + $money) : (int)$money;
       });
       $steps->Then('/^I should see (\d+)\$ on the screen$/', function($world, $money) {
           assertEquals($money, $world->money);


### PR DESCRIPTION
The travis build failed because of an unexpected php Notice on php5.5:
https://travis-ci.org/Behat/Behat/builds/6243493
