### PR TITLE
Added ability to set gherkin parser language via behat.yml

### DIFF
--- a/src/Behat/Behat/Console/Processor/GherkinProcessor.php
+++ b/src/Behat/Behat/Console/Processor/GherkinProcessor.php
@@ -89,5 +89,10 @@ class GherkinProcessor extends Processor
             $cache = new FileCache($path);
             $this->container->get('gherkin.loader.gherkin_file')->setCache($cache);
         }
+
+        $language = $this->container->getParameter('behat.options.feature_language');
+        if ($language) {
+            $this->container->get('gherkin.parser')->setDefaultLanguage($language);
+        }
     }
 }

--- a/src/Behat/Behat/DependencyInjection/Configuration/Configuration.php
+++ b/src/Behat/Behat/DependencyInjection/Configuration/Configuration.php
@@ -118,6 +118,9 @@ class Configuration
                         scalarNode('append_snippets')->
                             defaultNull()->
                         end()->
+                        scalarNode('feature_language')->
+                            defaultNull()->
+                        end()->
                     end()->
                 end()->
             end()->

--- a/src/Behat/Behat/DependencyInjection/config/behat.xml
+++ b/src/Behat/Behat/DependencyInjection/config/behat.xml
@@ -29,6 +29,7 @@
         <parameter key="behat.options.dry_run">null</parameter>
         <parameter key="behat.options.stop_on_failure">null</parameter>
         <parameter key="behat.options.append_snippets">null</parameter>
+        <parameter key="behat.options.feature_language">null</parameter>
 
         <!-- Gherkin Parser -->
         <parameter key="gherkin.class">Behat\Gherkin\Gherkin</parameter>


### PR DESCRIPTION
**Feature:** Configurable default parser language
  As a feature writer
  I want to set a default feature file language in behat.yml
  So that I do not have to write # language: xx in every file

---

I am unsure how to write a test in `.feature` format for this change. Suggestions are more than welcome.

This PR is depending on https://github.com/Behat/Gherkin/pull/54

---

**Example usage**

```
default:
  options:
    feature_language: nl
```
