### PR TITLE
Renamed private properties in behat events to support Symfony's Serializer calls.

### DIFF
--- a/src/Behat/Behat/Event/FeatureEvent.php
+++ b/src/Behat/Behat/Event/FeatureEvent.php
@@ -23,20 +23,20 @@ class FeatureEvent extends Event implements EventInterface
 {
     private $feature;
     private $result;
-    private $parameters;
+    private $contextParameters;
 
     /**
      * Initializes feature event.
      *
      * @param FeatureNode $feature
-     * @param mixed       $parameters
+     * @param mixed       $contextParameters
      * @param integer     $result
      */
-    public function __construct(FeatureNode $feature, $parameters, $result = null)
+    public function __construct(FeatureNode $feature, $contextParameters, $result = null)
     {
-        $this->feature    = $feature;
-        $this->parameters = $parameters;
-        $this->result     = $result;
+        $this->feature           = $feature;
+        $this->contextParameters = $contextParameters;
+        $this->result            = $result;
     }
 
     /**
@@ -56,7 +56,7 @@ class FeatureEvent extends Event implements EventInterface
      */
     public function getContextParameters()
     {
-        return $this->parameters;
+        return $this->contextParameters;
     }
 
     /**

--- a/src/Behat/Behat/Event/StepEvent.php
+++ b/src/Behat/Behat/Event/StepEvent.php
@@ -33,7 +33,7 @@ class StepEvent extends Event implements EventInterface
     const FAILED    = 4;
 
     private $step;
-    private $parent;
+    private $logicalParent;
     private $context;
     private $result;
     private $definition;
@@ -44,24 +44,24 @@ class StepEvent extends Event implements EventInterface
      * Initializes step event.
      *
      * @param StepNode            $step
-     * @param ScenarioNode        $parent
+     * @param ScenarioNode        $logicalParent
      * @param ContextInterface    $context
      * @param integer             $result
      * @param DefinitionInterface $definition
      * @param \Exception          $exception
      * @param DefinitionSnippet   $snippet
      */
-    public function __construct(StepNode $step, ScenarioNode $parent, ContextInterface $context,
+    public function __construct(StepNode $step, ScenarioNode $logicalParent, ContextInterface $context,
                                 $result = null, DefinitionInterface $definition = null,
                                 \Exception $exception = null, DefinitionSnippet $snippet = null)
     {
-        $this->step       = $step;
-        $this->parent     = $parent;
-        $this->context    = $context;
-        $this->result     = $result;
-        $this->definition = $definition;
-        $this->exception  = $exception;
-        $this->snippet    = $snippet;
+        $this->step          = $step;
+        $this->logicalParent = $logicalParent;
+        $this->context       = $context;
+        $this->result        = $result;
+        $this->definition    = $definition;
+        $this->exception     = $exception;
+        $this->snippet       = $snippet;
     }
 
     /**
@@ -81,7 +81,7 @@ class StepEvent extends Event implements EventInterface
      */
     public function getLogicalParent()
     {
-        return $this->parent;
+        return $this->logicalParent;
     }
 
     /**

--- a/src/Behat/Behat/Event/SuiteEvent.php
+++ b/src/Behat/Behat/Event/SuiteEvent.php
@@ -23,20 +23,20 @@ class SuiteEvent extends Event implements EventInterface
 {
     private $logger;
     private $completed;
-    private $parameters;
+    private $contextParameters;
 
     /**
      * Initializes suite event.
      *
-     * @param LoggerDataCollector $logger     suite logger
-     * @param mixed               $parameters context parameters
-     * @param Boolean             $completed  is suite completed
+     * @param LoggerDataCollector $logger            suite logger
+     * @param mixed               $contextParameters context parameters
+     * @param Boolean             $completed         is suite completed
      */
-    public function __construct(LoggerDataCollector $logger, $parameters, $completed)
+    public function __construct(LoggerDataCollector $logger, $contextParameters, $completed)
     {
-        $this->logger     = $logger;
-        $this->parameters = $parameters;
-        $this->completed  = (Boolean) $completed;
+        $this->logger            = $logger;
+        $this->contextParameters = $contextParameters;
+        $this->completed         = (Boolean) $completed;
     }
 
     /**
@@ -56,7 +56,7 @@ class SuiteEvent extends Event implements EventInterface
      */
     public function getContextParameters()
     {
-        return $this->parameters;
+        return $this->contextParameters;
     }
 
     /**


### PR DESCRIPTION
Problem happens when you try to serialize behat events with Symfony Serializer. Default behavior of serializer (with GetSetMethodNormalizer()) assumes that object's attribute names match getters, which is not true for some of the behat events.

Since, there's no big deal in how the private properties are named, I've prepared a pull request, which makes all of them match their getters.
