### PR TITLE
Change default value for boolean nodes

### DIFF
--- a/src/Behat/Behat/DependencyInjection/Configuration/Configuration.php
+++ b/src/Behat/Behat/DependencyInjection/Configuration/Configuration.php
@@ -104,13 +104,13 @@ class Configuration
                             defaultNull()->
                         end()->
                         booleanNode('strict')->
-                            defaultNull()->
+                            defaultFalse()->
                         end()->
                         booleanNode('dry_run')->
-                            defaultNull()->
+                            defaultFalse()->
                         end()->
                         booleanNode('stop_on_failure')->
-                            defaultNull()->
+                            defaultFalse()->
                         end()->
                         scalarNode('rerun')->
                             defaultNull()->

--- a/src/Behat/Behat/DependencyInjection/config/behat.xml
+++ b/src/Behat/Behat/DependencyInjection/config/behat.xml
@@ -25,9 +25,9 @@
         <!-- Options -->
         <parameter key="behat.options.cache">null</parameter>
         <parameter key="behat.options.rerun">null</parameter>
-        <parameter key="behat.options.strict">null</parameter>
-        <parameter key="behat.options.dry_run">null</parameter>
-        <parameter key="behat.options.stop_on_failure">null</parameter>
+        <parameter key="behat.options.strict">false</parameter>
+        <parameter key="behat.options.dry_run">false</parameter>
+        <parameter key="behat.options.stop_on_failure">false</parameter>
         <parameter key="behat.options.append_snippets">null</parameter>
 
         <!-- Gherkin Parser -->


### PR DESCRIPTION
Hi,

As seen in #273, all the boolean nodes had a `null` default value, instead of an expected `false` value, which would make more sense.

I didn't add tests for now, because the fact is as this has an impact on some features (like the `dry-run`, even though the behat test on this feature passes, or the `strict` mode that does not have any), and that these features are still passing and doing as expected.

I'm also waiting on the travis run to check up this PR, as when I run it on my computer, it fails because of a language problem (the features are parsed correctly, the but the result is in french, so it fails on "expected X passed, had X succès" for example).

**edit :** OK it seems to fail on the develop branch failures, so this PR should pass. :)

Cheers.
