### PR TITLE
allowing strings for boolean options to better support BEHAT_PARAMS

### DIFF
--- a/features/annotations/boolish_environment_parameter.feature
+++ b/features/annotations/boolish_environment_parameter.feature
@@ -125,3 +125,19 @@ You can implement step definitions for undefined steps with these snippets:
       | off    |
       | no     |
       | 0      |
+
+  Scenario Outline: Non-boolish strict option
+    Given "BEHAT_PARAMS" environment variable is set to:
+      """
+      options[strict]=<strict>&formatter[parameters][time]=false
+      """
+    When I run "behat --no-ansi -f progress features/coffee.feature"
+    Then it should fail with:
+      """
+      [Symfony\Component\Config\Definition\Exception\InvalidTypeException]
+        Invalid type for path "behat.options.strict". Expected boolean, but got string.
+      """
+    Examples:
+      | strict    |
+      | null      |
+      | dont-care |

--- a/src/Behat/Behat/DependencyInjection/Configuration/Configuration.php
+++ b/src/Behat/Behat/DependencyInjection/Configuration/Configuration.php
@@ -58,7 +58,9 @@ class Configuration
     protected function appendConfigChildrens(TreeBuilder $tree)
     {
         $boolFilter = function ($v) {
-            return filter_var($v, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            $filtered = filter_var($v, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+            return (null === $filtered) ? $v : $filtered;
         };
 
         return $tree->root('behat')->


### PR DESCRIPTION
Same as Behat/Symfony2Extension#40. Please refer to that PR for the discussion.

This PR is against 2.5. Let me know if you want me to resubmit it for 3.0 instead (or additionally).
