### PR TITLE
Fix junit filenames

### DIFF
--- a/src/Behat/Behat/DependencyInjection/Configuration/Services.php
+++ b/src/Behat/Behat/DependencyInjection/Configuration/Services.php
@@ -49,6 +49,7 @@ class Services
     private function setDefaultParameters(ContainerBuilder $container)
     {
         $container->setParameter('paths.base', null);
+        $container->setParameter('paths.features', '%paths.base%/features');
         $container->setParameter('paths.lib', null);
         $container->setParameter('paths.i18n', '%paths.lib%/i18n.php');
         $container->setParameter('paths.gherkin.lib', null);
@@ -260,6 +261,10 @@ class Services
             'base_path',
             '%paths.base%'
         ));
+        $definition->addMethodCall('setParameter', array(
+            'features_path',
+            '%paths.features%'
+        ));
         $definition->addTag('output.formatter');
         $container->setDefinition('output.formatter.junit', $definition);
 
@@ -377,7 +382,7 @@ class Services
 
         $definition = new Definition('Behat\Behat\Suite\Generator\GherkinSuiteGenerator', array(
             array(
-                'paths'    => array('%paths.base%/features'),
+                'paths'    => array('%paths.features%'),
                 'contexts' => array('FeatureContext')
             )
         ));

--- a/src/Behat/Behat/Output/Formatter/CliFormatter.php
+++ b/src/Behat/Behat/Output/Formatter/CliFormatter.php
@@ -62,6 +62,7 @@ abstract class CliFormatter implements FormatterInterface
             'decorated'       => true,
             'time'            => true,
             'base_path'       => null,
+            'features_path'   => null,
             'output'          => null,
             'output_path'     => null,
             'support_path'    => null,

--- a/src/Behat/Behat/Output/Formatter/JunitFormatter.php
+++ b/src/Behat/Behat/Output/Formatter/JunitFormatter.php
@@ -120,8 +120,13 @@ class JunitFormatter extends CliFormatter
     public function prepareTestSuite(FeatureEvent $event)
     {
         $feature = $event->getFeature();
+        $replace = array(
+            $this->getParameter('features_path') => '',
+            DIRECTORY_SEPARATOR => '-',
+            '.feature' => '.xml'
+        );
 
-        $this->filename = sprintf('TEST-%s.xml', basename($feature->getFile(), '.feature'));
+        $this->filename = 'TEST' . strtr($feature->getFile(), $replace);
         $this->failures = $this->tests = $this->skipped = $this->time = 0;
         $this->testCases = array();
         $this->stdout = '';


### PR DESCRIPTION
JUnit Formatter overwrites files when features have same filenames but in the different dirs
