### PR TITLE
Multiline description support (fixes #287)

### DIFF
--- a/features/syntax_help.feature
+++ b/features/syntax_help.feature
@@ -214,6 +214,12 @@ Feature: Syntax helpers
 
           /**
            * Eating apples
+           * 
+           * More details on eating apples, and a list:
+           * - one
+           * - two
+           * --
+           * Internal note not showing in help
            *
            * @When /^I ate (\d+) apples?$/
            */
@@ -244,6 +250,10 @@ Feature: Syntax helpers
 
       default | When /^I ate (\d+) apples?$/
               | Eating apples
+              |
+              | More details on eating apples, and a list:
+              | - one
+              | - two
               | at `FeatureContext::iAteApples()`
 
       default | When /^I found (\d+) apples?$/

--- a/src/Behat/Behat/Context/Reader/Loader/AnnotatedContextLoader.php
+++ b/src/Behat/Behat/Context/Reader/Loader/AnnotatedContextLoader.php
@@ -118,14 +118,24 @@ class AnnotatedContextLoader implements LoaderInterface
         }
 
         if ($docBlock = $method->getDocComment()) {
-            $description = null;
+            // Remove indentation
+            $description = preg_replace('/^[\s\t]*/m', '', $docBlock);
+            // Remove block comment syntax
+            $description = preg_replace('/^\/\*\*\s*|^\s*\*\s|^\s*\*\/$/m', '', $description);
+            // Remove annotations
+            $description = preg_replace('/^@.*$/m', '', $description);
+            // Ignore docs after a "--" separator
+            if(preg_match('/^--.*$/m', $description)) {
+                $descriptionParts = preg_split('/^--.*$/m', $description);
+                $description = array_shift($descriptionParts);
+            }
+            // Trim leading and trailing newlines
+            $description = trim($description, "\n");
 
             foreach (explode("\n", $docBlock) as $docLine) {
                 $docLine = preg_replace('/^\/\*\*\s*|^\s*\*\s*|\s*\*\/$|\s*$/', '', $docLine);
-
+                // Ignore lines without annotations
                 if ('' !== trim($docLine) && 0 !== strpos(trim($docLine), '@')) {
-                    $description = trim($docLine);
-
                     continue;
                 }
 

--- a/src/Behat/Behat/Definition/Support/DefinitionsPrinter.php
+++ b/src/Behat/Behat/Definition/Support/DefinitionsPrinter.php
@@ -128,10 +128,12 @@ class DefinitionsPrinter extends DispatchingService
                 ));
 
                 if ($definition->getDescription()) {
-                    $lines[] = strtr('{space}<dimmed>|</dimmed> {description}', array(
-                        '{space}'       => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
-                        '{description}' => $definition->getDescription()
-                    ));
+                    foreach(explode("\n", $definition->getDescription()) as $descriptionLine) {
+                        $lines[] = strtr('{space}<dimmed>|</dimmed> {description}', array(
+                            '{space}'       => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
+                            '{description}' => $descriptionLine
+                        ));
+                    }
                 }
 
                 $lines[] = strtr('{space}<dimmed>|</dimmed> at `{path}`', array(


### PR DESCRIPTION
Supports more verbose descriptions in AnnotatedContextLoader,
as well as internal notes which aren’t printed with the descriptions.
