### PR TITLE
Fixed wrong step definition

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -162,7 +162,7 @@ class FeatureContext implements Context
     /**
      * Checks whether specified file exists and contains specified string.
      *
-     * @Given /^"([^"]*)" file should contain:$/
+     * @Then /^"([^"]*)" file should contain:$/
      *
      * @param   string       $path file path
      * @param   PyStringNode $text file content


### PR DESCRIPTION
Given should be Then because the step validates things. It is also only
used as a Then step in the features.
