### PR TITLE
Simplified the implementation of Scenario listeners

### DIFF
--- a/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
@@ -10,8 +10,7 @@
 
 namespace Behat\Behat\Hook\Call;
 
-use Behat\Behat\Tester\Event\ExampleTested;
-use Behat\Behat\Tester\Event\ScenarioTested;
+use Behat\Behat\Tester\Event\AbstractScenarioTested;
 use Behat\Gherkin\Filter\NameFilter;
 use Behat\Gherkin\Filter\TagFilter;
 use Behat\Gherkin\Node\FeatureNode;
@@ -35,7 +34,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
      */
     public function filterMatches(LifecycleEvent $event)
     {
-        if (!$event instanceof ScenarioTested && !$event instanceof ExampleTested) {
+        if (!$event instanceof AbstractScenarioTested) {
             return false;
         }
         if (null === ($filterString = $this->getFilterString())) {
@@ -43,11 +42,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
         }
 
         $feature = $event->getFeature();
-        if ($event instanceof ScenarioTested) {
-            $scenario = $event->getScenario();
-        } else {
-            $scenario = $event->getExample();
-        }
+        $scenario = $event->getScenario();
 
         return $this->isMatch($feature, $scenario, $filterString);
     }

--- a/src/Behat/Behat/Output/PrettyFormatter.php
+++ b/src/Behat/Behat/Output/PrettyFormatter.php
@@ -322,7 +322,7 @@ class PrettyFormatter extends TranslatableCliFormatter
 
     public function printExamplesHeader(ExampleTested $event)
     {
-        $example = $event->getExample();
+        $example = $event->getScenario();
         $outline = $this->currentScenario;
         $index = array_search($example, $outline->getExamples());
 
@@ -370,7 +370,7 @@ class PrettyFormatter extends TranslatableCliFormatter
 
     public function printExampleRow(ExampleTested $event)
     {
-        $example = $event->getExample();
+        $example = $event->getScenario();
 
         $this->printBeforeHookCallResults($this->currentExampleEvent->getHookCallResults(), '      ');
 
@@ -384,7 +384,7 @@ class PrettyFormatter extends TranslatableCliFormatter
 
         if (TestResult::FAILED === $event->getResultCode()) {
             $feature = $event->getFeature();
-            $scenario = $event->getExample();
+            $scenario = $event->getScenario();
             $this->failedScenarioPaths[] = sprintf('%s:%s', $feature->getFile(), $scenario->getLine());
         }
         $this->scenarioStats[$event->getResultCode()]++;
@@ -423,7 +423,7 @@ class PrettyFormatter extends TranslatableCliFormatter
 
         $this->writeln(sprintf('      %s', $row));
 
-        foreach ($this->currentAfterStepEvents as $i => $afterEvent) {
+        foreach ($this->currentAfterStepEvents as $afterEvent) {
             $this->printStepOutputOrException($afterEvent->getTestResult(), '      ');
         }
     }
@@ -438,7 +438,7 @@ class PrettyFormatter extends TranslatableCliFormatter
                 continue;
             }
 
-            $index = array_search($event->getStep(), $this->currentExampleEvent->getExample()->getSteps());
+            $index = array_search($event->getStep(), $this->currentExampleEvent->getScenario()->getSteps());
             $header = $outline->getExampleTable()->getRow(0);
             $steps = $outline->getSteps();
             $outlineStepText = $steps[$index]->getText();

--- a/src/Behat/Behat/Output/ProgressFormatter.php
+++ b/src/Behat/Behat/Output/ProgressFormatter.php
@@ -179,7 +179,7 @@ class ProgressFormatter extends TranslatableCliFormatter
         $this->scenarioStats[$event->getResultCode()]++;
         if (TestResult::FAILED === $event->getResultCode()) {
             $feature = $event->getFeature();
-            $scenario = $event instanceof ExampleTested ? $event->getExample() : $event->getScenario();
+            $scenario = $event->getScenario();
             $this->failedScenarioPaths[] = sprintf('%s:%s', $this->relativizePath($feature->getFile()), $scenario->getLine());
         }
     }

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Tester\Cli;
 
+use Behat\Behat\Tester\Event\AbstractScenarioTested;
 use Behat\Behat\Tester\Event\ExampleTested;
 use Behat\Behat\Tester\Event\ScenarioTested;
 use Behat\Behat\Tester\Result\TestResult;
@@ -83,7 +84,7 @@ class RerunController implements Controller
                 $this,
                 'collectFailedScenario'
             ), -50);
-        $this->eventDispatcher->addListener(ExampleTested::AFTER, array($this, 'collectFailedExample'), -50);
+        $this->eventDispatcher->addListener(ExampleTested::AFTER, array($this, 'collectFailedScenario'), -50);
         $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'writeCache'), -50);
         $this->key = $this->generateKey($input);
 
@@ -101,9 +102,9 @@ class RerunController implements Controller
     /**
      * Records scenario if it is failed.
      *
-     * @param ScenarioTested $event
+     * @param AbstractScenarioTested $event
      */
-    public function collectFailedScenario(ScenarioTested $event)
+    public function collectFailedScenario(AbstractScenarioTested $event)
     {
         if (!$this->getFileName()) {
             return;
@@ -116,26 +117,6 @@ class RerunController implements Controller
         $scenario = $event->getScenario();
 
         $this->lines[] = $feature->getFile() . ':' . $scenario->getLine();
-    }
-
-    /**
-     * Records outline example if it is failed.
-     *
-     * @param ExampleTested $event
-     */
-    public function collectFailedExample(ExampleTested $event)
-    {
-        if (!$this->getFileName()) {
-            return;
-        }
-        if (TestResult::FAILED !== $event->getResultCode()) {
-            return;
-        }
-
-        $feature = $event->getFeature();
-        $example = $event->getExample();
-
-        $this->lines[] = $feature->getFile() . ':' . $example->getLine();
     }
 
     /**

--- a/src/Behat/Behat/Tester/Event/AbstractScenarioTested.php
+++ b/src/Behat/Behat/Tester/Event/AbstractScenarioTested.php
@@ -10,7 +10,13 @@
 
 namespace Behat\Behat\Tester\Event;
 
+use Behat\Behat\Tester\Result\StepContainerTestResult;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Behat\Testwork\Call\CallResults;
+use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Hook\Event\LifecycleEvent;
+use Behat\Testwork\Suite\Suite;
 
 /**
  * Abstract scenario tested event.
@@ -19,4 +25,96 @@ use Behat\Testwork\Hook\Event\LifecycleEvent;
  */
 abstract class AbstractScenarioTested extends LifecycleEvent
 {
+    /**
+     * @var FeatureNode
+     */
+    private $feature;
+    /**
+     * @var ScenarioInterface
+     */
+    private $scenario;
+    /**
+     * @var StepContainerTestResult
+     */
+    private $testResult;
+    /**
+     * @var null|CallResults
+     */
+    private $hookCallResults;
+
+    /**
+     * Initializes event.
+     *
+     * @param Suite                   $suite
+     * @param Environment             $environment
+     * @param FeatureNode             $feature
+     * @param ScenarioInterface            $scenario
+     * @param null|StepContainerTestResult $testResult
+     * @param null|CallResults        $hookCallResults
+     */
+    public function __construct(
+        Suite $suite,
+        Environment $environment,
+        FeatureNode $feature,
+        ScenarioInterface $scenario,
+        StepContainerTestResult $testResult = null,
+        CallResults $hookCallResults = null
+    ) {
+        parent::__construct($suite, $environment);
+
+        $this->feature = $feature;
+        $this->scenario = $scenario;
+        $this->testResult = $testResult;
+        $this->hookCallResults = $hookCallResults;
+    }
+
+    /**
+     * Returns feature.
+     *
+     * @return FeatureNode
+     */
+    public function getFeature()
+    {
+        return $this->feature;
+    }
+
+    /**
+     * Returns scenario node.
+     *
+     * @return ScenarioInterface
+     */
+    public function getScenario()
+    {
+        return $this->scenario;
+    }
+
+    /**
+     * Returns scenario test result (if scenario was tested).
+     *
+     * @return null|StepContainerTestResult
+     */
+    public function getTestResult()
+    {
+        return $this->testResult;
+    }
+
+    /**
+     * Returns hook call results.
+     *
+     * @return null|CallResults
+     */
+    public function getHookCallResults()
+    {
+        return $this->hookCallResults;
+    }
+
+    /**
+     * Returns step tester result status.
+     *
+     * @return integer
+     */
+    public function getResultCode()
+    {
+        return $this->testResult->getResultCode();
+    }
 }

--- a/src/Behat/Behat/Tester/Event/ExampleTested.php
+++ b/src/Behat/Behat/Tester/Event/ExampleTested.php
@@ -27,96 +27,29 @@ class ExampleTested extends AbstractScenarioTested
     const BEFORE = 'tester.example_tested.before';
     const AFTER = 'tester.example_tested.after';
 
-    /**
-     * @var FeatureNode
-     */
-    private $feature;
-    /**
-     * @var ExampleNode
-     */
-    private $example;
-    /**
-     * @var null|StepContainerTestResult
-     */
-    private $testResult;
-    /**
-     * @var null|CallResults
-     */
-    private $hookCallResults;
-
-    /**
-     * Initializes event.
-     *
-     * @param Suite                   $suite
-     * @param Environment             $environment
-     * @param FeatureNode             $feature
-     * @param ExampleNode             $example
-     * @param null|StepContainerTestResult $testResult
-     * @param null|CallResults        $hookCallResults
-     */
     public function __construct(
         Suite $suite,
         Environment $environment,
         FeatureNode $feature,
-        ExampleNode $example,
+        ExampleNode $scenario,
         StepContainerTestResult $testResult = null,
         CallResults $hookCallResults = null
     ) {
-        parent::__construct($suite, $environment);
-
-        $this->feature = $feature;
-        $this->example = $example;
-        $this->testResult = $testResult;
-        $this->hookCallResults = $hookCallResults;
+        parent::__construct(
+            $suite,
+            $environment,
+            $feature,
+            $scenario,
+            $testResult,
+            $hookCallResults
+        );
     }
 
     /**
-     * Returns feature.
-     *
-     * @return FeatureNode
-     */
-    public function getFeature()
-    {
-        return $this->feature;
-    }
-
-    /**
-     * Returns example node.
-     *
      * @return ExampleNode
      */
-    public function getExample()
+    public function getScenario()
     {
-        return $this->example;
-    }
-
-    /**
-     * Returns example test result (if scenario was tested).
-     *
-     * @return null|StepContainerTestResult
-     */
-    public function getTestResult()
-    {
-        return $this->testResult;
-    }
-
-    /**
-     * Returns hook call results.
-     *
-     * @return null|CallResults
-     */
-    public function getHookCallResults()
-    {
-        return $this->hookCallResults;
-    }
-
-    /**
-     * Returns step tester result status.
-     *
-     * @return integer
-     */
-    public function getResultCode()
-    {
-        return $this->testResult->getResultCode();
+        return parent::getScenario();
     }
 }

--- a/src/Behat/Behat/Tester/Event/ScenarioTested.php
+++ b/src/Behat/Behat/Tester/Event/ScenarioTested.php
@@ -10,13 +10,6 @@
 
 namespace Behat\Behat\Tester\Event;
 
-use Behat\Behat\Tester\Result\StepContainerTestResult;
-use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioNode;
-use Behat\Testwork\Call\CallResults;
-use Behat\Testwork\Environment\Environment;
-use Behat\Testwork\Suite\Suite;
-
 /**
  * Scenario event.
  *
@@ -26,97 +19,4 @@ class ScenarioTested extends AbstractScenarioTested
 {
     const BEFORE = 'tester.scenario_tested.before';
     const AFTER = 'tester.scenario_tested.after';
-
-    /**
-     * @var FeatureNode
-     */
-    private $feature;
-    /**
-     * @var ScenarioNode
-     */
-    private $scenario;
-    /**
-     * @var StepContainerTestResult
-     */
-    private $testResult;
-    /**
-     * @var null|CallResults
-     */
-    private $hookCallResults;
-
-    /**
-     * Initializes event.
-     *
-     * @param Suite                   $suite
-     * @param Environment             $environment
-     * @param FeatureNode             $feature
-     * @param ScenarioNode            $scenario
-     * @param null|StepContainerTestResult $testResult
-     * @param null|CallResults        $hookCallResults
-     */
-    public function __construct(
-        Suite $suite,
-        Environment $environment,
-        FeatureNode $feature,
-        ScenarioNode $scenario,
-        StepContainerTestResult $testResult = null,
-        CallResults $hookCallResults = null
-    ) {
-        parent::__construct($suite, $environment);
-
-        $this->feature = $feature;
-        $this->scenario = $scenario;
-        $this->testResult = $testResult;
-        $this->hookCallResults = $hookCallResults;
-    }
-
-    /**
-     * Returns feature.
-     *
-     * @return FeatureNode
-     */
-    public function getFeature()
-    {
-        return $this->feature;
-    }
-
-    /**
-     * Returns scenario node.
-     *
-     * @return ScenarioNode
-     */
-    public function getScenario()
-    {
-        return $this->scenario;
-    }
-
-    /**
-     * Returns scenario test result (if scenario was tested).
-     *
-     * @return null|StepContainerTestResult
-     */
-    public function getTestResult()
-    {
-        return $this->testResult;
-    }
-
-    /**
-     * Returns hook call results.
-     *
-     * @return null|CallResults
-     */
-    public function getHookCallResults()
-    {
-        return $this->hookCallResults;
-    }
-
-    /**
-     * Returns step tester result status.
-     *
-     * @return integer
-     */
-    public function getResultCode()
-    {
-        return $this->testResult->getResultCode();
-    }
 }


### PR DESCRIPTION
ExampleTested now uses getScenario to return its ExampleNode (implementing ScenarioInterface), like ScenarioTested, simplifying the implementation of listener running for each scenario. They can depend on AbstractScenarioTested without doing instanceof checks to get the scenario.
Closes #390
