### PR TITLE
Simplified the ContextInitializer interface

### DIFF
--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -123,9 +123,7 @@ class ContextEnvironmentHandler implements EnvironmentHandler
         $context = new $classname($constructorArguments);
 
         foreach ($this->initializers as $initializer) {
-            if ($initializer->supportsContext($context)) {
-                $initializer->initializeContext($context);
-            }
+            $initializer->initializeContext($context);
         }
 
         return $context;

--- a/src/Behat/Behat/Context/Initializer/ContextInitializer.php
+++ b/src/Behat/Behat/Context/Initializer/ContextInitializer.php
@@ -22,15 +22,6 @@ use Behat\Behat\Context\Context;
 interface ContextInitializer
 {
     /**
-     * Checks if initializer supports provided context.
-     *
-     * @param Context $context
-     *
-     * @return Boolean
-     */
-    public function supportsContext(Context $context);
-
-    /**
      * Initializes provided context.
      *
      * @param Context $context


### PR DESCRIPTION
The supportsContext method has been removed. All initializers are called for each context. They should return early if they don't support it.
Closes #389
