### PR TITLE
Removed the concept of suite parameters from Testwork

### DIFF
--- a/features/config_inheritance.feature
+++ b/features/config_inheritance.feature
@@ -73,10 +73,9 @@ Feature: Config inheritance
           /** @When this scenario executes */
           public function thisScenarioExecutes() {}
 
-          /** @Then the context config should be merged */
-          public function theContextConfigMerged() {
-              \PHPUnit_Framework_Assert::assertEquals('val1', $this->parameters['param1']);
-              \PHPUnit_Framework_Assert::assertEquals('val2', $this->parameters['param2']);
+          /** @Then the context parameters should be overwritten */
+          public function theContextParametersOverwrite() {
+              \PHPUnit_Framework_Assert::assertEquals(array('param2' => 'val2'), $this->parameters);
           }
 
           /** @Then the extension config should be merged */
@@ -144,7 +143,7 @@ Feature: Config inheritance
       Feature:
         Scenario:
           When this scenario executes
-          Then the context config should be merged
+          Then the context parameters should be overwritten
           And the extension config should be merged
       """
 

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -29,7 +29,7 @@ Feature: hooks
            * @BeforeFeature
            */
           static public function doSomethingBeforeFeature($event) {
-              $params = $event->getSuite()->getParameters();
+              $params = $event->getSuite()->getSetting('parameters');
               echo "= do something ".$params['before_feature'];
           }
 
@@ -37,7 +37,7 @@ Feature: hooks
            * @AfterFeature
            */
           static public function doSomethingAfterFeature($event) {
-              $params = $event->getSuite()->getParameters();
+              $params = $event->getSuite()->getSetting('parameters');
               echo "= do something ".$params['after_feature'];
           }
 

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -66,7 +66,8 @@ class ContextEnvironmentHandler implements EnvironmentHandler
      */
     public function buildEnvironment(Suite $suite)
     {
-        $contextPool = new UninitializedContextPool($suite->getParameters());
+        $constructorArguments = $suite->hasSetting('parameters') ? (array) $suite->getSetting('parameters') : array();
+        $contextPool = new UninitializedContextPool($constructorArguments);
 
         foreach ($this->getContextClasses($suite) as $class) {
             $contextPool->registerContextClass($class);

--- a/src/Behat/Behat/Gherkin/Suite/Generator/GherkinSuiteGenerator.php
+++ b/src/Behat/Behat/Gherkin/Suite/Generator/GherkinSuiteGenerator.php
@@ -50,17 +50,11 @@ class GherkinSuiteGenerator implements SuiteGenerator
     }
 
     /**
-     * Generate suite with provided name, settings and parameters.
-     *
-     * @param string $suiteName
-     * @param array  $settings
-     * @param array  $parameters
-     *
-     * @return Suite
+     * {@inheritdoc}
      */
-    public function generateSuite($suiteName, array $settings, array $parameters)
+    public function generateSuite($suiteName, array $settings)
     {
-        return new GenericSuite($suiteName, $this->mergeDefaultSettings($settings), $parameters);
+        return new GenericSuite($suiteName, $this->mergeDefaultSettings($settings));
     }
 
     /**

--- a/src/Behat/Testwork/Suite/Cli/SuiteController.php
+++ b/src/Behat/Testwork/Suite/Cli/SuiteController.php
@@ -86,7 +86,7 @@ class SuiteController implements Controller
             }
 
             $this->registry->registerSuiteConfiguration(
-                $name, $config['type'], $config['settings'], $config['parameters']
+                $name, $config['type'], $config['settings']
             );
         }
     }

--- a/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
+++ b/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
@@ -32,13 +32,12 @@ interface SuiteGenerator
     public function supportsTypeAndSettings($type, array $settings);
 
     /**
-     * Generate suite with provided name, settings and parameters.
+     * Generate suite with provided name and settings.
      *
      * @param string $suiteName
      * @param array  $settings
-     * @param array  $parameters
      *
      * @return Suite
      */
-    public function generateSuite($suiteName, array $settings, array $parameters);
+    public function generateSuite($suiteName, array $settings);
 }

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -27,23 +27,17 @@ class GenericSuite implements Suite
      * @var array
      */
     private $settings = array();
-    /**
-     * @var array
-     */
-    private $parameters = array();
 
     /**
      * Initializes suite.
      *
      * @param string $name
      * @param array  $settings
-     * @param array  $parameters
      */
-    public function __construct($name, array $settings, array $parameters)
+    public function __construct($name, array $settings)
     {
         $this->name = $name;
         $this->settings = $settings;
-        $this->parameters = $parameters;
     }
 
     /**
@@ -98,49 +92,5 @@ class GenericSuite implements Suite
         }
 
         return $this->settings[$key];
-    }
-
-    /**
-     * Returns custom parameters.
-     *
-     * @return array
-     */
-    public function getParameters()
-    {
-        return $this->parameters;
-    }
-
-    /**
-     * Checks if parameter with provided name exists.
-     *
-     * @param string $key
-     *
-     * @return Boolean
-     */
-    public function hasParameter($key)
-    {
-        return isset($this->parameters[$key]);
-    }
-
-    /**
-     * Returns parameter value by its key.
-     *
-     * @param string $key
-     *
-     * @return mixed
-     *
-     * @throws ParameterNotFoundException If parameter is not set
-     */
-    public function getParameter($key)
-    {
-        if (!$this->hasParameter($key)) {
-            throw new ParameterNotFoundException(sprintf(
-                '`%s` suite does not have a `%s`.',
-                $this->getName(),
-                $key
-            ), $this->getName(), $key);
-        }
-
-        return $this->parameters[$key];
     }
 }

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -92,7 +92,7 @@ class SuiteExtension implements Extension
                             : array();
 
                         foreach ($suite as $key => $val) {
-                            $suiteKeys = array('enabled', 'type', 'settings', 'parameters');
+                            $suiteKeys = array('enabled', 'type', 'settings');
                             if (!in_array($key, $suiteKeys)) {
                                 $suite['settings'][$key] = $val;
                                 unset($suite[$key]);
@@ -114,11 +114,6 @@ class SuiteExtension implements Extension
                         ->defaultValue(null)
                     ->end()
                     ->arrayNode('settings')
-                        ->defaultValue(array())
-                        ->useAttributeAsKey('name')
-                        ->prototype('variable')->end()
-                    ->end()
-                    ->arrayNode('parameters')
                         ->defaultValue(array())
                         ->useAttributeAsKey('name')
                         ->prototype('variable')->end()
@@ -169,9 +164,8 @@ class SuiteExtension implements Extension
             }
 
             $configuredSuites[$name] = array(
-                'type'       => $config['type'],
-                'settings'   => $config['settings'],
-                'parameters' => $config['parameters']
+                'type'     => $config['type'],
+                'settings' => $config['settings'],
             );
         }
 

--- a/src/Behat/Testwork/Suite/Suite.php
+++ b/src/Behat/Testwork/Suite/Suite.php
@@ -50,29 +50,4 @@ interface Suite
      * @return mixed
      */
     public function getSetting($key);
-
-    /**
-     * Returns custom parameters.
-     *
-     * @return array
-     */
-    public function getParameters();
-
-    /**
-     * Checks if parameter with provided name exists.
-     *
-     * @param string $key
-     *
-     * @return Boolean
-     */
-    public function hasParameter($key);
-
-    /**
-     * Returns parameter value by its key.
-     *
-     * @param string $key
-     *
-     * @return mixed
-     */
-    public function getParameter($key);
 }

--- a/src/Behat/Testwork/Suite/SuiteRegistry.php
+++ b/src/Behat/Testwork/Suite/SuiteRegistry.php
@@ -58,11 +58,10 @@ class SuiteRegistry implements SuiteRepository
      * @param string $name
      * @param string $type
      * @param array  $settings
-     * @param array  $parameters
      *
      * @throws SuiteConfigurationException
      */
-    public function registerSuiteConfiguration($name, $type, array $settings, array $parameters)
+    public function registerSuiteConfiguration($name, $type, array $settings)
     {
         if (isset($this->suiteConfigurations[$name])) {
             throw new SuiteConfigurationException(sprintf(
@@ -71,7 +70,7 @@ class SuiteRegistry implements SuiteRepository
             ), $name);
         }
 
-        $this->suiteConfigurations[$name] = array($type, $settings, $parameters);
+        $this->suiteConfigurations[$name] = array($type, $settings);
         $this->suitesGenerated = false;
     }
 
@@ -88,9 +87,9 @@ class SuiteRegistry implements SuiteRepository
 
         $this->suites = array();
         foreach ($this->suiteConfigurations as $name => $configuration) {
-            list($type, $settings, $parameters) = $configuration;
+            list($type, $settings) = $configuration;
 
-            $this->suites[] = $this->generateSuite($name, $type, $settings, $parameters);
+            $this->suites[] = $this->generateSuite($name, $type, $settings);
         }
 
         $this->suitesGenerated = true;
@@ -104,20 +103,19 @@ class SuiteRegistry implements SuiteRepository
      * @param string $name
      * @param string $type
      * @param array  $settings
-     * @param array  $parameters
      *
      * @return Suite
      *
      * @throws SuiteGenerationException If no appropriate generator found
      */
-    private function generateSuite($name, $type, array $settings, array $parameters)
+    private function generateSuite($name, $type, array $settings)
     {
         foreach ($this->generators as $generator) {
             if (!$generator->supportsTypeAndSettings($type, $settings)) {
                 continue;
             }
 
-            return $generator->generateSuite($name, $settings, $parameters);
+            return $generator->generateSuite($name, $settings);
         }
 
         throw new SuiteGenerationException(sprintf(


### PR DESCRIPTION
Context parameters passed to the context constructor are now stored as a setting among others and is specific to Behat.
Closes #396
