### PR TITLE
Error with a non-zero exit code

### DIFF
--- a/bin/behat
+++ b/bin/behat
@@ -19,11 +19,12 @@ function includeIfExists($file)
 }
 
 if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
-    die(
+    fwrite(STDERR,
         'You must set up the project dependencies, run the following commands:'.PHP_EOL.
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL
     );
+    exit(1);
 }
 
 $factory = new \Behat\Behat\ApplicationFactory();


### PR DESCRIPTION
If the composer autoload file isn't available, write a useful message to `stderr` and return a non-zero exit code.

This stops CI environments etc. silently failing if the vendors aren't installed.
Granted, this isn't a likely situation, but better cover yourself than not.
