### PR TITLE
Context arguments

### DIFF
--- a/features/config_inheritance.feature
+++ b/features/config_inheritance.feature
@@ -10,19 +10,17 @@ Feature: Config inheritance
         - behat.yml.dist
 
       default:
-        suites:
-          default:
-            parameters:
-              param2: val2
+        contexts:
+          FeatureContext:
+            param2: val2
         extensions:
           custom_extension.php:
             param1: val2
 
       custom_profile:
-        suites:
-          default:
-            parameters:
-              param2: val2
+        contexts:
+          FeatureContext:
+            param2: val2
         extensions:
           custom_extension.php:
             param1: val2
@@ -30,22 +28,20 @@ Feature: Config inheritance
     Given a file named "behat.yml.dist" with:
       """
       default:
-        suites:
-          default:
-            parameters:
-              param1: val1
-              param2: val1
+        contexts:
+          FeatureContext:
+            param1: val1
+            param2: val1
         extensions:
           custom_extension.php:
             param1: val1
             param2: val1
 
       custom_profile:
-        suites:
-          default:
-            parameters:
-              param1: val1
-              param2: val1
+        contexts:
+          FeatureContext:
+            param1: val1
+            param2: val1
         extensions:
           custom_extension.php:
             param1: val1

--- a/features/context.feature
+++ b/features/context.feature
@@ -184,13 +184,12 @@ Feature: Context consistency
     Given a file named "behat.yml" with:
       """
       default:
-        suites:
-          default:
-            parameters:
-              parameter1: val_one
-              parameter2:
-                everzet: behat_admin
-                avalanche123: behat_admin
+        contexts:
+          FeatureContext:
+            parameter1: val_one
+            parameter2:
+              everzet: behat_admin
+              avalanche123: behat_admin
       """
     And a file named "features/params.feature" with:
       """

--- a/src/Behat/Behat/Context/Argument/ArgumentResolver.php
+++ b/src/Behat/Behat/Context/Argument/ArgumentResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Argument;
+
+use Behat\Behat\Context\ArgumentHolder;
+
+/**
+ * Context constructor argument resolver.
+ *
+ * Used by ArgumentHolder to resolve specific arguments placeholders.
+ *
+ * @see ArgumentHolder
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+interface ArgumentResolver
+{
+    /**
+     * Resolves context constructor arguments.
+     *
+     * @param string $classname
+     * @param mixed[] $arguments
+     *
+     * @return mixed[]
+     */
+    public function resolveArguments($classname, array $arguments);
+}

--- a/src/Behat/Behat/Context/ArgumentHolder.php
+++ b/src/Behat/Behat/Context/ArgumentHolder.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context;
+
+use Behat\Behat\Context\Argument\ArgumentResolver;
+
+/**
+ * Context constructors argument holder.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+class ArgumentHolder
+{
+    /**
+     * @var ArgumentResolver[]
+     */
+    private $resolvers = array();
+    /**
+     * @var mixed[][string]
+     */
+    private $arguments;
+
+    /**
+     * Registers context argument resolver.
+     *
+     * @param ArgumentResolver $resolver
+     */
+    public function registerArgumentResolver(ArgumentResolver $resolver)
+    {
+        $this->resolvers[] = $resolver;
+    }
+
+    /**
+     * Sets specific context class arguments.
+     *
+     * @param string  $classname
+     * @param mixed[] $arguments
+     */
+    public function setContextArguments($classname, array $arguments)
+    {
+        $this->arguments[$classname] = $arguments;
+    }
+
+    /**
+     * Returns arguments for a specific context class.
+     *
+     * @param string $classname
+     *
+     * @return mixed[]
+     */
+    public function getContextArguments($classname)
+    {
+        return isset($this->arguments[$classname]) ? $this->resolveArguments($classname) : array();
+    }
+
+    /**
+     * Loads and resolves arguments for a specific class.
+     *
+     * @param string $classname
+     *
+     * @return mixed[]
+     */
+    protected function resolveArguments($classname)
+    {
+        $arguments = $this->arguments[$classname];
+        foreach ($this->resolvers as $resolver) {
+            $arguments = $resolver->resolveArguments($classname, $arguments);
+        }
+
+        return $arguments;
+    }
+}

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Context\Environment\Handler;
 
+use Behat\Behat\Context\ArgumentHolder;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Environment\InitializedContextEnvironment;
 use Behat\Behat\Context\Environment\UninitializedContextEnvironment;
@@ -28,9 +29,23 @@ use Behat\Testwork\Suite\Suite;
 class ContextEnvironmentHandler implements EnvironmentHandler
 {
     /**
+     * @var ArgumentHolder
+     */
+    private $argumentHolder;
+    /**
      * @var ContextInitializer[]
      */
     private $initializers = array();
+
+    /**
+     * Initializes environment handler.
+     *
+     * @param ArgumentHolder $holder
+     */
+    public function __construct(ArgumentHolder $holder)
+    {
+        $this->argumentHolder = $holder;
+    }
 
     /**
      * Registers context initializer.
@@ -64,9 +79,7 @@ class ContextEnvironmentHandler implements EnvironmentHandler
      */
     public function buildEnvironment(Suite $suite)
     {
-        $constructorArguments = $suite->hasSetting('parameters') ? (array) $suite->getSetting('parameters') : array();
-        $environment = new UninitializedContextEnvironment($suite, $constructorArguments);
-
+        $environment = new UninitializedContextEnvironment($suite);
         foreach ($this->getContextClasses($suite) as $class) {
             $environment->registerContextClass($class);
         }
@@ -97,11 +110,9 @@ class ContextEnvironmentHandler implements EnvironmentHandler
      */
     public function isolateEnvironment(Environment $uninitializedEnvironment, $testSubject = null)
     {
-        $constructorArguments = $uninitializedEnvironment->getConstructorArguments();
         $environment = new InitializedContextEnvironment($uninitializedEnvironment->getSuite());
-
         foreach ($uninitializedEnvironment->getContextClasses() as $class) {
-            $context = $this->initializeContext($class, $constructorArguments);
+            $context = $this->initializeContext($class, $this->argumentHolder->getContextArguments($class));
             $environment->registerContext($context);
         }
 

--- a/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
@@ -14,6 +14,7 @@ use Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler;
 use Behat\Behat\Context\Exception\ContextNotFoundException;
 use Behat\Behat\Context\Exception\WrongContextClassException;
 use Behat\Testwork\Environment\StaticEnvironment;
+use Behat\Testwork\Suite\Suite;
 
 /**
  * Uninitialized context environment.
@@ -30,22 +31,15 @@ class UninitializedContextEnvironment extends StaticEnvironment implements Conte
      * @var string[]
      */
     private $contextClasses = array();
-    /**
-     * @var array
-     */
-    private $constructorArguments = array();
 
     /**
      * Initializes environment.
      *
-     * @param string $suiteName
-     * @param array  $constructorArguments
+     * @param Suite $suite
      */
-    public function __construct($suiteName, array $constructorArguments = array())
+    public function __construct(Suite $suite)
     {
-        parent::__construct($suiteName);
-
-        $this->constructorArguments = $constructorArguments;
+        parent::__construct($suite);
     }
 
     /**
@@ -105,15 +99,5 @@ class UninitializedContextEnvironment extends StaticEnvironment implements Conte
     public function hasContextClass($class)
     {
         return isset($this->contextClasses[$class]);
-    }
-
-    /**
-     * Returns constructor arguments
-     *
-     * @return array
-     */
-    public function getConstructorArguments()
-    {
-        return $this->constructorArguments;
     }
 }

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -75,8 +75,7 @@ class SuiteExtension implements Extension
             ->defaultValue(array('default' => array(
                 'enabled'    => true,
                 'type'       => null,
-                'settings'   => array(),
-                'parameters' => array()
+                'settings'   => array()
             )))
             ->treatNullLike(array())
             ->treatFalseLike(array())


### PR DESCRIPTION
Depends on #418 

From now on, there is no `parameters` section under the `suite`. Context parameters are passed
through `contexts` section in `behat.yml`:

``` yml
  default:
    suites:
      customer:
        contexts: [ CustomerContext, PackageContext ]
    contexts:
      CustomerContext:
        - value1
        - value2
      PackageContext:
        - http://behat.org
```

Those parameters also could be a placeholders, automatically resolvable by custom context argument
resolvers. Context argument resolvers are extensions implementing `ArgumentResolver` interface that
could add new ways of integration with custom framework. For example, this:

``` yml
  default:
    contexts:
      YourApp\CustomerBundle\Features\Context\CustomerContext:
        @app:customer.repository
```

in case of Symfony2Extension could load `customer.repository` service from application container
and pass it as a CustomerContext constructor argument. /cc @stof
