### PR TITLE
Updated Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: php
 php: [5.3, 5.4, 5.5, hhvm]
 
 branches:
-  only:
-    - /^v?\d+\.\d+(?:\.\d+)?$/
+  except:
+    - /^bugfix\/.*$/
+    - /^feature\/.*$/
+    - /^optimization\/.*$/
 
 matrix:
   allow_failures:


### PR DESCRIPTION
- To not test all Symfony2 versions against HHVM
- To test only maintainance and release branches
