### PR TITLE
Fixed the GroupedSubjectIterator when dealing with an empty iterator

### DIFF
--- a/src/Behat/Testwork/Subject/GroupedSubjectIterator.php
+++ b/src/Behat/Testwork/Subject/GroupedSubjectIterator.php
@@ -83,8 +83,13 @@ class GroupedSubjectIterator implements SubjectIterator
     public function rewind()
     {
         $this->position = 0;
-        if (isset($this->iterators[$this->position])) {
+        while (isset($this->iterators[$this->position])) {
             $this->iterators[$this->position]->rewind();
+
+            if ($this->iterators[$this->position]->valid()) {
+                break;
+            }
+            $this->position++;
         }
     }
 
@@ -94,12 +99,14 @@ class GroupedSubjectIterator implements SubjectIterator
     public function next()
     {
         $this->iterators[$this->position]->next();
-        if (!$this->iterators[$this->position]->valid()) {
+        while (!$this->iterators[$this->position]->valid()) {
             $this->position++;
 
-            if (isset($this->iterators[$this->position])) {
-                $this->iterators[$this->position]->rewind();
+            if (!isset($this->iterators[$this->position])) {
+                break;
             }
+
+            $this->iterators[$this->position]->rewind();
         }
     }
 


### PR DESCRIPTION
If one of the subject iterators is empty, the GroupedSubjectIterator needs to move to the next iterator, otherwise the iteration will be incomplete.

I detected this by running the Symfony2Extension suites: https://travis-ci.org/Behat/Symfony2Extension/jobs/16745992
When the locator is not used, the BundleFeatureLocator returns an empty iterator, and it has an higher priority than the core locator so the empty iterator comes first when grouping. Because of the previous logic, rewinding the grouped iterator would set it on the first iterator so `->valid()` would return `false` and the iteration would stop without ever reaching the next iterator. The same change was required in `next` for empty iterators later in the group.
