### PR TITLE
Added tests for the GroupedSubjectIterator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,6 @@ before_script:
   - export PATH=./bin:$PATH
   - echo "<?php echo '@php5' . implode(',@php5.', range(3, PHP_MINOR_VERSION));" > php_version_tags.php
 
-script: behat -fprogress --tags '~@php-version,'`php php_version_tags.php`
+script:
+  - phpunit
+  - behat -fprogress --tags '~@php-version,'`php php_version_tags.php`

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
 
     "require-dev": {
         "symfony/process": "~2.1",
+        "phpspec/prophecy-phpunit": "~1.0",
         "phpunit/phpunit": "~3.7.28"
     },
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Behat test suite">
+            <directory>./tests/Behat/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/Behat/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Behat/Testwork/Subject/ArraySubjectIterator.php
+++ b/src/Behat/Testwork/Subject/ArraySubjectIterator.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\Subject;
+
+use ArrayIterator;
+use Behat\Testwork\Suite\Suite;
+
+class ArraySubjectIterator extends ArrayIterator implements SubjectIterator
+{
+    /**
+     * @var Suite
+     */
+    private $suite;
+
+    public function __construct(Suite $suite, $array = array())
+    {
+        $this->suite = $suite;
+        parent::__construct($array);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSuite()
+    {
+        return $this->suite;
+    }
+}

--- a/tests/Behat/Tests/Testwork/Subject/GroupedSubjectIteratorTest.php
+++ b/tests/Behat/Tests/Testwork/Subject/GroupedSubjectIteratorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Behat\Tests\Testwork\Subject;
+
+use Behat\Testwork\Subject\ArraySubjectIterator;
+use Behat\Testwork\Subject\EmptySubjectIterator;
+use Behat\Testwork\Subject\GroupedSubjectIterator;
+use Prophecy\PhpUnit\ProphecyTestCase;
+
+class GroupedSubjectIteratorTest extends ProphecyTestCase
+{
+    public function testIterationWithEmptyAtBeginning()
+    {
+        $suite = $this->prophesize('Behat\Testwork\Suite\Suite')->reveal();
+
+        $iterator = new GroupedSubjectIterator($suite, array(
+            new EmptySubjectIterator($suite),
+            new ArraySubjectIterator($suite, array($this->prophesize()->reveal())),
+        ));
+
+        $this->assertEquals(1, iterator_count($iterator));
+    }
+
+    public function testIterationWithEmptyInMiddle()
+    {
+        $suite = $this->prophesize('Behat\Testwork\Suite\Suite')->reveal();
+
+        $iterator = new GroupedSubjectIterator($suite, array(
+            new ArraySubjectIterator($suite, array($this->prophesize()->reveal())),
+            new EmptySubjectIterator($suite),
+            new ArraySubjectIterator($suite, array($this->prophesize()->reveal())),
+        ));
+
+        $this->assertEquals(2, iterator_count($iterator));
+    }
+}


### PR DESCRIPTION
This will avoid regressions for the fix done in #430. I haven't worked on tests this weekend, and so you merged before they got added.

It also adds an ArraySubjectIterator in Testwork for cases where the subjects cannot be lazy-loaded. 
I wanted a real iterator for the integration tests (mocking the iterator to be sure it worked well would have been a real pain), so adding this class made things easier, and I consider it can be part of the code itself for cases where lazyness is not an option. However, a lazy iterator should be always preferred whenever possible to limit memory usage.
