### PR TITLE
Multiline description support (fixes #287)

### DIFF
--- a/features/syntax_help.feature
+++ b/features/syntax_help.feature
@@ -214,6 +214,12 @@ Feature: Syntax helpers
 
           /**
            * Eating apples
+           * 
+           * More details on eating apples, and a list:
+           * - one
+           * - two
+           * --
+           * Internal note not showing in help
            *
            * @When /^I ate (\d+) apples?$/
            */
@@ -244,6 +250,10 @@ Feature: Syntax helpers
 
       default | When /^I ate (\d+) apples?$/
               | Eating apples
+              |
+              | More details on eating apples, and a list:
+              | - one
+              | - two
               | at `FeatureContext::iAteApples()`
 
       default | When /^I found (\d+) apples?$/

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
@@ -49,40 +49,90 @@ class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
         $output = array();
 
         foreach ($definitions as $definition) {
-            $lines = array();
             $regex = $this->getDefinitionPattern($suite, $definition);
 
             if (null !== $search && false === mb_strpos($regex, $search, 0, 'utf8')) {
                 continue;
             }
 
-            $lines[] = strtr(
-                '{suite} <def_dimmed>|</def_dimmed> <info>{type}</info> <def_regex>{regex}</def_regex>', array(
-                    '{suite}' => $suite->getName(),
-                    '{type}'  => $definition->getType(),
-                    '{regex}' => $regex,
-                )
-            );
-
-            if ($definition->getDescription()) {
-                $lines[] = strtr(
-                    '{space}<def_dimmed>|</def_dimmed> {description}', array(
-                        '{space}'       => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
-                        '{description}' => $definition->getDescription()
-                    )
-                );
-            }
-
-            $lines[] = strtr(
-                '{space}<def_dimmed>|</def_dimmed> at `{path}`', array(
-                    '{space}' => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
-                    '{path}'  => $definition->getPath()
-                )
+            $lines = array_merge(
+                $this->extractHeader($suite, $definition),
+                $this->extractDescription($suite, $definition),
+                $this->extractFooter($suite, $definition)
             );
 
             $output[] = implode(PHP_EOL, $lines) . PHP_EOL;
         }
 
         $this->write(rtrim(implode(PHP_EOL, $output)));
+    }
+
+    /**
+     * Extracts the formatted header from the definition.
+     * 
+     * @param Suite      $suite
+     * @param Definition $definition
+     * 
+     * @return string[]
+     */
+    private function extractHeader(Suite $suite, Definition $definition)
+    {
+        $regex = $this->getDefinitionPattern($suite, $definition);
+        $lines = array();
+        $lines[] = strtr(
+            '{suite} <def_dimmed>|</def_dimmed> <info>{type}</info> <def_regex>{regex}</def_regex>', array(
+                '{suite}' => $suite->getName(),
+                '{type}'  => $definition->getType(),
+                '{regex}' => $regex,
+            )
+        );
+
+        return $lines;
+    }
+
+    /**
+     * Extracts the formatted description from the definition.
+     * 
+     * @param Suite      $suite
+     * @param Definition $definition
+     * 
+     * @return string[]
+     */
+    private function extractDescription(Suite $suite, Definition $definition)
+    {
+        $lines = array();
+        if ($description = $definition->getDescription()) {
+            foreach (explode("\n", $description) as $descriptionLine) {
+                $lines[] = strtr(
+                    '{space}<def_dimmed>|</def_dimmed> {description}', array(
+                        '{space}'       => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
+                        '{description}' => $descriptionLine
+                    )
+                );
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Extracts the formatted footer from the definition.
+     * 
+     * @param Suite      $suite
+     * @param Definition $definition
+     * 
+     * @return string[]
+     */
+    private function extractFooter(Suite $suite, Definition $definition)
+    {
+        $lines = array();
+        $lines[] = strtr(
+            '{space}<def_dimmed>|</def_dimmed> at `{path}`', array(
+                '{space}' => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
+                '{path}'  => $definition->getPath()
+            )
+        );
+
+        return $lines;
     }
 }


### PR DESCRIPTION
Supports more verbose descriptions in AnnotatedContextReader,
as well as internal notes which aren’t printed with the descriptions.

Rebased my original pull request (#355) against 3.0.

The pre-existing regex has since been moved to a constant (`self::DOCLINE_TRIMMER_REGEX`). I've added a couple of new regexes. Do you want me to change those to constants as well? I think it'll make the code less readable though.

One of the added regexes ("Remove block comment syntax") is nearly the same as `self::DOCLINE_TRIMMER_REGEX`, but serves a slightly different purpose: Multiline checks, and retains whitespace apart from the first occurrence, in order to allow for visible indents in descriptions (e.g. for lists).
