### PR TITLE
Remove final keyword from createOutputStream()

### DIFF
--- a/src/Behat/Testwork/Output/Printer/ConsoleOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/ConsoleOutputPrinter.php
@@ -190,7 +190,7 @@ class ConsoleOutputPrinter implements OutputPrinter
      *
      * @throws BadOutputPathException
      */
-    final protected function createOutputStream()
+    protected function createOutputStream()
     {
         if (null === $this->outputPath) {
             $stream = fopen('php://stdout', 'w');


### PR DESCRIPTION
From the PHPdoc of the method:

> Override this method & call flushOutputConsole() to write output in another stream

Overriding a method that is final sounds like great fun, but isn't really possible ;-)
