### PR TITLE
Simplified the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: [5.3, 5.4, 5.5, hhvm]
+php: [5.3, 5.4, 5.5, 5.6, 5.3.3, hhvm]
 
 branches:
   except:
@@ -11,25 +11,16 @@ branches:
 matrix:
   allow_failures:
     - php: hhvm
-  exclude:
-    - php: hhvm
-      env: SYMFONY_VERSION='2.1.*'
-    - php: hhvm
-      env: SYMFONY_VERSION='2.2.*'
-    - php: hhvm
-      env: SYMFONY_VERSION='2.3.*'
   include:
-    - php: 5.3.3
-      env: SYMFONY_VERSION='2.4.*'
-
-env:
-  - SYMFONY_VERSION='2.1.*'
-  - SYMFONY_VERSION='2.2.*'
-  - SYMFONY_VERSION='2.3.*'
-  - SYMFONY_VERSION='2.4.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.1.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.2.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.3.*'
 
 before_script:
-  - composer require --no-update symfony/symfony=$SYMFONY_VERSION
+  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
   - composer install --dev --prefer-source
   - export PATH=./bin:$PATH
   - echo "<?php echo '@php5' . implode(',@php5.', range(3, PHP_MINOR_VERSION));" > php_version_tags.php


### PR DESCRIPTION
Instead of testing all PHP versions against all Symfony versions, the composer installation runs an unmodified composer.json for most jobs, thus using the latest stable symfony components (which also ensure we don't miss a dependency). Only a few jobs are running other Symfony versions, on
PHP 5.5.
This makes the build matrix going down from 14 jobs to 9 (while PHP 5.6 has also been added, which would have meant 18 jobs on the previous matrix setup). Given that Travis limits the number of concurrent jobs (5 per github organization currently), this will help making builds faster.
