### PR TITLE
Fixed the merging of TestResults instances

### DIFF
--- a/src/Behat/Testwork/Tester/Result/TestResults.php
+++ b/src/Behat/Testwork/Tester/Result/TestResults.php
@@ -48,7 +48,7 @@ final class TestResults implements TestResult, Countable, IteratorAggregate
      */
     public static function merge(TestResults $first, TestResults $second)
     {
-        return new static($first->toArray(), $second->toArray());
+        return new static(array_merge($first->toArray(), $second->toArray()));
     }
 
     /**


### PR DESCRIPTION
The merging was actually not done (detected by Scrutinizer telling me that the second argument of the constructor was unused).
However, the `merge()` method does not seem to be used. I haven't found any place calling it. It is a left-over of a previous implementation ? Should we remove the method instead of fixing it ?
