### PR TITLE
require dom, mbstring extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,8 @@
 
     "require": {
         "php":                           ">=5.3.3",
+        "ext-dom":                       "*",
+        "ext-mbstring":                  "*",
         "behat/gherkin":                 "~4.0",
         "behat/transliterator":          "~1.0",
         "symfony/console":               "~2.1",


### PR DESCRIPTION
without it i get ugly error:

```
$ bin/behat --init
PHP Fatal error:  Class 'DOMDocument' not found in vendor/symfony/config/Symfony/Component/Config/Util/XmlUtils.php on line 52
PHP Fatal error:  Call to undefined function Behat\Behat\DependencyInjection\mb_internal_encoding() in vendor/behat/behat/src/Behat/Behat/DependencyInjection/BehatExtension.php on line 54
```

with it it get nice error from composer:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested PHP extension ext-dom * is missing from your system.
  Problem 2
    - The requested PHP extension ext-mbstring * is missing from your system.
```
