### PR TITLE
Declare dependency on mbstring extension, used by various parts of Behat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 
     "require": {
         "php":                           ">=5.3.3",
+        "ext-mbstring":                  "*",
         "behat/gherkin":                 "~4.1",
         "behat/transliterator":          "~1.0",
         "symfony/console":               "~2.1",


### PR DESCRIPTION
The mbstring extension is present in default PHP builds, but not necessarily in custom ones, but Behat needs it.
