### PR TITLE
Improved the error reporting for invalid regexes in step definitions

### DIFF
--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -1,0 +1,33 @@
+Feature: Step Definition Pattern
+  In order to fix my mistakes easily
+  As a step definitions developer
+  I need to be told when a pattern is invalid
+
+  Scenario: Simple Arguments Transformations
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @Then /I am (foo/
+           */
+          public function invalidRegex() {
+          }
+      }
+      """
+    And a file named "features/step_patterns.feature" with:
+      """
+      Feature: Step Pattern
+        Scenario:
+          Then I am foo
+      """
+    When I run "behat -f progress --no-colors"
+    Then it should fail with:
+      """
+      [Behat\Behat\Definition\Exception\InvalidPatternException]
+        The regex `/I am (foo/` is invalid:
+      """

--- a/src/Behat/Behat/Definition/Exception/InvalidPatternException.php
+++ b/src/Behat/Behat/Definition/Exception/InvalidPatternException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Definition\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Represents an exception caused by an invalid definition pattern (not able to transform it to a regex).
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+final class InvalidPatternException extends InvalidArgumentException implements DefinitionException
+{
+}

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Definition\Pattern\Policy;
 
+use Behat\Behat\Definition\Exception\InvalidPatternException;
 use Behat\Behat\Definition\Pattern\Pattern;
 use Behat\Transliterator\Transliterator;
 
@@ -54,7 +55,7 @@ final class RegexPatternPolicy implements PatternPolicy
      */
     public function supportsPattern($pattern)
     {
-        return false !== @preg_match($pattern, 'anything');
+        return (bool) preg_match('/^(?:\\{.*\\}|([~\\/#`]).*\1)[imsxADSUXJu]*$/s', $pattern);
     }
 
     /**
@@ -62,6 +63,13 @@ final class RegexPatternPolicy implements PatternPolicy
      */
     public function transformPatternToRegex($pattern)
     {
+        if (false === @preg_match($pattern, 'anything')) {
+            $error = error_get_last();
+            $errorMessage = isset($error['message']) ? $error['message'] : '';
+
+            throw new InvalidPatternException(sprintf('The regex `%s` is invalid: %s', $pattern, $errorMessage));
+        }
+
         return $pattern;
     }
 


### PR DESCRIPTION
If the pattern looks like a regex but is not valid, an exception is now thrown rather than letting it be considered as a turnip pattern.
The reasoning is that it is very easy to make a mistake in the regex (forgetting a closing parenthesis for instance, like in the scenario), especially when the regex is a bit complex. And debugging it is currently a huge pain.

"Looks like a regex" means that it starts with a regex delimiter, and ends with the corresponding delimiter optionally followed by some regex modifiers.
The list of supported delimiters is restricted compared to what PHP supports (i.e. any non-alphanumeric, non-backslash, non-whitespace char) to be sure we don't match something expected to be a turnip pattern by mistake by considering a really weird delimiter. We support ```, `/`, `~`, `#` or `{}`. This is technically a small BC break (if someone wrote a regex using another delimiter in 3.0). There is a way to preserve BC: support any valid regex or anything looking like a regex with these delimiters. This means that you would still get error reporting for invalid regexes using these supported delimiters, but you can still write regexes using other patterns as long as you don't make mistakes in them (like currently). What do you think @everzet ?
