### PR TITLE
Fixed the property type in the ContextSnippet

### DIFF
--- a/src/Behat/Behat/Context/Snippet/ContextSnippet.php
+++ b/src/Behat/Behat/Context/Snippet/ContextSnippet.php
@@ -29,9 +29,9 @@ final class ContextSnippet implements Snippet
      */
     private $template;
     /**
-     * @var string[]
+     * @var string
      */
-    private $contextClass = array();
+    private $contextClass;
 
     /**
      * Initializes definition snippet.


### PR DESCRIPTION
The wrong default value was not exposed to the code, givent hat the constructor always overwrite it. The wrong phpdoc was probably creating some weird stuff in the Scrutinizer checks (but I cannot check it as it is down)
