### PR TITLE
Updated the contribution guidelines for the branch renaming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,15 +5,15 @@ Behat is an open source, community-driven project. If you'd like to contribute,
 feel free to do this, but remember to follow this few simple rules:
 
 - Make your feature addition or bug fix,
-- __Always__ as base for your changes use `3.0` branch (all new 3.0 development
-  happens here, `master` branch is for releases & hotfixes only),
+- __Always__ as base for your changes use `master` branch (all new development
+  happens here),
 - Add `*.features` for those changes (please look into `features/` folder for
   some examples). This is important so we don't break it in a future version
   unintentionally,
 - Commit your code, but do not mess with `BehatApplication` version, or
   `CHANGES.md` one,
-- __Remember__: when you create Pull Request, always select `3.0` branch as
-  target, otherwise it will be closed.
+- __Remember__: when you create Pull Request, always select `master` branch as
+  target, otherwise it will be closed (this is selected by default).
 
 Backwards compatibility
 -----------------------

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ behat
 =====
 
 [![License](https://poser.pugx.org/behat/behat/license.png)](https://packagist.org/packages/behat/behat)
-[![Build Status](https://travis-ci.org/Behat/Behat.png?branch=3.0)](https://travis-ci.org/Behat/Behat)
-[![HHVM Status](http://hhvm.h4cc.de/badge/behat/behat.png?branch=3.0.x-dev)](http://hhvm.h4cc.de/package/behat/behat)
+[![Build Status](https://travis-ci.org/Behat/Behat.png?branch=master)](https://travis-ci.org/Behat/Behat)
+[![HHVM Status](http://hhvm.h4cc.de/badge/behat/behat.png?branch=master)](http://hhvm.h4cc.de/package/behat/behat)
 [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/Behat/Behat/badges/quality-score.png?s=ad84e95fc2405712f88a96d89b4f31dfe5c80fae)](https://scrutinizer-ci.com/g/Behat/Behat/)
 [![Latest Stable Version](https://poser.pugx.org/behat/behat/v/stable.png)](https://packagist.org/packages/behat/behat)
 [![Total Downloads](https://poser.pugx.org/behat/behat/downloads.png)](https://packagist.org/packages/behat/behat)
@@ -14,8 +14,8 @@ Versioning
 ----------
 
 Starting from `v3.0.0`, Behat is following [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
-This basically means that if all you do is implement interfaces (like [this one](https://github.com/Behat/Behat/blob/3.0/src/Behat/Behat/Context/ContextClass/ClassResolver.php#L15-L22))
-and use service constants (like [this one](https://github.com/Behat/Behat/blob/3.0/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php#L45)),
+This basically means that if all you do is implement interfaces (like [this one](https://github.com/Behat/Behat/blob/master/src/Behat/Behat/Context/ContextClass/ClassResolver.php#L15-L22))
+and use service constants (like [this one](https://github.com/Behat/Behat/blob/master/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php#L45)),
 you would not have any backwards compatibility issues with Behat up until `v4.0.0` (or later major)
 is released. Exception could be an extremely rare case where BC break is introduced as a measure
 to fix a serious issue.


### PR DESCRIPTION
The guidelines were already outdated by talking about a master branch for releases while this was only true in the Behat 2.x times btw
