### PR TITLE
Remove var_dump() from extensions.feature

### DIFF
--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -23,7 +23,7 @@ Feature: Extensions
           private $extension;
 
           public function setExtensionParameters(array $parameters) {
-              $this->extension = $parameters;var_dump($parameters);
+              $this->extension = $parameters;
           }
 
           /** @When this scenario executes */


### PR DESCRIPTION
The var_dump() seems to be a remnant of development work, not really part of the feature itself.
