### PR TITLE
Support for container parameters inside behat.yml

### DIFF
--- a/features/config_parameters.feature
+++ b/features/config_parameters.feature
@@ -1,0 +1,53 @@
+Feature: Config parameters
+  In order to reuse context parameters
+  As a context developer
+  I need to be able to specify global parameters in config file
+
+  Background:
+    Given a file named "behat.yml" with:
+    """
+    default:
+      suites:
+        default:
+          contexts:
+            - FeatureContext: [ %param1% ]
+    """
+    And a file named "behat_parameters.yml" with:
+    """
+    parameters:
+      param1: val1
+    """
+    And a file named "features/bootstrap/FeatureContext.php" with:
+    """
+    <?php
+
+    use Behat\Behat\Context\Context;
+
+    class FeatureContext implements Context
+    {
+        private $param1;
+
+        public function __construct($param1) {
+            $this->param1 = $param1;
+        }
+
+        /** @When this scenario executes */
+        public function thisScenarioExecutes() {}
+
+        /** @Then the context parameter should be set to global parameter */
+        public function theContextParametersOverwrite() {
+            \PHPUnit_Framework_Assert::assertEquals('val1', $this->param1);
+        }
+    }
+    """
+    And a file named "features/configs.feature" with:
+    """
+    Feature:
+      Scenario:
+        When this scenario executes
+        Then the context parameter should be set to global parameter
+    """
+
+  Scenario: Config should successfully set the parameter to context
+    When I run "behat -f progress --append-snippets"
+    Then it should pass

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -126,6 +126,20 @@ final class Application extends BaseApplication
     }
 
     /**
+     * Sets container parameters
+     *
+     * @param ContainerInterface $container
+     */
+    private function loadParameters(ContainerInterface $container)
+    {
+        $parameters = $this->configurationLoader->loadParameters();
+
+        foreach ($parameters as $name => $value) {
+            $container->setParameter($name, $value);
+        }
+    }
+
+    /**
      * Creates main command for application.
      *
      * @param InputInterface  $input
@@ -154,6 +168,7 @@ final class Application extends BaseApplication
 
         $container->setParameter('cli.command.name', $this->getName());
         $container->setParameter('paths.base', $basePath);
+        $this->loadParameters($container);
 
         $container->set('cli.input', $input);
         $container->set('cli.output', $output);

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -123,6 +123,25 @@ final class ConfigurationLoader
     }
 
     /**
+     * Returns array of parameters
+     *
+     * @return array
+     */
+    public function loadParameters()
+    {
+        $parametersPath = dirname($this->configurationPath) . DIRECTORY_SEPARATOR . 'behat_parameters.yml';
+        if (file_exists($parametersPath)) {
+            $config = (array) Yaml::parse($parametersPath);
+
+            if (array_key_exists('parameters', $config)) {
+                return $config['parameters'];
+            }
+        }
+
+        return array();
+    }
+
+    /**
      * Loads information from environment variable.
      *
      * @return array


### PR DESCRIPTION
Hi

I'm looking for a way to use global parameter in Behat 3. I need to use same parameter in many contexts and defining it by hand will be "bad" thing.

My idea is to be able to use parameters like in Symfony 2 when I can import them from external yml file.

``` yaml
parameters:
    baseurl: http://google.com

...
    Acme\Context:
        - %baseurl%
```

What's your opinion for this?
Also asking because maybe there is some way to do this with current code and I missed it reading the docs ;)
