### PR TITLE
Snippets from non english scenarios

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php":                           ">=5.3.3",
         "ext-mbstring":                  "*",
-        "behat/gherkin":                 "~4.1",
+        "behat/gherkin":                 "~4.2@dev",
         "behat/transliterator":          "~1.0",
         "symfony/console":               "~2.1",
         "symfony/config":                "~2.3",

--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -187,7 +187,7 @@ Feature: Append snippets option
           private function doSomethingUndefinedWith() {}
 
           /**
-           * @Given /^do something undefined with \$$/
+           * @Then /^do something undefined with \$$/
            */
           public function doSomethingUndefinedWith2()
           {
@@ -195,7 +195,7 @@ Feature: Append snippets option
           }
 
           /**
-           * @Given /^do something undefined with \\(\d+)$/
+           * @Then /^do something undefined with \\(\d+)$/
            */
           public function doSomethingUndefinedWith3($arg1)
           {
@@ -361,7 +361,7 @@ Feature: Append snippets option
           private function doSomethingUndefinedWith() {}
 
           /**
-           * @Given /^do something undefined with \$$/
+           * @Then /^do something undefined with \$$/
            */
           public function doSomethingUndefinedWith2()
           {
@@ -369,7 +369,7 @@ Feature: Append snippets option
           }
 
           /**
-           * @Given /^do something undefined with \\(\d+)$/
+           * @Then /^do something undefined with \\(\d+)$/
            */
           public function doSomethingUndefinedWith3($arg1)
           {
@@ -508,7 +508,7 @@ Feature: Append snippets option
             }
 
             /**
-             * @Given /^do something undefined with \$$/
+             * @Then /^do something undefined with \$$/
              */
             public function doSomethingUndefinedWith()
             {
@@ -524,7 +524,7 @@ Feature: Append snippets option
             }
 
             /**
-             * @Given /^do something undefined with \\(\d+)$/
+             * @Then /^do something undefined with \\(\d+)$/
              */
             public function doSomethingUndefinedWith2($arg1)
             {
@@ -599,7 +599,7 @@ Feature: Append snippets option
             }
 
             /**
-             * @Given do something undefined with $
+             * @Then do something undefined with $
              */
             public function doSomethingUndefinedWith()
             {
@@ -615,7 +615,7 @@ Feature: Append snippets option
             }
 
             /**
-             * @Given do something undefined with \:arg1
+             * @Then do something undefined with \:arg1
              */
             public function doSomethingUndefinedWith2($arg1)
             {
@@ -766,7 +766,7 @@ Feature: Append snippets option
           }
 
           /**
-           * @Given /^do something undefined with \$$/
+           * @Then /^do something undefined with \$$/
            */
           public function doSomethingUndefinedWith()
           {
@@ -782,7 +782,7 @@ Feature: Append snippets option
           }
 
           /**
-           * @Given /^do something undefined with \\(\d+)$/
+           * @Then /^do something undefined with \\(\d+)$/
            */
           public function doSomethingUndefinedWith2($arg1)
           {

--- a/features/context.feature
+++ b/features/context.feature
@@ -279,7 +279,7 @@ Feature: Context consistency
         }
 
         /**
-         * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
+         * @Then /^context parameter "([^"]*)" should be array with (\d+) elements$/
          */
         public function contextParameterShouldBeArrayWithElements($arg1, $arg2)
         {

--- a/features/format_options.feature
+++ b/features/format_options.feature
@@ -170,7 +170,7 @@ Feature: Format options
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {
@@ -252,7 +252,7 @@ Feature: Format options
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {
@@ -399,7 +399,7 @@ Feature: Format options
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {
@@ -478,7 +478,7 @@ Feature: Format options
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -138,7 +138,7 @@ Feature: I18n
       --- FeatureContext не содержит необходимых определений. Вы можете добавить их используя шаблоны:
 
           /**
-           * @Given /^Добавить "([^"]*)" число$/
+           * @Then /^Добавить "([^"]*)" число$/
            */
           public function dobavitChislo($arg1)
           {
@@ -174,7 +174,7 @@ Feature: I18n
       --- FeatureContext не содержит необходимых определений. Вы можете добавить их используя шаблоны:
 
           /**
-           * @Given /^Добавить "([^"]*)" число$/
+           * @Then /^Добавить "([^"]*)" число$/
            */
           public function dobavitChislo($arg1)
           {
@@ -210,7 +210,7 @@ Feature: I18n
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^Добавить "([^"]*)" число$/
+           * @Then /^Добавить "([^"]*)" число$/
            */
           public function dobavitChislo($arg1)
           {
@@ -246,7 +246,7 @@ Feature: I18n
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^Добавить "([^"]*)" число$/
+           * @Then /^Добавить "([^"]*)" число$/
            */
           public function dobavitChislo($arg1)
           {

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -179,7 +179,7 @@ Feature: Multiple formats
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {
@@ -270,7 +270,7 @@ Feature: Multiple formats
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {
@@ -314,7 +314,7 @@ Feature: Multiple formats
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {
@@ -443,7 +443,7 @@ Feature: Multiple formats
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {
@@ -489,7 +489,7 @@ Feature: Multiple formats
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^do something undefined$/
+           * @Then /^do something undefined$/
            */
           public function doSomethingUndefined()
           {

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -135,7 +135,7 @@ Feature: Pretty Formatter
       --- FeatureContext has missing steps. Define them with these snippets:
 
           /**
-           * @Given /^Something new$/
+           * @Then /^Something new$/
            */
           public function somethingNew()
           {

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -86,7 +86,7 @@ Feature: Snippets
           }
 
           /**
-           * @Given /^I should get a '([^']*)':$/
+           * @Then /^I should get a '([^']*)':$/
            */
           public function iShouldGetASuperString($arg1, PyStringNode $string)
           {
@@ -94,7 +94,7 @@ Feature: Snippets
           }
 
           /**
-           * @Given /^I should get a simple string:$/
+           * @Then /^I should get a simple string:$/
            */
           public function iShouldGetASimpleString(PyStringNode $string)
           {
@@ -110,7 +110,7 @@ Feature: Snippets
           }
 
           /**
-           * @Given /^do something undefined with \\(\d+)$/
+           * @When /^do something undefined with \\(\d+)$/
            */
           public function doSomethingUndefinedWith($arg1)
           {
@@ -126,7 +126,7 @@ Feature: Snippets
           }
 
           /**
-           * @Given /^I should get a "([^"]*)":$/
+           * @Then /^I should get a "([^"]*)":$/
            */
           public function iShouldGetA($arg1, PyStringNode $string)
           {
@@ -213,7 +213,7 @@ Feature: Snippets
           }
 
           /**
-           * @Given I should get a :arg1:
+           * @Then I should get a :arg1:
            */
           public function iShouldGetA($arg1, PyStringNode $string)
           {
@@ -221,7 +221,7 @@ Feature: Snippets
           }
 
           /**
-           * @Given I should get a simple string:
+           * @Then I should get a simple string:
            */
           public function iShouldGetASimpleString(PyStringNode $string)
           {
@@ -229,7 +229,7 @@ Feature: Snippets
           }
 
           /**
-           * @Given do something undefined with \:arg1
+           * @When do something undefined with \:arg1
            */
           public function doSomethingUndefinedWith($arg1)
           {

--- a/src/Behat/Behat/Context/Snippet/ContextSnippet.php
+++ b/src/Behat/Behat/Context/Snippet/ContextSnippet.php
@@ -68,9 +68,7 @@ final class ContextSnippet implements Snippet
      */
     public function getSnippet()
     {
-        $type = in_array($this->step->getType(), array('Given', 'When', 'Then')) ? $this->step->getType() : 'Given';
-
-        return sprintf($this->template, $type);
+        return sprintf($this->template, $this->step->getKeywordType());
     }
 
     /**

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
@@ -108,7 +108,7 @@ final class StepStatsListener implements EventListener
 
         $result = $event->getTestResult();
         $step = $event->getStep();
-        $text = sprintf('%s %s', $step->getType(), $step->getText());
+        $text = sprintf('%s %s', $step->getKeyword(), $step->getText());
         $exception = $this->getStepException($result);
 
         $path = $this->getStepPath($event, $exception);

--- a/src/Behat/Behat/Output/Node/Printer/Helper/WidthCalculator.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/WidthCalculator.php
@@ -98,7 +98,7 @@ final class WidthCalculator
     {
         $indentText = str_repeat(' ', intval($indentation));
 
-        $text = sprintf('%s%s %s', $indentText, $step->getType(), $step->getText());
+        $text = sprintf('%s%s %s', $indentText, $step->getKeyword(), $step->getText());
 
         return mb_strlen($text, 'utf8');
     }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -80,7 +80,7 @@ final class PrettySkippedStepPrinter implements StepPrinter
      */
     public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result)
     {
-        $this->printText($formatter->getOutputPrinter(), $step->getType(), $step->getText(), $result);
+        $this->printText($formatter->getOutputPrinter(), $step->getKeyword(), $step->getText(), $result);
         $this->pathPrinter->printStepPath($formatter, $scenario, $step, $result, mb_strlen($this->indentText, 'utf8'));
         $this->printArguments($formatter, $step->getArguments());
     }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -88,7 +88,7 @@ final class PrettyStepPrinter implements StepPrinter
      */
     public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result)
     {
-        $this->printText($formatter->getOutputPrinter(), $step->getType(), $step->getText(), $result);
+        $this->printText($formatter->getOutputPrinter(), $step->getKeyword(), $step->getText(), $result);
         $this->pathPrinter->printStepPath($formatter, $scenario, $step, $result, mb_strlen($this->indentText, 'utf8'));
         $this->printArguments($formatter, $step->getArguments(), $result);
         $this->printStdOut($formatter->getOutputPrinter(), $result);

--- a/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
@@ -79,7 +79,7 @@ class ConsoleSnippetPrinter implements SnippetPrinter
         $this->output->writeln('--- ' . $message . PHP_EOL);
 
         foreach ($steps as $step) {
-            $this->output->writeln(sprintf('    <snippet_undefined>%s %s</snippet_undefined>', $step->getType(), $step->getText()));
+            $this->output->writeln(sprintf('    <snippet_undefined>%s %s</snippet_undefined>', $step->getKeyword(), $step->getText()));
         }
 
         $this->output->writeln('');


### PR DESCRIPTION
Generate snippets with `@Given`, `@Then`, `@When` from non english scenarios. 
After added keyword type to `StepNode` in **Gherkin 4.2.x-dev** (see Behat/Gherkin#69) .

Also snippets with keyword types `And`, `But` are normalized to `Given`, `When`, or `Then`. 
Rule: Get type from previous step if exists, else set to `Given`.

Fixes #277, #317
