### PR TITLE
check if argument is string in isStringAndMatchesPattern

### DIFF
--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -257,7 +257,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer
             $definitionCall->getFeature()->getLanguage()
         );
 
-        return is_string($argumentValue) ? (bool) preg_match($regex, $argumentValue, $match) : false;
+        return is_string($argumentValue) && preg_match($regex, $argumentValue, $match);
     }
 
     /**


### PR DESCRIPTION
Just does what the function name says it should do...

Current behaviour sometimes produces warnings if transformation result is not string 
`Warning: preg_match() expects parameter 2 to be string`
