### PR TITLE
Add PendingException use statement to SimpleClassGenerator

### DIFF
--- a/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
@@ -26,6 +26,7 @@ final class SimpleClassGenerator implements ClassGenerator
 <?php
 
 {namespace}use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 


### PR DESCRIPTION
Generated `FeatureContext` classes otherwise throw a `Fatal error: Class 'PendingException' not found`. We need to `use` the exception class.
