### PR TITLE
Enable "null" TableNode/PyStringNode parameters

### DIFF
--- a/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
@@ -221,6 +221,26 @@ final class RepositorySearchEngine implements SearchEngine
                 continue;
             }
 
+            // Enable with and without TableNode/PyStringNode parameter, eg:
+            //  /** @Then /^I should get an email on "(?P<email>[^"]+)"(?:| with:)$/ */
+            //  public function iShouldGetAnEmail($email, PyStringNode $text = null)
+            //  {
+            //      //...
+            //      if ($text) {
+            //          // Check the content also if it is set
+            //      }
+            //  }
+            // ---
+            // Then I should get an email on "test1@mail.com"
+            // #...
+            // Then I should get an email on "test2@mail.com" with:
+            //  """
+            //  This is a test mail!
+            //  """
+            if ($parameter->allowsNull()) {
+                continue;
+            }
+
             throw new UnknownParameterValueException(sprintf(
                 'Can not find a matching value for an argument `%s` of the method `%s`.',
                 $name,


### PR DESCRIPTION
We are using some tests when we allow the null TableNode or PyStringNode . Eg:

test.feature

```
Then I should get an email on "test1@mail.com"
#...
Then I should get an email on "test2@mail.com" with:
 """
 This is a test mail!
 """
# OR
When I run "assetic:dump" command
# ...
When I run "assetic:dump" command with:
    | option   |
    | --e=prod |
    | --vvv    |
```

FeatureContext.php

```
<?php
/** @Then /^I should get an email on "(?P<email>[^"]+)"(?:| with:)$/ */
public function iShouldGetAnEmail($email, PyStringNode $text = null)
{
    //...
    if ($text) {
        // Check the content also if it is set
    }
}
```
