### PR TITLE
Argument validation fails if the default value is null

### DIFF
--- a/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
@@ -217,7 +217,7 @@ final class RepositorySearchEngine implements SearchEngine
         foreach ($parameters as $num => $parameter) {
             $name = $parameter->getName();
 
-            if (isset($arguments[$num]) || isset($arguments[$name])) {
+            if (array_key_exists($num, $arguments) || array_key_exists($name, $arguments)) {
                 continue;
             }
 


### PR DESCRIPTION
Related to #586, if the default argument is provided but it's a `null`, the `isset()` check will fail. `array_key_exists` must be used instead.
