### PR TITLE
Feature to enable table row transformations

### DIFF
--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -59,6 +59,11 @@ Feature: Step Arguments Transformations
               return new User($username, $age);
           }
 
+          /** @Transform row:username */
+          public function createUserNamesFromTable($tableRow) {
+              return $tableRow['username'];
+          }
+
           /** @Transform /^\d+$/ */
           public function castToNumber($number) {
               return intval($number);
@@ -98,6 +103,13 @@ Feature: Step Arguments Transformations
           public function ageMustBe($age) {
               PHPUnit_Framework_Assert::assertEquals($age, $this->user->getAge());
               PHPUnit_Framework_Assert::assertInternalType('int', $age);
+          }
+
+          /**
+           * @Then the Usernames must be:
+           */
+          public function usernamesMustBe(array $usernames) {
+              PHPUnit_Framework_Assert::assertEquals($usernames[0], $this->user->getUsername());
           }
 
           /**
@@ -184,6 +196,26 @@ Feature: Step Arguments Transformations
 
       2 scenarios (2 passed)
       6 steps (6 passed)
+      """
+  Scenario: Table Row Arguments Transformations
+    Given a file named "features/table_row_arguments.feature" with:
+      """
+      Feature: Step Arguments
+        Scenario:
+          Given I am user:
+            | username | age |
+            | ever.zet | 22  |
+          Then the Usernames must be:
+            | username |
+            | ever.zet |
+      """
+    When I run "behat -f progress --no-colors"
+    Then it should pass with:
+      """
+      ..
+
+      1 scenario (1 passed)
+      2 steps (2 passed)
       """
 
   Scenario: Named Arguments Transformations

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -114,6 +114,15 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer
             return $this->applyTableTransformation($definitionCall, $transformation, $value);
         }
 
+        if ($this->isApplicableTableRowTransformation($transformation, $value)) {
+            $rows = array();
+            foreach ($value as $row) {
+                $rows[] = $this->applyTableTransformation($definitionCall, $transformation, $row);
+            }
+
+            return $rows;
+        }
+
         if ($this->isApplicablePatternTransformation($definitionCall, $transformation, $value, $arguments)) {
             return $this->applyPatternTransformation($definitionCall, $transformation, $arguments);
         }
@@ -230,6 +239,21 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer
         }
 
         return false;
+    }
+
+    /**
+     * @param Transformation $transformation
+     * @param mixed          $value
+     *
+     * @return Boolean
+     */
+    private function isApplicableTableRowTransformation(Transformation $transformation, $value)
+    {
+        if (!$value instanceof TableNode) {
+            return false;
+        };
+
+        return $transformation->getPattern() === 'row:' . implode(',', $value->getRow(0));
     }
 
     /**


### PR DESCRIPTION
This enables table row transformations.

Typical use case for a table transformation:
 ```php
/**
 * @transform table:username,age
 */
public function transformShowsTable(TableNode $table)
{
    $users = [];
    foreach ($table as $row) {
        $users[] = new User($row['username'], $row['age'];
    }
    return $users;
}
```

The loop is pretty boilerplate, so this PR enables the following:

```php
/**
 * @transform row:username,age
 */
public function transformShowsTable(array $row)
{
    return new User($row['username'], $row['age'];
}
```