### PR TITLE
Allow any whitespace character at end of file

### DIFF
--- a/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
+++ b/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
@@ -64,7 +64,7 @@ final class ContextSnippetAppender implements SnippetAppender
             }
 
             $generated = rtrim(strtr($snippet->getSnippet(), array('\\' => '\\\\', '$' => '\\$')));
-            $content = preg_replace('/}[ \n]*$/', "\n" . $generated . "\n}\n", $content);
+            $content = preg_replace('/}\s*$/', "\n" . $generated . "\n}\n", $content);
             $path = $reflection->getFileName();
 
             file_put_contents($path, $content);


### PR DESCRIPTION
Changing regex to allow for any whitespace character (including \r and \t) at the end of the file

E.g. In Windows it wasn't working because it uses CRLF instead of LF at the end of the lines.
