### PR TITLE
Change comment color from black to magenta

### DIFF
--- a/src/Behat/Behat/Output/Printer/ConsoleOutputPrinter.php
+++ b/src/Behat/Behat/Output/Printer/ConsoleOutputPrinter.php
@@ -57,7 +57,7 @@ final class ConsoleOutputPrinter extends BasePrinter
             'passed_param'  => new OutputFormatterStyle('green', null, array('bold')),
             'skipped'       => new OutputFormatterStyle('cyan'),
             'skipped_param' => new OutputFormatterStyle('cyan', null, array('bold')),
-            'comment'       => new OutputFormatterStyle('black'),
+            'comment'       => new OutputFormatterStyle('magenta'),
             'tag'           => new OutputFormatterStyle('cyan')
         );
     }


### PR DESCRIPTION
Most consols have black background. Since you used a black font color the "failed steps" it wasn't visible at all. This is why I changed the color to magenta.
