### PR TITLE
[POC] Draft of a digest formatter

### DIFF
--- a/features/digest_format.feature
+++ b/features/digest_format.feature
@@ -1,0 +1,54 @@
+Feature: Digest Formatter
+  In order to have an overview of the project features
+  As a feature writer
+  I need to have digest formatter
+
+  Scenario: Complex
+    Given a file named "features/World.feature" with:
+      """
+      Feature: World consistency
+        In order to maintain stable behaviors
+        As a features developer
+        I want, that "World" flushes between scenarios
+
+        Background:
+          Given I have entered 10
+
+        Scenario: Undefined
+          Then I must have 10
+          And Something new
+          Then I must have 10
+
+        Scenario: Pending
+          Then I must have 10
+          And Something not done yet
+          Then I must have 10
+
+        Scenario: Failed
+          When I add 4
+          Then I must have 13
+
+        Scenario Outline: Passed & Failed
+          Given I must have 10
+          When I add <value>
+          Then I must have <result>
+
+          Examples:
+            | value | result |
+            |  5    | 16     |
+            |  10   | 20     |
+            |  23   | 32     |
+      """
+    When I run "behat --no-colors -f digest"
+    Then it should pass with:
+      """
+      Feature: World consistency
+        In order to maintain stable behaviors
+        As a features developer
+        I want, that "World" flushes between scenarios
+
+        Scenario: Undefined       # features/World.feature:9
+        Scenario: Pending         # features/World.feature:14
+        Scenario: Failed          # features/World.feature:19
+        Scenario: Passed & Failed # features/World.feature:23
+      """

--- a/features/digest_format.feature
+++ b/features/digest_format.feature
@@ -3,52 +3,47 @@ Feature: Digest Formatter
   As a feature writer
   I need to have digest formatter
 
-  Scenario: Complex
-    Given a file named "features/World.feature" with:
+  Scenario: Simple
+    Given a file named "features/bootstrap/FeatureContext.php" with:
       """
-      Feature: World consistency
-        In order to maintain stable behaviors
+      <?php
+
+      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+          Behat\Behat\Tester\Exception\PendingException;
+      use Behat\Gherkin\Node\PyStringNode,
+          Behat\Gherkin\Node\TableNode;
+
+      class FeatureContext implements CustomSnippetAcceptingContext
+      {
+          public static function getAcceptedSnippetType() { return 'regex'; }
+      }
+      """
+    Given a file named "features/digest.feature" with:
+      """
+      Feature: Provide a digest of my features
+        In order to easily browse my application's features
         As a features developer
-        I want, that "World" flushes between scenarios
+        I want to have access to a digest of my features
 
-        Background:
-          Given I have entered 10
+        Scenario: It starts here
+          Given something
+          When something new
+          Then something should have happened
 
-        Scenario: Undefined
-          Then I must have 10
-          And Something new
-          Then I must have 10
+        Scenario: It continues here
+          Given something doesn't exist
+          When something else
+          Then something or not
 
-        Scenario: Pending
-          Then I must have 10
-          And Something not done yet
-          Then I must have 10
-
-        Scenario: Failed
-          When I add 4
-          Then I must have 13
-
-        Scenario Outline: Passed & Failed
-          Given I must have 10
-          When I add <value>
-          Then I must have <result>
-
-          Examples:
-            | value | result |
-            |  5    | 16     |
-            |  10   | 20     |
-            |  23   | 32     |
+        Scenario: It ends here
+          When nothing
+          Then void
       """
-    When I run "behat --no-colors -f digest"
+    When I run "behat --no-colors -f digest --no-snippets"
     Then it should pass with:
       """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-
-        Scenario: Undefined       # features/World.feature:9
-        Scenario: Pending         # features/World.feature:14
-        Scenario: Failed          # features/World.feature:19
-        Scenario: Passed & Failed # features/World.feature:23
+      Feature Provide a digest of my features features/digest.feature
+       6 It starts here
+       11 It continues here
+       16 It ends here
       """

--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -15,6 +15,7 @@ use Behat\Behat\Definition\ServiceContainer\DefinitionExtension;
 use Behat\Behat\EventDispatcher\ServiceContainer\EventDispatcherExtension;
 use Behat\Behat\Gherkin\ServiceContainer\GherkinExtension;
 use Behat\Behat\Hook\ServiceContainer\HookExtension;
+use Behat\Behat\Output\ServiceContainer\Formatter\DigestFormatterFactory;
 use Behat\Behat\Output\ServiceContainer\Formatter\PrettyFormatterFactory;
 use Behat\Behat\Output\ServiceContainer\Formatter\ProgressFormatterFactory;
 use Behat\Behat\Snippet\ServiceContainer\SnippetExtension;
@@ -135,6 +136,7 @@ final class ApplicationFactory extends BaseFactory
         return array(
             new PrettyFormatterFactory($processor),
             new ProgressFormatterFactory($processor),
+            new DigestFormatterFactory($processor),
         );
     }
 }

--- a/src/Behat/Behat/Output/Node/Printer/Digest/DigestFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Digest/DigestFeaturePrinter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Behat\Behat\Output\Node\Printer\Digest;
+
+use Behat\Behat\Output\Node\Printer\FeaturePrinter;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Testwork\Output\Formatter;
+use Behat\Testwork\Tester\Result\TestResult;
+
+class DigestFeaturePrinter implements FeaturePrinter
+{
+    protected $indentText;
+
+    public function __construct($indentation = 0, $subIndentation = 2)
+    {
+        $this->indentText = str_repeat(' ', intval($indentation));
+    }
+
+    public function printFooter(Formatter $formatter, TestResult $result)
+    {
+        $formatter->getOutputPrinter()->writeln();
+    }
+
+    public function printHeader(Formatter $formatter, FeatureNode $feature)
+    {
+        $printer = $formatter->getOutputPrinter();
+        $printer->write(sprintf('%s{+pending_param}%s{-pending_param}', $this->indentText, $feature->getKeyword()));
+
+        if ($title = $feature->getTitle()) {
+            $printer->write(sprintf(' {+passed}%s{-passed} {+comment}%s{-comment}', $title, $feature->getFile()));
+        }
+
+        $printer->writeln();
+    }
+}

--- a/src/Behat/Behat/Output/Node/Printer/Digest/DigestFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Digest/DigestFeaturePrinter.php
@@ -9,10 +9,19 @@ use Behat\Testwork\Tester\Result\TestResult;
 
 class DigestFeaturePrinter implements FeaturePrinter
 {
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @var integer
+     */
     protected $indentText;
 
-    public function __construct($indentation = 0, $subIndentation = 2)
+    public function __construct($basePath, $indentation = 0)
     {
+        $this->basePath = $basePath;
         $this->indentText = str_repeat(' ', intval($indentation));
     }
 
@@ -26,10 +35,29 @@ class DigestFeaturePrinter implements FeaturePrinter
         $printer = $formatter->getOutputPrinter();
         $printer->write(sprintf('%s{+pending_param}%s{-pending_param}', $this->indentText, $feature->getKeyword()));
 
-        if ($title = $feature->getTitle()) {
-            $printer->write(sprintf(' {+passed}%s{-passed} {+comment}%s{-comment}', $title, $feature->getFile()));
-        }
+        $printer->write(sprintf(
+            ' {+passed}%s{-passed} {+comment}%s{-comment}',
+            $feature->getTitle(),
+            $this->relativizePaths($feature->getFile())
+        ));
+
 
         $printer->writeln();
+    }
+
+    /**
+     * Transforms path to relative.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function relativizePaths($path)
+    {
+        if (!$this->basePath) {
+            return $path;
+        }
+
+        return str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $path);
     }
 }

--- a/src/Behat/Behat/Output/Node/Printer/Digest/DigestScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Digest/DigestScenarioPrinter.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Output\Node\Printer\Digest;
+
+use Behat\Behat\Output\Node\Printer\ScenarioPrinter;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioLikeInterface as Scenario;
+use Behat\Gherkin\Node\TaggedNodeInterface;
+use Behat\Testwork\Output\Formatter;
+use Behat\Testwork\Output\Printer\OutputPrinter;
+use Behat\Testwork\Tester\Result\TestResult;
+
+/**
+ * Prints scenario headers (with tags, keyword and long title) and footers.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class DigestScenarioPrinter implements ScenarioPrinter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function printHeader(Formatter $formatter, FeatureNode $feature, Scenario $scenario)
+    {
+        $printer = $formatter->getOutputPrinter();
+
+
+        $title = $scenario->getTitle();
+        if ('' === $title) {
+            $title = '{+exception}Untitled scenario{-exception}';
+        }
+        $printer->write(sprintf(' {+comment}%s{-comment} %s', $scenario->getLine(), $title));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function printFooter(Formatter $formatter, TestResult $result)
+    {
+        $formatter->getOutputPrinter()->writeln();
+    }
+}

--- a/src/Behat/Behat/Output/Node/Printer/Digest/DigestSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Digest/DigestSetupPrinter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Behat\Behat\Output\Node\Printer\Digest;
+
+use Behat\Testwork\Output\Formatter;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
+use Behat\Behat\Output\Node\Printer\SetupPrinter;
+
+class DigestSetupPrinter implements SetupPrinter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function printSetup(Formatter $formatter, Setup $setup)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function printTeardown(Formatter $formatter, Teardown $teardown)
+    {
+    }
+}
+

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/DigestFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/DigestFormatterFactory.php
@@ -1,0 +1,243 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Output\ServiceContainer\Formatter;
+
+use Behat\Behat\Definition\ServiceContainer\DefinitionExtension;
+use Behat\Behat\EventDispatcher\Event\BackgroundTested;
+use Behat\Behat\EventDispatcher\Event\OutlineTested;
+use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use Behat\Testwork\Exception\ServiceContainer\ExceptionExtension;
+use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
+use Behat\Testwork\Output\ServiceContainer\OutputExtension;
+use Behat\Testwork\ServiceContainer\ServiceProcessor;
+use Behat\Testwork\Translator\ServiceContainer\TranslatorExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Behat digest formatter factory.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+class DigestFormatterFactory implements FormatterFactory
+{
+    /**
+     * @var ServiceProcessor
+     */
+    private $processor;
+
+    /*
+     * Available services
+     */
+    const ROOT_LISTENER_ID = 'output.node.listener.digest';
+    const RESULT_TO_STRING_CONVERTER_ID = 'output.node.printer.result_to_string';
+
+    /*
+     * Available extension points
+     */
+    const ROOT_LISTENER_WRAPPER_TAG = 'output.node.listener.digest.wrapper';
+
+    /**
+     * Initializes extension.
+     *
+     * @param null|ServiceProcessor $processor
+     */
+    public function __construct(ServiceProcessor $processor = null)
+    {
+        $this->processor = $processor ? : new ServiceProcessor();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFormatter(ContainerBuilder $container)
+    {
+        $this->loadRootNodeListener($container);
+
+        $this->loadCorePrinters($container);
+
+        $this->loadFormatter($container);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function processFormatter(ContainerBuilder $container)
+    {
+        $this->processListenerWrappers($container);
+    }
+
+    /**
+     * Loads digest formatter node event listener.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function loadRootNodeListener(ContainerBuilder $container)
+    {
+        $definition = new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', array(
+            array(
+                new Definition('Behat\Behat\Output\Node\EventListener\AST\FeatureListener', array(
+                    new Reference('output.node.printer.digest.feature'),
+                    new Reference('output.node.printer.digest.feature_setup'),
+                )),
+                new Definition('Behat\Behat\Output\Node\EventListener\AST\ScenarioNodeListener', array(
+                    ScenarioTested::AFTER_SETUP,
+                    ScenarioTested::AFTER,
+                    new Reference('output.node.printer.digest.scenario'),
+                    new Reference('output.node.printer.digest.scenario_setup')
+                )),
+            )
+        ));
+        $container->setDefinition(self::ROOT_LISTENER_ID, $definition);
+    }
+
+    /**
+     * Loads formatter itself.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function loadFormatter(ContainerBuilder $container)
+    {
+        $definition = new Definition('Behat\Testwork\Output\NodeEventListeningFormatter', array(
+            'digest',
+            'Prints the feature as is.',
+            array(
+            ),
+            $this->createOutputPrinterDefinition(),
+            new Reference(self::ROOT_LISTENER_ID),
+        ));
+        $definition->addTag(OutputExtension::FORMATTER_TAG, array('priority' => 100));
+        $container->setDefinition(OutputExtension::FORMATTER_TAG . '.digest', $definition);
+    }
+
+    /**
+     * Loads feature, scenario and step printers.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function loadCorePrinters(ContainerBuilder $container)
+    {
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Digest\DigestFeaturePrinter');
+        $container->setDefinition('output.node.printer.digest.feature', $definition);
+
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Digest\DigestSetupPrinter', array(
+            new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
+            new Reference(ExceptionExtension::PRESENTER_ID),
+            0,
+            true,
+            true
+        ));
+        $container->setDefinition('output.node.printer.digest.feature_setup', $definition);
+
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Digest\DigestScenarioPrinter');
+        $container->setDefinition('output.node.printer.digest.scenario', $definition);
+
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Digest\DigestSetupPrinter', array(
+            new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
+            new Reference(ExceptionExtension::PRESENTER_ID),
+            2
+        ));
+        $container->setDefinition('output.node.printer.digest.scenario_setup', $definition);
+    }
+
+    /**
+     * Loads printer helpers.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function loadPrinterHelpers(ContainerBuilder $container)
+    {
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Helper\WidthCalculator');
+        $container->setDefinition('output.node.printer.pretty.width_calculator', $definition);
+
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Helper\StepTextPainter', array(
+            new Reference(DefinitionExtension::PATTERN_TRANSFORMER_ID),
+            new Reference(self::RESULT_TO_STRING_CONVERTER_ID)
+        ));
+        $container->setDefinition('output.node.printer.pretty.step_text_painter', $definition);
+
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter');
+        $container->setDefinition(self::RESULT_TO_STRING_CONVERTER_ID, $definition);
+    }
+
+    /**
+     * Creates output printer definition.
+     *
+     * @return Definition
+     */
+    protected function createOutputPrinterDefinition()
+    {
+        return new Definition('Behat\Behat\Output\Printer\ConsoleOutputPrinter');
+    }
+
+    /**
+     * Creates root listener definition.
+     *
+     * @param mixed $listener
+     *
+     * @return Definition
+     */
+    protected function rearrangeBackgroundEvents($listener)
+    {
+        return new Definition('Behat\Behat\Output\Node\EventListener\Flow\FirstBackgroundFiresFirstListener', array(
+            new Definition('Behat\Behat\Output\Node\EventListener\Flow\OnlyFirstBackgroundFiresListener', array(
+                $listener
+            ))
+        ));
+    }
+
+    /**
+     * Creates contextual proxy listener.
+     *
+     * @param string       $beforeEventName
+     * @param string       $afterEventName
+     * @param Definition[] $listeners
+     *
+     * @return Definition
+     */
+    protected function proxySiblingEvents($beforeEventName, $afterEventName, array $listeners)
+    {
+        return new Definition('Behat\Behat\Output\Node\EventListener\Flow\FireOnlySiblingsListener',
+            array(
+                $beforeEventName,
+                $afterEventName,
+                new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', array($listeners))
+            )
+        );
+    }
+
+    /**
+     * Creates contextual proxy listener.
+     *
+     * @param string $name
+     * @param mixed  $value
+     * @param mixed  $listener
+     *
+     * @return Definition
+     */
+    protected function proxyEventsIfParameterIsSet($name, $value, Definition $listener)
+    {
+        return new Definition('Behat\Testwork\Output\Node\EventListener\Flow\FireOnlyIfFormatterParameterListener',
+            array($name, $value, $listener)
+        );
+    }
+
+    /**
+     * Processes all registered pretty formatter node listener wrappers.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function processListenerWrappers(ContainerBuilder $container)
+    {
+        $this->processor->processWrapperServices($container, self::ROOT_LISTENER_ID, self::ROOT_LISTENER_WRAPPER_TAG);
+    }
+}

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/DigestFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/DigestFormatterFactory.php
@@ -126,7 +126,9 @@ class DigestFormatterFactory implements FormatterFactory
      */
     protected function loadCorePrinters(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Digest\DigestFeaturePrinter');
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Digest\DigestFeaturePrinter', array(
+            '%paths.base%'
+        ));
         $container->setDefinition('output.node.printer.digest.feature', $definition);
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Digest\DigestSetupPrinter', array(


### PR DESCRIPTION
After reading https://github.com/Behat/Behat/issues/337,
I came up with the idea of implementing that formatter to get a list of scenarios.

My goal is to make it available through `behat --digest` (like `behat --config-reference`) and to make it usefull to quickly find a scenario file/line to execute this particular one.

For the moment, one must use `behat --dry-run -f digest --no-snippets`
Here's the result:
![screenshot from 2014-09-15 12 17 23](https://cloud.githubusercontent.com/assets/668604/4269833/8512845a-3cc1-11e4-9c77-732a573a9454.png)

In my opinion, if you think it's better to keep it as a formatter (than a --digest option), then test result should be displayed next to the scenario title with a tick, an "X", or anything that show the actual scenario execution result (one might still run with --dry-run to quicky view the list).

This is open to discussion, I used "digest" instead of "terse" cause it simply makes more sense to me.