### PR TITLE
Added support for row table transformations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php":                           ">=5.3.3",
         "ext-mbstring":                  "*",
-        "behat/gherkin":                 "~4.3",
+        "behat/gherkin":                 "~4.4",
         "behat/transliterator":          "~1.0",
         "symfony/console":               "~2.1",
         "symfony/config":                "~2.3",

--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -50,6 +50,15 @@ Feature: Step Arguments Transformations
               return new User($username, $age);
           }
 
+          /** @Transform rowtable:username,age */
+          public function createUserFromRowTable(TableNode $table) {
+              $hash     = $table->getRowsHash();
+              $username = $hash['username'];
+              $age      = $hash['age'];
+
+              return new User($username, $age);
+          }
+
           /** @Transform /^\d+$/ */
           public function castToNumber($number) {
               return intval($number);
@@ -139,6 +148,32 @@ Feature: Step Arguments Transformations
           Given I am user:
             | username | age |
             | vasiljev | 30  |
+          Then Username must be "vasiljev"
+          And Age must be 30
+      """
+    When I run "behat -f progress --no-colors"
+    Then it should pass with:
+      """
+      ......
+
+      2 scenarios (2 passed)
+      6 steps (6 passed)
+      """
+  Scenario: Row Table Arguments Transformations
+    Given a file named "features/row_table_arguments.feature" with:
+      """
+      Feature: Step Arguments
+        Scenario:
+          Given I am user:
+            | username | ever.zet |
+            | age      | 22       |
+          Then Username must be "ever.zet"
+          And Age must be 22
+
+        Scenario:
+          Given I am user:
+            | username | vasiljev |
+            | age      | 30       |
           Then Username must be "vasiljev"
           And Age must be 30
       """

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -15,6 +15,7 @@ use Behat\Behat\Definition\Pattern\PatternTransformer;
 use Behat\Behat\Transformation\Call\TransformationCall;
 use Behat\Behat\Transformation\Transformation;
 use Behat\Behat\Transformation\TransformationRepository;
+use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\ArgumentInterface;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Call\CallCenter;
@@ -165,6 +166,8 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer
     /**
      * Checks if provided transformation is applicable table transformation.
      *
+     * Supports both tables with columns as the headings and rows as the headings.
+     *
      * @param Transformation $transformation
      * @param mixed          $value
      *
@@ -172,11 +175,61 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer
      */
     private function isApplicableTableTransformation(Transformation $transformation, $value)
     {
+        if ($this->isApplicableColumnTableTransformation($transformation, $value)) {
+            return true;
+        }
+
+        return $this->isApplicableRowTableTransformation($transformation, $value);
+    }
+
+    /**
+     * Checks if provided transformation is applicable column table transformation.
+     *
+     * @param Transformation $transformation
+     * @param mixed          $value
+     *
+     * @return Boolean
+     */
+    private function isApplicableColumnTableTransformation(Transformation $transformation, $value)
+    {
         if (!$value instanceof TableNode) {
             return false;
         };
 
         return $transformation->getPattern() === 'table:' . implode(',', $value->getRow(0));
+    }
+
+    /**
+     * Checks if provided transformation is applicable row table transformation.
+     *
+     * @param Transformation $transformation
+     * @param mixed          $value
+     *
+     * @return Boolean
+     */
+    private function isApplicableRowTableTransformation(Transformation $transformation, $value)
+    {
+        if (!$value instanceof TableNode) {
+            return false;
+        };
+
+        // What we're doing here is checking that we have a 2 column table.
+        // This bit checks we have two columns
+        try {
+            $value->getColumn(1);
+        } catch (NodeException $e) {
+            return false;
+        }
+
+        // And here we check we don't have a 3rd column
+        try {
+            $value->getColumn(2);
+        } catch (NodeException $e) {
+            // Once we know the table could be a row table, we check against the pattern.
+            return $transformation->getPattern() === 'rowtable:' . implode(',', $value->getColumn(0));
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
When testing single things with large numbers of values it's often handy to lay them out as a row hash table, rather than the usual column hash table. 

This patch adds support for allowing transformations on those tables, allowing us to make these steps more re-usable like we already can for column based tables

Here's a little example:

The PHP for the context
```php
/** @Transform rowtable:username,age */
public function createUserFromRowTable(TableNode $table) {
    $hash     = $table->getRowsHash();
    $username = $hash['username'];
    $age      = $hash['age'];

    return new User($username, $age);
}
```

Example input Gherkin
```gherkin
Scenario:
  Given I am user:
    | username | ever.zet |
    | age      | 22       |
  Then Username must be "ever.zet"
  And Age must be 22
```

Depends on: Behat/Gherkin#89

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/behat/behat/654)
<!-- Reviewable:end -->
