### PR TITLE
Passing file contents rather than filename

### DIFF
--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -171,7 +171,7 @@ final class ConfigurationLoader
         }
 
         $basePath = rtrim(dirname($configPath), DIRECTORY_SEPARATOR);
-        $config = (array) Yaml::parse($configPath);
+        $config = (array) Yaml::parse(file_get_contents($configPath));
 
         return $this->loadConfigs($basePath, $config, $profile);
     }


### PR DESCRIPTION
The ability to pass file names was deprecated in symfonys YAML component v2.2 and will be removed in 3.0.
since Behat uses "symfony/yaml": "~2.1" it'll fetch 2.2 as well and throws a PHP Deprecated Warning.
