### PR TITLE
Fix the testsuite when the OS locale is not English

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -138,6 +138,14 @@ class FeatureContext implements Context
                 strtr('--format-settings=\'{"timer": false}\'', array('\'' => '"', '"' => '\"'))
             )
         );
+
+        // Don't reset the LANG variable on HHVM, because it breaks HHVM itself
+        if (!defined('HHVM_VERSION')) {
+            $env = $this->process->getEnv();
+            $env['LANG'] = 'en'; // Ensures that the default language is en, whatever the OS locale is.
+            $this->process->setEnv($env);
+        }
+
         $this->process->start();
         $this->process->wait();
     }


### PR DESCRIPTION
The environment is inherited in subprocesses, so the LANG variable should be reset to be sure that the default language is English when running Behat in the scenarios.
Setting the variable to an invalid locale is easier than ensuring there is no variable at all.
