### PR TITLE
Fixed Yaml::parse() deprecated usage in Configuration\Loader

### DIFF
--- a/src/Behat/Behat/DependencyInjection/Configuration/Loader.php
+++ b/src/Behat/Behat/DependencyInjection/Configuration/Loader.php
@@ -103,7 +103,7 @@ class Loader
         }
 
         $basePath = rtrim(dirname($configPath), DIRECTORY_SEPARATOR);
-        $config   = Yaml::parse($configPath);
+        $config   = Yaml::parse(file_get_contents($configPath));
         $configs  = array();
 
         // first load default profile from current config, but only if custom profile requested


### PR DESCRIPTION
Fixes the following deprecation warning in the 2.5 branch:

```PHP Deprecated:  The ability to pass file names to Yaml::parse() was deprecated in 2.7 and will be removed in 3.0. Please, pass the contents of the file instead. in [...]/vendor/symfony/yaml/Symfony/Component/Yaml/Yaml.php on line 58```

An alternative would be to restrict the `symfony/yaml` dependency in `composer.json` from `~2.0` to `~2.0,<2.7`? 

From what I can tell, YAML parsing is already tested in `config_inheritance.feature`. There's 5 failures when running the tests locally (on PHP 5.4.24, OSX), but those are the same 5 failures than on a standard 2.5 checkout. Let's see what Travis CI says.