### PR TITLE
Fixed deprecation on setFallbackLocale from symfony/translation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ matrix:
     - php: hhvm
   include:
     - php: 5.5
-      env: SYMFONY_VERSION='2.0.*'
-    - php: 5.5
-      env: SYMFONY_VERSION='2.1.*'
-    - php: 5.5
-      env: SYMFONY_VERSION='2.2.*'
-    - php: 5.5
       env: SYMFONY_VERSION='2.3.*'
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "php":                           ">=5.3.1",
         "behat/gherkin":                 "~2.3.0",
         "symfony/console":               "~2.0",
-        "symfony/config":                "~2.0",
+        "symfony/config":                "~2.3",
         "symfony/dependency-injection":  "~2.0",
         "symfony/event-dispatcher":      "~2.0",
-        "symfony/translation":           "~2.0",
+        "symfony/translation":           "~2.3",
         "symfony/yaml":                  "~2.0",
         "symfony/finder":                "~2.0"
     },

--- a/src/Behat/Behat/DependencyInjection/config/behat.xml
+++ b/src/Behat/Behat/DependencyInjection/config/behat.xml
@@ -305,8 +305,10 @@
                 <service class="%behat.translator.message_selector.class%" />
             </argument>
 
-            <call method="setFallbackLocale">
-                <argument>en</argument>
+            <call method="setFallbackLocales">
+                <argument type="collection">
+                    <argument>en</argument>
+                </argument>
             </call>
 
             <!-- Translation loaders -->


### PR DESCRIPTION
For the 2.5 branch. Similar error and fix to #680.

Original error: Deprecated: The setFallbackLocale() method is deprecated since version 2.3 and will be removed in 3.0. Use setFallbackLocales() instead. in [...]/vendor/symfony/translation/Symfony/Component/Translation/Translator.php on line 163

Same as #680, we could also solve this by a more specific, lower `symfony/translation` requirement. Also, there'll likely be 5 unrelated test failures here on the Travis CI run.