### PR TITLE
Improved exceptions

### DIFF
--- a/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
+++ b/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
@@ -118,7 +118,7 @@ final class SuiteWithContextsSetup implements SuiteSetup
 
         if (!is_array($contexts)) {
             throw new SuiteConfigurationException(
-                sprintf('`contexts` setting of the "%s" suite is expected to be an array, %s given.',
+                sprintf('`contexts` setting of the "%s" suite is expected to be an array, `%s` given.',
                     $suite->getName(),
                     gettype($contexts)
                 ),

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -54,7 +54,7 @@ final class PatternTransformer
             }
         }
 
-        throw new UnsupportedPatternTypeException(sprintf('Can not find policy for a pattern type "%s".', $type), $type);
+        throw new UnsupportedPatternTypeException(sprintf('Can not find policy for a pattern type `%s`.', $type), $type);
     }
 
     /**
@@ -74,6 +74,6 @@ final class PatternTransformer
             }
         }
 
-        throw new UnknownPatternException(sprintf('Can not find policy for a pattern "%s".', $pattern), $pattern);
+        throw new UnknownPatternException(sprintf('Can not find policy for a pattern `%s`.', $pattern), $pattern);
     }
 }

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -355,9 +355,9 @@ final class GherkinExtension implements Extension
         }
 
         throw new ExtensionException(sprintf(
-            '`%s` filter is not supported by the `filters` option of gherkin extension. Supported types are %s.',
+            '`%s` filter is not supported by the `filters` option of gherkin extension. Supported types are `%s`.',
             $type,
-            implode(', ', array('`role`', '`name`', '`tags`'))
+            implode('`, `', array('role', 'name', 'tags'))
         ), 'gherkin');
     }
 }

--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -168,10 +168,10 @@ final class LazyFeatureIterator implements SpecificationIterator
         }
 
         throw new SuiteConfigurationException(sprintf(
-            '`%s` filter is not supported by the `%s` suite. Supported types are %s.',
+            '`%s` filter is not supported by the `%s` suite. Supported types are `%s`.',
             $type,
             $suite->getName(),
-            implode(', ', array('`role`', '`name`', '`tags`'))
+            implode('`, `', array('role', 'name', 'tags'))
         ), $suite->getName());
     }
 

--- a/src/Behat/Testwork/Output/OutputManager.php
+++ b/src/Behat/Testwork/Output/OutputManager.php
@@ -78,8 +78,9 @@ final class OutputManager
     {
         if (!$this->isFormatterRegistered($name)) {
             throw new FormatterNotFoundException(sprintf(
-                '`%s` formatter is not found or has not been properly registered.',
-                $name
+                '`%s` formatter is not found or has not been properly registered. Registered formatters: `%s`.',
+                $name,
+                implode('`, `', array_keys($this->formatters))
             ), $name);
         }
 

--- a/src/Behat/Testwork/Suite/SuiteRegistry.php
+++ b/src/Behat/Testwork/Suite/SuiteRegistry.php
@@ -117,7 +117,7 @@ final class SuiteRegistry implements SuiteRepository
         }
 
         throw new SuiteGenerationException(sprintf(
-            'Can not find suite generator for a suite "%s" of type "%s".',
+            'Can not find suite generator for a suite `%s` of type `%s`.',
             $name,
             $type
         ), $name);


### PR DESCRIPTION
- Show registered formatters in "formatter not found" exception
- All exceptions use "`" to delimit literals