### PR TITLE
Add missing --no-colors

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -23,7 +23,7 @@ Feature: Config
         Scenario:
           When this scenario executes
       """
-    When I run "behat -f progress --append-snippets"
+    When I run "behat -f progress --no-colors --append-snippets"
     Then it should pass with:
       """
       U


### PR DESCRIPTION
Without this, I get `Failed asserting that "some binary string that has the correct text" contains "the expected text"` on Windows (not sure it happends on Linux).