### PR TITLE
Class loader problem with Doctrine annotations

### DIFF
--- a/bin/behat
+++ b/bin/behat
@@ -18,7 +18,12 @@ function includeIfExists($file)
     }
 }
 
-if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
+
+if ( (!$loader = includeIfExists(__DIR__.'/../app/autoload.php')) 
+    && (!$loader = includeIfExists(__DIR__.'/../../../../app/autoload.php')) 
+    && (!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) 
+    && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) 
+{
     fwrite(STDERR,
         'You must set up the project dependencies, run the following commands:'.PHP_EOL.
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.


### PR DESCRIPTION
I've stumbled on Doctrine annotation classes loading problem i.e. if I use behat in Symfony2 app, I get this:

```[Semantical Error] The annotation "@Doctrine\ORM\Mapping\Table" in class Acme\AcmeBundle\Entity\Some does not exist, or could not be auto-loaded. (Doctrine\Common\Annotations\AnnotationException)```

Symfony has it's own autoloader file where its registering class loader instance in Doctrines AnnotationRegistry, without it Doctrine annotations does not work, and I don't see clear way to get loader instance in @BeforeScenario method. 

Thought, Behat isn't wired to Symfony or Doctrine, so maybe this problem with custom class loader needs wider view.

P.S. 
I don't consider this as clear way to get loader instance, it's a hack to me:
```$loader = spl_autoload_functions()[0][0];```