### PR TITLE
[POC] running scenarios in separate processes

### DIFF
--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
@@ -65,9 +65,9 @@ final class EventDispatchingExercise implements Exercise
     /**
      * {@inheritdoc}
      */
-    public function test(array $iterators, $skip = false)
+    public function test(array $iterators, $skip = false, $batch)
     {
-        return $this->baseExercise->test($iterators, $skip);
+        return $this->baseExercise->test($iterators, $skip, $batch);
     }
 
     /**

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
@@ -67,9 +67,9 @@ final class EventDispatchingSuiteTester implements SuiteTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, SpecificationIterator $iterator, $skip = false)
+    public function test(Environment $env, SpecificationIterator $iterator, $skip = false, $batch)
     {
-        return $this->baseTester->test($env, $iterator, $skip);
+        return $this->baseTester->test($env, $iterator, $skip, $batch);
     }
 
     /**

--- a/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
+++ b/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
@@ -68,9 +68,9 @@ final class HookableSuiteTester implements SuiteTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, SpecificationIterator $iterator, $skip)
+    public function test(Environment $env, SpecificationIterator $iterator, $skip, $batch)
     {
-        return $this->baseTester->test($env, $iterator, $skip);
+        return $this->baseTester->test($env, $iterator, $skip, $batch);
     }
 
     /**

--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -140,10 +140,15 @@ final class ExerciseController implements Controller
     private function testSpecifications(InputInterface $input, array $specifications)
     {
         $skip = $input->getOption('dry-run') || $this->skip;
+        $batch = true;
+
+        if (!empty($input->getArgument('paths'))) {
+            $batch = false;
+        }
 
         $setup = $this->exercise->setUp($specifications, $skip);
         $skip = !$setup->isSuccessful() || $skip;
-        $testResult = $this->exercise->test($specifications, $skip);
+        $testResult = $this->exercise->test($specifications, $skip, $batch);
         $teardown = $this->exercise->tearDown($specifications, $skip, $testResult);
 
         $result = new IntegerTestResult($testResult->getResultCode());

--- a/src/Behat/Testwork/Tester/Exercise.php
+++ b/src/Behat/Testwork/Tester/Exercise.php
@@ -40,7 +40,7 @@ interface Exercise
      *
      * @return TestResult
      */
-    public function test(array $iterators, $skip);
+    public function test(array $iterators, $skip, $batch);
 
     /**
      * Tears down exercise after a test.

--- a/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php
+++ b/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php
@@ -60,7 +60,7 @@ final class RuntimeExercise implements Exercise
     /**
      * {@inheritdoc}
      */
-    public function test(array $iterators, $skip = false)
+    public function test(array $iterators, $skip = false, $batch)
     {
         $results = array();
         foreach (GroupedSpecificationIterator::group($iterators) as $iterator) {
@@ -68,7 +68,7 @@ final class RuntimeExercise implements Exercise
 
             $setup = $this->suiteTester->setUp($environment, $iterator, $skip);
             $localSkip = !$setup->isSuccessful() || $skip;
-            $testResult = $this->suiteTester->test($environment, $iterator, $localSkip);
+            $testResult = $this->suiteTester->test($environment, $iterator, $localSkip, $batch);
             $teardown = $this->suiteTester->tearDown($environment, $iterator, $localSkip, $testResult);
 
             $integerResult = new IntegerTestResult($testResult->getResultCode());

--- a/src/Behat/Testwork/Tester/SuiteTester.php
+++ b/src/Behat/Testwork/Tester/SuiteTester.php
@@ -43,7 +43,7 @@ interface SuiteTester
      *
      * @return TestResult
      */
-    public function test(Environment $env, SpecificationIterator $iterator, $skip);
+    public function test(Environment $env, SpecificationIterator $iterator, $skip, $batch);
 
     /**
      * Tears down suite after a test.


### PR DESCRIPTION
This is a quick POC for running each scenario as a different process. It will require some refactoring in order to make it work properly, but just wanted to know if the community wants to go this way before spending more time on it.

The reason for this is that our suite eats up memory fast. Our app is on top of Sylius and Symfony, we've tried to make sure the container was released, we looked for memory leaks ... etc etc, but the memory just grew after each scenario and wasn't released before the next one would run.

File inclussion in autoloaders are never released from memory until the php session is closed, so memory usage grows due to this fact too.

By running a scenario in a different process the memory is released after each one.