### PR TITLE
Allow no tests to be considered passing tests.

### DIFF
--- a/src/Behat/Testwork/Tester/Result/TestResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestResult.php
@@ -21,6 +21,7 @@ interface TestResult
     const SKIPPED = 10;
     const PENDING = 20;
     const FAILED = 99;
+    const NO_TESTS = -100;
 
     /**
      * Checks that test has passed.

--- a/src/Behat/Testwork/Tester/Result/TestResults.php
+++ b/src/Behat/Testwork/Tester/Result/TestResults.php
@@ -21,7 +21,6 @@ use IteratorAggregate;
  */
 final class TestResults implements TestResult, Countable, IteratorAggregate
 {
-    const NO_TESTS = -100;
 
     /**
      * @var TestResult[]
@@ -43,7 +42,8 @@ final class TestResults implements TestResult, Countable, IteratorAggregate
      */
     public function isPassed()
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED == $this->getResultCode() ||
+          self::NO_TESTS == $this->getResultCode();
     }
 
     /**

--- a/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
@@ -52,7 +52,8 @@ final class TestWithSetupResult implements TestResult
      */
     public function isPassed()
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED == $this->getResultCode() ||
+          self::NO_TESTS == $this->getResultCode();
     }
 
     /**


### PR DESCRIPTION
I've run into an issue where no tests is considered test failure when running with --strict. Some of our suites have to be excluded from tests but this then breaks phing which expects a 0 error code.

This change would mean that $result->isPassed() would return true if the return code was 0 or -100 (no tests).

In the event that this breaks some kind of backwards compatibility, I'd also be happy to look at creating a new flag for this.