### PR TITLE
Environment configuration should override file configuration

### DIFF
--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -99,16 +99,16 @@ final class ConfigurationLoader
         $configs = array();
         $this->profileFound = false;
 
-        // first is ENV config
-        foreach ($this->loadEnvironmentConfiguration() as $config) {
-            $configs[] = $config;
-        }
-
-        // second is file configuration (if there is some)
+        // first is file configuration (if there is some)
         if ($this->configurationPath) {
             foreach ($this->loadFileConfiguration($this->configurationPath, $profile) as $config) {
                 $configs[] = $config;
             }
+        }
+
+        // second is ENV config
+        foreach ($this->loadEnvironmentConfiguration() as $config) {
+            $configs[] = $config;
         }
 
         // if specific profile has not been found


### PR DESCRIPTION
From my point of view, configuration defined by environment variable (BEHAT_PARAMS) should override values defined in behat.yml.
Given the order behat actually merge them, it's the opposite :)