### PR TITLE
Fixes #727 - set xdebug.max_nesting_level to 256 if xdebug extension is loaded

### DIFF
--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -89,6 +89,16 @@ final class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
+        // xdebug's default nesting level of 100 is not enough
+        if (extension_loaded('xdebug')
+            && false === strpos(ini_get('disable_functions'), 'ini_set')
+        ) {
+            $oldValue = ini_get('xdebug.max_nesting_level');
+            if ($oldValue === false || $oldValue < 256) {
+                ini_set('xdebug.max_nesting_level', 256);
+            }
+        }
+
         if (is_file($path = $input->getParameterOption(array('--config', '-c')))) {
             $this->configurationLoader->setConfigurationFilePath($path);
         }


### PR DESCRIPTION
In #727 a fatal error is reported when the xdebug setting for `max_nesting_level` is left on its default `100`.

This fix is just setting the value to 256 in behat.php when the xdebug extension is loaded.