### PR TITLE
Remove an argument from StreamOutputPrinter::getOutputFactory() call

### DIFF
--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -126,7 +126,7 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
             $fileName .= '.'.$extension;
         }
 
-        $this->getOutputFactory($fileName)->setFileName($fileName);
+        $this->getOutputFactory()->setFileName($fileName);
         $this->flush();
     }
 


### PR DESCRIPTION
The getOutputFactory() method does not have an argument.