### PR TITLE
Making method compatible with Symfony 2.7

### DIFF
--- a/src/Behat/Behat/Console/Input/InputDefinition.php
+++ b/src/Behat/Behat/Console/Input/InputDefinition.php
@@ -24,7 +24,7 @@ class InputDefinition extends BaseDefinition
      *
      * @return string The synopsis
      */
-    public function getSynopsis()
+    public function getSynopsis($short = false)
     {
         $elements = array();
         $isSwitch = false;


### PR DESCRIPTION
Without this, PHP throws an error. We're not using this argument - and I don't think that's a huge deal, but we are suppressing this error. In Symfony 2.6 and earlier before the parent argument was added, this extra arg won't cause an issue.

See symfony/symfony#13220 and symfony/symfony#14782

Thanks!