### PR TITLE
Compatibility with Symfony 2.7 components.

### DIFF
--- a/src/Behat/Behat/Console/Input/InputDefinition.php
+++ b/src/Behat/Behat/Console/Input/InputDefinition.php
@@ -20,11 +20,9 @@ use Symfony\Component\Console\Input\InputDefinition as BaseDefinition;
 class InputDefinition extends BaseDefinition
 {
     /**
-     * Gets the synopsis.
-     *
-     * @return string The synopsis
+     * {@inheritdoc}
      */
-    public function getSynopsis()
+    public function getSynopsis($short = false)
     {
         $elements = array();
         $isSwitch = false;

--- a/src/Behat/Behat/DependencyInjection/config/behat.xml
+++ b/src/Behat/Behat/DependencyInjection/config/behat.xml
@@ -305,8 +305,10 @@
                 <service class="%behat.translator.message_selector.class%" />
             </argument>
 
-            <call method="setFallbackLocale">
-                <argument>en</argument>
+            <call method="setFallbackLocales">
+                <argument type="collection">
+                    <argument key="0">en</argument>
+                </argument>
             </call>
 
             <!-- Translation loaders -->


### PR DESCRIPTION
Resolves:
* PHP Strict standards:  Declaration of Behat\Behat\Console\Input\InputDefinition::getSynopsis() should be compatible with Symfony\Component\Console\Input\InputDefinition::getSynopsis($short = false)
* PHP Deprecated:  The Symfony\Component\Translation\Translator::setFallbackLocale method is deprecated since version 2.3 and will be removed in 3.0. Use the setFallbackLocales() method instead.

