### PR TITLE
Remove usage from expected output in scenarios verifying failed output

### DIFF
--- a/features/context.feature
+++ b/features/context.feature
@@ -311,10 +311,6 @@ Feature: Context consistency
       """
       [Behat\Testwork\Suite\Exception\SuiteConfigurationException]
         `contexts` setting of the "default" suite is expected to be an array, string given.
-
-
-
-      behat [-s|--suite="..."] [-f|--format="..."] [-o|--out="..."] [--format-settings="..."] [--init] [--lang="..."] [--name="..."] [--tags="..."] [--role="..."] [--story-syntax] [-d|--definitions="..."] [--append-snippets] [--no-snippets] [--strict] [--rerun] [--stop-on-failure] [--dry-run] [paths]
       """
 
   Scenario: Unexisting custom context class
@@ -341,10 +337,6 @@ Feature: Context consistency
     """
     [Behat\Behat\Context\Exception\ContextNotFoundException]
       `UnexistentContext` context class not found and can not be used.
-
-
-
-    behat [-s|--suite="..."] [-f|--format="..."] [-o|--out="..."] [--format-settings="..."] [--init] [--lang="..."] [--name="..."] [--tags="..."] [--role="..."] [--story-syntax] [-d|--definitions="..."] [--append-snippets] [--no-snippets] [--strict] [--rerun] [--stop-on-failure] [--dry-run] [paths]
     """
 
   Scenario: Unexisting context argument
@@ -373,10 +365,6 @@ Feature: Context consistency
       """
       [Behat\Testwork\Argument\Exception\UnknownParameterValueException]
         `CoreContext::__construct()` does not expect argument `$unexistingParam`.
-
-
-
-      behat [-s|--suite="..."] [-f|--format="..."] [-o|--out="..."] [--format-settings="..."] [--init] [--lang="..."] [--name="..."] [--tags="..."] [--role="..."] [--story-syntax] [-d|--definitions="..."] [--append-snippets] [--no-snippets] [--strict] [--rerun] [--stop-on-failure] [--dry-run] [paths]
       """
 
   Scenario: Suite without contexts and FeatureContext available

--- a/features/suite.feature
+++ b/features/suite.feature
@@ -252,10 +252,6 @@ Feature: Suites
       """
       Behat\Testwork\Suite\Exception\SuiteConfigurationException]
         `paths` setting of the "first" suite is expected to be an array, string given.
-
-
-
-      behat [-s|--suite="..."] [-f|--format="..."] [-o|--out="..."] [--format-settings="..."] [--init] [--lang="..."] [--name="..."] [--tags="..."] [--role="..."] [--story-syntax] [-d|--definitions="..."] [--append-snippets] [--no-snippets] [--strict] [--rerun] [--stop-on-failure] [--dry-run] [paths]
       """
 
   Scenario: Role-based suites


### PR DESCRIPTION
This will make scenarios less sensitive to changes in the way Symfony displays usage details. Usage output is not relevant to the scenarios we expected it in anyway.

Fixes #751 
