### PR TITLE
Support for negative numbers without surrounding quotes

### DIFF
--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -535,3 +535,35 @@ Feature: Step Definition Pattern
       1 scenario (1 passed)
       1 step (1 passed)
       """
+
+  Scenario: Negative number parameters without quotes
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @Given I have a negative number :num
+           */
+          public function multipleWrongNamedParameters($num) {
+          PHPUnit_Framework_Assert::assertEquals('-3', $num);
+          }
+      }
+      """
+    And a file named "features/step_patterns.feature" with:
+      """
+      Feature: Step Pattern
+        Scenario:
+          Given I have a negative number -3
+      """
+    When I run "behat -f progress --no-colors"
+    Then it should pass with:
+      """
+      .
+
+      1 scenario (1 passed)
+      1 step (1 passed)
+      """

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -20,7 +20,7 @@ use Behat\Transliterator\Transliterator;
  */
 final class TurnipPatternPolicy implements PatternPolicy
 {
-    const TOKEN_REGEX = "[\"']?(?P<%s>(?<=\")[^\"]*(?=\")|(?<=')[^']*(?=')|[\w\.\,]+)['\"]?";
+    const TOKEN_REGEX = "[\"']?(?P<%s>(?<=\")[^\"]*(?=\")|(?<=')[^']*(?=')|\-?[\w\.\,]+)['\"]?";
 
     const PLACEHOLDER_REGEXP = "/\\\:(\w+)/";
     const OPTIONAL_WORD_REGEXP = '/(\s)?\\\\\(([^\\\]+)\\\\\)(\s)?/';
@@ -32,7 +32,7 @@ final class TurnipPatternPolicy implements PatternPolicy
     private static $placeholderPatterns = array(
         "/(?<!\w)\"[^\"]+\"(?!\w)/",
         "/(?<!\w)'[^']+'(?!\w)/",
-        "/(?<!\w|\.|\,)\d+(?:[\.\,]\d+)?(?!\w|\.|\,)/"
+        "/(?<!\w|\.|\,)\-?\d+(?:[\.\,]\d+)?(?!\w|\.|\,)/"
     );
 
     /**


### PR DESCRIPTION
When a definition parameter is not quoted, it is still interpreted as a parameter as long as it has a numeric value. However, the regex only included digit (\d), period (.), and comma (,) characters. I added a hyphen character (-), as this is the symbol commonly used to represent negative numbers when a user is typing on a computer keyboard.

Prior to this commit, the hyphen would get ejected in the generated snippet (`*@Given I have a negative number -:num*/`) and the value passed would be positive instead of negative. This behavior could be corrected by adding quotes in the Gherkin file ("-3" instead of just -3), but the behavior is still counter-intuitive. The lexer is already interpreting numeric sequences, so it makes sense to at least support negative numbers. More complex number notations (hexadecimal, scientific, etc) will still need to be quoted to work properly.