### PR TITLE
Bugfix: notice ob_end_clean()

### DIFF
--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -133,7 +133,7 @@ final class RuntimeCallHandler implements CallHandler
      */
     private function stopErrorAndOutputBuffering()
     {
-        ob_end_clean();
+        if (ob_get_length()) ob_end_clean();
         restore_error_handler();
     }
 }

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -133,7 +133,9 @@ final class RuntimeCallHandler implements CallHandler
      */
     private function stopErrorAndOutputBuffering()
     {
-        if (ob_get_length()) ob_end_clean();
+        if (ob_get_length()) {
+            ob_end_clean();
+        }
         restore_error_handler();
     }
 }


### PR DESCRIPTION
I'm getting a notice `Notice: ob_end_clean(): failed to delete buffer. No buffer to delete in vendor/behat/behat/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php line 137` which is really weird because the method is only called from `handleCall`, maybe its a PHP bug.
The notice causes the tests to fail. This patch prevents the notice if `ob_start` failed for some reason.

![screen shot 2015-06-17 at 14 37 36](https://cloud.githubusercontent.com/assets/44893/8206999/7fe36ca4-14fe-11e5-8a05-11a0a2ddf79d.png)
