### PR TITLE
Throw exception if requested config file (-c) does not exist

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -8,7 +8,7 @@ Feature: Config
       """
       """
     And a file named "features/bootstrap/FeatureContext.php" with:
-    """
+      """
       <?php
 
       use Behat\Behat\Context\Context;
@@ -18,7 +18,7 @@ Feature: Config
       }
       """
     And a file named "features/config.feature" with:
-    """
+      """
       Feature:
         Scenario:
           When this scenario executes
@@ -38,10 +38,10 @@ Feature: Config
 
   Scenario: Alternative configuration file
     Given a file named "alternative-behat.yml" with:
-    """
+      """
       """
     And a file named "features/bootstrap/FeatureContext.php" with:
-    """
+      """
       <?php
 
       use Behat\Behat\Context\Context;
@@ -51,7 +51,7 @@ Feature: Config
       }
       """
     And a file named "features/config.feature" with:
-    """
+      """
       Feature:
         Scenario:
           When this scenario executes
@@ -71,7 +71,7 @@ Feature: Config
 
   Scenario: Alternative configuration file could not be found
     Given a file named "features/bootstrap/FeatureContext.php" with:
-    """
+      """
       <?php
 
       use Behat\Behat\Context\Context;
@@ -81,13 +81,13 @@ Feature: Config
       }
       """
     And a file named "features/config.feature" with:
-    """
+      """
       Feature:
         Scenario:
           When this scenario executes
       """
     When I run "behat -f progress --no-colors --append-snippets --config=missing-behat.yml"
     Then it should fail with:
-    """
+      """
       The requested config file does not exist
       """

--- a/features/config.feature
+++ b/features/config.feature
@@ -35,3 +35,59 @@ Feature: Config
 
           When this scenario executes
       """
+
+  Scenario: Alternative configuration file
+    Given a file named "alternative-behat.yml" with:
+    """
+      """
+    And a file named "features/bootstrap/FeatureContext.php" with:
+    """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+      }
+      """
+    And a file named "features/config.feature" with:
+    """
+      Feature:
+        Scenario:
+          When this scenario executes
+      """
+    When I run "behat -f progress --no-colors --append-snippets --config=alternative-behat.yml"
+    Then it should pass with:
+      """
+      U
+
+      1 scenario (1 undefined)
+      1 step (1 undefined)
+
+      --- Snippets for the following steps in the default suite were not generated (check your configuration):
+
+          When this scenario executes
+      """
+
+  Scenario: Alternative configuration file could not be found
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+    """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+      }
+      """
+    And a file named "features/config.feature" with:
+    """
+      Feature:
+        Scenario:
+          When this scenario executes
+      """
+    When I run "behat -f progress --no-colors --append-snippets --config=missing-behat.yml"
+    Then it should fail with:
+    """
+      The requested config file does not exist
+      """

--- a/features/parameters.feature
+++ b/features/parameters.feature
@@ -102,7 +102,7 @@ Feature: Parameters
       default:
         formatters: ~
       """
-    When I run "behat --no-colors -c unexistent"
+    When I run "behat --no-colors"
     Then it should pass with:
       """
       Feature: Math
@@ -136,7 +136,7 @@ Feature: Parameters
       default:
         formatters: ~
       """
-    When I run "behat --no-colors -c unexistent"
+    When I run "behat --no-colors"
     Then it should pass with:
       """
       Feature: Math

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -100,6 +100,11 @@ final class Application extends BaseApplication
             }
         }
 
+        // Ignore all other inputs if config-reference is set:
+        if ($input->hasParameterOption(array('--config-reference'))) {
+            $input = new ArrayInput(array('--config-reference' => true));
+        }
+
         // Check the requested config file exists
         if ($path = $input->getParameterOption(array('--config', '-c'))) {
             if (!is_file($path)) {
@@ -110,10 +115,6 @@ final class Application extends BaseApplication
         }
 
         $this->add($this->createCommand($input, $output));
-
-        if ($input->hasParameterOption(array('--config-reference'))) {
-            $input = new ArrayInput(array('--config-reference' => true));
-        }
 
         return parent::doRun($input, $output);
     }

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -100,12 +100,10 @@ final class Application extends BaseApplication
             }
         }
 
-        // Ignore all other inputs if config-reference is set:
         if ($input->hasParameterOption(array('--config-reference'))) {
             $input = new ArrayInput(array('--config-reference' => true));
         }
 
-        // Check the requested config file exists
         if ($path = $input->getParameterOption(array('--config', '-c'))) {
             if (!is_file($path)) {
                 throw new ConfigurationLoadingException("The requested config file does not exist");

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -12,6 +12,7 @@ namespace Behat\Testwork\Cli;
 
 use Behat\Testwork\ServiceContainer\Configuration\ConfigurationLoader;
 use Behat\Testwork\ServiceContainer\ContainerLoader;
+use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -99,7 +100,12 @@ final class Application extends BaseApplication
             }
         }
 
-        if (is_file($path = $input->getParameterOption(array('--config', '-c')))) {
+        // Check the requested config file exists
+        if ($path = $input->getParameterOption(array('--config', '-c'))) {
+            if (!is_file($path)) {
+                throw new ConfigurationLoadingException("The requested config file does not exist");
+            }
+
             $this->configurationLoader->setConfigurationFilePath($path);
         }
 


### PR DESCRIPTION
Relates to issue #759 which I thought was clearly a bug, not alerting users that they have specifically requested a config file that gets quietly ignored.

However, running the existing tests showed two failures from this change in `parameters.feature`. I've "fixed" those failures, but I'm not 100% sure if the `-c unexistent` part was desirable there, or even harmful? Hmm.