### PR TITLE
TeamCity and jUnit output

### DIFF
--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -527,67 +527,6 @@
       """
     And the file "junit/default.xml" should be a valid document according to "junit.xsd"
 
-  Scenario: Aborting due to PHP error
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
-          Behat\Behat\Tester\Exception\PendingException;
-
-      class FeatureContext implements CustomSnippetAcceptingContext
-      {
-          private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
-
-          /**
-           * @Given /I have entered (\d+)/
-           */
-          public function iHaveEntered($num) {
-              $this->value = $num;
-          }
-
-          /**
-           * @Then /I must have (\d+)/
-           */
-          public function iMustHave($num) {
-              PHPUnit_Framework_Assert::assertEqual($num, $this->value);
-          }
-
-          /**
-           * @When /I add (\d+)/
-           */
-          public function iAdd($num) {
-              $this->value += $num;
-          }
-      }
-      """
-    And a file named "features/World.feature" with:
-      """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-
-        Background:
-          Given I have entered 10
-
-        Scenario: Failed
-          When I add 4
-          Then I must have 14
-      """
-    When I run "behat --no-colors -f junit -o junit"
-    Then it should fail with:
-      """
-      Call to undefined method PHPUnit_Framework_Assert::assertEqual
-      """
-    And "junit/default.xml" file xml should be like:
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default"/>
-      """
-
   Scenario: Aborting due invalid output path
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -65,7 +65,6 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
         $this->testSuites = $this->domDocument->createElement('testsuites');
         $this->domDocument->appendChild($this->testSuites);
         $this->addAttributesToNode($this->testSuites, array_merge(array('name' => $name), $testsuitesAttributes));
-        $this->flush();
     }
 
     /**


### PR DESCRIPTION
Hello.

The Behat first creates empty xml files (containing empty testsuites tag only) and fills them after the test is passed. But the TeamCity does realtime monitoring, so it processes emty xml files when they appear and does not return to them later after data is filled in. So in fact the TeamCity gets no infomation about tests failed or passed. It would be great if behat could create filled files at once avoiding empty ones.

Thanks.