### PR TITLE
Fix JUnit output for Jenkins

### DIFF
--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
@@ -61,17 +61,17 @@ class JUnitStepPrinter implements StepPrinter
 
         switch ($result->getResultCode()) {
             case TestResult::FAILED:
-                $outputPrinter->addTestcaseChild('failure', $attributes, $message);
+                $outputPrinter->addTestcaseChild('failure', $attributes, $step->getText());
                 break;
 
             case TestResult::PENDING:
                 $attributes['type'] = 'pending';
-                $outputPrinter->addTestcaseChild('error', $attributes, $message);
+                $outputPrinter->addTestcaseChild('error', $attributes, $step->getText());
                 break;
 
             case StepResult::UNDEFINED:
                 $attributes['type'] = 'undefined';
-                $outputPrinter->addTestcaseChild('error', $attributes, $message);
+                $outputPrinter->addTestcaseChild('error', $attributes, $step->getText());
                 break;
         }
     }

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
@@ -61,17 +61,17 @@ class JUnitStepPrinter implements StepPrinter
 
         switch ($result->getResultCode()) {
             case TestResult::FAILED:
-                $outputPrinter->addTestcaseChild('failure', $attributes);
+                $outputPrinter->addTestcaseChild('failure', $attributes, $message);
                 break;
 
             case TestResult::PENDING:
                 $attributes['type'] = 'pending';
-                $outputPrinter->addTestcaseChild('error', $attributes);
+                $outputPrinter->addTestcaseChild('error', $attributes, $message);
                 break;
 
             case StepResult::UNDEFINED:
                 $attributes['type'] = 'undefined';
-                $outputPrinter->addTestcaseChild('error', $attributes);
+                $outputPrinter->addTestcaseChild('error', $attributes, $message);
                 break;
         }
     }


### PR DESCRIPTION
The current implementation of JUnit output does not work for Jenkins, always causing it to show the steps as passed.

This PR fixes the output format.