### PR TITLE
Performance improvement to regex transformation

### DIFF
--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -29,7 +29,7 @@ final class TurnipPatternPolicy implements PatternPolicy
     /**
      * @var string[]
      */
-    private $regexCache = [];
+    private $regexCache = array();
 
     /**
      * @var string[]

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -29,6 +29,11 @@ final class TurnipPatternPolicy implements PatternPolicy
     /**
      * @var string[]
      */
+    private $regexCache = [];
+
+    /**
+     * @var string[]
+     */
     private static $placeholderPatterns = array(
         "/(?<!\w)\"[^\"]+\"(?!\w)/",
         "/(?<!\w)'[^']+'(?!\w)/",
@@ -75,6 +80,18 @@ final class TurnipPatternPolicy implements PatternPolicy
      * {@inheritdoc}
      */
     public function transformPatternToRegex($pattern)
+    {
+        if (!isset($this->regexCache[$pattern])) {
+            $this->regexCache[$pattern] = $this->createTransformedRegex($pattern);
+        }
+        return $this->regexCache[$pattern];
+    }
+
+    /**
+     * @param string $pattern
+     * @return string
+     */
+    private function createTransformedRegex($pattern)
     {
         $regex = preg_quote($pattern, '/');
 


### PR DESCRIPTION
This PR uses array caching in the transformation of Turnip step annotations to regular expressions.

It will not noticeably affect those users who have lots of suites, each with its own Context.  However, if the user's tests are organised using traits and a single Context, this yields a significant performance improvement for large suites.

The number of times the `TurnipPatternPolicy::transformPatternToRegex()` method is executed is `(steps executed)*(step definitions available)` - in our case `5k * 670 = 3.35M`.  Blackfire reports the inclusive CPU time of the `TurnipPatternPolicy::transformPatternToRegex()` method as ~26.3% of total execution time without this PR, and negligible after the change proposed.

Clearly, using traits, a single context and only one suite isn't an approach that scales well in Behat-land.  Nevertheless, I think simple caching here is going to help performance for unwieldy test suites.