### PR TITLE
Use proper scope names in ScenarioHook

### DIFF
--- a/src/Behat/Behat/Hook/Scope/ScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/ScenarioScope.php
@@ -21,8 +21,8 @@ use Behat\Testwork\Hook\Scope\HookScope;
  */
 interface ScenarioScope extends HookScope
 {
-    const BEFORE = 'feature.before';
-    const AFTER = 'feature.after';
+    const BEFORE = 'scenario.before';
+    const AFTER = 'scenario.after';
 
     /**
      * Returns scope feature.


### PR DESCRIPTION
The scopes names were using `feature.before` and `feature.after` in `ScenarioHook`, while it should be `scenario.before` and `scenario.after`.

Can't see which tests I should update, I'll take a look (it should be within `hooks.feature` I guess ?)