### PR TITLE
Allow the recursive directory iterator to iterate symbolic links

### DIFF
--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -131,13 +131,19 @@ final class FilesystemFeatureLocator implements SpecificationLocator
             return array($absolutePath);
         }
 
-        $iterator = new RegexIterator(
-            new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($absolutePath)
-            ), '/^.+\.feature$/i',
+        $RDI = new RecursiveDirectoryIterator(
+            $absolutePath,
+            RecursiveDirectoryIterator::FOLLOW_SYMLINKS |
+            RecursiveDirectoryIterator::SKIP_DOTS
+        );
+        $RII = new recursiveIteratorIterator($RDI);
+        $REX = new RegexIterator(
+            $RII,
+            '/^.+\.feature$/i',
             RegexIterator::MATCH
         );
-        $paths = array_map('strval', iterator_to_array($iterator));
+
+        $paths = array_map('strval', iterator_to_array($REX));
         uasort($paths, 'strnatcasecmp');
 
         return $paths;

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -131,19 +131,18 @@ final class FilesystemFeatureLocator implements SpecificationLocator
             return array($absolutePath);
         }
 
-        $RDI = new RecursiveDirectoryIterator(
-            $absolutePath,
-            RecursiveDirectoryIterator::FOLLOW_SYMLINKS |
-            RecursiveDirectoryIterator::SKIP_DOTS
-        );
-        $RII = new recursiveIteratorIterator($RDI);
-        $REX = new RegexIterator(
-            $RII,
+        $iterator = new RegexIterator(
+            new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator(
+                    $absolutePath,
+                    RecursiveDirectoryIterator::FOLLOW_SYMLINKS | RecursiveDirectoryIterator::SKIP_DOTS
+                )
+            ),
             '/^.+\.feature$/i',
             RegexIterator::MATCH
         );
 
-        $paths = array_map('strval', iterator_to_array($REX));
+        $paths = array_map('strval', iterator_to_array($iterator));
         uasort($paths, 'strnatcasecmp');
 
         return $paths;


### PR DESCRIPTION
Directory iterator is not iterating through symbolic links as it did in behat 1.x and most of behat 2.x.
The new RecursiveDirectoryIterator needs to be explicitly told to follow symlinks or it will not.