### PR TITLE
Catch PHP7 errors implementing Throwable

### DIFF
--- a/features/catch_throwable.feature
+++ b/features/catch_throwable.feature
@@ -1,0 +1,63 @@
+@php-version @php7
+Feature: Support PHP 7 Throwable
+  In order for my test suite to continue running despite fatal errors in my code
+  As a feature developer
+  I need Behat to gracefully handle errors implementing the Throwable interface
+
+  Background:
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context,
+          Behat\Behat\Exception\PendingException;
+      use Behat\Gherkin\Node\PyStringNode,
+          Behat\Gherkin\Node\TableNode;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @When /^I have some code with a fatal error$/
+           */
+          public function iHaveSomeCodeWithFatalError()
+          {
+              ("not an object")->method();
+          }
+
+          /**
+           * @Then /^I should be skipped$/
+           */
+          public function iShouldBeSkipped()
+          {
+          }
+      }
+      """
+    And a file named "features/fatal_errors.feature" with:
+      """
+      Feature: Fatal error in scenario
+        In order to test the handling of the PHP 7 Throwable interface
+        As a contributor of Behat
+        I need to have a FeatureContext that contains errors that were fatal in previous PHP versions
+
+        Scenario: Handling of a fatal error
+          When I have some code with a fatal error
+          Then I should be skipped
+      """
+
+  Scenario: Handling of a fatal error
+    When I run "behat --no-colors"
+    Then it should fail
+    And the output should contain:
+      """
+        Scenario: Handling of a fatal error        # features/fatal_errors.feature:6
+          When I have some code with a fatal error # FeatureContext::iHaveSomeCodeWithFatalError()
+            Fatal error: Call to a member function method() on string (Behat\Testwork\Exception\FatalThrowableError)
+          Then I should be skipped                 # FeatureContext::iShouldBeSkipped()
+
+      --- Failed scenarios:
+
+          features/fatal_errors.feature:6
+
+      1 scenario (1 failed)
+      2 steps (1 failed, 1 skipped)
+      """

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -538,6 +538,7 @@
       """
     And the file "junit/default.xml" should be a valid document according to "junit.xsd"
 
+  @php-version @php5.3 @php5.4
   Scenario: Aborting due to PHP error
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """

--- a/src/Behat/Testwork/Call/CallCenter.php
+++ b/src/Behat/Testwork/Call/CallCenter.php
@@ -11,10 +11,12 @@
 namespace Behat\Testwork\Call;
 
 use Behat\Testwork\Call\Exception\CallHandlingException;
+use Behat\Testwork\Call\Exception\FatalThrowableError;
 use Behat\Testwork\Call\Filter\CallFilter;
 use Behat\Testwork\Call\Filter\ResultFilter;
 use Behat\Testwork\Call\Handler\CallHandler;
 use Exception;
+use Throwable;
 
 /**
  * Makes calls and handles results using registered handlers.
@@ -81,6 +83,8 @@ final class CallCenter
             $filteredResult = $this->filterResult($result);
         } catch (Exception $e) {
             return new CallResult($call, null, $e, null);
+        } catch (Throwable $e) {
+            return new CallResult($call, null, new FatalThrowableError($e), null);
         }
 
         return $filteredResult;

--- a/src/Behat/Testwork/Call/Exception/FatalThrowableError.php
+++ b/src/Behat/Testwork/Call/Exception/FatalThrowableError.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\Call\Exception;
+
+use ErrorException;
+use ParseError;
+use Throwable;
+use TypeError;
+
+/**
+ * Fatal Throwable Error.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class FatalThrowableError extends ErrorException
+{
+    public function __construct(Throwable $e)
+    {
+        if ($e instanceof ParseError) {
+            $message = 'Parse error: '.$e->getMessage();
+            $severity = E_PARSE;
+        } elseif ($e instanceof TypeError) {
+            $message = 'Type error: '.$e->getMessage();
+            $severity = E_RECOVERABLE_ERROR;
+        } else {
+            $message = 'Fatal error: '.$e->getMessage();
+            $severity = E_ERROR;
+        }
+
+        parent::__construct(
+            $message,
+            $e->getCode(),
+            $severity,
+            $e->getFile(),
+            $e->getLine()
+        );
+
+        $this->setTrace($e->getTrace());
+    }
+
+    private function setTrace($trace)
+    {
+        $traceReflector = new \ReflectionProperty('Exception', 'trace');
+        $traceReflector->setAccessible(true);
+        $traceReflector->setValue($this, $trace);
+    }
+}


### PR DESCRIPTION
Resolves #831 

Questions:

- ~~How to correctly handle the version differences? JUnit formatter/feature might be problematic~~ 
- `FatalThrowableError` has been re-appropriated from Symfony, do I need to include licensing?


