### PR TITLE
"imports: " should consoider .dist files as well

### DIFF
--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -242,17 +242,22 @@ final class ConfigurationLoader
      */
     private function parseImport($basePath, $path, $profile)
     {
-        if (!file_exists($path) && file_exists($basePath . DIRECTORY_SEPARATOR . $path)) {
-            $path = $basePath . DIRECTORY_SEPARATOR . $path;
+        $tmpPaths = array(
+            $path,
+            $basePath . DIRECTORY_SEPARATOR . $path,
+            $path . '.dist',
+            $basePath . DIRECTORY_SEPARATOR . $path . '.dist',
+        );
+
+        foreach ($tmpPaths as $tmpPath) {
+            if (file_exists($tmpPath)) {
+                return $this->loadFileConfiguration($tmpPath, $profile);
+            }
         }
 
-        if (!file_exists($path)) {
-            throw new ConfigurationLoadingException(sprintf(
-                'Can not import `%s` configuration file. File not found.',
-                $path
-            ));
-        }
-
-        return $this->loadFileConfiguration($path, $profile);
+        throw new ConfigurationLoadingException(sprintf(
+            'Can not import `%s` configuration file. File not found.',
+            $path
+        ));
     }
 }


### PR DESCRIPTION
When using `imports: [foo.yml, bar.yml]` in my behat.yml, it would be cool, if there was a fallback to `foo.yml.dist` and `bar.yml.dist`, if the non-dist files don't exists.

So I could check in the dists into VCS and locally change only the non-versioned ymls.

(_And en passant changing the code `ConfigurationLoader::parseImport()` to avoid this a bit confusing `file_exists && !file_exists` stuff_ :)