### PR TITLE
Allow searchResult to be accessed after a skipped test

### DIFF
--- a/src/Behat/Behat/Tester/Result/SkippedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/SkippedStepResult.php
@@ -33,6 +33,16 @@ final class SkippedStepResult implements StepResult, DefinedStepResult
     {
         $this->searchResult = $searchResult;
     }
+    
+    /**
+     * Returns definition search result.
+     *
+     * @return SearchResult
+     */
+    public function getSearchResult()
+    {
+        return $this->searchResult;
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
I'm writing a custom formatter to get the arguments passed into a test. With an ExecutedStepResult I can just find these in the searchResult attribute, but I can't do the same with the SkippedStepResult class.