### PR TITLE
Added JUnitSetupPrinter

### DIFF
--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
@@ -12,14 +12,17 @@ namespace Behat\Behat\Output\Node\EventListener\JUnit;
 
 use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
 use Behat\Behat\EventDispatcher\Event\AfterScenarioTested;
+use Behat\Behat\EventDispatcher\Event\AfterStepSetup;
 use Behat\Behat\EventDispatcher\Event\AfterStepTested;
 use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Behat\EventDispatcher\Event\StepTested;
 use Behat\Behat\Output\Node\Printer\FeaturePrinter;
 use Behat\Behat\Output\Node\Printer\JUnit\JUnitScenarioPrinter;
+use Behat\Behat\Output\Node\Printer\SetupPrinter;
 use Behat\Behat\Output\Node\Printer\StepPrinter;
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Testwork\EventDispatcher\Event\AfterSetup;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Node\EventListener\EventListener;
 use Symfony\Component\EventDispatcher\Event;
@@ -44,6 +47,10 @@ final class JUnitFeatureElementListener implements EventListener
      */
     private $stepPrinter;
     /**
+     * @var SetupPrinter
+     */
+    private $setupPrinter;
+    /**
      * @var FeatureNode
      */
     private $beforeFeatureTestedEvent;
@@ -55,19 +62,28 @@ final class JUnitFeatureElementListener implements EventListener
      * @var AfterStepTested[]
      */
     private $afterStepTestedEvents = array();
+    /**
+     * @var AfterSetup[]
+     */
+    private $afterStepSetupEvents = array();
 
     /**
      * Initializes listener.
      *
-     * @param FeaturePrinter       $featurePrinter
+     * @param FeaturePrinter $featurePrinter
      * @param JUnitScenarioPrinter $scenarioPrinter
-     * @param StepPrinter          $stepPrinter
+     * @param StepPrinter $stepPrinter
+     * @param SetupPrinter $setupPrinter
      */
-    public function __construct(FeaturePrinter $featurePrinter, JUnitScenarioPrinter $scenarioPrinter, StepPrinter $stepPrinter)
+    public function __construct(FeaturePrinter $featurePrinter,
+                                JUnitScenarioPrinter $scenarioPrinter,
+                                StepPrinter $stepPrinter,
+                                SetupPrinter $setupPrinter)
     {
         $this->featurePrinter = $featurePrinter;
         $this->scenarioPrinter = $scenarioPrinter;
         $this->stepPrinter = $stepPrinter;
+        $this->setupPrinter = $setupPrinter;
     }
 
     /**
@@ -79,7 +95,9 @@ final class JUnitFeatureElementListener implements EventListener
             $this->captureScenarioEvent($event);
         }
 
-        if ($event instanceof StepTested) {
+        if ($event instanceof StepTested
+            || $event instanceof AfterStepSetup
+        ) {
             $this->captureStepEvent($event);
         }
 
@@ -96,11 +114,13 @@ final class JUnitFeatureElementListener implements EventListener
     {
         if ($event instanceof AfterScenarioTested) {
             $this->afterScenarioTestedEvents[$event->getScenario()->getLine()] = array(
-                'event' => $event,
-                'step_events' => $this->afterStepTestedEvents,
+                'event'             => $event,
+                'step_events'       => $this->afterStepTestedEvents,
+                'step_setup_events' => $this->afterStepSetupEvents,
             );
 
             $this->afterStepTestedEvents = array();
+            $this->afterStepSetupEvents = array();
         }
     }
 
@@ -121,12 +141,15 @@ final class JUnitFeatureElementListener implements EventListener
     /**
      * Captures step tested event.
      *
-     * @param StepTested $event
+     * @param Event $event
      */
-    private function captureStepEvent(StepTested $event)
+    private function captureStepEvent(Event $event)
     {
         if ($event instanceof AfterStepTested) {
             $this->afterStepTestedEvents[$event->getStep()->getLine()] = $event;
+        }
+        if ($event instanceof AfterStepSetup) {
+            $this->afterStepSetupEvents[$event->getStep()->getLine()] = $event;
         }
     }
 
@@ -148,8 +171,13 @@ final class JUnitFeatureElementListener implements EventListener
             $afterScenarioTested = $afterScenario['event'];
             $this->scenarioPrinter->printOpenTag($formatter, $afterScenarioTested->getFeature(), $afterScenarioTested->getScenario(), $afterScenarioTested->getTestResult());
 
+            /** @var AfterStepSetup $afterStepSetup */
+            foreach ($afterScenario['step_setup_events'] as $afterStepSetup) {
+                $this->setupPrinter->printSetup($formatter, $afterStepSetup->getSetup());
+            }
             foreach ($afterScenario['step_events'] as $afterStepTested) {
                 $this->stepPrinter->printStep($formatter, $afterScenarioTested->getScenario(), $afterStepTested->getStep(), $afterStepTested->getTestResult());
+                $this->setupPrinter->printTeardown($formatter, $afterStepTested->getTeardown());
             }
         }
 

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
@@ -1,0 +1,87 @@
+<?php
+namespace Behat\Behat\Output\Node\Printer\JUnit;
+
+use Behat\Behat\Hook\Scope\StepScope;
+use Behat\Behat\Output\Node\Printer\SetupPrinter;
+use Behat\Testwork\Call\CallResult;
+use Behat\Testwork\Call\CallResults;
+use Behat\Testwork\Exception\ExceptionPresenter;
+use Behat\Testwork\Hook\Call\HookCall;
+use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
+use Behat\Testwork\Hook\Tester\Setup\HookedTeardown;
+use Behat\Testwork\Output\Formatter;
+use Behat\Testwork\Output\Printer\JUnitOutputPrinter;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
+
+/**
+ * @author: Jakob Erdmann <jakob.erdmann@rocket-internet.com>
+ */
+class JUnitSetupPrinter implements SetupPrinter
+{
+
+    /** @var ExceptionPresenter */
+    private $exceptionPresenter;
+
+    public function __construct(ExceptionPresenter $exceptionPresenter)
+    {
+        $this->exceptionPresenter = $exceptionPresenter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function printSetup(Formatter $formatter, Setup $setup)
+    {
+        if (!$setup->isSuccessful()) {
+            if ($setup instanceof HookedSetup) {
+                $this->handleHookCalls($formatter, $setup->getHookCallResults(), 'setup');
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function printTeardown(Formatter $formatter, Teardown $teardown)
+    {
+        if (!$teardown->isSuccessful()) {
+            if ($teardown instanceof HookedTeardown) {
+                $this->handleHookCalls($formatter, $teardown->getHookCallResults(), 'teardown');
+            }
+        }
+    }
+
+    /**
+     * @param Formatter $formatter
+     * @param CallResults $results
+     * @param string $messageType
+     */
+    private function handleHookCalls(Formatter $formatter, CallResults $results, $messageType)
+    {
+        /** @var CallResult $hookCallResult */
+        foreach ($results as $hookCallResult) {
+            if ($hookCallResult->hasException()) {
+                /** @var HookCall $call */
+                $call = $hookCallResult->getCall();
+                $scope = $call->getScope();
+                /** @var JUnitOutputPrinter $outputPrinter */
+                $outputPrinter = $formatter->getOutputPrinter();
+
+                $message = '';
+                if ($scope instanceof StepScope) {
+                    $message .= $scope->getStep()->getKeyword() . ' ' . $scope->getStep()->getText() . ': ';
+                }
+                $message .= $this->exceptionPresenter->presentException($hookCallResult->getException());
+
+                $attributes = array(
+                    'message' => $message,
+                    'type'    => $messageType,
+                );
+
+                $outputPrinter->addTestcaseChild('failure', $attributes);
+
+            }
+        }
+    }
+}

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
@@ -10,12 +10,12 @@
 
 namespace Behat\Behat\Output\ServiceContainer\Formatter;
 
-use Behat\Testwork\Output\ServiceContainer\OutputExtension;
 use Behat\Testwork\Exception\ServiceContainer\ExceptionExtension;
 use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Definition;
+use Behat\Testwork\Output\ServiceContainer\OutputExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Behat junit formatter factory.
@@ -86,6 +86,13 @@ final class JUnitFormatterFactory implements FormatterFactory
             new Reference(ExceptionExtension::PRESENTER_ID),
         ));
         $container->setDefinition('output.node.printer.junit.step', $definition);
+
+        $definition = new Definition(
+            'Behat\Behat\Output\Node\Printer\JUnit\JUnitSetupPrinter', array(
+            new Reference(ExceptionExtension::PRESENTER_ID),
+        )
+        );
+        $container->setDefinition('output.node.printer.junit.setup', $definition);
     }
 
     /**
@@ -110,6 +117,7 @@ final class JUnitFormatterFactory implements FormatterFactory
                     new Reference('output.node.printer.junit.feature'),
                     new Reference('output.node.printer.junit.scenario'),
                     new Reference('output.node.printer.junit.step'),
+                    new Reference('output.node.printer.junit.setup'),
                 )),
             ),
         ));


### PR DESCRIPTION
I noticed that errors from @BeforeStep and @AfterStep hooks are not listed in the JUnit export. This causes Jenkins to not recognize the test as failed and therefore it is not listed under failed Tests.

This change adds a SetupPrinter to JUnit export which will add all Step hook failures to the export and marks them as either ``setup`` or ``teardown`` type.