### PR TITLE
Fix #859: Include basepath in generateKey

### DIFF
--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -44,17 +44,23 @@ final class RerunController implements Controller
      * @var string[]
      */
     private $lines = array();
+    /**
+     * @var string
+     */
+    private $basepath;
 
     /**
      * Initializes controller.
      *
      * @param EventDispatcherInterface $eventDispatcher
      * @param null|string              $cachePath
+     * @param string                   $basepath
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher, $cachePath)
+    public function __construct(EventDispatcherInterface $eventDispatcher, $cachePath, $basepath)
     {
         $this->eventDispatcher = $eventDispatcher;
         $this->cachePath = null !== $cachePath ? rtrim($cachePath, DIRECTORY_SEPARATOR) : null;
+        $this->basepath = $basepath;
     }
 
     /**
@@ -152,7 +158,8 @@ final class RerunController implements Controller
             implode(' ', $input->getOption('name')) .
             implode(' ', $input->getOption('tags')) .
             $input->getOption('role') .
-            $input->getArgument('paths')
+            $input->getArgument('paths') .
+            $this->basepath
         );
     }
 

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -227,7 +227,8 @@ class TesterExtension extends BaseExtension
     {
         $definition = new Definition('Behat\Behat\Tester\Cli\RerunController', array(
             new Reference(EventDispatcherExtension::DISPATCHER_ID),
-            $cachePath
+            $cachePath,
+            $container->getParameter('paths.base')
         ));
         $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 200));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.rerun', $definition);


### PR DESCRIPTION
Executing multiple runs at one time over write
rerun file of previous run. Avoid doing so by
including basepath of each run to generate uniquekey