### PR TITLE
Use only one autoloader if possible

### DIFF
--- a/bin/behat
+++ b/bin/behat
@@ -15,17 +15,19 @@ if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
     require $autoload;
 }
 
-if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
-    require($autoload);
-} elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
-    require($autoload);
-} else {
-    fwrite(STDERR,
-        'You must set up the project dependencies, run the following commands:'.PHP_EOL.
-        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
-        'php composer.phar install'.PHP_EOL
-    );
-    exit(1);
+if (!class_exists('Behat\Behat\ApplicationFactory', true)) {
+    if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
+        require($autoload);
+    } elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
+        require($autoload);
+    } else {
+        fwrite(STDERR,
+            'You must set up the project dependencies, run the following commands:'.PHP_EOL.
+            'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+            'php composer.phar install'.PHP_EOL
+        );
+        exit(1);
+    }
 }
 
 $factory = new \Behat\Behat\ApplicationFactory();


### PR DESCRIPTION
Hi there,

So I finally had some time in my project to go on the hunt for some strange behaviour with 3.1.0RC2.
Because the project that I'm working on has a less then normal structure and behat is installed as a symlink, bin/behat managed to load 2 different and conflicting autoloaders.

Since #830 requires both autoloaders I added a simple check to see if the first/current working directory autoloader adds behat, if so when there is no need to load any extra autoloaders.

Let me know what you think.

Cheers,
Warnar