### PR TITLE
Handle interupts on PHP7

### DIFF
--- a/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -40,6 +40,7 @@ class EventDispatcherExtension extends BaseExtension
         $this->loadEventDispatchingScenarioTester($container);
         $this->loadEventDispatchingExampleTester($container);
         $this->loadEventDispatchingStepTester($container);
+        $this->loadTickingStepTester($container);
     }
 
     /**
@@ -152,5 +153,23 @@ class EventDispatcherExtension extends BaseExtension
         ));
         $definition->addTag(TesterExtension::STEP_TESTER_WRAPPER_TAG, array('priority' => -9999));
         $container->setDefinition(TesterExtension::STEP_TESTER_WRAPPER_TAG . '.event_dispatching', $definition);
+    }
+
+    /**
+     * Loads ticking step tester.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function loadTickingStepTester(ContainerBuilder $container)
+    {
+        if (!function_exists('pcntl_signal')) {
+            return;
+        }
+
+        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\TickingStepTester', array(
+            new Reference(TesterExtension::STEP_TESTER_ID)
+        ));
+        $definition->addTag(TesterExtension::STEP_TESTER_WRAPPER_TAG, array('priority' => 9999));
+        $container->setDefinition(TesterExtension::STEP_TESTER_WRAPPER_TAG . '.ticking', $definition);
     }
 }

--- a/src/Behat/Behat/EventDispatcher/Tester/TickingStepTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/TickingStepTester.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\EventDispatcher\Tester;
+
+use Behat\Behat\Tester\Result\StepResult;
+use Behat\Behat\Tester\StepTester;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Testwork\Environment\Environment;
+
+/**
+ * Enable ticks during step testing to allow SigintController in Testwork
+ * to handle an interupt (on PHP7)
+ *
+ * @see Behat\Testwork\EventDispatcher\Cli\SigintController
+ *
+ * @author Peter Mitchell <peterjmit@gmail.com>
+ */
+final class TickingStepTester implements StepTester
+{
+    /**
+     * @var StepTester
+     */
+    private $baseTester;
+
+    /**
+     * Initializes tester.
+     *
+     * @param StepTester  $baseTester
+     */
+    public function __construct(StepTester $baseTester)
+    {
+        $this->baseTester = $baseTester;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    {
+        return $this->baseTester->setUp($env, $feature, $step, $skip);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    {
+        declare(ticks = 1);
+
+        return $this->baseTester->test($env, $feature, $step, $skip);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
+    {
+        return $this->baseTester->tearDown($env, $feature, $step, $skip, $result);
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/Behat/Behat/issues/832

It appears that the scoping of the declare statement prevents ticks from being emitted on PHP7. This PR decorates StepTester to declare ticks during step testing and therefore allow interrupts to occur mid-spec.

I initially looked at decorating a class in `Testwork` so that this code was closer to the `SigintController` but Testwork only goes as far as the suite level if I have understood things correctly.

On reading the documentation for `declare(ticks = 1)` it almost seems like the behaviour prior to PHP7 may have been a bug, and things are now behaving as expected (might explain the lack of response on the PHP bug filed?).