### PR TITLE
[WIP] Allow to use wildcards in imports

### DIFF
--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -221,8 +221,8 @@ final class ConfigurationLoader
     {
         $configs = array();
         foreach ($paths as $path) {
-            foreach (glob($path) as $matchedPath) {
-                foreach ($this->parseImport($basePath, $matchedPath, $profile) as $importConfig) {
+            foreach ($this->resolveImport($basePath, $path) as $resolvedPath) {
+                foreach ($this->loadFileConfiguration($resolvedPath, $profile) as $importConfig) {
                     $configs[] = $importConfig;
                 }
             }
@@ -232,29 +232,29 @@ final class ConfigurationLoader
     }
 
     /**
-     * Parses import.
+     * Resolves import path.
      *
      * @param string $basePath
      * @param string $path
-     * @param string $profile
      *
      * @return array
      *
-     * @throws ConfigurationLoadingException If import file not found
+     * @throws ConfigurationLoadingException If the path can not be resolved
      */
-    private function parseImport($basePath, $path, $profile)
+    private function resolveImport($basePath, $path)
     {
-        if (!file_exists($path) && file_exists($basePath . DIRECTORY_SEPARATOR . $path)) {
+        if (false === $resolvedPaths = glob($path)) {
+            throw new ConfigurationLoadingException(sprintf('Can not resolve import path `%s`.', $path));
+        }
+
+        if (!$resolvedPaths) {
             $path = $basePath . DIRECTORY_SEPARATOR . $path;
+
+            if (false === $resolvedPaths = glob($path)) {
+                throw new ConfigurationLoadingException(sprintf('Can not resolve import path `%s`.', $path));
+            }
         }
 
-        if (!file_exists($path)) {
-            throw new ConfigurationLoadingException(sprintf(
-                'Can not import `%s` configuration file. File not found.',
-                $path
-            ));
-        }
-
-        return $this->loadFileConfiguration($path, $profile);
+        return $resolvedPaths;
     }
 }

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -221,8 +221,10 @@ final class ConfigurationLoader
     {
         $configs = array();
         foreach ($paths as $path) {
-            foreach ($this->parseImport($basePath, $path, $profile) as $importConfig) {
-                $configs[] = $importConfig;
+            foreach (glob($path) as $matchedPath) {
+                foreach ($this->parseImport($basePath, $matchedPath, $profile) as $importConfig) {
+                    $configs[] = $importConfig;
+                }
             }
         }
 


### PR DESCRIPTION
This PR provides a feature that will allow to use wildcards (provided by the glob function) in the config imports.

For example:
```yaml
imports:
    - path/*/behat.yml
```