### PR TITLE
Multiline step definitions

### DIFF
--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -239,6 +239,47 @@ Feature: Step Definition Pattern
         Token name should not exceed 32 characters, but `too1234567891123456789012345678901` was used.
       """
 
+  Scenario: Multiline definitions
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @Given I don't provide \
+           *      parameter
+           * @Given I can provide \
+           *        parameter :param
+           */
+          public function parameterCouldBeNull($param = null) {
+            PHPUnit_Framework_Assert::assertNull($param);
+          }
+      }
+      """
+    And a file named "features/step_patterns.feature" with:
+      """
+      Feature: Step Pattern
+        Scenario:
+          Given I don't provide parameter
+          And I can provide parameter 2
+      """
+    When I run "behat -f progress --no-colors"
+    Then it should fail with:
+      """
+      .F
+
+      --- Failed steps:
+
+          And I can provide parameter 2 # features/step_patterns.feature:4
+            Failed asserting that '2' is null.
+
+      1 scenario (1 failed)
+      2 steps (1 passed, 1 failed)
+      """
+
   Scenario: Definition parameter with ordered values
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """

--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -249,7 +249,8 @@ Feature: Step Definition Pattern
       class FeatureContext implements Context
       {
           /**
-           * @Given I don't provide \
+           * @Given I don'\
+           * t provide \
            *      parameter
            * @Given I can provide \
            *        parameter :param

--- a/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
@@ -111,6 +111,7 @@ final class AnnotatedContextReader implements ContextReader
     {
         $callees = array();
         $description = $this->readDescription($docBlock);
+        $docBlock = $this->mergeMultilines($docBlock);
 
         foreach (explode("\n", $docBlock) as $docLine) {
             $docLine = preg_replace(self::DOCLINE_TRIMMER_REGEX, '', $docLine);
@@ -129,6 +130,18 @@ final class AnnotatedContextReader implements ContextReader
         }
 
         return $callees;
+    }
+
+    /**
+     * Merges multiline strings (strings ending with "\")
+     *
+     * @param string $docBlock
+     *
+     * @return string
+     */
+    private function mergeMultilines($docBlock)
+    {
+        return preg_replace("#\\\\$\s*\*\s*([^\\\\$]+)#m", '$1', $docBlock);
     }
 
     /**

--- a/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
@@ -141,7 +141,7 @@ final class AnnotatedContextReader implements ContextReader
      */
     private function mergeMultilines($docBlock)
     {
-        return preg_replace("#\\\\$\s*\*\s*([^\\\\$]+)#m", '$1', $docBlock);
+        return preg_replace("#\\\\$\s*+\*\s*+([^\\\\$]++)#m", '$1', $docBlock);
     }
 
     /**


### PR DESCRIPTION
If you put "\" at the end of your step definition, Behat will expect next line to continue that definition:

    * @Given my stepdef \
    *        continues \
    *        for couple of lines

is equivalent to:

    * @Given my stepdef continues for couple of lines

Closes #348 