### PR TITLE
Provide clearer exception message when long token names used

### DIFF
--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -211,6 +211,34 @@ Feature: Step Definition Pattern
       1 step (1 passed)
       """
 
+  Scenario: Using too long token names
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @Given I provide parameter :too1234567891123456789012345678901
+           */
+          public function parameterCouldBeNull($param) {}
+      }
+      """
+    And a file named "features/step_patterns.feature" with:
+      """
+      Feature: Step Pattern
+        Scenario:
+          Given I provide parameter 123
+      """
+    When I run "behat -f progress --no-colors"
+    Then it should fail with:
+      """
+      [Behat\Behat\Definition\Exception\InvalidPatternException]
+        Token name should not exceed 32 characters, but `too1234567891123456789012345678901` was used.
+      """
+
   Scenario: Definition parameter with ordered values
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -140,7 +140,7 @@ final class TurnipPatternPolicy implements PatternPolicy
 
     private function replaceTokenWithRegexCaptureGroup($tokenMatch)
     {
-        if (mb_strlen($tokenMatch[1]) >= 32) {
+        if (strlen($tokenMatch[1]) >= 32) {
             throw new InvalidPatternException(
                 "Token name should not exceed 32 characters, but `{$tokenMatch[1]}` was used."
             );

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -11,6 +11,7 @@
 namespace Behat\Behat\Definition\Pattern\Policy;
 
 use Behat\Behat\Definition\Pattern\Pattern;
+use Behat\Behat\Definition\Exception\InvalidPatternException;
 use Behat\Transliterator\Transliterator;
 
 /**
@@ -132,9 +133,20 @@ final class TurnipPatternPolicy implements PatternPolicy
 
         return preg_replace_callback(
             self::PLACEHOLDER_REGEXP,
-            function ($match) use ($tokenRegex) { return sprintf($tokenRegex, $match[1]); },
+            array($this, 'replaceTokenWithRegexCaptureGroup'),
             $regex
         );
+    }
+
+    private function replaceTokenWithRegexCaptureGroup($tokenMatch)
+    {
+        if (mb_strlen($tokenMatch[1]) >= 32) {
+            throw new InvalidPatternException(
+                "Token name should not exceed 32 characters, but `{$tokenMatch[1]}` was used."
+            );
+        }
+
+        return sprintf(self::TOKEN_REGEX, $tokenMatch[1]);
     }
 
     /**


### PR DESCRIPTION
TurnipPatternPolicy defines the transformation of turnip notation into a
regular expression using named captures.

PHP forbids usage of capture names longer than 32 symbols. That was
generating cryptic error message. This commit provides clearer
exception.

Closes #872 