### PR TITLE
From-string object transformer

### DIFF
--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -424,7 +424,7 @@ Feature: Step Arguments Transformations
       --- Failed steps:
 
           Given I am "everzet" # features/my.feature:3
-            Argument `user` of `FeatureContext::iAm()` was type-hinted as `User`, but `User::fromString($string)` is not implemented.
+            Argument `$user` of `FeatureContext::iAm()` was type-hinted as `User`, but `User::fromString($string)` is not implemented.
             Either implement `User::fromString($string)` method or define your own custom transformation for the argument.
 
       1 scenario (1 failed)

--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -424,7 +424,8 @@ Feature: Step Arguments Transformations
       --- Failed steps:
 
           Given I am "everzet" # features/my.feature:3
-            Method fromString does not exist (ReflectionException)
+            Argument `user` of `FeatureContext::iAm()` was type-hinted as `User`, but `User::fromString($string)` is not implemented.
+            Either implement `User::fromString($string)` method or define your own custom transformation for the argument.
 
       1 scenario (1 failed)
       2 steps (1 failed, 1 skipped)

--- a/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
+++ b/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
@@ -100,7 +100,11 @@ final class DefinitionArgumentsTransformer implements CallFilter
                 continue;
             }
 
-            return $transformer->transformArgument($definitionCall, $index, $value);
+            $transformedValue = $transformer->transformArgument($definitionCall, $index, $value);
+
+            if ($value !== $transformedValue) {
+                return $transformedValue;
+            }
         }
 
         return $value;

--- a/src/Behat/Behat/Transformation/Exception/FactoryMethodNotFound.php
+++ b/src/Behat/Behat/Transformation/Exception/FactoryMethodNotFound.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Transformation\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Represents an exception caused by usage of type-hinted step definition argument without factory method.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class FactoryMethodNotFound extends InvalidArgumentException implements TransformationException
+{
+    /**
+     * @var string
+     */
+    private $class;
+    /**
+     * @var string
+     */
+    private $method;
+
+    /**
+     * Initializes exception.
+     *
+     * @param string $message
+     * @param string   $class
+     */
+    public function __construct($message, $class, $method)
+    {
+        parent::__construct($message);
+
+        $this->class = $class;
+        $this->method = $method;
+    }
+
+    /**
+     * Returns class name.
+     *
+     * @return string
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * Return factory method name.
+     *
+     * @return string
+     */
+    public function getFactoryMethod()
+    {
+        return $this->method;
+    }
+}

--- a/src/Behat/Behat/Transformation/Exception/FactoryMethodNotFound.php
+++ b/src/Behat/Behat/Transformation/Exception/FactoryMethodNotFound.php
@@ -32,14 +32,15 @@ final class FactoryMethodNotFound extends InvalidArgumentException implements Tr
      * Initializes exception.
      *
      * @param string $message
-     * @param string   $class
+     * @param string $class
+     * @param string $factoryMethod
      */
-    public function __construct($message, $class, $method)
+    public function __construct($message, $class, $factoryMethod)
     {
         parent::__construct($message);
 
         $this->class = $class;
-        $this->method = $method;
+        $this->method = $factoryMethod;
     }
 
     /**

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -123,6 +123,10 @@ class TransformationExtension implements Extension
         ));
         $definition->addTag(self::ARGUMENT_TRANSFORMER_TAG, array('priority' => 50));
         $container->setDefinition(self::ARGUMENT_TRANSFORMER_TAG . '.repository', $definition);
+
+        $definition = new Definition('Behat\Behat\Transformation\Transformer\FromStringObjectTransformer', array());
+        $definition->addTag(self::ARGUMENT_TRANSFORMER_TAG, array('priority' => 0));
+        $container->setDefinition(self::ARGUMENT_TRANSFORMER_TAG . '.from_string_object', $definition);
     }
 
     /**

--- a/src/Behat/Behat/Transformation/Transformer/FromStringObjectTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/FromStringObjectTransformer.php
@@ -44,9 +44,10 @@ final class FromStringObjectTransformer implements ArgumentTransformer
         if (!$class->hasMethod($factoryMethod) || 1 !== $class->getMethod($factoryMethod)->getNumberOfParameters()) {
             $definitionPath = $definitionCall->getCallee()->getPath();
             $className = $class->getName();
+            $argumentIndicator = is_string($argumentIndex) ? "`\$$argumentIndex`" : ($argumentIndex + 1);
 
             throw new FactoryMethodNotFound(
-                "Argument `$argumentIndex` of `$definitionPath` was type-hinted as `$className`, " .
+                "Argument $argumentIndicator of `$definitionPath` was type-hinted as `$className`, " .
                 "but `$className::$factoryMethod(\$string)` is not implemented.\n" .
                 "Either implement `$className::$factoryMethod(\$string)` method or define your own custom " .
                 "transformation for the argument.",

--- a/src/Behat/Behat/Transformation/Transformer/FromStringObjectTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/FromStringObjectTransformer.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Transformation\Transformer;
+
+use Behat\Behat\Definition\Call\DefinitionCall;
+use Closure;
+use ReflectionMethod;
+use ReflectionParameter;
+
+/**
+ * Transforms typehinted parameters using their `fromString` factory method (if exists).
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class FromStringObjectTransformer implements ArgumentTransformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    {
+        return !is_object($argumentValue) && null !== $this->getParameterFactoryByIndex($definitionCall, $argumentIndex);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transformArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    {
+        return $this->getParameterFactoryByIndex($definitionCall, $argumentIndex)->invoke(null, $argumentValue);
+    }
+
+    /**
+     * Attempts to get definition parameter using its index (parameter position or name).
+     *
+     * @param DefinitionCall $definitionCall
+     * @param string|integer $argumentIndex
+     *
+     * @return ReflectionMethod|null
+     */
+    private function getParameterFactoryByIndex(DefinitionCall $definitionCall, $argumentIndex)
+    {
+        $parameters = array_filter(
+            array_filter($this->getCallParameters($definitionCall),
+                $this->hasIndex($argumentIndex)
+            ),
+            $this->isClassWithMethod('fromString')
+        );
+
+        return count($parameters) ? current($parameters)->getClass()->getMethod('fromString') : null;
+    }
+
+    /**
+     * Extracts parameters from provided definition call.
+     *
+     * @param DefinitionCall $definitionCall
+     *
+     * @return ReflectionParameter[]
+     */
+    private function getCallParameters(DefinitionCall $definitionCall)
+    {
+        return $definitionCall->getCallee()->getReflection()->getParameters();
+    }
+
+    /**
+     * Returns appropriate closure for filtering parameter by index.
+     *
+     * @param string|integer $index
+     *
+     * @return Closure
+     */
+    private function hasIndex($index)
+    {
+        return is_string($index) ? $this->hasName($index) : $this->hasPosition($index);
+    }
+
+    /**
+     * Returns closure to filter parameter by name.
+     *
+     * @param string $index
+     *
+     * @return Closure
+     */
+    private function hasName($index)
+    {
+        return function (ReflectionParameter $parameter) use ($index) {
+            return $index === $parameter->getName();
+        };
+    }
+
+    /**
+     * Returns closure to filter parameter by position.
+     *
+     * @param integer $index
+     *
+     * @return Closure
+     */
+    private function hasPosition($index)
+    {
+        return function (ReflectionParameter $parameter) use ($index) {
+            return $index === $parameter->getPosition();
+        };
+    }
+
+    /**
+     * Returns closure to filter parameter by typehinted class and its method name.
+     *
+     * @param string $methodName
+     *
+     * @return Closure
+     */
+    private function isClassWithMethod($methodName)
+    {
+        return function (ReflectionParameter $parameter) use ($methodName) {
+            return $parameter->getClass();
+        };
+    }
+}

--- a/src/Behat/Behat/Transformation/Transformer/FromStringObjectTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/FromStringObjectTransformer.php
@@ -43,13 +43,15 @@ final class FromStringObjectTransformer implements ArgumentTransformer
         if (!$class->hasMethod(self::FACTORY_METHOD)) {
             throw new FactoryMethodNotFound(
                 sprintf(
-                    "Argument `%s` of `%s` was type-hinted as `%s`, but `%s::fromString(\$string)` is not implemented.\n" .
-                    "Either implement `%s::fromString(\$string)` method or define your own custom transformation for the argument.",
+                    "Argument `%s` of `%s` was type-hinted as `%s`, but `%s::%s(\$string)` is not implemented.\n" .
+                    "Either implement `%s::%s(\$string)` method or define your own custom transformation for the argument.",
                     $argumentIndex,
                     $definitionCall->getCallee()->getPath(),
                     $class->getName(),
                     $class->getName(),
-                    $class->getName()
+                    self::FACTORY_METHOD,
+                    $class->getName(),
+                    self::FACTORY_METHOD
                 ),
                 $class->getName(),
                 self::FACTORY_METHOD


### PR DESCRIPTION
## TLDR;

This PR introduces automatic ValueObject transformer into Behat. It is first half of #863. It has following attributes:

1. Is automatically executed for all your class type-hints in your step definitions
2. Attempts to automatically transform such arguments calling typehint's `fromString()` factory method
3. Has the lowest precedence of all transformers. Meaning that if you provide any other kind of transformation that matches said argument, from-string object transformer wouldn't get executed

## Basic usage

### Feature

Given simple feature:

```gherkin
Feature:
  Scenario:
    Given I am "everzet"
```

### Stepdef

And a step definition, using type-hint:

```php
class User {
    public function __construct($name) { $this->name = $name; }
}

class FeatureContext implements Context
{
    /** @Given I am :user */
    public function iAm(User $user) {
        // TODO: do something with $user
    }
}
```

### Test

When you attempt to execute this, you'll get exception like this:

```bash
...> Method fromString does not exist
```

There are now two possible routes out of this situation...

### Fix

#### Route 1: Write custom transformation

As before, you can write your own custom transformation and it will work as it always did:

```php
class User {
    public function __construct($name) { $this->name = $name; }
}

class FeatureContext implements Context
{
    /** @Transform :user */
    public function transformUser($user) {
        return new User($user);
    }

    /** @Given I am :user */
    public function iAm(User $user) {
        // TODO: do something with $user
    }
}
```

#### Route 2: Add `fromString`

Or, you can add `fromString` factory method to your `User` class and that will also work exactly as you might expect:

```php
class User {
    private function __construct($name) { $this->name = $name; }
    static public function fromString($name) { return new static($name); }
}

class FeatureContext implements Context
{
    /** @Given I am :user */
    public function iAm(User $user) {
        // TODO: do something with $user
    }
}
```

## Implications

There are no known BC breaks or implications on existing codebases. Please, highlight if you are aware of any.