### PR TITLE
Fix context isolation for Scenario Outlines

### DIFF
--- a/features/outlines.feature
+++ b/features/outlines.feature
@@ -215,3 +215,51 @@ Feature: Scenario Outlines
       6 scenarios (2 passed, 4 failed)
       30 steps (26 passed, 4 failed)
       """
+
+  Scenario: Scenario outline examples isolation
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          private $number = 0;
+
+          /**
+           * @When I add :number
+           */
+           public function iAdd($number) {
+              $this->number += intval($number);
+           }
+
+           /**
+            * @Then the result should be :result
+            */
+           public function theResultShouldBe($result) {
+              PHPUnit_Framework_Assert::assertEquals(intval($result), $this->number);
+           }
+      }
+      """
+    And a file named "features/math.feature" with:
+      """
+      Feature: Math
+        Scenario Outline:
+          When I add <add>
+          Then the result should be <result>
+
+          Examples:
+            | add | result |
+            | 12  | 12     |
+            | 3   | 3      |
+            | 5   | 5      |
+      """
+    When I run "behat --no-colors -f progress features/math.feature"
+    Then it should pass with:
+      """
+      ......
+
+      3 scenarios (3 passed)
+      6 steps (6 passed)
+      """

--- a/src/Behat/Behat/Tester/Runtime/IsolatingScenarioTester.php
+++ b/src/Behat/Behat/Tester/Runtime/IsolatingScenarioTester.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Tester\Runtime;
+
+use Behat\Behat\Tester\ScenarioTester;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioInterface as Scenario;
+use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\Environment\EnvironmentManager;
+use Behat\Testwork\Tester\Result\IntegerTestResult;
+use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Result\TestWithSetupResult;
+use Behat\Testwork\Tester\Setup\SuccessfulSetup;
+use Behat\Testwork\Tester\Setup\SuccessfulTeardown;
+
+/**
+ * Scenario tester that isolates the environment for each scenario.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class IsolatingScenarioTester implements ScenarioTester
+{
+    /**
+     * @var ScenarioTester
+     */
+    private $decoratedTester;
+    /**
+     * @var EnvironmentManager
+     */
+    private $envManager;
+
+    /**
+     * Initialises tester.
+     *
+     * @param ScenarioTester     $decoratedTester
+     * @param EnvironmentManager $envManager
+     */
+    public function __construct(ScenarioTester $decoratedTester, EnvironmentManager $envManager)
+    {
+        $this->decoratedTester = $decoratedTester;
+        $this->envManager = $envManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
+    {
+        return new SuccessfulSetup();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
+    {
+        $isolatedEnvironment = $this->envManager->isolateEnvironment($env, $scenario);
+
+        $setup = $this->decoratedTester->setUp($isolatedEnvironment, $feature, $scenario, $skip);
+        $localSkip = !$setup->isSuccessful() || $skip;
+        $testResult = $this->decoratedTester->test($isolatedEnvironment, $feature, $scenario, $localSkip);
+        $teardown = $this->decoratedTester->tearDown($isolatedEnvironment, $feature, $scenario, $localSkip, $testResult);
+
+        $integerResult = new IntegerTestResult($testResult->getResultCode());
+
+        return new TestWithSetupResult($setup, $integerResult, $teardown);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
+    {
+        return new SuccessfulTeardown();
+    }
+}

--- a/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
@@ -49,6 +49,8 @@ final class RuntimeFeatureTester implements SpecificationTester
      * @param ScenarioTester     $scenarioTester
      * @param OutlineTester      $outlineTester
      * @param EnvironmentManager $envManager
+     *
+     * TODO: Remove EnvironmentManager parameter in next major
      */
     public function __construct(
         ScenarioTester $scenarioTester,
@@ -75,13 +77,12 @@ final class RuntimeFeatureTester implements SpecificationTester
     {
         $results = array();
         foreach ($feature->getScenarios() as $scenario) {
-            $isolatedEnvironment = $this->envManager->isolateEnvironment($env, $scenario);
             $tester = $scenario instanceof OutlineNode ? $this->outlineTester : $this->scenarioTester;
 
-            $setup = $tester->setUp($isolatedEnvironment, $feature, $scenario, $skip);
+            $setup = $tester->setUp($env, $feature, $scenario, $skip);
             $localSkip = !$setup->isSuccessful() || $skip;
-            $testResult = $tester->test($isolatedEnvironment, $feature, $scenario, $localSkip);
-            $teardown = $tester->tearDown($isolatedEnvironment, $feature, $scenario, $localSkip, $testResult);
+            $testResult = $tester->test($env, $feature, $scenario, $localSkip);
+            $teardown = $tester->tearDown($env, $feature, $scenario, $localSkip, $testResult);
 
             $integerResult = new IntegerTestResult($testResult->getResultCode());
             $results[] = new TestWithSetupResult($setup, $integerResult, $teardown);

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -146,9 +146,17 @@ class TesterExtension extends BaseExtension
         $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeScenarioTester', array(
             new Reference('tester.step_container'),
             new Reference(self::BACKGROUND_TESTER_ID)
-
         ));
         $container->setDefinition(self::SCENARIO_TESTER_ID, $definition);
+
+        // Proper isolation for scenarios
+        $definition = new Definition('Behat\Behat\Tester\Runtime\IsolatingScenarioTester', array(
+                new Reference(self::SCENARIO_TESTER_ID),
+                new Reference(EnvironmentExtension::MANAGER_ID)
+            )
+        );
+        $definition->addTag(self::SCENARIO_TESTER_WRAPPER_TAG, array('priority' => -999999));
+        $container->setDefinition(self::SCENARIO_TESTER_WRAPPER_TAG . '.isolating', $definition);
     }
 
     /**
@@ -183,6 +191,15 @@ class TesterExtension extends BaseExtension
             new Reference(self::BACKGROUND_TESTER_ID)
         ));
         $container->setDefinition(self::EXAMPLE_TESTER_ID, $definition);
+
+        // Proper isolation for examples
+        $definition = new Definition('Behat\Behat\Tester\Runtime\IsolatingScenarioTester', array(
+                new Reference(self::EXAMPLE_TESTER_ID),
+                new Reference(EnvironmentExtension::MANAGER_ID)
+            )
+        );
+        $definition->addTag(self::EXAMPLE_TESTER_WRAPPER_TAG, array('priority' => -999999));
+        $container->setDefinition(self::EXAMPLE_TESTER_WRAPPER_TAG . '.isolating', $definition);
     }
 
     /**


### PR DESCRIPTION
This PR fixes context isolation for Scenario Outlines. It achieves that without BC breaks by implementing additional tester decorator - `IsolatingScenarioTester`. It's a bit clunky, but totally working solution until the next major, when we can break BC.