### PR TITLE
Give more context for pending/failed steps with progress formatter

### DIFF
--- a/features/context.feature
+++ b/features/context.feature
@@ -162,19 +162,19 @@ Feature: Context consistency
 
       --- Failed steps:
 
-          Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 5 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 5.
 
-          Scenario: Found more apples    # features/apples.feature:13
+      002 Scenario: Found more apples    # features/apples.feature:13
             Then I should have 10 apples # features/apples.feature:15
               Failed asserting that 13 matches expected 10.
 
-          Example: | 3   | 1     | 3      | # features/apples.feature:24
+      003 Example: | 3   | 1     | 3      | # features/apples.feature:24
             Then I should have 3 apples     # features/apples.feature:20
               Failed asserting that 1 matches expected 3.
 
-          Example: | 2   | 2     | 4      | # features/apples.feature:26
+      004 Example: | 2   | 2     | 4      | # features/apples.feature:26
             Then I should have 4 apples     # features/apples.feature:20
               Failed asserting that 3 matches expected 4.
 

--- a/features/context.feature
+++ b/features/context.feature
@@ -162,17 +162,21 @@ Feature: Context consistency
 
       --- Failed steps:
 
-          Then I should have 5 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 5.
+          Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 5 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 5.
 
-          Then I should have 10 apples # features/apples.feature:15
-            Failed asserting that 13 matches expected 10.
+          Scenario: Found more apples    # features/apples.feature:13
+            Then I should have 10 apples # features/apples.feature:15
+              Failed asserting that 13 matches expected 10.
 
-          Then I should have 3 apples # features/apples.feature:20
-            Failed asserting that 1 matches expected 3.
+          Example: | 3   | 1     | 3      | # features/apples.feature:24
+            Then I should have 3 apples     # features/apples.feature:20
+              Failed asserting that 1 matches expected 3.
 
-          Then I should have 4 apples # features/apples.feature:20
-            Failed asserting that 3 matches expected 4.
+          Example: | 2   | 2     | 4      | # features/apples.feature:26
+            Then I should have 4 apples     # features/apples.feature:20
+              Failed asserting that 3 matches expected 4.
 
       5 scenarios (1 passed, 4 failed)
       18 steps (14 passed, 4 failed)

--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -274,8 +274,9 @@ Feature: Step Definition Pattern
 
       --- Failed steps:
 
-          And I can provide parameter 2 # features/step_patterns.feature:4
-            Failed asserting that '2' is null.
+          Scenario:                       # features/step_patterns.feature:2
+            And I can provide parameter 2 # features/step_patterns.feature:4
+              Failed asserting that '2' is null.
 
       1 scenario (1 failed)
       2 steps (1 passed, 1 failed)

--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -274,7 +274,7 @@ Feature: Step Definition Pattern
 
       --- Failed steps:
 
-          Scenario:                       # features/step_patterns.feature:2
+      001 Scenario:                       # features/step_patterns.feature:2
             And I can provide parameter 2 # features/step_patterns.feature:4
               Failed asserting that '2' is null.
 

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -86,8 +86,9 @@ Feature: Error Reporting
     """
     --- Failed steps:
 
-        When I access array index 0 # features/e_notice_in_scenario.feature:10
-          Notice: Undefined offset: 0 in features/bootstrap/FeatureContext.php line 24
+        Scenario: Access undefined index # features/e_notice_in_scenario.feature:9
+          When I access array index 0    # features/e_notice_in_scenario.feature:10
+            Notice: Undefined offset: 0 in features/bootstrap/FeatureContext.php line 24
 
     2 scenarios (1 passed, 1 failed)
     7 steps (5 passed, 1 failed, 1 skipped)

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -86,7 +86,7 @@ Feature: Error Reporting
     """
     --- Failed steps:
 
-        Scenario: Access undefined index # features/e_notice_in_scenario.feature:9
+    001 Scenario: Access undefined index # features/e_notice_in_scenario.feature:9
           When I access array index 0    # features/e_notice_in_scenario.feature:10
             Notice: Undefined offset: 0 in features/bootstrap/FeatureContext.php line 24
 

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -154,19 +154,23 @@ Feature: I18n
 
       --- Проваленные шаги:
 
-          То Я должен иметь 13 # features/World.feature:22
-            Failed asserting that 14 matches expected 13.
+          Сценарий: Провален     # features/World.feature:20
+            То Я должен иметь 13 # features/World.feature:22
+              Failed asserting that 14 matches expected 13.
 
-          То Я должен иметь 16 # features/World.feature:27
-            Failed asserting that 15 matches expected 16.
+          Example: | 5        | 16        | # features/World.feature:31
+            То Я должен иметь 16            # features/World.feature:27
+              Failed asserting that 15 matches expected 16.
 
-          То Я должен иметь 32 # features/World.feature:27
-            Failed asserting that 33 matches expected 32.
+          Example: | 23       | 32        | # features/World.feature:33
+            То Я должен иметь 32            # features/World.feature:27
+              Failed asserting that 33 matches expected 32.
 
       --- Шаги в ожидании:
 
-          И Что-то еще не сделано # FeatureContext::somethingNotDone()
-            TODO: write pending definition
+          Сценарий: В ожидании      # features/World.feature:15
+            И Что-то еще не сделано # FeatureContext::somethingNotDone()
+              TODO: write pending definition
 
       6 сценариев (1 пройден, 3 провалено, 1 не определен, 1 в ожидании)
       23 шага (16 пройдено, 3 провалено, 1 не определен, 1 в ожидании, 2 пропущено)
@@ -190,19 +194,23 @@ Feature: I18n
 
       --- Failed steps:
 
-          То Я должен иметь 13 # features/World.feature:22
-            Failed asserting that 14 matches expected 13.
+          Сценарий: Провален     # features/World.feature:20
+            То Я должен иметь 13 # features/World.feature:22
+              Failed asserting that 14 matches expected 13.
 
-          То Я должен иметь 16 # features/World.feature:27
-            Failed asserting that 15 matches expected 16.
+          Example: | 5        | 16        | # features/World.feature:31
+            То Я должен иметь 16            # features/World.feature:27
+              Failed asserting that 15 matches expected 16.
 
-          То Я должен иметь 32 # features/World.feature:27
-            Failed asserting that 33 matches expected 32.
+          Example: | 23       | 32        | # features/World.feature:33
+            То Я должен иметь 32            # features/World.feature:27
+              Failed asserting that 33 matches expected 32.
 
       --- Pending steps:
 
-          И Что-то еще не сделано # FeatureContext::somethingNotDone()
-            TODO: write pending definition
+          Сценарий: В ожидании      # features/World.feature:15
+            И Что-то еще не сделано # FeatureContext::somethingNotDone()
+              TODO: write pending definition
 
       6 scenarios (1 passed, 3 failed, 1 undefined, 1 pending)
       23 steps (16 passed, 3 failed, 1 undefined, 1 pending, 2 skipped)
@@ -226,19 +234,23 @@ Feature: I18n
 
       --- Failed steps:
 
-          То Я должен иметь 13 # features/World.feature:22
-            Failed asserting that 14 matches expected 13.
+          Сценарий: Провален     # features/World.feature:20
+            То Я должен иметь 13 # features/World.feature:22
+              Failed asserting that 14 matches expected 13.
 
-          То Я должен иметь 16 # features/World.feature:27
-            Failed asserting that 15 matches expected 16.
+          Example: | 5        | 16        | # features/World.feature:31
+            То Я должен иметь 16            # features/World.feature:27
+              Failed asserting that 15 matches expected 16.
 
-          То Я должен иметь 32 # features/World.feature:27
-            Failed asserting that 33 matches expected 32.
+          Example: | 23       | 32        | # features/World.feature:33
+            То Я должен иметь 32            # features/World.feature:27
+              Failed asserting that 33 matches expected 32.
 
       --- Pending steps:
 
-          И Что-то еще не сделано # FeatureContext::somethingNotDone()
-            TODO: write pending definition
+          Сценарий: В ожидании      # features/World.feature:15
+            И Что-то еще не сделано # FeatureContext::somethingNotDone()
+              TODO: write pending definition
 
       6 scenarios (1 passed, 3 failed, 1 undefined, 1 pending)
       23 steps (16 passed, 3 failed, 1 undefined, 1 pending, 2 skipped)

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -154,21 +154,21 @@ Feature: I18n
 
       --- Проваленные шаги:
 
-          Сценарий: Провален     # features/World.feature:20
+      001 Сценарий: Провален     # features/World.feature:20
             То Я должен иметь 13 # features/World.feature:22
               Failed asserting that 14 matches expected 13.
 
-          Example: | 5        | 16        | # features/World.feature:31
+      002 Example: | 5        | 16        | # features/World.feature:31
             То Я должен иметь 16            # features/World.feature:27
               Failed asserting that 15 matches expected 16.
 
-          Example: | 23       | 32        | # features/World.feature:33
+      003 Example: | 23       | 32        | # features/World.feature:33
             То Я должен иметь 32            # features/World.feature:27
               Failed asserting that 33 matches expected 32.
 
       --- Шаги в ожидании:
 
-          Сценарий: В ожидании      # features/World.feature:15
+      001 Сценарий: В ожидании      # features/World.feature:15
             И Что-то еще не сделано # FeatureContext::somethingNotDone()
               TODO: write pending definition
 
@@ -194,21 +194,21 @@ Feature: I18n
 
       --- Failed steps:
 
-          Сценарий: Провален     # features/World.feature:20
+      001 Сценарий: Провален     # features/World.feature:20
             То Я должен иметь 13 # features/World.feature:22
               Failed asserting that 14 matches expected 13.
 
-          Example: | 5        | 16        | # features/World.feature:31
+      002 Example: | 5        | 16        | # features/World.feature:31
             То Я должен иметь 16            # features/World.feature:27
               Failed asserting that 15 matches expected 16.
 
-          Example: | 23       | 32        | # features/World.feature:33
+      003 Example: | 23       | 32        | # features/World.feature:33
             То Я должен иметь 32            # features/World.feature:27
               Failed asserting that 33 matches expected 32.
 
       --- Pending steps:
 
-          Сценарий: В ожидании      # features/World.feature:15
+      001 Сценарий: В ожидании      # features/World.feature:15
             И Что-то еще не сделано # FeatureContext::somethingNotDone()
               TODO: write pending definition
 
@@ -234,21 +234,21 @@ Feature: I18n
 
       --- Failed steps:
 
-          Сценарий: Провален     # features/World.feature:20
+      001 Сценарий: Провален     # features/World.feature:20
             То Я должен иметь 13 # features/World.feature:22
               Failed asserting that 14 matches expected 13.
 
-          Example: | 5        | 16        | # features/World.feature:31
+      002 Example: | 5        | 16        | # features/World.feature:31
             То Я должен иметь 16            # features/World.feature:27
               Failed asserting that 15 matches expected 16.
 
-          Example: | 23       | 32        | # features/World.feature:33
+      003 Example: | 23       | 32        | # features/World.feature:33
             То Я должен иметь 32            # features/World.feature:27
               Failed asserting that 33 matches expected 32.
 
       --- Pending steps:
 
-          Сценарий: В ожидании      # features/World.feature:15
+      001 Сценарий: В ожидании      # features/World.feature:15
             И Что-то еще не сделано # FeatureContext::somethingNotDone()
               TODO: write pending definition
 

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -167,11 +167,13 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+          Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
 
-          Then I should have 8 apples # features/apples.feature:25
-            Failed asserting that 7 matches expected 8.
+          Example: | 0   | 4     | 8      | # features/apples.feature:30
+            Then I should have 8 apples     # features/apples.feature:25
+              Failed asserting that 7 matches expected 8.
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)
@@ -258,11 +260,13 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+          Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
 
-          Then I should have 8 apples # features/apples.feature:25
-            Failed asserting that 7 matches expected 8.
+          Example: | 0   | 4     | 8      | # features/apples.feature:30
+            Then I should have 8 apples     # features/apples.feature:25
+              Failed asserting that 7 matches expected 8.
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)
@@ -302,11 +306,13 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+          Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
 
-          Then I should have 8 apples # features/apples.feature:25
-            Failed asserting that 7 matches expected 8.
+          Example: | 0   | 4     | 8      | # features/apples.feature:30
+            Then I should have 8 apples     # features/apples.feature:25
+              Failed asserting that 7 matches expected 8.
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)
@@ -472,11 +478,13 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+          Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
 
-          Then I should have 8 apples # features/apples.feature:25
-            Failed asserting that 7 matches expected 8.
+          Example: | 0   | 4     | 8      | # features/apples.feature:30
+            Then I should have 8 apples     # features/apples.feature:25
+              Failed asserting that 7 matches expected 8.
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)
@@ -568,11 +576,13 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+          Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
 
-          Then I should have 8 apples # features/apples.feature:25
-            Failed asserting that 7 matches expected 8.
+          Example: | 0   | 4     | 8      | # features/apples.feature:30
+            Then I should have 8 apples     # features/apples.feature:25
+              Failed asserting that 7 matches expected 8.
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -167,11 +167,11 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-          Example: | 0   | 4     | 8      | # features/apples.feature:30
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
               Failed asserting that 7 matches expected 8.
 
@@ -260,11 +260,11 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-          Example: | 0   | 4     | 8      | # features/apples.feature:30
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
               Failed asserting that 7 matches expected 8.
 
@@ -306,11 +306,11 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-          Example: | 0   | 4     | 8      | # features/apples.feature:30
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
               Failed asserting that 7 matches expected 8.
 
@@ -478,11 +478,11 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-          Example: | 0   | 4     | 8      | # features/apples.feature:30
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
               Failed asserting that 7 matches expected 8.
 
@@ -576,11 +576,11 @@ Feature: Multiple formats
 
       --- Failed steps:
 
-          Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-          Example: | 0   | 4     | 8      | # features/apples.feature:30
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
               Failed asserting that 7 matches expected 8.
 

--- a/features/outlines.feature
+++ b/features/outlines.feature
@@ -200,17 +200,21 @@ Feature: Scenario Outlines
 
       --- Failed steps:
 
-          Then The result should be 15 # features/math.feature:9
-            Failed asserting that 20 matches expected 15.
+          Example: | 5       | 4       | 15     | # features/math.feature:14
+            Then The result should be 15          # features/math.feature:9
+              Failed asserting that 20 matches expected 15.
 
-          Then The result should be 7 # features/math.feature:20
-            Failed asserting that 6 matches expected 7.
+          Scenario:                     # features/math.feature:16
+            Then The result should be 7 # features/math.feature:20
+              Failed asserting that 6 matches expected 7.
 
-          Then The result should be 2 # features/math.feature:26
-            Failed asserting that 5 matches expected 2.
+          Example: | 50      | 10      | 2      | # features/math.feature:31
+            Then The result should be 2           # features/math.feature:26
+              Failed asserting that 5 matches expected 2.
 
-          Then The result should be 4 # features/math.feature:26
-            Failed asserting that 5 matches expected 4.
+          Example: | 50      | 10      | 4      | # features/math.feature:32
+            Then The result should be 4           # features/math.feature:26
+              Failed asserting that 5 matches expected 4.
 
       6 scenarios (2 passed, 4 failed)
       30 steps (26 passed, 4 failed)

--- a/features/outlines.feature
+++ b/features/outlines.feature
@@ -200,19 +200,19 @@ Feature: Scenario Outlines
 
       --- Failed steps:
 
-          Example: | 5       | 4       | 15     | # features/math.feature:14
+      001 Example: | 5       | 4       | 15     | # features/math.feature:14
             Then The result should be 15          # features/math.feature:9
               Failed asserting that 20 matches expected 15.
 
-          Scenario:                     # features/math.feature:16
+      002 Scenario:                     # features/math.feature:16
             Then The result should be 7 # features/math.feature:20
               Failed asserting that 6 matches expected 7.
 
-          Example: | 50      | 10      | 2      | # features/math.feature:31
+      003 Example: | 50      | 10      | 2      | # features/math.feature:31
             Then The result should be 2           # features/math.feature:26
               Failed asserting that 5 matches expected 2.
 
-          Example: | 50      | 10      | 4      | # features/math.feature:32
+      004 Example: | 50      | 10      | 4      | # features/math.feature:32
             Then The result should be 4           # features/math.feature:26
               Failed asserting that 5 matches expected 4.
 

--- a/features/rerun.feature
+++ b/features/rerun.feature
@@ -105,11 +105,11 @@ Feature: Rerun
 
       --- Failed steps:
 
-          Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-          Example: | 0   | 4     | 8      | # features/apples.feature:29
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29
             Then I should have 8 apples     # features/apples.feature:24
               Failed asserting that 7 matches expected 8.
 
@@ -126,11 +126,11 @@ Feature: Rerun
 
     --- Failed steps:
 
-        Scenario: I'm little hungry   # features/apples.feature:9
+    001 Scenario: I'm little hungry   # features/apples.feature:9
           Then I should have 3 apples # features/apples.feature:11
             Failed asserting that 2 matches expected 3.
 
-        Example: | 0   | 4     | 8      | # features/apples.feature:29
+    002 Example: | 0   | 4     | 8      | # features/apples.feature:29
           Then I should have 8 apples     # features/apples.feature:24
             Failed asserting that 7 matches expected 8.
 
@@ -181,7 +181,7 @@ Feature: Rerun
 
     --- Failed steps:
 
-        Scenario: I'm little hungry   # features/apples.feature:9
+    001 Scenario: I'm little hungry   # features/apples.feature:9
           Then I should have 3 apples # features/apples.feature:11
             Failed asserting that 2 matches expected 3.
 

--- a/features/rerun.feature
+++ b/features/rerun.feature
@@ -105,11 +105,13 @@ Feature: Rerun
 
       --- Failed steps:
 
-          Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+          Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
 
-          Then I should have 8 apples # features/apples.feature:24
-            Failed asserting that 7 matches expected 8.
+          Example: | 0   | 4     | 8      | # features/apples.feature:29
+            Then I should have 8 apples     # features/apples.feature:24
+              Failed asserting that 7 matches expected 8.
 
       6 scenarios (4 passed, 2 failed)
       21 steps (19 passed, 2 failed)
@@ -124,11 +126,13 @@ Feature: Rerun
 
     --- Failed steps:
 
-        Then I should have 3 apples # features/apples.feature:11
-          Failed asserting that 2 matches expected 3.
+        Scenario: I'm little hungry   # features/apples.feature:9
+          Then I should have 3 apples # features/apples.feature:11
+            Failed asserting that 2 matches expected 3.
 
-        Then I should have 8 apples # features/apples.feature:24
-          Failed asserting that 7 matches expected 8.
+        Example: | 0   | 4     | 8      | # features/apples.feature:29
+          Then I should have 8 apples     # features/apples.feature:24
+            Failed asserting that 7 matches expected 8.
 
     2 scenarios (2 failed)
     7 steps (5 passed, 2 failed)
@@ -177,8 +181,9 @@ Feature: Rerun
 
     --- Failed steps:
 
-        Then I should have 3 apples # features/apples.feature:11
-          Failed asserting that 2 matches expected 3.
+        Scenario: I'm little hungry   # features/apples.feature:9
+          Then I should have 3 apples # features/apples.feature:11
+            Failed asserting that 2 matches expected 3.
 
     1 scenario (1 failed)
     3 steps (2 passed, 1 failed)

--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -155,8 +155,9 @@ Feature: Different result types
 
       --- Pending steps:
 
-          Given human have ordered very very very hot "coffee" # FeatureContext::humanOrdered()
-            TODO: write pending definition
+          Scenario: When the coffee ready                        # features/coffee.feature:9
+            Given human have ordered very very very hot "coffee" # FeatureContext::humanOrdered()
+              TODO: write pending definition
 
       1 scenario (1 undefined)
       3 steps (1 undefined, 1 pending, 1 skipped)
@@ -178,8 +179,9 @@ Feature: Different result types
 
       --- Pending steps:
 
-          Given human have ordered very very very hot "coffee" # FeatureContext::humanOrdered()
-            TODO: write pending definition
+          Scenario: When the coffee ready                        # features/coffee.feature:9
+            Given human have ordered very very very hot "coffee" # FeatureContext::humanOrdered()
+              TODO: write pending definition
 
       1 scenario (1 undefined)
       3 steps (1 undefined, 1 pending, 1 skipped)
@@ -249,11 +251,13 @@ Feature: Different result types
 
       --- Failed steps:
 
-          Then I should see 12$ on the screen # features/coffee.feature:10
-            Failed asserting that 10 matches expected '12'.
+          Scenario: Check thrown amount         # features/coffee.feature:9
+            Then I should see 12$ on the screen # features/coffee.feature:10
+              Failed asserting that 10 matches expected '12'.
 
-          Then I should see 31$ on the screen # features/coffee.feature:14
-            Failed asserting that 30 matches expected '31'.
+          Scenario: Additional throws           # features/coffee.feature:12
+            Then I should see 31$ on the screen # features/coffee.feature:14
+              Failed asserting that 30 matches expected '31'.
 
       2 scenarios (2 failed)
       6 steps (3 passed, 2 failed, 1 skipped)
@@ -335,11 +339,13 @@ Feature: Different result types
 
       --- Failed steps:
 
-          Given I have no water # features/coffee.feature:10
-            NO water in coffee machine!!! (Exception)
+          Scenario: I have no water # features/coffee.feature:9
+            Given I have no water   # features/coffee.feature:10
+              NO water in coffee machine!!! (Exception)
 
-          And I have no electricity # features/coffee.feature:17
-            NO electricity in coffee machine!!! (Exception)
+          Scenario: I have no electricity # features/coffee.feature:15
+            And I have no electricity     # features/coffee.feature:17
+              NO electricity in coffee machine!!! (Exception)
 
       2 scenarios (2 failed)
       10 steps (3 passed, 2 failed, 5 skipped)
@@ -393,10 +399,11 @@ Feature: Different result types
 
       --- Failed steps:
 
-          Given human have chosen "Latte" # features/coffee.feature:7
-            Ambiguous match of "human have chosen "Latte"":
-            to `/^human have chosen "([^"]*)"$/` from FeatureContext::chosen()
-            to `/^human have chosen "Latte"$/` from FeatureContext::chosenLatte()
+          Scenario: Ambiguous coffee type   # features/coffee.feature:6
+            Given human have chosen "Latte" # features/coffee.feature:7
+              Ambiguous match of "human have chosen "Latte"":
+              to `/^human have chosen "([^"]*)"$/` from FeatureContext::chosen()
+              to `/^human have chosen "Latte"$/` from FeatureContext::chosenLatte()
 
       1 scenario (1 failed)
       2 steps (1 failed, 1 skipped)
@@ -485,8 +492,9 @@ Feature: Different result types
 
       --- Failed steps:
 
-          Given customer bought coffee # features/coffee.feature:7
-            User Error: some error in features/bootstrap/FeatureContext.php line 12
+          Scenario: Redundant menu       # features/coffee.feature:6
+            Given customer bought coffee # features/coffee.feature:7
+              User Error: some error in features/bootstrap/FeatureContext.php line 12
 
       1 scenario (1 failed)
       2 steps (1 failed, 1 skipped)

--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -155,7 +155,7 @@ Feature: Different result types
 
       --- Pending steps:
 
-          Scenario: When the coffee ready                        # features/coffee.feature:9
+      001 Scenario: When the coffee ready                        # features/coffee.feature:9
             Given human have ordered very very very hot "coffee" # FeatureContext::humanOrdered()
               TODO: write pending definition
 
@@ -179,7 +179,7 @@ Feature: Different result types
 
       --- Pending steps:
 
-          Scenario: When the coffee ready                        # features/coffee.feature:9
+      001 Scenario: When the coffee ready                        # features/coffee.feature:9
             Given human have ordered very very very hot "coffee" # FeatureContext::humanOrdered()
               TODO: write pending definition
 
@@ -251,11 +251,11 @@ Feature: Different result types
 
       --- Failed steps:
 
-          Scenario: Check thrown amount         # features/coffee.feature:9
+      001 Scenario: Check thrown amount         # features/coffee.feature:9
             Then I should see 12$ on the screen # features/coffee.feature:10
               Failed asserting that 10 matches expected '12'.
 
-          Scenario: Additional throws           # features/coffee.feature:12
+      002 Scenario: Additional throws           # features/coffee.feature:12
             Then I should see 31$ on the screen # features/coffee.feature:14
               Failed asserting that 30 matches expected '31'.
 
@@ -339,11 +339,11 @@ Feature: Different result types
 
       --- Failed steps:
 
-          Scenario: I have no water # features/coffee.feature:9
+      001 Scenario: I have no water # features/coffee.feature:9
             Given I have no water   # features/coffee.feature:10
               NO water in coffee machine!!! (Exception)
 
-          Scenario: I have no electricity # features/coffee.feature:15
+      002 Scenario: I have no electricity # features/coffee.feature:15
             And I have no electricity     # features/coffee.feature:17
               NO electricity in coffee machine!!! (Exception)
 
@@ -399,7 +399,7 @@ Feature: Different result types
 
       --- Failed steps:
 
-          Scenario: Ambiguous coffee type   # features/coffee.feature:6
+      001 Scenario: Ambiguous coffee type   # features/coffee.feature:6
             Given human have chosen "Latte" # features/coffee.feature:7
               Ambiguous match of "human have chosen "Latte"":
               to `/^human have chosen "([^"]*)"$/` from FeatureContext::chosen()
@@ -492,7 +492,7 @@ Feature: Different result types
 
       --- Failed steps:
 
-          Scenario: Redundant menu       # features/coffee.feature:6
+      001 Scenario: Redundant menu       # features/coffee.feature:6
             Given customer bought coffee # features/coffee.feature:7
               User Error: some error in features/bootstrap/FeatureContext.php line 12
 

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -156,11 +156,13 @@ Feature: Snippets
 
       --- Pending steps:
 
-          Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
-            TODO: write pending definition
+          Scenario: Single quotes              # features/coffee.feature:6
+            Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
+              TODO: write pending definition
 
-          Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
-            TODO: write pending definition
+          Scenario: Double quotes              # features/coffee.feature:18
+            Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
+              TODO: write pending definition
 
       2 scenarios (2 pending)
       11 steps (2 pending, 9 skipped)
@@ -257,11 +259,13 @@ Feature: Snippets
 
       --- Pending steps:
 
-          Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
-            TODO: write pending definition
+          Scenario: Single quotes              # features/coffee.feature:6
+            Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
+              TODO: write pending definition
 
-          Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
-            TODO: write pending definition
+          Scenario: Double quotes              # features/coffee.feature:18
+            Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
+              TODO: write pending definition
 
       2 scenarios (2 pending)
       11 steps (2 pending, 9 skipped)

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -156,11 +156,11 @@ Feature: Snippets
 
       --- Pending steps:
 
-          Scenario: Single quotes              # features/coffee.feature:6
+      001 Scenario: Single quotes              # features/coffee.feature:6
             Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
               TODO: write pending definition
 
-          Scenario: Double quotes              # features/coffee.feature:18
+      002 Scenario: Double quotes              # features/coffee.feature:18
             Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
               TODO: write pending definition
 
@@ -259,11 +259,11 @@ Feature: Snippets
 
       --- Pending steps:
 
-          Scenario: Single quotes              # features/coffee.feature:6
+      001 Scenario: Single quotes              # features/coffee.feature:6
             Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
               TODO: write pending definition
 
-          Scenario: Double quotes              # features/coffee.feature:18
+      002 Scenario: Double quotes              # features/coffee.feature:18
             Given I have magically created 10$ # FeatureContext::iHaveMagicallyCreated()
               TODO: write pending definition
 

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -214,7 +214,7 @@ final class ListPrinter
      */
     private function printStepStat(OutputPrinter $printer, $number, StepStatV2 $stat, $style)
     {
-        $maxLength = max(mb_strlen($stat->getScenarioText()), mb_strlen($stat->getStepText()) + 2) + 1;
+        $maxLength = max(mb_strlen($stat->getScenarioText(), 'utf8'), mb_strlen($stat->getStepText(), 'utf8') + 2) + 1;
 
         $printer->writeln(
             sprintf('%03d {+%s}%s{-%s}%s{+comment}# %s{-comment}',
@@ -222,7 +222,7 @@ final class ListPrinter
                 $style,
                 $stat->getScenarioText(),
                 $style,
-                str_pad(' ', $maxLength - mb_strlen($stat->getScenarioText())),
+                str_pad(' ', $maxLength - mb_strlen($stat->getScenarioText(), 'utf8')),
                 $this->relativizePaths($stat->getScenarioPath())
             )
         );
@@ -232,7 +232,7 @@ final class ListPrinter
                 $style,
                 $stat->getStepText(),
                 $style,
-                str_pad(' ', $maxLength - mb_strlen($stat->getStepText()) - 2),
+                str_pad(' ', $maxLength - mb_strlen($stat->getStepText(), 'utf8') - 2),
                 $this->relativizePaths($stat->getStepPath())
             )
         );

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -109,9 +109,9 @@ final class ListPrinter
 
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
 
-        foreach ($stepStats as $stepStat) {
+        foreach ($stepStats as $num => $stepStat) {
             if ($stepStat instanceof StepStatV2) {
-                $this->printStepStat($printer, $stepStat, $style);
+                $this->printStepStat($printer, $num + 1, $stepStat, $style);
             } elseif ($stepStat instanceof StepStat) {
                 $this->printStat($printer, $stepStat->getText(), $stepStat->getPath(), $style, $stepStat->getStdOut(), $stepStat->getError());
             }
@@ -208,15 +208,17 @@ final class ListPrinter
      * Prints hook stat.
      *
      * @param OutputPrinter $printer
+     * @param integer       $number
      * @param StepStatV2    $stat
      * @param string        $style
      */
-    private function printStepStat(OutputPrinter $printer, StepStatV2 $stat, $style)
+    private function printStepStat(OutputPrinter $printer, $number, StepStatV2 $stat, $style)
     {
         $maxLength = max(mb_strlen($stat->getScenarioText()), mb_strlen($stat->getStepText()) + 2) + 1;
 
         $printer->writeln(
-            sprintf('    {+%s}%s{-%s}%s{+comment}# %s{-comment}',
+            sprintf('%03d {+%s}%s{-%s}%s{+comment}# %s{-comment}',
+                $number,
                 $style,
                 $stat->getScenarioText(),
                 $style,

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -13,6 +13,7 @@ namespace Behat\Behat\Output\Node\Printer;
 use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
 use Behat\Behat\Output\Statistics\HookStat;
 use Behat\Behat\Output\Statistics\ScenarioStat;
+use Behat\Behat\Output\Statistics\StepStatV2;
 use Behat\Behat\Output\Statistics\StepStat;
 use Behat\Testwork\Exception\ExceptionPresenter;
 use Behat\Testwork\Output\Printer\OutputPrinter;
@@ -109,12 +110,11 @@ final class ListPrinter
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
 
         foreach ($stepStats as $stepStat) {
-            $name = $stepStat->getText();
-            $path = $stepStat->getPath();
-            $stdOut = $stepStat->getStdOut();
-            $error = $stepStat->getError();
-
-            $this->printStat($printer, $name, $path, $style, $stdOut, $error);
+            if ($stepStat instanceof StepStatV2) {
+                $this->printStepStat($printer, $stepStat, $style);
+            } elseif ($stepStat instanceof StepStat) {
+                $this->printStat($printer, $stepStat->getText(), $stepStat->getPath(), $style, $stepStat->getStdOut(), $stepStat->getError());
+            }
         }
     }
 
@@ -136,12 +136,7 @@ final class ListPrinter
 
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
         foreach ($failedHookStats as $hookStat) {
-            $name = $hookStat->getName();
-            $path = $hookStat->getPath();
-            $stdOut = $hookStat->getStdOut();
-            $error = $hookStat->getError();
-
-            $this->printStat($printer, $name, $path, $style, $stdOut, $error);
+            $this->printHookStat($printer, $hookStat, $style);
         }
     }
 
@@ -154,6 +149,8 @@ final class ListPrinter
      * @param string        $style
      * @param null|string   $stdOut
      * @param null|string   $error
+     *
+     * @deprecated Remove in 4.0
      */
     private function printStat(OutputPrinter $printer, $name, $path, $style, $stdOut, $error)
     {
@@ -170,6 +167,84 @@ final class ListPrinter
 
         if ($error) {
             $exceptionString = implode("\n", array_map($pad, explode("\n", $error)));
+            $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $exceptionString, $style));
+        }
+
+        $printer->writeln();
+    }
+
+    /**
+     * Prints hook stat.
+     *
+     * @param OutputPrinter $printer
+     * @param HookStat      $hookStat
+     * @param string        $style
+     */
+    private function printHookStat(OutputPrinter $printer, HookStat $hookStat, $style)
+    {
+        $printer->writeln(
+            sprintf('    {+%s}%s{-%s} {+comment}# %s{-comment}',
+                $style, $hookStat->getName(), $style, $this->relativizePaths($hookStat->getPath())
+            )
+        );
+
+        $pad = function ($line) { return '      ' . $line; };
+
+        if (null !== $hookStat->getStdOut()) {
+            $padText = function ($line) { return '      │ ' . $line; };
+            $stdOutString = array_map($padText, explode("\n", $hookStat->getStdOut()));
+            $printer->writeln(implode("\n", $stdOutString));
+        }
+
+        if ($hookStat->getError()) {
+            $exceptionString = implode("\n", array_map($pad, explode("\n", $hookStat->getError())));
+            $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $exceptionString, $style));
+        }
+
+        $printer->writeln();
+    }
+
+    /**
+     * Prints hook stat.
+     *
+     * @param OutputPrinter $printer
+     * @param StepStatV2    $stat
+     * @param string        $style
+     */
+    private function printStepStat(OutputPrinter $printer, StepStatV2 $stat, $style)
+    {
+        $maxLength = max(mb_strlen($stat->getScenarioText()), mb_strlen($stat->getStepText()) + 2) + 1;
+
+        $printer->writeln(
+            sprintf('    {+%s}%s{-%s}%s{+comment}# %s{-comment}',
+                $style,
+                $stat->getScenarioText(),
+                $style,
+                str_pad(' ', $maxLength - mb_strlen($stat->getScenarioText())),
+                $this->relativizePaths($stat->getScenarioPath())
+            )
+        );
+
+        $printer->writeln(
+            sprintf('      {+%s}%s{-%s}%s{+comment}# %s{-comment}',
+                $style,
+                $stat->getStepText(),
+                $style,
+                str_pad(' ', $maxLength - mb_strlen($stat->getStepText()) - 2),
+                $this->relativizePaths($stat->getStepPath())
+            )
+        );
+
+        $pad = function ($line) { return '        ' . $line; };
+
+        if (null !== $stat->getStdOut()) {
+            $padText = function ($line) { return '        │ ' . $line; };
+            $stdOutString = array_map($padText, explode("\n", $stat->getStdOut()));
+            $printer->writeln(implode("\n", $stdOutString));
+        }
+
+        if ($stat->getError()) {
+            $exceptionString = implode("\n", array_map($pad, explode("\n", $stat->getError())));
             $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $exceptionString, $style));
         }
 

--- a/src/Behat/Behat/Output/Statistics/StepStatV2.php
+++ b/src/Behat/Behat/Output/Statistics/StepStatV2.php
@@ -11,22 +11,28 @@
 namespace Behat\Behat\Output\Statistics;
 
 /**
- * Behat step stat.
+ * Second iteration of Behat step stat, with a scenario information.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @deprecated in favour of StepStatV2 and to be removed in 4.0
  */
-class StepStat
+final class StepStatV2 extends StepStat
 {
     /**
      * @var string
      */
-    private $text;
+    private $scenarioTitle;
     /**
      * @var string
      */
-    private $path;
+    private $scenarioPath;
+    /**
+     * @var string
+     */
+    private $stepText;
+    /**
+     * @var string
+     */
+    private $stepPath;
     /**
      * @var integer
      */
@@ -43,19 +49,45 @@ class StepStat
     /**
      * Initializes step stat.
      *
-     * @param string      $text
-     * @param string      $path
+     * @param string      $scenarioTitle
+     * @param string      $scenarioPath
+     * @param string      $stepText
+     * @param string      $stepPath
      * @param integer     $resultCode
      * @param null|string $error
      * @param null|string $stdOut
      */
-    public function __construct($text, $path, $resultCode, $error = null, $stdOut = null)
+    public function __construct($scenarioTitle, $scenarioPath, $stepText, $stepPath, $resultCode, $error = null, $stdOut = null)
     {
-        $this->text = $text;
-        $this->path = $path;
+        parent::__construct($stepText, $stepPath, $resultCode, $error, $stdOut);
+
+        $this->scenarioTitle = $scenarioTitle;
+        $this->scenarioPath = $scenarioPath;
+        $this->stepText = $stepText;
+        $this->stepPath = $stepPath;
         $this->resultCode = $resultCode;
         $this->error = $error;
         $this->stdOut = $stdOut;
+    }
+
+    /**
+     * Returns associated scenario text.
+     *
+     * @return string
+     */
+    public function getScenarioText()
+    {
+        return $this->scenarioTitle;
+    }
+
+    /**
+     * Returns associated scenario path.
+     *
+     * @return string
+     */
+    public function getScenarioPath()
+    {
+        return $this->scenarioPath;
     }
 
     /**
@@ -63,9 +95,9 @@ class StepStat
      *
      * @return string
      */
-    public function getText()
+    public function getStepText()
     {
-        return $this->text;
+        return $this->stepText;
     }
 
     /**
@@ -73,9 +105,9 @@ class StepStat
      *
      * @return string
      */
-    public function getPath()
+    public function getStepPath()
     {
-        return $this->path;
+        return $this->stepPath;
     }
 
     /**


### PR DESCRIPTION
Change in scenario:

```diff
-          Then I should have 5 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 5.
+          002 Scenario: I'm little hungry   # features/apples.feature:9
+                Then I should have 5 apples # features/apples.feature:11
+                  Failed asserting that 2 matches expected 5.
```

Change in outline example:

```diff
-          Then I should have 4 apples # features/apples.feature:20
-            Failed asserting that 3 matches expected 4.
+          001 Example: | 2   | 2     | 4      | # features/apples.feature:26
+                Then I should have 4 apples     # features/apples.feature:20
+                  Failed asserting that 3 matches expected 4.
```

Closes #688