### PR TITLE
Append snippets revamp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
 
     "require-dev": {
-        "symfony/process": "~2.1|~3.0",
+        "symfony/process": "~2.5|~3.0",
         "phpunit/phpunit": "~4.5",
         "herrera-io/box": "~1.6.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-mbstring":                  "*",
         "behat/gherkin":                 "~4.4",
         "behat/transliterator":          "~1.0",
-        "symfony/console":               "~2.1||~3.0",
+        "symfony/console":               "~2.5||~3.0",
         "symfony/config":                "~2.3||~3.0",
         "symfony/dependency-injection":  "~2.1||~3.0",
         "symfony/event-dispatcher":      "~2.1||~3.0",

--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -8,17 +8,15 @@ Feature: Append snippets option
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $apples = 0;
           private $parameters;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           public function __construct(array $parameters = array()) {
               $this->parameters = $parameters;
@@ -120,22 +118,20 @@ Feature: Append snippets option
       """
 
   Scenario: Append snippets to main context
-    When I run "behat -f progress --append-snippets"
+    When I run "behat -f progress --append-snippets --snippets-for=FeatureContext --snippets-type=regex"
     Then "features/bootstrap/FeatureContext.php" file should contain:
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $apples = 0;
           private $parameters;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           public function __construct(array $parameters = array()) {
               $this->parameters = $parameters;
@@ -233,16 +229,14 @@ Feature: Append snippets option
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext;
+      use Behat\Behat\Context\Context;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $apples = 0;
           private $parameters;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           public function __construct(array $parameters = array()) {
               $this->parameters = $parameters;
@@ -294,22 +288,20 @@ Feature: Append snippets option
           private function doSomethingUndefinedWith() {}
       }
       """
-    When I run "behat -f progress --append-snippets"
+    When I run "behat -f progress --append-snippets --snippets-for=FeatureContext --snippets-type=regex"
     Then "features/bootstrap/FeatureContext.php" file should contain:
       """
       <?php
 
       use Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Behat\Context\CustomSnippetAcceptingContext;
+      use Behat\Behat\Context\Context;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $apples = 0;
           private $parameters;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           public function __construct(array $parameters = array()) {
               $this->parameters = $parameters;
@@ -407,14 +399,12 @@ Feature: Append snippets option
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext;
+      use Behat\Behat\Context\Context;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $apples = 0;
           private $parameters;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           public function __construct(array $parameters = array()) {
               $this->parameters = $parameters;
@@ -466,7 +456,7 @@ Feature: Append snippets option
           private function doSomethingUndefinedWith() {}
       }
       """
-    When I run "behat -f progress --append-snippets"
+    When I run "behat -f progress --append-snippets --snippets-for=FeatureContext --snippets-type=regex"
     Then "features/bootstrap/FeatureContext.php" file should contain:
       """
       <?php
@@ -474,14 +464,12 @@ Feature: Append snippets option
       use Behat\Gherkin\Node\TableNode;
       use Behat\Gherkin\Node\PyStringNode;
       use Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Behat\Context\CustomSnippetAcceptingContext;
+      use Behat\Behat\Context\Context;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $apples = 0;
           private $parameters;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           public function __construct(array $parameters = array()) {
               $this->parameters = $parameters;
@@ -573,260 +561,6 @@ Feature: Append snippets option
           }
       }
       """
-
-    Scenario: Append snippets to two contexts
-      Given a file named "features/bootstrap/FirstContext.php" with:
-        """
-        <?php
-
-        use Behat\Behat\Tester\Exception\PendingException;
-        use Behat\Behat\Context\CustomSnippetAcceptingContext;
-        use Behat\Gherkin\Node\TableNode;
-        use Behat\Gherkin\Node\PyStringNode;
-
-        class FirstContext implements CustomSnippetAcceptingContext
-        {
-            public static function getAcceptedSnippetType() { return 'regex'; }
-        }
-        """
-      And a file named "features/bootstrap/SecondContext.php" with:
-        """
-        <?php
-
-        use Behat\Behat\Tester\Exception\PendingException;
-        use Behat\Behat\Context\SnippetAcceptingContext;
-        use Behat\Gherkin\Node\TableNode;
-        use Behat\Gherkin\Node\PyStringNode;
-
-        class SecondContext implements SnippetAcceptingContext
-        {
-        }
-        """
-      And a file named "behat.yml" with:
-        """
-        default:
-          suites:
-            first:
-              contexts: [ FirstContext ]
-            second:
-              contexts: [ SecondContext ]
-        """
-      When I run "behat -f progress --append-snippets --no-colors"
-      Then it should pass with:
-        """
-        UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU
-
-        14 scenarios (14 undefined)
-        58 steps (58 undefined)
-
-        u features/bootstrap/FirstContext.php - `I have 3 apples` definition added
-        u features/bootstrap/FirstContext.php - `I ate 1 apple` definition added
-        u features/bootstrap/FirstContext.php - `I should have 3 apples` definition added
-        u features/bootstrap/FirstContext.php - `I found 5 apples` definition added
-        u features/bootstrap/FirstContext.php - `do something undefined with $` definition added
-        u features/bootstrap/FirstContext.php - `I ate 3 apples` definition added
-        u features/bootstrap/FirstContext.php - `do something undefined with \1` definition added
-        u features/bootstrap/FirstContext.php - `pystring:` definition added
-        u features/bootstrap/FirstContext.php - `pystring 5:` definition added
-        u features/bootstrap/FirstContext.php - `table:` definition added
-        u features/bootstrap/SecondContext.php - `I have 3 apples` definition added
-        u features/bootstrap/SecondContext.php - `I ate 1 apple` definition added
-        u features/bootstrap/SecondContext.php - `I should have 3 apples` definition added
-        u features/bootstrap/SecondContext.php - `I found 5 apples` definition added
-        u features/bootstrap/SecondContext.php - `do something undefined with $` definition added
-        u features/bootstrap/SecondContext.php - `I ate 3 apples` definition added
-        u features/bootstrap/SecondContext.php - `do something undefined with \1` definition added
-        u features/bootstrap/SecondContext.php - `pystring:` definition added
-        u features/bootstrap/SecondContext.php - `pystring 5:` definition added
-        u features/bootstrap/SecondContext.php - `table:` definition added
-        """
-      And "features/bootstrap/FirstContext.php" file should contain:
-        """
-        <?php
-
-        use Behat\Behat\Tester\Exception\PendingException;
-        use Behat\Behat\Context\CustomSnippetAcceptingContext;
-        use Behat\Gherkin\Node\TableNode;
-        use Behat\Gherkin\Node\PyStringNode;
-
-        class FirstContext implements CustomSnippetAcceptingContext
-        {
-            public static function getAcceptedSnippetType() { return 'regex'; }
-
-            /**
-             * @Given /^I have (\d+) apples$/
-             */
-            public function iHaveApples($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @When /^I ate (\d+) apple$/
-             */
-            public function iAteApple($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Then /^I should have (\d+) apples$/
-             */
-            public function iShouldHaveApples($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @When /^I found (\d+) apples$/
-             */
-            public function iFoundApples($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Then /^do something undefined with \$$/
-             */
-            public function doSomethingUndefinedWith()
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @When /^I ate (\d+) apples$/
-             */
-            public function iAteApples($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Then /^do something undefined with \\(\d+)$/
-             */
-            public function doSomethingUndefinedWith2($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Given /^pystring:$/
-             */
-            public function pystring(PyStringNode $string)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Given /^pystring (\d+):$/
-             */
-            public function pystring2($arg1, PyStringNode $string)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Given /^table:$/
-             */
-            public function table(TableNode $table)
-            {
-                throw new PendingException();
-            }
-        }
-        """
-      And "features/bootstrap/SecondContext.php" file should contain:
-        """
-        <?php
-
-        use Behat\Behat\Tester\Exception\PendingException;
-        use Behat\Behat\Context\SnippetAcceptingContext;
-        use Behat\Gherkin\Node\TableNode;
-        use Behat\Gherkin\Node\PyStringNode;
-
-        class SecondContext implements SnippetAcceptingContext
-        {
-
-            /**
-             * @Given I have :arg1 apples
-             */
-            public function iHaveApples($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @When I ate :arg1 apple
-             */
-            public function iAteApple($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Then I should have :arg1 apples
-             */
-            public function iShouldHaveApples($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @When I found :arg1 apples
-             */
-            public function iFoundApples($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Then do something undefined with $
-             */
-            public function doSomethingUndefinedWith()
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @When I ate :arg1 apples
-             */
-            public function iAteApples($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Then do something undefined with \:arg1
-             */
-            public function doSomethingUndefinedWith2($arg1)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Given pystring:
-             */
-            public function pystring(PyStringNode $string)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Given pystring :arg1:
-             */
-            public function pystring2($arg1, PyStringNode $string)
-            {
-                throw new PendingException();
-            }
-
-            /**
-             * @Given table:
-             */
-            public function table(TableNode $table)
-            {
-                throw new PendingException();
-            }
-        }
-        """
 
   Scenario: Append snippets to accepting context only
     Given a file named "features/bootstrap/FirstContext.php" with:
@@ -834,13 +568,12 @@ Feature: Append snippets option
       <?php
 
       use Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Behat\Context\CustomSnippetAcceptingContext;
+      use Behat\Behat\Context\Context;
       use Behat\Gherkin\Node\TableNode;
       use Behat\Gherkin\Node\PyStringNode;
 
-      class FirstContext implements CustomSnippetAcceptingContext
+      class FirstContext implements Context
       {
-          public static function getAcceptedSnippetType() { return 'regex'; }
       }
       """
     And a file named "features/bootstrap/SecondContext.php" with:
@@ -863,7 +596,7 @@ Feature: Append snippets option
           second:
             contexts: [ SecondContext ]
       """
-    When I run "behat -f progress --append-snippets --no-colors"
+    When I run "behat -f progress --append-snippets --snippets-for=FirstContext --snippets-type=regex --no-colors"
     Then it should pass with:
       """
       UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU
@@ -909,13 +642,12 @@ Feature: Append snippets option
       <?php
 
       use Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Behat\Context\CustomSnippetAcceptingContext;
+      use Behat\Behat\Context\Context;
       use Behat\Gherkin\Node\TableNode;
       use Behat\Gherkin\Node\PyStringNode;
 
-      class FirstContext implements CustomSnippetAcceptingContext
+      class FirstContext implements Context
       {
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given /^I have (\d+) apples$/

--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -871,7 +871,7 @@ Feature: Append snippets option
       14 scenarios (14 undefined)
       58 steps (58 undefined)
 
-      --- Snippets for the following steps in the second suite were not generated (does your context implement SnippetAcceptingContext interface?):
+      --- Use --snippets-for CLI option to generate snippets for following second suite steps:
 
           Given I have 3 apples
           When I ate 1 apple

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -166,12 +166,7 @@ class FeatureContext implements Context
         $env['SHELL_INTERACTIVE'] = true;
 
         $this->process->setEnv($env);
-
-        if (method_exists($this->process, 'setStdin')) {
-            $this->process->setStdin($answerString);
-        } else {
-            $this->process->setInput($answerString);
-        }
+        $this->process->setInput($answerString);
 
         $this->iRunBehat($argumentsString);
     }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -166,7 +166,12 @@ class FeatureContext implements Context
         $env['SHELL_INTERACTIVE'] = true;
 
         $this->process->setEnv($env);
-        $this->process->setInput($answerString);
+
+        if (method_exists($this->process, 'setStdin')) {
+            $this->process->setStdin($answerString);
+        } else {
+            $this->process->setInput($answerString);
+        }
 
         $this->iRunBehat($argumentsString);
     }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -66,6 +66,7 @@ class FeatureContext implements Context
         $this->workingDir = $dir;
         $this->phpBin = $php;
         $this->process = new Process(null);
+        $this->process->setTimeout(10);
     }
 
     /**
@@ -147,8 +148,26 @@ class FeatureContext implements Context
             $this->process->setEnv($env);
         }
 
-        $this->process->start();
-        $this->process->wait();
+        $this->process->run();
+    }
+
+    /**
+     * Runs behat command with provided parameters in interactive mode
+     *
+     * @When /^I answer "([^"]+)" when running "behat(?: ((?:\"|[^"])*))?"$/
+     *
+     * @param string $answerString
+     * @param string $argumentsString
+     */
+    public function iRunBehatInteractively($answerString, $argumentsString)
+    {
+        $env = $this->process->getEnv();
+        $env['SHELL_INTERACTIVE'] = true;
+
+        $this->process->setEnv($env);
+        $this->process->setInput("0");
+
+        $this->iRunBehat($argumentsString);
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -10,6 +10,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
+use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -165,7 +166,7 @@ class FeatureContext implements Context
         $env['SHELL_INTERACTIVE'] = true;
 
         $this->process->setEnv($env);
-        $this->process->setInput("0");
+        $this->process->setInput($answerString);
 
         $this->iRunBehat($argumentsString);
     }

--- a/features/config.feature
+++ b/features/config.feature
@@ -31,7 +31,7 @@ Feature: Config
       1 scenario (1 undefined)
       1 step (1 undefined)
 
-      --- Snippets for the following steps in the default suite were not generated (does your context implement SnippetAcceptingContext interface?):
+      --- Use --snippets-for CLI option to generate snippets for following default suite steps:
 
           When this scenario executes
       """
@@ -64,7 +64,7 @@ Feature: Config
       1 scenario (1 undefined)
       1 step (1 undefined)
 
-      --- Snippets for the following steps in the default suite were not generated (does your context implement SnippetAcceptingContext interface?):
+      --- Use --snippets-for CLI option to generate snippets for following default suite steps:
 
           When this scenario executes
       """

--- a/features/context.feature
+++ b/features/context.feature
@@ -8,7 +8,7 @@ Feature: Context consistency
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
@@ -66,23 +66,21 @@ Feature: Context consistency
           }
       }
 
-      class FeatureContext extends CoreContext implements CustomSnippetAcceptingContext
+      class FeatureContext extends CoreContext implements Context
       {
-          public static function getAcceptedSnippetType() { return 'regex'; }
       }
       """
     And a file named "features/bootstrap/CustomContext.php" with:
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class CustomContext implements CustomSnippetAcceptingContext
+      class CustomContext implements Context
       {
-          public static function getAcceptedSnippetType() { return 'regex'; }
       }
       """
 
@@ -264,7 +262,7 @@ Feature: Context consistency
           Then context parameter "parameter1" should be equal to "val_one"
           And context parameter "parameter2" should be array with 2 elements
       """
-  When I run "behat --no-colors -f progress features/params.feature"
+  When I run "behat --no-colors -f progress --snippets-type=regex --snippets-for=CustomContext features/params.feature"
   Then it should pass with:
     """
     UU

--- a/features/context.feature
+++ b/features/context.feature
@@ -407,7 +407,7 @@ Feature: Context consistency
       1 scenario (1 undefined)
       3 steps (3 undefined)
 
-      --- Snippets for the following steps in the first suite were not generated (does your context implement SnippetAcceptingContext interface?):
+      --- Use --snippets-for CLI option to generate snippets for following first suite steps:
 
           Given I have 3 apples
           When I ate 1 apple

--- a/features/format_options.feature
+++ b/features/format_options.feature
@@ -8,17 +8,15 @@ Feature: Format options
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $apples = 0;
           private $parameters;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           public function __construct(array $parameters = array()) {
               $this->parameters = $parameters;
@@ -113,7 +111,7 @@ Feature: Format options
       """
 
   Scenario: --no-colors option
-    When I run "behat --no-colors"
+    When I run "behat --no-colors --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Feature: Apples story
@@ -195,7 +193,7 @@ Feature: Format options
       """
 
   Scenario: --no-paths option
-    When I run "behat --no-colors --format-settings='{\"paths\": false}'"
+    When I run "behat --no-colors --format-settings='{\"paths\": false}' --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Feature: Apples story
@@ -333,7 +331,7 @@ Feature: Format options
       """
 
   Scenario: --expand option
-    When I run "behat --no-colors --format-settings='{\"expand\": true}'"
+    When I run "behat --no-colors --format-settings='{\"expand\": true}' --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Feature: Apples story
@@ -424,7 +422,7 @@ Feature: Format options
       """
 
   Scenario: --no-multiline option
-    When I run "behat --no-colors --format-settings='{\"multiline\": false}'"
+    When I run "behat --no-colors --format-settings='{\"multiline\": false}' --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Feature: Apples story

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -8,16 +8,14 @@ Feature: I18n
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value = 0;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given /Я ввел (\d+)/
@@ -86,7 +84,7 @@ Feature: I18n
       """
 
   Scenario: Pretty
-    When I run "behat --no-colors -f pretty --lang=ru"
+    When I run "behat --no-colors -f pretty --lang=ru --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Функционал: Постоянство мира
@@ -147,7 +145,7 @@ Feature: I18n
       """
 
   Scenario: Progress
-    When I run "behat --no-colors -f progress --lang=ru"
+    When I run "behat --no-colors -f progress --lang=ru --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       ..U-..P-..F...F.......F
@@ -187,7 +185,7 @@ Feature: I18n
       """
 
   Scenario: Progress with unexisting locale
-    When I run "behat --no-colors -f progress --lang=xx"
+    When I run "behat --no-colors -f progress --lang=xx --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       ..U-..P-..F...F.......F
@@ -227,7 +225,7 @@ Feature: I18n
       """
 
   Scenario: Progress with unexisting locale
-    When I run "behat --no-colors -f progress --lang=xx"
+    When I run "behat --no-colors -f progress --lang=xx --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       ..U-..P-..F...F.......F

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -8,14 +8,12 @@
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given /I have entered (\d+)/
@@ -89,7 +87,7 @@
           | 5     | 15     |
           | 10    | 20     |
       """
-    When I run "behat --no-colors -f junit -o junit"
+    When I run "behat --no-colors -f junit -o junit --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       --- FeatureContext has missing steps. Define them with these snippets:
@@ -135,14 +133,12 @@
     """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given /I have entered (\d+)/
@@ -283,13 +279,11 @@
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext;
+      use Behat\Behat\Context\Context;
 
-      class SmallKidContext implements CustomSnippetAcceptingContext
+      class SmallKidContext implements Context
       {
           protected $strongLevel;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given I am not strong
@@ -317,13 +311,11 @@
     """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext;
+      use Behat\Behat\Context\Context;
 
-      class OldManContext implements CustomSnippetAcceptingContext
+      class OldManContext implements Context
       {
           protected $strongLevel;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given I am not strong
@@ -418,14 +410,12 @@
     """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @BeforeScenario
@@ -478,14 +468,12 @@
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given /I have entered (\d+)/
@@ -544,14 +532,12 @@
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given /I have entered (\d+)/
@@ -605,12 +591,11 @@
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
-        public static function getAcceptedSnippetType() { return 'regex'; }
       }
       """
     And a file named "junit.txt" with:
@@ -628,14 +613,12 @@
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @BeforeStep
@@ -686,14 +669,12 @@
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @AfterStep

--- a/features/legacy_snippets.feature
+++ b/features/legacy_snippets.feature
@@ -1,7 +1,7 @@
-Feature: Snippets generation and addition
-  In order to not manually write definitions every time
-  As a feature tester
-  I need tool to generate snippets for me
+Feature: Legacy Snippets
+
+  This is a deprecated usage of snippets and it is planned to go away in 4.0
+  use functionality described in `snippets.feature` instead!
 
   Background:
     Given a file named "features/coffee.feature" with:
@@ -37,19 +37,21 @@ Feature: Snippets generation and addition
             '''
       """
 
-  Scenario: Generating regex snippets for particular context
+  Scenario: Regex snippets
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
-      use Behat\Behat\Context\Context,
+      use Behat\Behat\Context\CustomSnippetAcceptingContext,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements Context {}
+      class FeatureContext implements CustomSnippetAcceptingContext {
+          public static function getAcceptedSnippetType() { return 'regex'; }
+      }
       """
-    When I run "behat --no-colors --snippets-for=FeatureContext --snippets-type=regex -f progress features/coffee.feature"
+    When I run "behat --no-colors -f progress features/coffee.feature"
     Then it should pass with:
       """
       UUUUUUUUUUU
@@ -132,19 +134,21 @@ Feature: Snippets generation and addition
           }
       """
 
-  Scenario: Appending regex snippets to a particular context
+  Scenario: Regex snippets are working
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
-      use Behat\Behat\Context\Context,
+      use Behat\Behat\Context\CustomSnippetAcceptingContext,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements Context {}
+      class FeatureContext implements CustomSnippetAcceptingContext {
+          public static function getAcceptedSnippetType() { return 'regex'; }
+      }
       """
-    When I run "behat --no-colors -f progress --snippets-for=FeatureContext --snippets-type=regex --append-snippets features/coffee.feature"
+    When I run "behat --no-colors -f progress --append-snippets features/coffee.feature"
     And I run "behat --no-colors -f progress features/coffee.feature"
     Then it should pass with:
       """
@@ -164,19 +168,19 @@ Feature: Snippets generation and addition
       11 steps (2 pending, 9 skipped)
       """
 
-  Scenario: Generating turnip snippets for a particular context
+  Scenario: Turnip snippets
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
-      use Behat\Behat\Context\Context,
+      use Behat\Behat\Context\SnippetAcceptingContext,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements Context {}
+      class FeatureContext implements SnippetAcceptingContext { }
       """
-    When I run "behat --no-colors -f progress --snippets-for=FeatureContext features/coffee.feature"
+    When I run "behat --no-colors -f progress features/coffee.feature"
     Then it should pass with:
       """
       UUUUUUUUUUU
@@ -235,19 +239,19 @@ Feature: Snippets generation and addition
           }
       """
 
-  Scenario: Appending turnip snippets to a particular context
+  Scenario: Turnip snippets are working
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
-      use Behat\Behat\Context\Context,
+      use Behat\Behat\Context\SnippetAcceptingContext,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements Context {}
+      class FeatureContext implements SnippetAcceptingContext { }
       """
-    When I run "behat --no-colors -f progress --append-snippets --snippets-for=FeatureContext features/coffee.feature"
+    When I run "behat --no-colors -f progress --append-snippets features/coffee.feature"
     And I run "behat --no-colors -f progress features/coffee.feature"
     Then it should pass with:
       """
@@ -267,14 +271,14 @@ Feature: Snippets generation and addition
       11 steps (2 pending, 9 skipped)
       """
 
-  Scenario: Generating snippets for steps that have numbers with decimal points
+  Scenario: Numbers with decimal points
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
-      use Behat\Behat\Context\Context;
+      use Behat\Behat\Context\SnippetAcceptingContext;
 
-      class FeatureContext implements Context {}
+      class FeatureContext implements SnippetAcceptingContext {}
       """
     And a file named "features/coffee.feature" with:
       """
@@ -283,7 +287,7 @@ Feature: Snippets generation and addition
           Then 5 should have value of £10
           And 7 should have value of £7.2
       """
-    When I run "behat -f progress --no-colors --append-snippets --snippets-for=FeatureContext"
+    When I run "behat -f progress --no-colors --append-snippets"
     And I run "behat -f pretty --no-colors"
     Then it should pass with:
       """
@@ -298,14 +302,17 @@ Feature: Snippets generation and addition
       2 steps (1 pending, 1 skipped)
       """
 
-  Scenario: Generating snippets for steps that have string followed by decimal number
+  Scenario: Parameter with decimal number following string
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
       use Behat\Behat\Context\Context;
+      use Behat\Behat\Context\SnippetAcceptingContext;
 
-      class FeatureContext implements Context {}
+      class FeatureContext implements Context, SnippetAcceptingContext
+      {
+      }
       """
     And a file named "features/coffee.feature" with:
       """
@@ -313,7 +320,7 @@ Feature: Snippets generation and addition
         Scenario:
           Given I have a package v2.5
       """
-    When I run "behat -f progress --no-colors --snippets-for=FeatureContext"
+    When I run "behat -f progress --no-colors"
     Then it should pass with:
       """
       U
@@ -332,14 +339,17 @@ Feature: Snippets generation and addition
           }
       """
 
-  Scenario: Generating snippets for steps with slashes
+  Scenario: Step with slashes
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
       use Behat\Behat\Context\Context;
+      use Behat\Behat\Context\SnippetAcceptingContext;
 
-      class FeatureContext implements Context {}
+      class FeatureContext implements Context, SnippetAcceptingContext
+      {
+      }
       """
     And a file named "features/coffee.feature" with:
       """
@@ -347,7 +357,7 @@ Feature: Snippets generation and addition
         Scenario:
           Then images should be uploaded to web/uploads/media/default/0001/01/
       """
-    When I run "behat -f progress --no-colors --snippets-for=FeatureContext"
+    When I run "behat -f progress --no-colors"
     Then it should pass with:
       """
       U

--- a/features/locale_configuration.feature
+++ b/features/locale_configuration.feature
@@ -8,14 +8,13 @@ Feature: Locale configuration
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
         Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
         Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
-          public static function getAcceptedSnippetType() { return 'regex'; }
       }
       """
 

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -8,17 +8,15 @@ Feature: Multiple formats
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $apples = 0;
           private $parameters;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           public function __construct(array $parameters = array()) {
               $this->parameters = $parameters;
@@ -113,7 +111,7 @@ Feature: Multiple formats
       """
 
   Scenario: 2 formats, default output
-    When I run "behat --no-colors -f pretty -f progress --format-settings='{\"multiline\": false}'"
+    When I run "behat --no-colors -f pretty -f progress --format-settings='{\"multiline\": false}' --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Feature: Apples story
@@ -206,7 +204,7 @@ Feature: Multiple formats
       """
 
   Scenario: 2 formats, same output
-    When I run "behat --no-colors -f pretty -f progress --out=std --format-settings='{\"multiline\": false}'"
+    When I run "behat --no-colors -f pretty -f progress --out=std --format-settings='{\"multiline\": false}' --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Feature: Apples story
@@ -299,7 +297,7 @@ Feature: Multiple formats
       """
 
   Scenario: 2 formats, write first to file
-    When I run "behat --no-colors -f pretty -o apples.pretty -f progress -o std --format-settings='{\"multiline\": false, \"paths\": false}'"
+    When I run "behat --no-colors -f pretty -o apples.pretty -f progress -o std --format-settings='{\"multiline\": false, \"paths\": false}' --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       ..F......U.......F.....UU
@@ -395,7 +393,7 @@ Feature: Multiple formats
       """
 
   Scenario: 2 formats, write second to file
-    When I run "behat --no-colors -f pretty -o std --format=progress --out=apples.progress --format-settings='{\"multiline\": false, \"paths\": false}'"
+    When I run "behat --no-colors -f pretty -o std --format=progress --out=apples.progress --format-settings='{\"multiline\": false, \"paths\": false}' --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Feature: Apples story
@@ -491,7 +489,7 @@ Feature: Multiple formats
       """
 
   Scenario: 2 formats, write both to files
-    When I run "behat --no-colors -f pretty -o app.pretty -f progress -o app.progress --format-settings='{\"multiline\": false, \"paths\": false}'"
+    When I run "behat --no-colors -f pretty -o app.pretty -f progress -o app.progress --format-settings='{\"multiline\": false, \"paths\": false}' --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       --- FeatureContext has missing steps. Define them with these snippets:

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -8,16 +8,14 @@ Feature: Pretty Formatter
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
           private $value;
-
-          public static function getAcceptedSnippetType() { return 'regex'; }
 
           /**
            * @Given /I have entered (\d+)/
@@ -83,7 +81,7 @@ Feature: Pretty Formatter
             |  10   | 20     |
             |  23   | 32     |
       """
-    When I run "behat --no-colors -f pretty"
+    When I run "behat --no-colors -f pretty --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       Feature: World consistency

--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -27,16 +27,14 @@ Feature: Different result types
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext {
-          public static function getAcceptedSnippetType() { return 'regex'; }
-      }
+      class FeatureContext implements Context {}
       """
-    When I run "behat --no-colors -f progress features/coffee.feature"
+    When I run "behat --no-colors -f progress features/coffee.feature --snippets-for=FeatureContext --snippets-type=regex"
     Then it should pass with:
       """
       UUUUUU
@@ -70,7 +68,7 @@ Feature: Different result types
               throw new PendingException();
           }
       """
-    When I run "behat --no-colors --strict -f progress features/coffee.feature"
+    When I run "behat --no-colors --strict -f progress features/coffee.feature --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       UUUUUU
@@ -124,15 +122,13 @@ Feature: Different result types
       """
       <?php
 
-      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+      use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
           Behat\Gherkin\Node\TableNode;
 
-      class FeatureContext implements CustomSnippetAcceptingContext
+      class FeatureContext implements Context
       {
-          public static function getAcceptedSnippetType() { return 'regex'; }
-
           /**
            * @Given /^human have ordered very very very hot "([^"]*)"$/
            */
@@ -148,7 +144,7 @@ Feature: Different result types
           }
       }
       """
-    When I run "behat --no-colors -f progress features/coffee.feature"
+    When I run "behat --no-colors -f progress features/coffee.feature --snippets-for=FeatureContext --snippets-type=regex"
     Then it should pass with:
       """
       P-U
@@ -172,7 +168,7 @@ Feature: Different result types
               throw new PendingException();
           }
       """
-    When I run "behat --no-colors --strict -f progress features/coffee.feature"
+    When I run "behat --no-colors --strict -f progress features/coffee.feature --snippets-for=FeatureContext --snippets-type=regex"
     Then it should fail with:
       """
       P-U

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -365,3 +365,70 @@ Feature: Snippets generation and addition
               throw new PendingException();
           }
       """
+
+  Scenario: Generating snippets using interactive --snippets-for
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context,
+          Behat\Behat\Tester\Exception\PendingException;
+      use Behat\Gherkin\Node\PyStringNode,
+          Behat\Gherkin\Node\TableNode;
+
+      class FeatureContext implements Context {}
+      """
+    When I answer "0" when running "behat --no-colors -f progress --snippets-for"
+    Then it should pass
+    And the output should contain:
+      """
+      --- FeatureContext has missing steps. Define them with these snippets:
+
+          /**
+           * @Given I have magically created :arg1$
+           */
+          public function iHaveMagicallyCreated($arg1)
+          {
+              throw new PendingException();
+          }
+
+          /**
+           * @When I have chose :arg1 in coffee machine
+           */
+          public function iHaveChoseInCoffeeMachine($arg1)
+          {
+              throw new PendingException();
+          }
+
+          /**
+           * @Then I should have :arg1
+           */
+          public function iShouldHave($arg1)
+          {
+              throw new PendingException();
+          }
+
+          /**
+           * @Then I should get a :arg1:
+           */
+          public function iShouldGetA($arg1, PyStringNode $string)
+          {
+              throw new PendingException();
+          }
+
+          /**
+           * @Then I should get a simple string:
+           */
+          public function iShouldGetASimpleString(PyStringNode $string)
+          {
+              throw new PendingException();
+          }
+
+          /**
+           * @When do something undefined with \:arg1
+           */
+          public function doSomethingUndefinedWith($arg1)
+          {
+              throw new PendingException();
+          }
+      """

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -378,7 +378,7 @@ Feature: Snippets generation and addition
 
       class FeatureContext implements Context {}
       """
-    When I answer "0" when running "behat --no-colors -f progress --snippets-for"
+    When I answer "1" when running "behat --no-colors -f progress --snippets-for"
     Then it should pass
     And the output should contain:
       """

--- a/i18n.php
+++ b/i18n.php
@@ -1,7 +1,7 @@
 <?php return array(
     'en'    => array(
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%1%</snippet_keyword> has missing steps. Define them with these snippets:</snippet_undefined>',
-        'snippet_missing_title'   => '<snippet_undefined>Snippets for the following steps in the <snippet_keyword>%1%</snippet_keyword> suite were not generated (does your context implement SnippetAcceptingContext interface?):</snippet_undefined>',
+        'snippet_missing_title'   => '<snippet_undefined>Use <snippet_keyword>--snippets-for</snippet_keyword> CLI option to generate snippets for following <snippet_keyword>%1%</snippet_keyword> suite steps:</snippet_undefined>',
         'skipped_scenarios_title' => 'Skipped scenarios:',
         'failed_scenarios_title'  => 'Failed scenarios:',
         'failed_hooks_title'      => 'Failed hooks:',

--- a/i18n.php
+++ b/i18n.php
@@ -1,5 +1,6 @@
 <?php return array(
     'en'    => array(
+        'snippet_context_choice'  => '<snippet_undefined><snippet_keyword>%1%</snippet_keyword> suite has undefined steps. Please choose the context to generate snippets:</snippet_undefined>',
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%1%</snippet_keyword> has missing steps. Define them with these snippets:</snippet_undefined>',
         'snippet_missing_title'   => '<snippet_undefined>Use <snippet_keyword>--snippets-for</snippet_keyword> CLI option to generate snippets for following <snippet_keyword>%1%</snippet_keyword> suite steps:</snippet_undefined>',
         'skipped_scenarios_title' => 'Skipped scenarios:',

--- a/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
+++ b/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
@@ -10,15 +10,14 @@
 
 namespace Behat\Behat\Context\Cli;
 
-use Behat\Behat\Context\Environment\ContextEnvironment;
 use Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator;
+use Behat\Behat\Context\Snippet\Generator\FixedContextIdentifier;
 use Behat\Testwork\Cli\Controller;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Configures which context snippets are generated for.
@@ -31,13 +30,21 @@ final class ContextSnippetsController implements Controller
      * @var ContextSnippetGenerator
      */
     private $generator;
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
 
     /**
      * Initialises controller.
+     *
+     * @param ContextSnippetGenerator $generator
+     * @param TranslatorInterface     $translator
      */
-    public function __construct(ContextSnippetGenerator $generator)
+    public function __construct(ContextSnippetGenerator $generator, TranslatorInterface $translator)
     {
         $this->generator = $generator;
+        $this->translator = $translator;
     }
 
     /**
@@ -62,41 +69,16 @@ final class ContextSnippetsController implements Controller
     public function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->hasParameterOption('--snippets-for')) {
-            $this->generator->setContextClassGetter($this->createContextClassGetter($input, $output));
+            $identifier =
+                null !== $input->getOption('snippets-for')
+                    ? new FixedContextIdentifier($input->getOption('snippets-for'))
+                    : new InteractiveContextIdentifier($this->translator, $input, $output);
+
+            $this->generator->setContextIdentifier($identifier);
         }
 
         if (null !== $input->getOption('snippets-type')) {
             $this->generator->setSnippetsType($input->getOption('snippets-type'));
         }
-    }
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return \Closure
-     */
-    private function createContextClassGetter(InputInterface $input, OutputInterface $output)
-    {
-        if (null !== $input->getOption('snippets-for')) {
-            return function () use ($input) {
-                return $input->getOption('snippets-for');
-            };
-        }
-
-        return function (ContextEnvironment $environment) use ($input, $output) {
-            $output->writeln('');
-            $helper = new QuestionHelper();
-            $question = new ChoiceQuestion(
-                sprintf(
-                    ' <snippet_undefined><snippet_keyword>%s</snippet_keyword> suite has undefined steps. ' .
-                    'Please choose the context to generate snippets:</snippet_undefined>' . "\n",
-                    $environment->getSuite()->getName()),
-                $environment->getContextClasses(),
-                current($environment->getContextClasses())
-            );
-
-            return $helper->ask($input, $output, $question);
-        };
     }
 }

--- a/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
+++ b/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Cli;
+
+use Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator;
+use Behat\Testwork\Cli\Controller;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Configures which context snippets are generated for.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class ContextSnippetsController implements Controller
+{
+    /**
+     * @var ContextSnippetGenerator
+     */
+    private $generator;
+
+    /**
+     * Initialises controller.
+     */
+    public function __construct(ContextSnippetGenerator $generator)
+    {
+        $this->generator = $generator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(SymfonyCommand $command)
+    {
+        $command
+            ->addOption(
+                '--snippets-for', null, InputOption::VALUE_REQUIRED,
+                "Specifies which context class to generate snippets for."
+            )
+            ->addOption(
+                '--snippets-type', null, InputOption::VALUE_REQUIRED,
+                "Specifies which type of snippets (turnip, regex) to generate."
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (null !== $input->getOption('snippets-for')) {
+            $this->generator->generateSnippetsForContext($input->getOption('snippets-for'));
+        }
+
+        if (null !== $input->getOption('snippets-type')) {
+            $this->generator->generateSnippetType($input->getOption('snippets-type'));
+        }
+    }
+}

--- a/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
+++ b/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Context\Cli;
 
 use Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator;
 use Behat\Behat\Context\Snippet\Generator\FixedContextIdentifier;
+use Behat\Behat\Context\Snippet\Generator\FixedPatternIdentifier;
 use Behat\Testwork\Cli\Controller;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -78,7 +79,7 @@ final class ContextSnippetsController implements Controller
         }
 
         if (null !== $input->getOption('snippets-type')) {
-            $this->generator->setSnippetsType($input->getOption('snippets-type'));
+            $this->generator->setPatternIdentifier(new FixedPatternIdentifier($input->getOption('snippets-type')));
         }
     }
 }

--- a/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
+++ b/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Cli;
+
+use Behat\Behat\Context\Environment\ContextEnvironment;
+use Behat\Behat\Context\Snippet\Generator\TargetContextIdentifier;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Interactive identifier that asks user for input.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class InteractiveContextIdentifier implements TargetContextIdentifier
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+    /**
+     * @var InputInterface
+     */
+    private $input;
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * Initialises identifier.
+     *
+     * @param TranslatorInterface $translator
+     * @param InputInterface      $input
+     * @param OutputInterface     $output
+     */
+    public function __construct(TranslatorInterface $translator, InputInterface $input, OutputInterface $output)
+    {
+        $this->translator = $translator;
+        $this->input = $input;
+        $this->output = $output;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function guessTargetContextClass(ContextEnvironment $environment)
+    {
+        $suiteName = $environment->getSuite()->getName();
+        $contextClasses = $environment->getContextClasses();
+
+        if (!count($contextClasses)) {
+            return null;
+        }
+
+        $message = $this->translator->trans('snippet_context_choice', array('%1%' => $suiteName), 'output');
+        $choices = array_values(array_merge(array('None'), $contextClasses));
+        $default = current($contextClasses);
+
+        $answer = $this->askQuestion($message, $choices, $default);
+
+        return 'None' !== $answer ? $answer : null;
+    }
+
+    /**
+     * Asks user question.
+     *
+     * @param string   $message
+     * @param string[] $choices
+     * @param string   $default
+     *
+     * @return string
+     */
+    private function askQuestion($message, $choices, $default)
+    {
+        $this->output->writeln('');
+        $helper = new QuestionHelper();
+        $question = new ChoiceQuestion(' ' . $message . "\n", $choices, $default);
+
+        return $helper->ask($this->input, $this->output, $question);
+    }
+}

--- a/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
+++ b/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
@@ -68,7 +68,7 @@ final class InteractiveContextIdentifier implements TargetContextIdentifier
         $choices = array_values(array_merge(array('None'), $contextClasses));
         $default = current($contextClasses);
 
-        $answer = $this->askQuestion($message, $choices, $default);
+        $answer = $this->askQuestion('>> ' . $message, $choices, $default);
 
         return 'None' !== $answer ? $answer : null;
     }

--- a/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
@@ -26,14 +26,13 @@ final class SimpleClassGenerator implements ClassGenerator
 <?php
 
 {namespace}use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 
 /**
  * Defines application features from the specific context.
  */
-class {className} implements Context, SnippetAcceptingContext
+class {className} implements Context
 {
     /**
      * Initializes context.

--- a/src/Behat/Behat/Context/CustomSnippetAcceptingContext.php
+++ b/src/Behat/Behat/Context/CustomSnippetAcceptingContext.php
@@ -18,6 +18,8 @@ use Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator;
  * @see ContextSnippetGenerator
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @deprecated will be removed in 4.0. Use --snippets-for and --snippets-type CLI options instead
  */
 interface CustomSnippetAcceptingContext extends SnippetAcceptingContext
 {

--- a/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
+++ b/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
@@ -14,6 +14,7 @@ use Behat\Behat\Definition\ServiceContainer\DefinitionExtension;
 use Behat\Behat\Snippet\ServiceContainer\SnippetExtension;
 use Behat\Testwork\Argument\ServiceContainer\ArgumentExtension;
 use Behat\Testwork\Autoloader\ServiceContainer\AutoloaderExtension;
+use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\Environment\ServiceContainer\EnvironmentExtension;
 use Behat\Testwork\Filesystem\ServiceContainer\FilesystemExtension;
 use Behat\Testwork\ServiceContainer\Extension;
@@ -39,6 +40,7 @@ final class ContextExtension implements Extension
      * Available services
      */
     const FACTORY_ID = 'context.factory';
+    const CONTEXT_SNIPPET_GENERATOR_ID = 'snippet.generator.context';
 
     /*
      * Available extension points
@@ -98,6 +100,7 @@ final class ContextExtension implements Extension
         $this->loadSuiteSetup($container);
         $this->loadSnippetAppender($container);
         $this->loadSnippetGenerators($container);
+        $this->loadSnippetsController($container);
         $this->loadDefaultClassGenerators($container);
         $this->loadDefaultContextReaders($container);
     }
@@ -194,7 +197,19 @@ final class ContextExtension implements Extension
             new Reference(DefinitionExtension::PATTERN_TRANSFORMER_ID)
         ));
         $definition->addTag(SnippetExtension::GENERATOR_TAG, array('priority' => 50));
-        $container->setDefinition(SnippetExtension::GENERATOR_TAG . '.context', $definition);
+        $container->setDefinition(self::CONTEXT_SNIPPET_GENERATOR_ID, $definition);
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    protected function loadSnippetsController(ContainerBuilder $container)
+    {
+        $definition = new Definition('Behat\Behat\Context\Cli\ContextSnippetsController', array(
+            new Reference(self::CONTEXT_SNIPPET_GENERATOR_ID)
+        ));
+        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 410));
+        $container->setDefinition(CliExtension::CONTROLLER_TAG . '.context_snippets', $definition);
     }
 
     /**

--- a/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
+++ b/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
@@ -206,7 +206,8 @@ final class ContextExtension implements Extension
     protected function loadSnippetsController(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Context\Cli\ContextSnippetsController', array(
-            new Reference(self::CONTEXT_SNIPPET_GENERATOR_ID)
+            new Reference(self::CONTEXT_SNIPPET_GENERATOR_ID),
+            new Reference(TranslatorExtension::TRANSLATOR_ID)
         ));
         $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 410));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.context_snippets', $definition);

--- a/src/Behat/Behat/Context/Snippet/Generator/CachedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/CachedContextIdentifier.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+use Behat\Behat\Context\Environment\ContextEnvironment;
+
+/**
+ * Decorates actual identifier and caches its answers per suite.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class CachedContextIdentifier implements TargetContextIdentifier
+{
+    /**
+     * @var TargetContextIdentifier
+     */
+    private $decoratedIdentifier;
+    /**
+     * @var array
+     */
+    private $contextClasses = array();
+
+    /**
+     * Initialise the identifier.
+     *
+     * @param TargetContextIdentifier $identifier
+     */
+    public function __construct(TargetContextIdentifier $identifier)
+    {
+        $this->decoratedIdentifier = $identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessTargetContextClass(ContextEnvironment $environment)
+    {
+        $suiteKey = $environment->getSuite()->getName();
+
+        if (array_key_exists($suiteKey, $this->contextClasses)) {
+            return $this->contextClasses[$suiteKey];
+        }
+
+        return $this->contextClasses[$suiteKey] = $this->decoratedIdentifier->guessTargetContextClass($environment);
+    }
+}

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextInterfaceBasedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextInterfaceBasedContextIdentifier.php
@@ -19,7 +19,7 @@ use Behat\Behat\Context\Environment\ContextEnvironment;
  *
  * @deprecated in favour of --snippets-for and will be removed in 4.0
  */
-final class SnippetAcceptingContextIdentifier implements TargetContextIdentifier
+final class ContextInterfaceBasedContextIdentifier implements TargetContextIdentifier
 {
     /**
      * {@inheritdoc}

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextInterfaceBasedPatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextInterfaceBasedPatternIdentifier.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+/**
+ * Identifier that uses context interfaces to guess the pattern type.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @deprecated in favour of --snippet-type and will be removed in 4.0
+ */
+final class ContextInterfaceBasedPatternIdentifier implements PatternIdentifier
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function guessPatternType($contextClass)
+    {
+        if (!in_array('Behat\Behat\Context\CustomSnippetAcceptingContext', class_implements($contextClass))) {
+            return null;
+        }
+
+        return $contextClass::getAcceptedSnippetType();
+    }
+}

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -48,6 +48,14 @@ TPL;
      * @var PatternTransformer
      */
     private $patternTransformer;
+    /**
+     * @var null|string
+     */
+    private $snippetAcceptingClass;
+    /**
+     * @var null|string
+     */
+    private $snippetType;
 
     /**
      * Initializes snippet generator.
@@ -57,6 +65,26 @@ TPL;
     public function __construct(PatternTransformer $patternTransformer)
     {
         $this->patternTransformer = $patternTransformer;
+    }
+
+    /**
+     * Sets the context class to generate snippets for.
+     *
+     * @param null|string $contextClass
+     */
+    public function generateSnippetsForContext($contextClass = null)
+    {
+        $this->snippetAcceptingClass = $contextClass;
+    }
+
+    /**
+     * Sets the type of snippets to generate.
+     *
+     * @param null|string $snippetType
+     */
+    public function generateSnippetType($snippetType = null)
+    {
+        $this->snippetType = $snippetType;
     }
 
     /**
@@ -110,6 +138,10 @@ TPL;
      */
     private function getSnippetAcceptingContextClass(ContextEnvironment $environment)
     {
+        if (null !== $this->snippetAcceptingClass) {
+            return $this->snippetAcceptingClass;
+        }
+
         foreach ($environment->getContextClasses() as $class) {
             if (in_array('Behat\Behat\Context\SnippetAcceptingContext', class_implements($class))) {
                 return $class;
@@ -128,6 +160,10 @@ TPL;
      */
     private function getPatternType($contextClass)
     {
+        if (null !== $this->snippetType) {
+            return $this->snippetType;
+        }
+
         if (!in_array('Behat\Behat\Context\CustomSnippetAcceptingContext', class_implements($contextClass))) {
             return null;
         }

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -53,9 +53,9 @@ TPL;
      */
     private $contextIdentifier;
     /**
-     * @var null|string
+     * @var PatternIdentifier
      */
-    private $snippetsType;
+    private $patternIdentifier;
 
     /**
      * Initializes snippet generator.
@@ -66,7 +66,8 @@ TPL;
     {
         $this->patternTransformer = $patternTransformer;
 
-        $this->setContextIdentifier(new SnippetAcceptingContextIdentifier());
+        $this->setContextIdentifier(new ContextInterfaceBasedContextIdentifier());
+        $this->setPatternIdentifier(new ContextInterfaceBasedPatternIdentifier());
     }
 
     /**
@@ -80,13 +81,13 @@ TPL;
     }
 
     /**
-     * Sets the type of snippets to generate.
+     * Sets target pattern type identifier.
      *
-     * @param null|string $snippetsType
+     * @param PatternIdentifier $identifier
      */
-    public function setSnippetsType($snippetsType = null)
+    public function setPatternIdentifier(PatternIdentifier $identifier)
     {
-        $this->snippetsType = $snippetsType;
+        $this->patternIdentifier = $identifier;
     }
 
     /**
@@ -118,7 +119,7 @@ TPL;
         }
 
         $contextClass = $this->contextIdentifier->guessTargetContextClass($environment);
-        $patternType = $this->getPatternType($contextClass);
+        $patternType = $this->patternIdentifier->guessPatternType($contextClass);
         $stepText = $step->getText();
         $pattern = $this->patternTransformer->generatePattern($patternType, $stepText);
 
@@ -129,26 +130,6 @@ TPL;
         $usedClasses = $this->getUsedClasses($step);
 
         return new ContextSnippet($step, $snippetTemplate, $contextClass, $usedClasses);
-    }
-
-    /**
-     * Returns snippet-type that provided context class accepts.
-     *
-     * @param string $contextClass
-     *
-     * @return null|string
-     */
-    private function getPatternType($contextClass)
-    {
-        if (null !== $this->snippetsType) {
-            return $this->snippetsType;
-        }
-
-        if (!in_array('Behat\Behat\Context\CustomSnippetAcceptingContext', class_implements($contextClass))) {
-            return null;
-        }
-
-        return $contextClass::getAcceptedSnippetType();
     }
 
     /**

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -138,7 +138,7 @@ TPL;
      */
     private function getSnippetAcceptingContextClass(ContextEnvironment $environment)
     {
-        if (null !== $this->snippetAcceptingClass) {
+        if (null !== $this->snippetAcceptingClass && in_array($this->snippetAcceptingClass, $environment->getContextClasses())) {
             return $this->snippetAcceptingClass;
         }
 

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedContextIdentifier.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+use Behat\Behat\Context\Environment\ContextEnvironment;
+
+/**
+ * Identifier that always returns same context, if it is defined in the suite.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class FixedContextIdentifier implements TargetContextIdentifier
+{
+    /**
+     * @var
+     */
+    private $contextClass;
+
+    /**
+     * Initialises identifier.
+     *
+     * @param string $contextClass
+     */
+    public function __construct($contextClass)
+    {
+        $this->contextClass = $contextClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessTargetContextClass(ContextEnvironment $environment)
+    {
+        if ($environment->hasContextClass($this->contextClass)) {
+            return $this->contextClass;
+        }
+
+        return null;
+    }
+}

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+use Behat\Behat\Context\Context;
+
+/**
+ * Identifier that always returns same pattern type.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class FixedPatternIdentifier implements PatternIdentifier
+{
+    /**
+     * @var string
+     */
+    private $patternType;
+
+    /**
+     * Initialises identifier.
+     *
+     * @param string $patternType
+     */
+    public function __construct($patternType)
+    {
+        $this->patternType = $patternType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessPatternType($contextClass)
+    {
+        return $this->patternType;
+    }
+}

--- a/src/Behat/Behat/Context/Snippet/Generator/PatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/PatternIdentifier.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+use Behat\Behat\Context\Context;
+
+/**
+ * Identifies target pattern for snippets.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+interface PatternIdentifier
+{
+    /**
+     * Attempts to guess the target pattern type from the context.
+     *
+     * @param string $contextClass
+     *
+     * @return null|string
+     */
+    public function guessPatternType($contextClass);
+}

--- a/src/Behat/Behat/Context/Snippet/Generator/SnippetAcceptingContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/SnippetAcceptingContextIdentifier.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+use Behat\Behat\Context\Environment\ContextEnvironment;
+
+/**
+ * Identifier that uses context interfaces to guess which one is target.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @deprecated in favour of --snippets-for and will be removed in 4.0
+ */
+final class SnippetAcceptingContextIdentifier implements TargetContextIdentifier
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function guessTargetContextClass(ContextEnvironment $environment)
+    {
+        foreach ($environment->getContextClasses() as $class) {
+            if (in_array('Behat\Behat\Context\SnippetAcceptingContext', class_implements($class))) {
+                return $class;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Behat/Behat/Context/Snippet/Generator/TargetContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/TargetContextIdentifier.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+use Behat\Behat\Context\Environment\ContextEnvironment;
+
+/**
+ * Identifies target context for snippets.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+interface TargetContextIdentifier
+{
+    /**
+     * Attempts to guess the target context class from the environment.
+     *
+     * @param ContextEnvironment $environment
+     *
+     * @return null|string
+     */
+    public function guessTargetContextClass(ContextEnvironment $environment);
+}

--- a/src/Behat/Behat/Context/SnippetAcceptingContext.php
+++ b/src/Behat/Behat/Context/SnippetAcceptingContext.php
@@ -18,6 +18,8 @@ use Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator;
  * @see ContextSnippetGenerator
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @deprecated will be removed in 4.0. Use --snippets-for CLI option instead
  */
 interface SnippetAcceptingContext extends Context
 {


### PR DESCRIPTION
## TLDR;

`SnippetAcceptingContext` and `CustomSnippetAcceptingContext` were both deprecated and together with their support will be removed in 4.0.

Instead of them two new CLI options were introduced:

* `--snippets-for=CONTEXT_CLASS` - Specifies which context class Behat should generate snippets for.
* `--snippets-type=[regex|turnip]` - Specifies which snippet type Behat should generate.

`=CONTEXT_CLASS` is optional in `--snippets-for=CONTEXT_CLASS` if you provide `--snippets-for` as a last option in CLI (`behat features/my.feature --snippets-for`). If no context class provided, Behat will run in interactive mode.

## LV;

Using interfaces as indicators for where to generate snippets was a pretty dumb idea on my part. I constantly stumble into team commits that include "removing stupid `SnippetAcceptingContext`" comments. Problem is, in Behat 3 your suite has more than one context and depending on which context you generate snippets to, Behat needs to generate different method names (to avoid collisions). You do need to tell Behat which context you're expecting snippets to go to, but using interfaces for that purposes wasn't the right way to go about it.

This PR ditches aforementioned interfaces in favour of two new explicit CLI options - `--snippets-for` and `--snippets-type`.

Both new options work perfectly fine with existing `--append-snippets` and `--no-snippets` options. So from now on, you would use one of the following combinations for your snippet-generating routine:

* `bin/behat --snippets-for=FeatureContext` - Will print snippets in terminal.
* `bin/behat --append-snippets --snippets-for=FeatureContext` - Will append `turnip` snippets into `FeatureContext`.
* `bin/behat --append-snippets --snippets-for=FeatureContext --snippets-type=regex` - Will append `regex` snippets into `FeatureContext`.

To help newcomers and experienced users alike, unhelpful message:

<img width="1003" alt="screen shot 2016-08-21 at 14 09 55" src="https://cloud.githubusercontent.com/assets/30813/17837355/17e054a6-67a9-11e6-9d19-49198eedd19f.png">

was replaced with:

<img width="637" alt="screen shot 2016-08-21 at 14 10 43" src="https://cloud.githubusercontent.com/assets/30813/17837358/22b18aee-67a9-11e6-99eb-a1f485b563cc.png">

If typing is not your cup of tea, providing `--snippets-for` as a last option without value given will run interactive mode:

<img width="591" alt="screen shot 2016-08-28 at 12 26 44" src="https://cloud.githubusercontent.com/assets/30813/18033388/e4469098-6d1a-11e6-8991-32ef96de9b38.png">
