### PR TITLE
Remove support for Symfony prior to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
     - php: 5.3
       env: DEPENDENCIES='low'
     - php: 5.6
-      env: SYMFONY_VERSION='2.3.*'
-    - php: 5.6
       env: SYMFONY_VERSION='2.7.*'
     - php: 5.6
       env: SYMFONY_VERSION='2.8.*'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
   * Transformations refactoring ([PR #905](https://github.com/Behat/Behat/pull/905))
   * `*SnippetAcceptingContext` interfaces deprecation ([PR #922](https://github.com/Behat/Behat/pull/922))
   * Exception handlers extension point added ([PR #931](https://github.com/Behat/Behat/pull/931))
+  * Bumped minimum dependencies version to Symfony 2.7 ([PR #927](https://github.com/Behat/Behat/pull/927)) 
 
 ### Bug fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,13 @@ where BC break is introduced as a measure to fix a serious issue.
 
 You can read detailed guidance on what BC means in [Symfony2 BC guide](http://symfony.com/doc/current/contributing/code/bc.html).
 
+Third-party dependencies & versioning
+-------------------------------------
+
+Starting from `v3.2.0` we also promise to not break the minimum required dependencies version (like Symfony) in the
+patch updates. However, we sometimes will need to break the minimum required versions for minor updates, but only in
+case where current version in question became unsupported or obsolete.
+
 Contributing to Formatter Translations
 --------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ to fix a serious issue.
 
 You can read detailed guidance on what BC means in [Symfony2 BC guide](http://symfony.com/doc/current/contributing/code/bc.html).
 
+Third-party dependencies & versioning
+-------------------------------------
+
+Starting from `v3.2.0` we also promise to not break the minimum required dependencies version (like Symfony) in the
+patch updates. However, we sometimes will need to break the minimum required versions for minor updates, but only in
+case where current version in question became unsupported or obsolete.
+
 Useful Links
 ------------
 

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
         "ext-mbstring":                  "*",
         "behat/gherkin":                 "~4.4",
         "behat/transliterator":          "~1.0",
-        "symfony/console":               "~2.5||~3.0",
-        "symfony/config":                "~2.3||~3.0",
-        "symfony/dependency-injection":  "~2.1||~3.0",
-        "symfony/event-dispatcher":      "~2.1||~3.0",
-        "symfony/translation":           "~2.3||~3.0",
-        "symfony/yaml":                  "~2.1||~3.0",
-        "symfony/class-loader":          "~2.1||~3.0"
+        "symfony/console":               "~2.7||~3.0",
+        "symfony/config":                "~2.7||~3.0",
+        "symfony/dependency-injection":  "~2.7||~3.0",
+        "symfony/event-dispatcher":      "~2.7||~3.0",
+        "symfony/translation":           "~2.7||~3.0",
+        "symfony/yaml":                  "~2.7||~3.0",
+        "symfony/class-loader":          "~2.7||~3.0"
     },
 
     "require-dev": {
-        "symfony/process": "~2.5|~3.0",
+        "symfony/process": "~2.7|~3.0",
         "phpunit/phpunit": "~4.5",
-        "herrera-io/box": "~1.6.1"
+        "herrera-io/box":  "~1.6.1"
     },
 
     "suggest": {


### PR DESCRIPTION
2.3 maintenance period effectively ended. The only actively maintained
Symfony 2.x versions are 2.7 and 2.8. I'm bumping minimum required Symfony
version to 2.7.