### PR TITLE
Exception handlers extension point

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
   * Transformations refactoring ([PR #905](https://github.com/Behat/Behat/pull/905))
   * `*SnippetAcceptingContext` interfaces deprecation ([PR #922](https://github.com/Behat/Behat/pull/922))
+  * Exception handlers extension point added ([PR #927](https://github.com/Behat/Behat/pull/927))
 
 ### Bug fixes
 

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -123,6 +123,7 @@ Feature: Extensions
         `inexistent_extension` extension file or class could not be located.
       """
 
+  @php-version @php7.0
   Scenario: Exception handlers extension
     Given a file named "behat.yml" with:
       """

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -163,12 +163,12 @@ Feature: Extensions
 
       class NonExistentClassPrinter extends Behat\Testwork\Call\Handler\Exception\ClassNotFoundHandler
       {
-          protected function handleNonExistentClass($class) { var_dump($class); }
+          public function handleNonExistentClass($class) { var_dump($class); }
       }
 
       class NonExistentMethodPrinter extends Behat\Testwork\Call\Handler\Exception\MethodNotFoundHandler
       {
-          protected function handleNonExistentMethod(array $callable) { var_dump($callable); }
+          public function handleNonExistentMethod(array $callable) { var_dump($callable); }
       }
 
       class CustomHandlers implements Extension {

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -51,7 +51,7 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
      *
      * @param string $class
      */
-    abstract protected function handleNonExistentClass($class);
+    abstract public function handleNonExistentClass($class);
 
     /**
      * Extracts missing class name from the exception.

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -11,7 +11,7 @@
 namespace Behat\Testwork\Call\Handler\Exception;
 
 use Behat\Testwork\Call\Handler\ExceptionHandler;
-use Throwable;
+use Error;
 
 /**
  * Handles class not found exceptions.
@@ -29,7 +29,7 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
      */
     final public function supportsException($exception)
     {
-        if (!$exception instanceof Throwable) {
+        if (!$exception instanceof Error) {
             return false;
         }
 
@@ -56,11 +56,11 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
     /**
      * Extracts missing class name from the exception.
      *
-     * @param Throwable $exception
+     * @param Error $exception
      *
      * @return null|string
      */
-    private function extractNonExistentClass(Throwable $exception)
+    private function extractNonExistentClass(Error $exception)
     {
         if (1 === preg_match(self::PATTERN, $exception->getMessage(), $matches)) {
             return $matches[1];

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\Call\Handler\Exception;
+
+use Behat\Testwork\Call\Handler\ExceptionHandler;
+use Throwable;
+
+/**
+ * Handles class not found exceptions.
+ *
+ * @see ExceptionHandler
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+abstract class ClassNotFoundHandler implements ExceptionHandler
+{
+    const PATTERN = "/^Class '([^']+)' not found$/";
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function supportsException($exception)
+    {
+        if (!$exception instanceof Throwable) {
+            return false;
+        }
+
+        return null !== $this->extractNonExistentClass($exception);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function handleException($exception)
+    {
+        $this->handleNonExistentClass($this->extractNonExistentClass($exception));
+
+        return $exception;
+    }
+
+    /**
+     * Override to handle non-existent class name.
+     *
+     * @param string $class
+     */
+    abstract protected function handleNonExistentClass($class);
+
+    /**
+     * Extracts missing class name from the exception.
+     *
+     * @param Throwable $exception
+     *
+     * @return null|string
+     */
+    private function extractNonExistentClass(Throwable $exception)
+    {
+        if (1 === preg_match(self::PATTERN, $exception->getMessage(), $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\Call\Handler\Exception;
+
+use Behat\Testwork\Call\Handler\ExceptionHandler;
+use Error;
+
+/**
+ * Handles method not found exceptions.
+ *
+ * @see ExceptionHandler
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+abstract class MethodNotFoundHandler implements ExceptionHandler
+{
+    const PATTERN = '/Call to undefined method ([^:]+)::([^\)]+)\(\)/';
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function supportsException($exception)
+    {
+        if (!$exception instanceof Error) {
+            return false;
+        }
+
+        return null !== $this->extractNonExistentCallable($exception);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function handleException($exception)
+    {
+        $this->handleNonExistentMethod($this->extractNonExistentCallable($exception));
+
+        return $exception;
+    }
+
+    /**
+     * Override to handle non-existent method.
+     *
+     * @param array $callable
+     */
+    abstract protected function handleNonExistentMethod(array $callable);
+
+    /**
+     * Extract callable from exception.
+     *
+     * @param Error $exception
+     *
+     * @return null|array
+     */
+    private function extractNonExistentCallable(Error $exception)
+    {
+        if (1 === preg_match(self::PATTERN, $exception->getMessage(), $matches)) {
+            return array($matches[1], $matches[2]);
+        }
+
+        return null;
+    }
+}

--- a/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
@@ -22,7 +22,7 @@ use Error;
  */
 abstract class MethodNotFoundHandler implements ExceptionHandler
 {
-    const PATTERN = '/Call to undefined method ([^:]+)::([^\)]+)\(\)/';
+    const PATTERN = '/^Call to undefined method ([^:]+)::([^\)]+)\(\)$/';
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
@@ -51,7 +51,7 @@ abstract class MethodNotFoundHandler implements ExceptionHandler
      *
      * @param array $callable
      */
-    abstract protected function handleNonExistentMethod(array $callable);
+    abstract public function handleNonExistentMethod(array $callable);
 
     /**
      * Extract callable from exception.

--- a/src/Behat/Testwork/Call/Handler/ExceptionHandler.php
+++ b/src/Behat/Testwork/Call/Handler/ExceptionHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\Call\Handler;
+
+/**
+ * Handles exceptions.
+ *
+ * @see CallCenter
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+interface ExceptionHandler
+{
+    /**
+     * Checks if handler supports exception.
+     *
+     * @param \Throwable $exception
+     *
+     * @return bool
+     */
+    public function supportsException($exception);
+
+    /**
+     * Handles exception and returns new one if necessary.
+     *
+     * @param \Throwable $exception
+     *
+     * @return \Throwable
+     */
+    public function handleException($exception);
+}

--- a/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
+++ b/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
@@ -35,6 +35,7 @@ final class CallExtension implements Extension
     const CALL_FILTER_TAG = 'call.call_filter';
     const CALL_HANDLER_TAG = 'call.call_handler';
     const RESULT_FILTER_TAG = 'call.result_filter';
+    const EXCEPTION_HANDLER_TAG = 'call.exception_handler';
 
     /**
      * @var ServiceProcessor
@@ -99,6 +100,7 @@ final class CallExtension implements Extension
         $this->processCallFilters($container);
         $this->processCallHandlers($container);
         $this->processResultFilters($container);
+        $this->processExceptionHandlers($container);
     }
 
     /**
@@ -167,6 +169,21 @@ final class CallExtension implements Extension
 
         foreach ($references as $reference) {
             $definition->addMethodCall('registerResultFilter', array($reference));
+        }
+    }
+
+    /**
+     * Registers all exception handlers to the CallCenter.
+     *
+     * @param ContainerBuilder $container
+     */
+    private function processExceptionHandlers(ContainerBuilder $container)
+    {
+        $references = $this->processor->findAndSortTaggedServices($container, CallExtension::EXCEPTION_HANDLER_TAG);
+        $definition = $container->getDefinition(CallExtension::CALL_CENTER_ID);
+
+        foreach ($references as $reference) {
+            $definition->addMethodCall('registerExceptionHandler', array($reference));
         }
     }
 }


### PR DESCRIPTION
This PR introduces new extension point into Testwork - exception handlers. In order to use it, the new tag and the interface were added to the core:

* [`Behat\Testwork\Call\ServiceContainer\CallExtension::EXCEPTION_HANDLER_TAG`](https://github.com/Behat/Behat/blob/feature/exception-handlers/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php#L38)
* [`Behat\Testwork\Call\Handler\ExceptionHandler`](https://github.com/Behat/Behat/blob/feature/exception-handlers/src/Behat/Testwork/Call/Handler/ExceptionHandler.php)

There are also two more specific versions of the handler:

* [`Behat\Testwork\Call\Handler\Exception\ClassNotFoundHandler`](https://github.com/Behat/Behat/blob/feature/exception-handlers/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php)
* [`Behat\Testwork\Call\Handler\Exception\MethodNotFoundHandler`](https://github.com/Behat/Behat/blob/feature/exception-handlers/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php)

Example of usage for both is provided in [the feature file](https://github.com/Behat/Behat/blob/feature/exception-handlers/features/extensions.feature#L126).