### PR TITLE
Strict stop on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+  * Stop execution on missing steps when running with `--stop-on-failure` and `--strict` options
 
 ## [3.2.0] - 2016-09-20
 ### Added

--- a/features/stop_on_failure.feature
+++ b/features/stop_on_failure.feature
@@ -57,6 +57,34 @@ Feature: Stop on failure
           When I have a step that fails
           Then I should have a scenario that failed
       """
+    And a file named "features/missing-step.feature" with:
+      """
+      Feature: Missing Step Feature
+        In order to test the stop-on-failure and strict features
+        As a behat developer
+        I need to have a feature with a missing step
+
+        Background:
+          Given I have a step that passes
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 2nd Passing
+          When I have a step that passes
+           And I have another step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 1st Failing
+          When I have a step that passes
+           And I have another step that is missing
+          Then I should have a scenario that failed
+
+        Scenario: 2st Failing
+          When I have a step that is missing
+          Then I should have a scenario that failed
+      """
     And a file named "features/passing.feature" with:
       """
       Feature: Passing Feature
@@ -116,6 +144,40 @@ Feature: Stop on failure
 
       3 scenarios (2 passed, 1 failed)
       11 steps (9 passed, 1 failed, 1 skipped)
+      """
+
+  Scenario: Just run feature
+    When I run "behat --no-colors --format-settings='{\"paths\": false}' --strict --stop-on-failure features/missing-step.feature"
+    Then it should fail with:
+      """
+      Feature: Missing Step Feature
+        In order to test the stop-on-failure and strict features
+        As a behat developer
+        I need to have a feature with a missing step
+
+        Background:
+          Given I have a step that passes
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 2nd Passing
+          When I have a step that passes
+          And I have another step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 1st Failing
+          When I have a step that passes
+          And I have another step that is missing
+          Then I should have a scenario that failed
+
+      3 scenarios (2 passed, 1 undefined)
+      11 steps (9 passed, 1 undefined, 1 skipped)
+
+      --- Use --snippets-for CLI option to generate snippets for following default suite steps:
+
+          And I have another step that is missing
       """
 
   Scenario: Just run feature


### PR DESCRIPTION
Given that
- `--strict` option will make the tests fail if there's a missing step
- `--stop-on-failure` option will stop test execution as soon as a step fails

If we run Behat with both options it will stop test execution as soon as it detects a missing step.

This PR should close issue #951