### PR TITLE
Further improve snippet generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Added
+### Changed
   * Stop execution on missing steps when running with `--stop-on-failure` and `--strict` options
 
 ## [3.2.0] - 2016-09-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-  * Stop execution on missing steps when running with `--stop-on-failure` and `--strict` options
+  * `--snippets-for` is not required now as interactive mode is the new default ([PR #955](https://github.com/Behat/Behat/pull/955))
+  * Stop execution on missing steps when running with `--stop-on-failure` and `--strict` options ([PR #954](https://github.com/Behat/Behat/pull/954))
 
 ## [3.2.0] - 2016-09-20
 ### Added

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -33,6 +33,10 @@ class FeatureContext implements Context
      * @var string
      */
     private $workingDir;
+    /**
+     * @var string
+     */
+    private $options = '--format-settings=\'{"timer": false}\' --no-interaction';
 
     /**
      * Cleans test folders in the temporary directory.
@@ -138,7 +142,7 @@ class FeatureContext implements Context
                 $this->phpBin,
                 escapeshellarg(BEHAT_BIN_PATH),
                 $argumentsString,
-                strtr('--format-settings=\'{"timer": false}\'', array('\'' => '"', '"' => '\"'))
+                strtr($this->options, array('\'' => '"', '"' => '\"'))
             )
         );
 
@@ -168,6 +172,7 @@ class FeatureContext implements Context
         $this->process->setEnv($env);
         $this->process->setInput($answerString);
 
+        $this->options = '--format-settings=\'{"timer": false}\'';
         $this->iRunBehat($argumentsString);
     }
 

--- a/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
+++ b/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
@@ -10,9 +10,13 @@
 
 namespace Behat\Behat\Context\Cli;
 
+use Behat\Behat\Context\Snippet\Generator\AggregatePatternIdentifier;
+use Behat\Behat\Context\Snippet\Generator\ContextInterfaceBasedContextIdentifier;
+use Behat\Behat\Context\Snippet\Generator\ContextInterfaceBasedPatternIdentifier;
 use Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator;
 use Behat\Behat\Context\Snippet\Generator\FixedContextIdentifier;
 use Behat\Behat\Context\Snippet\Generator\FixedPatternIdentifier;
+use Behat\Behat\Context\Snippet\Generator\AggregateContextIdentifier;
 use Behat\Testwork\Cli\Controller;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -69,17 +73,19 @@ final class ContextSnippetsController implements Controller
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($input->hasParameterOption('--snippets-for')) {
-            $identifier =
-                null !== $input->getOption('snippets-for')
-                    ? new FixedContextIdentifier($input->getOption('snippets-for'))
-                    : new InteractiveContextIdentifier($this->translator, $input, $output);
+        $this->generator->setContextIdentifier(
+            new AggregateContextIdentifier(array(
+                new ContextInterfaceBasedContextIdentifier(),
+                new FixedContextIdentifier($input->getOption('snippets-for')),
+                new InteractiveContextIdentifier($this->translator, $input, $output)
+            ))
+        );
 
-            $this->generator->setContextIdentifier($identifier);
-        }
-
-        if (null !== $input->getOption('snippets-type')) {
-            $this->generator->setPatternIdentifier(new FixedPatternIdentifier($input->getOption('snippets-type')));
-        }
+        $this->generator->setPatternIdentifier(
+            new AggregatePatternIdentifier(array(
+                new ContextInterfaceBasedPatternIdentifier(),
+                new FixedPatternIdentifier($input->getOption('snippets-type'))
+            ))
+        );
     }
 }

--- a/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
+++ b/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
@@ -57,7 +57,7 @@ final class InteractiveContextIdentifier implements TargetContextIdentifier
      */
     public function guessTargetContextClass(ContextEnvironment $environment)
     {
-        if (!$this->input->isInteractive()) {
+        if ($this->input->hasParameterOption('--no-interaction')) {
             return null;
         }
 

--- a/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
+++ b/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
@@ -57,6 +57,10 @@ final class InteractiveContextIdentifier implements TargetContextIdentifier
      */
     public function guessTargetContextClass(ContextEnvironment $environment)
     {
+        if (!$this->input->isInteractive()) {
+            return null;
+        }
+
         $suiteName = $environment->getSuite()->getName();
         $contextClasses = $environment->getContextClasses();
 

--- a/src/Behat/Behat/Context/Snippet/Generator/AggregateContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/AggregateContextIdentifier.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+use Behat\Behat\Context\Environment\ContextEnvironment;
+
+/**
+ * Uses multiple child identifiers - the first one that returns non-null result would
+ * be the winner.
+ *
+ * This behaviour was introduced in 3.x to support the BC for interface-focused
+ * context identifier, while providing better user experience (no need to explicitly
+ * call `--snippets-for` on `--append-snippets` when contexts do not implement any
+ * snippet accepting interfaces).
+ */
+final class AggregateContextIdentifier implements TargetContextIdentifier
+{
+    /**
+     * @var TargetContextIdentifier[]
+     */
+    private $identifiers;
+
+    /**
+     * Initialises identifier.
+     *
+     * @param TargetContextIdentifier[] $identifiers
+     */
+    public function __construct(array $identifiers)
+    {
+        $this->identifiers = $identifiers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessTargetContextClass(ContextEnvironment $environment)
+    {
+        foreach ($this->identifiers as $identifier) {
+            $contextClass = $identifier->guessTargetContextClass($environment);
+
+            if (null !== $contextClass) {
+                return $contextClass;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Behat/Behat/Context/Snippet/Generator/AggregatePatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/AggregatePatternIdentifier.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Snippet\Generator;
+
+/**
+ * Uses multiple child identifiers - the first one that returns non-null result would
+ * be the winner.
+ */
+final class AggregatePatternIdentifier implements PatternIdentifier
+{
+    /**
+     * @var PatternIdentifier[]
+     */
+    private $identifiers;
+
+    /**
+     * Initialises identifier.
+     *
+     * @param PatternIdentifier[] $identifiers
+     */
+    public function __construct(array $identifiers)
+    {
+        $this->identifiers = $identifiers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessPatternType($contextClass)
+    {
+        foreach ($this->identifiers as $identifier) {
+            $pattern = $identifier->guessPatternType($contextClass);
+
+            if (null !== $pattern) {
+                return $pattern;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -66,8 +66,8 @@ TPL;
     {
         $this->patternTransformer = $patternTransformer;
 
-        $this->setContextIdentifier(new ContextInterfaceBasedContextIdentifier());
-        $this->setPatternIdentifier(new ContextInterfaceBasedPatternIdentifier());
+        $this->setContextIdentifier(new FixedContextIdentifier(null));
+        $this->setPatternIdentifier(new FixedPatternIdentifier(null));
     }
 
     /**


### PR DESCRIPTION
Currently, when not using `SnippetAcceptingContext` interface (as it is deprecated), people are forced to use the `--snippets-for` flag in CLI. However, it is now obvious that for newcomers it is not transparent that `--snippets-for` has an interactive mode when called without argument. That causes unnecessary confusion.

This PR refactors slightly both pattern and context class identifiers to make both more flexible. As a result, context identifiers as of this commit operate in the following way:

1. If suite has any context implementing `SnippetAcceptingContext`, that class will be used for snippet generation.
2. If above is not true, but user explicitly provided a context class via `--snippets-for`, the provided class will be used
   instead.
3. If none of the above is  true, but the current CLI environment supports interactive mode - interactive mode will kick in automatically.
4. If none of the above is true, the help message asking user to use `--snippets-for` will be provided.

Closes #952 