### PR TITLE
Suite name with hyphen fix

### DIFF
--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -19,8 +19,6 @@ Feature: Rerun with multiple suite
           suite2:
             paths:
               - features/bananas.feature
-          suite-3:
-            paths: {}
       """
     And a file named "features/bootstrap/FeatureContext.php" with:
       """
@@ -295,12 +293,4 @@ Feature: Rerun with multiple suite
 
     2 scenarios (2 failed)
     7 steps (5 passed, 2 failed)
-    """
-
-  Scenario: Run suite with dash in name
-    When I run "behat --no-colors -f progress --suite suite-3"
-    Then it should pass with:
-    """
-    No scenarios
-    No steps
     """

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -19,6 +19,8 @@ Feature: Rerun with multiple suite
           suite2:
             paths:
               - features/bananas.feature
+          suite-3:
+            paths: {}
       """
     And a file named "features/bootstrap/FeatureContext.php" with:
       """
@@ -293,4 +295,12 @@ Feature: Rerun with multiple suite
 
     2 scenarios (2 failed)
     7 steps (5 passed, 2 failed)
+    """
+
+  Scenario: Run suite with dash in name
+    When I run "behat --no-colors -f progress --suite suite-3"
+    Then it should pass with:
+    """
+    No scenarios
+    No steps
     """

--- a/features/suite.feature
+++ b/features/suite.feature
@@ -534,3 +534,26 @@ Feature: Suites
       1 scenario (1 passed)
       3 steps (3 passed)
       """
+
+  Scenario: Running suite with a hyphen in suite name
+    Given a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          suite-with-hyphens:
+            paths: {}
+      """
+    And a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      class FeatureContext implements \Behat\Behat\Context\Context
+      {
+      }
+      """
+    When I run "behat --no-colors -f progress --suite suite-with-hyphens"
+    Then it should pass with:
+      """
+      No scenarios
+      No steps
+      """

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -82,6 +82,7 @@ final class SuiteExtension implements Extension
             ->treatNullLike(array())
             ->treatFalseLike(array())
             ->useAttributeAsKey('name')
+            ->normalizeKeys(false)
             ->prototype('array')
                 ->beforeNormalization()
                     ->ifTrue(function ($suite) {


### PR DESCRIPTION
This allows to use suites with hyphen in name in `--suite` CLI option.

Fixes #968.
I've included work from #969, but moved scenario to another feature file.

BTW this is a potential BC break for users who had hyphens in suite names and who used underscored version of names in `--suite` filters. 
With this PR `--suite=some_suite` will not work if suite has name `some-suite`.

However, this is a bugfix, and using underscored names was not documentated anywhere.
