### PR TITLE
Do not treat first argument as numbered argument if typehinted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
   * [#993](https://github.com/Behat/Behat/pull/993) Fix mixed arguments organizer not marking typehinted arguments as "defined"
+  * [#992](https://github.com/Behat/Behat/pull/993) Do not misinterpret first argument as a numbered argument if it is in fact typehinted
 
 ## [3.3.0] - 2016-12-25
 ### Added

--- a/features/helper_containers.feature
+++ b/features/helper_containers.feature
@@ -314,7 +314,6 @@ Feature: Per-suite helper containers
           default:
             contexts:
               - FirstContext:
-                - foo
                 - "@typehinted_service"
                 - bar
 
@@ -333,10 +332,7 @@ Feature: Per-suite helper containers
       <?php use Behat\Behat\Context\Context;
 
       class FirstContext implements Context {
-          public function __construct($foo, stdClass $service, $bar) {
-            // the first argument is a placeholder while #990 is still opened
-            // otherwise, if we had only the SharedService and $arg2, it would not
-            // show the fix that was made in #993
+          public function __construct(stdClass $service, $bar) {
           }
 
           /** @Given foo */

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -88,7 +88,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
         foreach ($arguments as $key => $val) {
             if ($this->isStringKeyAndExistsInParameters($key, $parameterNames)) {
                 $namedArguments[$key] = $val;
-            } elseif ($num = $this->getParameterNumberWithTypehintingValue($parameters, $val)) {
+            } elseif (null !== ($num = $this->getParameterNumberWithTypehintingValue($parameters, $val))) {
                 $typehintedArguments[$num] = $val;
             } else {
                 $numberedArguments[] = $val;


### PR DESCRIPTION
Fixes #990 : If the first argument (index 0) is typehinted, as `0 == false`, it was never registered as a typehinted argument but as a numbered argument.