### PR TITLE
Fix typehinted arguments not marking arguments as defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+  * [#993](https://github.com/Behat/Behat/pull/993) Fix mixed arguments organizer not marking typehinted arguments as "defined"
 
 ## [3.3.0] - 2016-12-25
 ### Added

--- a/features/helper_containers.feature
+++ b/features/helper_containers.feature
@@ -305,3 +305,44 @@ Feature: Per-suite helper containers
       """
     When I run "behat --no-colors -f progress features/container.feature"
     Then it should pass
+
+  Scenario: Mix of typehinted arguments and numbered arguments (fix #991)
+    Given a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - FirstContext:
+                - foo
+                - "@typehinted_service"
+                - bar
+
+            services:
+              typehinted_service:
+                class: stdClass
+      """
+    And a file named "features/container_args.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given foo
+      """
+    And a file named "features/bootstrap/FirstContext.php" with:
+      """
+      <?php use Behat\Behat\Context\Context;
+
+      class FirstContext implements Context {
+          public function __construct($foo, stdClass $service, $bar) {
+            // the first argument is a placeholder while #990 is still opened
+            // otherwise, if we had only the SharedService and $arg2, it would not
+            // show the fix that was made in #993
+          }
+
+          /** @Given foo */
+          public function foo() {
+          }
+      }
+      """
+    When I run "behat --no-colors -f progress features/container_args.feature"
+    Then it should pass

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -58,7 +58,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
 
         $arguments =
             $this->prepareNamedArguments($parameters, $named) +
-            $typehinted +
+            $this->prepareTypehintedArguments($typehinted) +
             $this->prepareNumberedArguments($parameters, $numbered) +
             $this->prepareDefaultArguments($parameters);
 
@@ -172,6 +172,29 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
 
         return $arguments;
     }
+
+    /**
+     * Captures argument value based on their respective typehints.
+     *
+     * Note ; as it is keeping in mind that $typeHintedArgument already has the
+     * right keys matching the correct parameter, it just iterates over this
+     * array in order to mark each arguments as "defined".
+     *
+     * @see https://github.com/Behat/Behat/pull/993#issuecomment-275669510
+     *
+     * @param mixed[] $typehintedArguments
+     *
+     * @return mixed[]
+     */
+    private function prepareTypehintedArguments(array $typehintedArguments)
+    {
+        foreach (array_keys($typehintedArguments) as $num) {
+            $this->markArgumentDefined($num);
+        }
+
+        return $typehintedArguments;
+    }
+
 
     /**
      * Captures argument values for undefined arguments based on their respective numbers.


### PR DESCRIPTION
Fixes #991 

Basically, array additions do some stuff that are not really expected ; if `null` is giving as a context constructor, it is skipped because it is how array additions behave.

Replacing it with a good old `array_merge` fixes that.

I'll add some unit tests for that.