### PR TITLE
Add support for Puli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - if [[ ${TRAVIS_PHP_VERSION:0:4} != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
 
 before_script:
-  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+  - 'if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e ''s/"prefer-stable": true/"prefer-stable": false/'' composer.json; fi;'
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update "symfony/symfony:${SYMFONY_VERSION}"; fi;
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-lowest; fi;

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,9 @@
     "require-dev": {
         "symfony/process": "~2.5|~3.0",
         "phpunit/phpunit": "~4.5",
-        "herrera-io/box": "~1.6.1"
+        "herrera-io/box": "~1.6.1",
+        "puli/composer-plugin": "^1.0@beta",
+        "puli/cli": "^1.0"
     },
 
     "suggest": {
@@ -52,6 +54,9 @@
             "dev-master": "3.2.x-dev"
         }
     },
+
+    "prefer-stable": true,
+    "minimum-stability": "dev",
 
     "bin": ["bin/behat"]
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/process": "~2.5|~3.0",
         "phpunit/phpunit": "~4.5",
         "herrera-io/box": "~1.6.1",
-        "puli/composer-plugin": "^1.0@beta",
+        "puli/composer-plugin": "dev-master",
         "puli/cli": "^1.0"
     },
 

--- a/puli.json
+++ b/puli.json
@@ -1,0 +1,286 @@
+{
+    "version": "1.0",
+    "name": "behat/behat",
+    "binding-types": {
+        "behat/extension": {
+            "parameters": {
+                "name": {}
+            }
+        }
+    },
+    "config": {
+        "bootstrap-file": "vendor/autoload.php"
+    },
+    "packages": {
+        "behat/gherkin": {
+            "install-path": "vendor/behat/gherkin",
+            "installer": "composer"
+        },
+        "behat/transliterator": {
+            "install-path": "vendor/behat/transliterator",
+            "installer": "composer"
+        },
+        "container-interop/container-interop": {
+            "install-path": "vendor/container-interop/container-interop",
+            "installer": "composer"
+        },
+        "doctrine/instantiator": {
+            "install-path": "vendor/doctrine/instantiator",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "herrera-io/box": {
+            "install-path": "vendor/herrera-io/box",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "justinrainbow/json-schema": {
+            "install-path": "vendor/justinrainbow/json-schema",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "padraic/humbug_get_contents": {
+            "install-path": "vendor/padraic/humbug_get_contents",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "padraic/phar-updater": {
+            "install-path": "vendor/padraic/phar-updater",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "paragonie/random_compat": {
+            "install-path": "vendor/paragonie/random_compat",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phine/exception": {
+            "install-path": "vendor/phine/exception",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phine/path": {
+            "install-path": "vendor/phine/path",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpdocumentor/reflection-common": {
+            "install-path": "vendor/phpdocumentor/reflection-common",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpdocumentor/reflection-docblock": {
+            "install-path": "vendor/phpdocumentor/reflection-docblock",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpdocumentor/type-resolver": {
+            "install-path": "vendor/phpdocumentor/type-resolver",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpspec/prophecy": {
+            "install-path": "vendor/phpspec/prophecy",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-code-coverage": {
+            "install-path": "vendor/phpunit/php-code-coverage",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-file-iterator": {
+            "install-path": "vendor/phpunit/php-file-iterator",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-text-template": {
+            "install-path": "vendor/phpunit/php-text-template",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-timer": {
+            "install-path": "vendor/phpunit/php-timer",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-token-stream": {
+            "install-path": "vendor/phpunit/php-token-stream",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/phpunit": {
+            "install-path": "vendor/phpunit/phpunit",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/phpunit-mock-objects": {
+            "install-path": "vendor/phpunit/phpunit-mock-objects",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "psr/container": {
+            "install-path": "vendor/psr/container",
+            "installer": "composer"
+        },
+        "psr/log": {
+            "install-path": "vendor/psr/log",
+            "installer": "composer"
+        },
+        "puli/cli": {
+            "install-path": "vendor/puli/cli",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/composer-plugin": {
+            "install-path": "vendor/puli/composer-plugin",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/discovery": {
+            "install-path": "vendor/puli/discovery",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/manager": {
+            "install-path": "vendor/puli/manager",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/repository": {
+            "install-path": "vendor/puli/repository",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/url-generator": {
+            "install-path": "vendor/puli/url-generator",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "ramsey/uuid": {
+            "install-path": "vendor/ramsey/uuid",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/comparator": {
+            "install-path": "vendor/sebastian/comparator",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/diff": {
+            "install-path": "vendor/sebastian/diff",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/environment": {
+            "install-path": "vendor/sebastian/environment",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/exporter": {
+            "install-path": "vendor/sebastian/exporter",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/global-state": {
+            "install-path": "vendor/sebastian/global-state",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/recursion-context": {
+            "install-path": "vendor/sebastian/recursion-context",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/version": {
+            "install-path": "vendor/sebastian/version",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "seld/jsonlint": {
+            "install-path": "vendor/seld/jsonlint",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/class-loader": {
+            "install-path": "vendor/symfony/class-loader",
+            "installer": "composer"
+        },
+        "symfony/config": {
+            "install-path": "vendor/symfony/config",
+            "installer": "composer"
+        },
+        "symfony/console": {
+            "install-path": "vendor/symfony/console",
+            "installer": "composer"
+        },
+        "symfony/debug": {
+            "install-path": "vendor/symfony/debug",
+            "installer": "composer"
+        },
+        "symfony/dependency-injection": {
+            "install-path": "vendor/symfony/dependency-injection",
+            "installer": "composer"
+        },
+        "symfony/event-dispatcher": {
+            "install-path": "vendor/symfony/event-dispatcher",
+            "installer": "composer"
+        },
+        "symfony/filesystem": {
+            "install-path": "vendor/symfony/filesystem",
+            "installer": "composer"
+        },
+        "symfony/polyfill-mbstring": {
+            "install-path": "vendor/symfony/polyfill-mbstring",
+            "installer": "composer"
+        },
+        "symfony/process": {
+            "install-path": "vendor/symfony/process",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/translation": {
+            "install-path": "vendor/symfony/translation",
+            "installer": "composer"
+        },
+        "symfony/yaml": {
+            "install-path": "vendor/symfony/yaml",
+            "installer": "composer"
+        },
+        "tedivm/jshrink": {
+            "install-path": "vendor/tedivm/jshrink",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/assert": {
+            "install-path": "vendor/webmozart/assert",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/console": {
+            "install-path": "vendor/webmozart/console",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/expression": {
+            "install-path": "vendor/webmozart/expression",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/glob": {
+            "install-path": "vendor/webmozart/glob",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/json": {
+            "install-path": "vendor/webmozart/json",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/path-util": {
+            "install-path": "vendor/webmozart/path-util",
+            "installer": "composer",
+            "env": "dev"
+        }
+    }
+}

--- a/src/Behat/Testwork/ApplicationFactory.php
+++ b/src/Behat/Testwork/ApplicationFactory.php
@@ -14,6 +14,9 @@ use Behat\Testwork\Cli\Application;
 use Behat\Testwork\ServiceContainer\Configuration\ConfigurationLoader;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
+use Behat\Testwork\ServiceContainer\Instantiator\ExtensionFileInstantiator;
+use Behat\Testwork\ServiceContainer\Instantiator\ExtensionClassInstantiator;
 
 /**
  * Defines the way application is created.
@@ -60,6 +63,19 @@ abstract class ApplicationFactory
     abstract protected function getConfigPath();
 
     /**
+     * Returns the extension instantiators
+     *
+     * @return ExtensionInstantiator[]
+     */
+    protected function getDefaultInstantiators()
+    {
+        return array(
+            new ExtensionClassInstantiator(),
+            new ExtensionFileInstantiator(),
+        );
+    }
+
+    /**
      * Creates application instance.
      *
      * @return Application
@@ -89,6 +105,6 @@ abstract class ApplicationFactory
      */
     protected function createExtensionManager()
     {
-        return new ExtensionManager($this->getDefaultExtensions());
+        return new ExtensionManager($this->getDefaultExtensions(), $this->getDefaultInstantiators());
     }
 }

--- a/src/Behat/Testwork/ApplicationFactory.php
+++ b/src/Behat/Testwork/ApplicationFactory.php
@@ -16,6 +16,7 @@ use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
 use Behat\Testwork\ServiceContainer\Instantiator\ExtensionFileInstantiator;
+use Behat\Testwork\ServiceContainer\Instantiator\ExtensionPuliInstantiator;
 use Behat\Testwork\ServiceContainer\Instantiator\ExtensionClassInstantiator;
 
 /**
@@ -69,10 +70,16 @@ abstract class ApplicationFactory
      */
     protected function getDefaultInstantiators()
     {
-        return array(
+        $instantiators = array(
             new ExtensionClassInstantiator(),
             new ExtensionFileInstantiator(),
         );
+
+        if (defined('PULI_FACTORY_CLASS') && class_exists(PULI_FACTORY_CLASS)) {
+            $instantiators[] = new ExtensionPuliInstantiator();
+        }
+
+        return $instantiators;
     }
 
     /**

--- a/src/Behat/Testwork/ApplicationFactory.php
+++ b/src/Behat/Testwork/ApplicationFactory.php
@@ -105,6 +105,6 @@ abstract class ApplicationFactory
      */
     protected function createExtensionManager()
     {
-        return new ExtensionManager($this->getDefaultExtensions(), $this->getDefaultInstantiators());
+        return new ExtensionManager($this->getDefaultExtensions(), null, $this->getDefaultInstantiators());
     }
 }

--- a/src/Behat/Testwork/ServiceContainer/ExtensionInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionInstantiator.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\ServiceContainer;
+
+use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
+
+/**
+ * Represents an instantiator for an Extension
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+interface ExtensionInstantiator
+{
+    /**
+     * Instantiates extension from its locator.
+     *
+     * @param string $locator
+     *
+     * @return Extension
+     *
+     * @throws ExtensionInitializationException
+     */
+    public function instantiate($locator);
+}

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -20,10 +20,6 @@ use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
 final class ExtensionManager
 {
     /**
-     * @var string
-     */
-    private $extensionsPath;
-    /**
      * @var Extension[]
      */
     private $extensions = array();
@@ -34,30 +30,24 @@ final class ExtensionManager
     private $debugInformation = array(
         'extensions_list' => array()
     );
+    /**
+     * @var ExtensionInstantiator[]
+     */
+    private $instantiators = array();
 
     /**
      * Initializes manager.
      *
-     * @param Extension[] $extensions     List of default extensions
-     * @param null|string $extensionsPath Base path where to search custom extension files
+     * @param Extension[]             $extensions    List of default extensions
+     * @param ExtensionInstantiator[] $instantiators Extension instantiators to use
      */
-    public function __construct(array $extensions, $extensionsPath = null)
+    public function __construct(array $extensions, array $instantiators)
     {
         foreach ($extensions as $extension) {
             $this->extensions[$extension->getConfigKey()] = $extension;
         }
 
-        $this->extensionsPath = $extensionsPath;
-    }
-
-    /**
-     * Sets path to directory in which manager will try to find extension files.
-     *
-     * @param null|string $path
-     */
-    public function setExtensionsPath($path)
-    {
-        $this->extensionsPath = $path;
+        $this->instantiators = $instantiators;
     }
 
     /**
@@ -129,21 +119,6 @@ final class ExtensionManager
     }
 
     /**
-     * Attempts to guess full extension class from relative.
-     *
-     * @param string $locator
-     *
-     * @return string
-     */
-    private function getFullExtensionClass($locator)
-    {
-        $parts = explode('\\', $locator);
-        $name = preg_replace('/Extension$/', '', end($parts)) . 'Extension';
-
-        return $locator . '\\ServiceContainer\\' . $name;
-    }
-
-    /**
      * Initializes extension by id.
      *
      * @param string $locator
@@ -175,20 +150,12 @@ final class ExtensionManager
      */
     private function instantiateExtension($locator)
     {
-        if (class_exists($class = $locator)) {
-            return new $class;
-        }
-
-        if (class_exists($class = $this->getFullExtensionClass($locator))) {
-            return new $class;
-        }
-
-        if (file_exists($locator)) {
-            return require($locator);
-        }
-
-        if (file_exists($path = $this->extensionsPath . DIRECTORY_SEPARATOR . $locator)) {
-            return require($path);
+        foreach ($this->instantiators as $instantiator) {
+            try {
+                return $instantiator->instantiate($locator);
+            } catch (ExtensionInitializationException $e) {
+                // ignored if the instantiator does not support the locator
+            }
         }
 
         throw new ExtensionInitializationException(sprintf(

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionClassInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionClassInstantiator.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\ServiceContainer\Instantiator;
+
+use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
+use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
+
+final class ExtensionClassInstantiator implements ExtensionInstantiator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function instantiate($locator)
+    {
+        if (class_exists($class = $locator)) {
+            return new $class;
+        }
+
+        if (class_exists($class = $this->getFullExtensionClass($locator))) {
+            return new $class;
+        }
+
+        throw new ExtensionInitializationException(sprintf(
+            '`%s` extension class could not be instantiated.',
+            $locator
+        ), $locator);
+    }
+
+    /**
+     * Attempts to guess full extension class from relative.
+     *
+     * @param string $locator
+     *
+     * @return string
+     */
+    private function getFullExtensionClass($locator)
+    {
+        $parts = explode('\\', $locator);
+        $name = preg_replace('/Extension$/', '', end($parts)) . 'Extension';
+
+        return sprintf('%s\\ServiceContainer\\%s', $locator, $name);
+    }
+}

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\ServiceContainer\Instantiator;
+
+use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
+use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
+
+final class ExtensionFileInstantiator implements ExtensionInstantiator
+{
+    /**
+     * @var string
+     */
+    private $extensionsPath;
+
+    public function __construct($extensionsPath = null)
+    {
+        $this->extensionsPath = $extensionsPath;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instantiate($locator)
+    {
+        if (file_exists($locator)) {
+            return require($locator);
+        }
+
+        if (file_exists($path = $this->extensionsPath . DIRECTORY_SEPARATOR . $locator)) {
+            return require($path);
+        }
+
+        throw new ExtensionInitializationException(sprintf(
+            '`%s` extension file could not be loaded.',
+            $locator
+        ), $locator);
+    }
+}

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
@@ -26,6 +26,16 @@ final class ExtensionFileInstantiator implements ExtensionInstantiator
     }
 
     /**
+     * Sets path to directory in which manager will try to find extension files.
+     *
+     * @param null|string $path
+     */
+    public function setExtensionsPath($path)
+    {
+        $this->extensionsPath = $path;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function instantiate($locator)

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionPuliInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionPuliInstantiator.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\ServiceContainer\Instantiator;
+
+use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
+use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
+
+final class ExtensionPuliInstantiator implements ExtensionInstantiator
+{
+    const PULI_TYPE = 'behat/extension';
+
+    private $extensions;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instantiate($locator)
+    {
+        $this->initializeExtensions();
+
+        if (isset($this->extensions[$locator])) {
+            return $this->extensions[$locator];
+        }
+
+        throw new ExtensionInitializationException(sprintf(
+            '`%s` extension could not be loaded through Puli.',
+            $locator
+        ), $locator);
+    }
+
+    private function initializeExtensions()
+    {
+        if (null !== $this->extensions) {
+            return $this->extensions;
+        }
+
+        if (!defined('PULI_FACTORY_CLASS') || !class_exists(PULI_FACTORY_CLASS)) {
+            return array();
+        }
+
+        $this->extensions = array();
+        $factoryClass = PULI_FACTORY_CLASS;
+
+        $factory = new $factoryClass;
+        $repository = $factory->createRepository();
+        $discovery = $factory->createDiscovery($repository);
+
+        foreach ($discovery->findBindings(self::PULI_TYPE) as $binding) {
+            $this->extensions[$binding->getClassName()] = $binding->getClassName();
+
+            if ($binding->hasParameterValue('name')) {
+                $this->extensions[$binding->getParameterValue('name')] = $binding->getClassName();
+            }
+        }
+
+        return $this->extensions;
+    }
+}


### PR DESCRIPTION
this implements what is described in #989, although it is right now pretty specific for puli (as there is no "standards" currently).

I am not sure how to test this, but maybe registering the built-in extensions in the puli json file, and then remove the `extensions` parameter from the constructor could lead to something ? And then test that a built-in extension loads itself correctly ?