### PR TITLE
Allow to use `*.yaml` configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+  * [#997](https://github.com/Behat/Behat/pull/997) Prioritize `*.yaml` extension for configuration files, as this extension is considered official.
+
 ### Fixed
   * [#993](https://github.com/Behat/Behat/pull/993) Fix mixed arguments organizer not marking typehinted arguments as "defined"
   * [#992](https://github.com/Behat/Behat/pull/993) Do not misinterpret first argument as a numbered argument if it is in fact typehinted

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -10,7 +10,6 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
-use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -85,6 +84,54 @@ class FeatureContext implements Context
     public function aFileNamedWith($filename, PyStringNode $content)
     {
         $content = strtr((string) $content, array("'''" => '"""'));
+        $this->createFile($this->workingDir . '/' . $filename, $content);
+    }
+
+    /**
+     * Creates a empty file with specified name in current workdir.
+     *
+     * @Given /^(?:there is )?a file named "([^"]*)"$/
+     *
+     * @param string $filename name of the file (relative path)
+     */
+    public function aFileNamed($filename)
+    {
+        $this->createFile($this->workingDir . '/' . $filename, '');
+    }
+
+    /**
+     * Creates a noop feature context in current workdir.
+     *
+     * @Given /^(?:there is )?a some feature context$/
+     */
+    public function aNoopFeatureContext()
+    {
+        $filename = 'features/bootstrap/FeatureContext.php';
+        $content = <<<'EOL'
+<?php
+
+use Behat\Behat\Context\Context;
+
+class FeatureContext implements Context
+{
+}
+EOL;
+        $this->createFile($this->workingDir . '/' . $filename, $content);
+    }
+
+        /**
+         * Creates a noop feature in current workdir.
+         *
+         * @Given /^(?:there is )?a some feature scenarios/
+         */
+        public function aNoopFeature()
+    {
+        $filename = 'features/bootstrap/FeatureContext.php';
+        $content = <<<'EOL'
+Feature:
+        Scenario:
+          When this scenario executes
+EOL;
         $this->createFile($this->workingDir . '/' . $filename, $content);
     }
 
@@ -174,6 +221,17 @@ class FeatureContext implements Context
 
         $this->options = '--format-settings=\'{"timer": false}\'';
         $this->iRunBehat($argumentsString);
+    }
+
+    /**
+     * Runs behat command in debug mode
+     *
+     * @When /^I run behat in debug mode$/
+     */
+    public function iRunBehatInDebugMode()
+    {
+        $this->options = '';
+        $this->iRunBehat('--debug');
     }
 
     /**

--- a/features/config.feature
+++ b/features/config.feature
@@ -91,3 +91,36 @@ Feature: Config
       """
       The requested config file does not exist
       """
+
+  Scenario: Prioritize *.yaml config file
+    Given a file named "behat.yaml"
+    Given a file named "behat.yml"
+    Given a some feature context
+    And a some feature scenarios
+    When I run behat in debug mode
+    Then the output should contain:
+      """
+      behat.yaml
+      """
+
+  Scenario: Load custom config instead of distribution
+    Given a file named "behat.yml"
+    Given a file named "behat.yaml.dist"
+    Given a some feature context
+    And a some feature scenarios
+    When I run behat in debug mode
+    Then the output should contain:
+      """
+      behat.yml
+      """
+
+  Scenario: Prioritize config file from root
+    Given a file named "behat.yaml.dist"
+    Given a file named "config/behat.yaml"
+    Given a some feature context
+    And a some feature scenarios
+    When I run behat in debug mode
+    Then the output should contain:
+      """
+      behat.yaml.dist
+      """

--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -111,11 +111,22 @@ final class ApplicationFactory extends BaseFactory
     protected function getConfigPath()
     {
         $cwd = rtrim(getcwd(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        $configDir = 'config' . DIRECTORY_SEPARATOR;
-        $paths = glob("{$cwd}{,{$configDir}}behat.y{a,}ml{,.dist}", GLOB_BRACE);
-
-        if (count($paths)) {
-            return current($paths);
+        $configDir = $cwd . 'config' . DIRECTORY_SEPARATOR;
+        $paths = array(
+            $cwd . 'behat.yaml',
+            $cwd . 'behat.yml',
+            $cwd . 'behat.yaml.dist',
+            $cwd . 'behat.yml.dist',
+            $configDir . 'behat.yaml',
+            $configDir . 'behat.yml',
+            $configDir . 'behat.yaml.dist',
+            $configDir . 'behat.yml.dist',
+        );
+        
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                return $path;
+            }
         }
 
         return null;

--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -110,16 +110,9 @@ final class ApplicationFactory extends BaseFactory
      */
     protected function getConfigPath()
     {
-        $cwd = rtrim(getcwd(), DIRECTORY_SEPARATOR);
-        $paths = array_filter(
-            array(
-                $cwd . DIRECTORY_SEPARATOR . 'behat.yml',
-                $cwd . DIRECTORY_SEPARATOR . 'behat.yml.dist',
-                $cwd . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'behat.yml',
-                $cwd . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'behat.yml.dist',
-            ),
-            'is_file'
-        );
+        $cwd = rtrim(getcwd(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $configDir = 'config' . DIRECTORY_SEPARATOR;
+        $paths = glob("{$cwd}{,{$configDir}}behat.y{a,}ml{,.dist}", GLOB_BRACE);
 
         if (count($paths)) {
             return current($paths);


### PR DESCRIPTION
This PR adds the ability to use `*.yaml` extension for the configuration, since this extension is considered official.

To keep backward compatibility but avoid extra file operation, checking with `is_file` was replaced with `glob`.