### PR TITLE
Feature/976 apostrophes vs capitals in snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
   * [#993](https://github.com/Behat/Behat/pull/993) Fix mixed arguments organizer not marking typehinted arguments as "defined"
   * [#992](https://github.com/Behat/Behat/pull/993) Do not misinterpret first argument as a numbered argument if it is in fact typehinted
+  
+### Added
+  * [#976](https://github.com/Behat/Behat/pull/1001): Add tests to check that snippets treat words containing apostrophes as a single word
 
 ## [3.3.0] - 2016-12-25
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3.3",
         "ext-mbstring": "*",
         "behat/gherkin": "^4.4.4",
-        "behat/transliterator": "~1.0",
+        "behat/transliterator": "^1.2",
         "symfony/console": "~2.5||~3.0",
         "symfony/config": "~2.3||~3.0",
         "symfony/dependency-injection": "~2.1||~3.0",

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -432,3 +432,55 @@ Feature: Snippets generation and addition
               throw new PendingException();
           }
       """
+
+  Scenario: Generating snippets for steps with apostrophes
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context {}
+      """
+    And a file named "features/coffee.feature" with:
+      """
+      Feature: Step Pattern
+        Scenario:
+          Given that it's eleven o'clock
+          When the guest's taxi has arrived
+          Then the guest says 'Goodbye'
+      """
+    When I run "behat -f progress --no-colors --snippets-for=FeatureContext"
+    Then it should pass with:
+      """
+      UUU
+
+      1 scenario (1 undefined)
+      3 steps (3 undefined)
+
+      --- FeatureContext has missing steps. Define them with these snippets:
+
+          /**
+           * @Given that it's eleven o'clock
+           */
+          public function thatItsElevenOclock()
+          {
+              throw new PendingException();
+          }
+
+          /**
+           * @When the guest's taxi has arrived
+           */
+          public function theGuestsTaxiHasArrived()
+          {
+              throw new PendingException();
+          }
+
+          /**
+           * @Then the guest says :arg1
+           */
+          public function theGuestSays($arg1)
+          {
+              throw new PendingException();
+          }
+      """


### PR DESCRIPTION
Addresses "Apostrophes causing unexpected capitals in snippets #976" with another PR on Behat/Transliterator (https://github.com/Behat/Transliterator/pull/18).