### PR TITLE
Use psr/container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/translation": "~2.3||~3.0",
         "symfony/yaml": "~2.1||~3.0",
         "symfony/class-loader": "~2.1||~3.0",
-        "container-interop/container-interop": "^1.1"
+        "psr/container": "^1.0"
     },
 
     "require-dev": {
@@ -38,6 +38,10 @@
         "behat/symfony2-extension": "for integration with Symfony2 web framework",
         "behat/yii-extension": "for integration with Yii web framework",
         "behat/mink-extension": "for integration with Mink testing framework"
+    },
+
+    "conflict": {
+        "container-interop/container-interop": "<1.2"
     },
 
     "autoload": {

--- a/features/helper_containers.feature
+++ b/features/helper_containers.feature
@@ -7,7 +7,7 @@ Feature: Per-suite helper containers
     - Having a container enables you to use its services as context arguments via `@name` syntax
     - Container is rebuilt and is isolated between scenarios
     - Container is configured via suite's `services` option
-    - Container is a class implementing `Interop\Container\ContainerInterface`
+    - Container is a class implementing `Psr\Container\ContainerInterface`
     - There is a built-in container if you need a very simple service-sharing, configurable through the same `services` setting
     - There is an extension point that allows Behat extensions provide their own containers for end-users via `@name` syntax
 
@@ -120,7 +120,7 @@ Feature: Per-suite helper containers
       """
     And a file named "features/bootstrap/MyContainer.php" with:
       """
-      <?php use Interop\Container\ContainerInterface;
+      <?php use Psr\Container\ContainerInterface;
 
       class MyContainer implements ContainerInterface {
           private $service;
@@ -154,7 +154,7 @@ Feature: Per-suite helper containers
       """
     And a file named "features/bootstrap/MyContainer.php" with:
       """
-      <?php use Interop\Container\ContainerInterface;
+      <?php use Psr\Container\ContainerInterface;
 
       class MyContainer implements ContainerInterface {
           private $service;
@@ -255,7 +255,7 @@ Feature: Per-suite helper containers
       """
     And a file named "features/bootstrap/MyContainer.php" with:
       """
-      <?php use Interop\Container\ContainerInterface;
+      <?php use Psr\Container\ContainerInterface;
 
       class MyContainer implements ContainerInterface {
           private $service;

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
@@ -11,7 +11,7 @@
 namespace Behat\Behat\HelperContainer\Argument;
 
 use Behat\Behat\Context\Argument\ArgumentResolver;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
 /**

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
@@ -16,7 +16,7 @@ use Behat\Behat\HelperContainer\Exception\WrongContainerClassException;
 use Behat\Behat\HelperContainer\Exception\WrongServicesConfigurationException;
 use Behat\Behat\HelperContainer\ServiceContainer\HelperContainerExtension;
 use Behat\Testwork\Suite\Suite;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\TaggedContainerInterface;
 
 /**
@@ -157,7 +157,7 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory
         if (!$container instanceof ContainerInterface) {
             throw new WrongContainerClassException(
                 sprintf(
-                    'Service container is expected to implement `Interop\Container\ContainerInterface`, but `%s` does not.',
+                    'Service container is expected to implement `Psr\Container\ContainerInterface`, but `%s` does not.',
                     get_class($container)
                 ),
                 get_class($container)

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -12,7 +12,7 @@ namespace Behat\Behat\HelperContainer;
 
 use Behat\Behat\HelperContainer\Exception\ServiceNotFoundException;
 use Behat\Behat\HelperContainer\Exception\WrongServicesConfigurationException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionMethod;
 

--- a/src/Behat/Behat/HelperContainer/Exception/HelperContainerException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/HelperContainerException.php
@@ -11,13 +11,13 @@
 namespace Behat\Behat\HelperContainer\Exception;
 
 use Behat\Testwork\Environment\Exception\EnvironmentException;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * All HelperContainer exceptions implement this interface.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-interface HelperContainerException extends ContainerException, EnvironmentException
+interface HelperContainerException extends ContainerExceptionInterface, EnvironmentException
 {
 }

--- a/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
@@ -10,15 +10,15 @@
 
 namespace Behat\Behat\HelperContainer\Exception;
 
-use Interop\Container\Exception\NotFoundException;
 use InvalidArgumentException;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Represents an exception thrown when service ID is not found inside the container.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class ServiceNotFoundException extends InvalidArgumentException implements HelperContainerException, NotFoundException
+final class ServiceNotFoundException extends InvalidArgumentException implements HelperContainerException, NotFoundExceptionInterface
 {
     /**
      * @var string


### PR DESCRIPTION
This replaces the now-deprecated `container-interop/container-interop` with `psr/container` in what-should-be-a BC way.

(The exceptions are now a different type, is that acceptable?)