### PR TITLE
Completely remove 5.3 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION='2.8.*'
     - php: 7.0
-      env: SYMFONY_VERSION='3.0.*'
-    - php: 7.0
       env: DEPENDENCIES='dev'
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.4
       env: DEPENDENCIES='low'
     - php: 5.6
       env: SYMFONY_VERSION='2.3.*'


### PR DESCRIPTION
In https://github.com/Behat/Behat/commit/f3e1481b6fca205ec9e0d1242be3d49af538624d, `5.3` was removed from the "php versions" matrix, but not from the test matrix. This fixes that.

It also allows to test on symfony `^3.0` on php7, as before it was only `3.0.*` (which isn't supported anymore)