### PR TITLE
Extension Instantiators abstraction

### DIFF
--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -120,7 +120,7 @@ Feature: Extensions
     Then it should fail with:
       """
       [Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException]
-        `inexistent_extension` extension file or class could not be located.
+        `inexistent_extension` extension could not be located.
       """
 
   @php-version @php7.0

--- a/src/Behat/Testwork/ApplicationFactory.php
+++ b/src/Behat/Testwork/ApplicationFactory.php
@@ -14,6 +14,9 @@ use Behat\Testwork\Cli\Application;
 use Behat\Testwork\ServiceContainer\Configuration\ConfigurationLoader;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
+use Behat\Testwork\ServiceContainer\Instantiator\ExtensionFileInstantiator;
+use Behat\Testwork\ServiceContainer\Instantiator\ExtensionClassInstantiator;
 
 /**
  * Defines the way application is created.
@@ -60,6 +63,19 @@ abstract class ApplicationFactory
     abstract protected function getConfigPath();
 
     /**
+     * Returns the extension instantiators
+     *
+     * @return ExtensionInstantiator[]
+     */
+    protected function getDefaultInstantiators()
+    {
+        return array(
+            new ExtensionClassInstantiator(),
+            new ExtensionFileInstantiator(),
+        );
+    }
+
+    /**
      * Creates application instance.
      *
      * @return Application
@@ -89,6 +105,6 @@ abstract class ApplicationFactory
      */
     protected function createExtensionManager()
     {
-        return new ExtensionManager($this->getDefaultExtensions());
+        return new ExtensionManager($this->getDefaultExtensions(), $this->getDefaultInstantiators());
     }
 }

--- a/src/Behat/Testwork/ServiceContainer/ExtensionInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionInstantiator.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\ServiceContainer;
+
+use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
+
+/**
+ * Represents an instantiator for an Extension
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+interface ExtensionInstantiator
+{
+    /**
+     * Instantiates extension from its locator.
+     *
+     * @param string $locator
+     *
+     * @return Extension
+     *
+     * @throws ExtensionInitializationException
+     */
+    public function instantiate($locator);
+}

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -40,14 +40,16 @@ final class ExtensionManager
     /**
      * Initializes manager.
      *
-     * @param Extension[]                         $extensions      List of default extensions
-     * @param ExtensionInstantiator[]|string|null $instantiators   Extension instantiators to use
+     * @param Extension[]                         $extensions              List of default extensions
+     * @param ExtensionInstantiator[]|string|null $extensionsInstantiators Extension instantiators to use
      */
-    public function __construct(array $extensions, $instantiators = null)
+    public function __construct(array $extensions, $extensionsInstantiators = null)
     {
         foreach ($extensions as $extension) {
             $this->extensions[$extension->getConfigKey()] = $extension;
         }
+
+        $instantiators = $extensionsInstantiators;
 
         // BC Layer, using default instantiators
         // to be removed in 4.0

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionClassInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionClassInstantiator.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\ServiceContainer\Instantiator;
+
+use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
+use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
+
+final class ExtensionClassInstantiator implements ExtensionInstantiator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function instantiate($locator)
+    {
+        if (class_exists($class = $locator)) {
+            return new $class;
+        }
+
+        if (class_exists($class = $this->getFullExtensionClass($locator))) {
+            return new $class;
+        }
+
+        throw new ExtensionInitializationException(sprintf(
+            '`%s` extension class could not be instantiated.',
+            $locator
+        ), $locator);
+    }
+
+    /**
+     * Attempts to guess full extension class from relative.
+     *
+     * @param string $locator
+     *
+     * @return string
+     */
+    private function getFullExtensionClass($locator)
+    {
+        $parts = explode('\\', $locator);
+        $name = preg_replace('/Extension$/', '', end($parts)) . 'Extension';
+
+        return sprintf('%s\\ServiceContainer\\%s', $locator, $name);
+    }
+}

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionClassInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionClassInstantiator.php
@@ -13,6 +13,19 @@ namespace Behat\Testwork\ServiceContainer\Instantiator;
 use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
 use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
 
+/**
+ * Instantiate an extension by its classname
+ *
+ * ```
+ *   extensions:
+ *       MyExtension:
+ *           # extension configuration
+ * ```
+ *
+ * Note that the `MyExtension` class must be autoloaded or autoloadable.
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
 final class ExtensionClassInstantiator implements ExtensionInstantiator
 {
     /**

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
@@ -13,6 +13,28 @@ namespace Behat\Testwork\ServiceContainer\Instantiator;
 use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
 use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
 
+/**
+ * Instantiate an extension by its filepath
+ *
+ * ```
+ *   extensions:
+ *       my_extension.php:
+ *           # extension configuration
+ * ```
+ *
+ * Note that the file *must* return an instance of the extension
+ *
+ * ```
+ * class MyExtension
+ * {
+ *     // ...
+ * }
+ *
+ * return new MyExtension();
+ * ```
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
 final class ExtensionFileInstantiator implements ExtensionInstantiator
 {
     /**

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\ServiceContainer\Instantiator;
+
+use Behat\Testwork\ServiceContainer\ExtensionInstantiator;
+use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
+
+final class ExtensionFileInstantiator implements ExtensionInstantiator
+{
+    /**
+     * @var string
+     */
+    private $extensionsPath;
+
+    public function __construct($extensionsPath = null)
+    {
+        $this->extensionsPath = $extensionsPath;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instantiate($locator)
+    {
+        if (file_exists($locator)) {
+            return require($locator);
+        }
+
+        if (file_exists($path = $this->extensionsPath . DIRECTORY_SEPARATOR . $locator)) {
+            return require($path);
+        }
+
+        throw new ExtensionInitializationException(sprintf(
+            '`%s` extension file could not be loaded.',
+            $locator
+        ), $locator);
+    }
+}

--- a/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
+++ b/src/Behat/Testwork/ServiceContainer/Instantiator/ExtensionFileInstantiator.php
@@ -26,6 +26,16 @@ final class ExtensionFileInstantiator implements ExtensionInstantiator
     }
 
     /**
+     * Sets path to directory in which manager will try to find extension files.
+     *
+     * @param null|string $path
+     */
+    public function setExtensionsPath($path)
+    {
+        $this->extensionsPath = $path;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function instantiate($locator)


### PR DESCRIPTION
See https://github.com/Behat/Behat/pull/995#discussion_r110239510 https://github.com/Behat/Behat/pull/995#issuecomment-280620803 This is basically #995 without Puli stuff

The instantiators are now separated and loaded in new array parameter `$instantiators` in the `ExtensionManager` class.

What could be done would be the following (to ease adding other instantiators) :
- Use a type of plugin loaded through composer (Thus binding even more Behat to Composer ?) ?
- Use the container to load instantiators (it is currently not the case) through a tag of some sort