### PR TITLE
Fix Parent / Child class argument ambiguity issue with MixedArgumentResolver

### DIFF
--- a/features/helper_containers.feature
+++ b/features/helper_containers.feature
@@ -342,3 +342,52 @@ Feature: Per-suite helper containers
       """
     When I run "behat --no-colors -f progress features/container_args.feature"
     Then it should pass
+
+  Scenario: Injecting typehinted arguments for a parent and child class (fix #1008)
+    Given a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - FirstContext:
+                - "@child_class"
+                - "@parent_class"
+            services:
+              parent_class:
+                class: ParentClass
+              child_class:
+                class: ChildClass
+      """
+    And a file named "features/container_args.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given foo
+      """
+    And a file named "features/bootstrap/FirstContext.php" with:
+      """
+      <?php use Behat\Behat\Context\Context;
+
+      class FirstContext implements Context {
+        public function __construct(ParentClass $parent, ChildClass $child) {
+        }
+
+        /** @Given foo */
+        public function foo() {
+
+        }
+      }
+      """
+    And a file named "features/bootstrap/ParentClass.php" with:
+      """
+      <?php
+      class ParentClass {}
+      """
+    And a file named "features/bootstrap/ChildClass.php" with:
+      """
+      <?php
+      class ChildClass extends ParentClass {}
+      """
+    When I run "behat --no-colors -f progress features/container_args.feature"
+    Then it should pass

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -190,7 +190,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * @param ReflectionParameter[] $parameters          Reflection Parameters (constructor argument requirements)
      * @param mixed[]               $typehintedArguments Resolved arguments
      *
-     * @return mixed[]
+     * @return mixed[] Ordered list of arguments, index is the constructor argument position, value is what will be injected
      */
     private function prepareTypehintedArguments(array $parameters, array $typehintedArguments)
     {

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -263,20 +263,16 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
         $filtered = $this->filterApplicableTypehintedParameters($parameters);
 
         foreach ($filtered as $num => $parameter) {
-            $reflectionClass = $parameter->getClass();
-
             foreach ($candidates as $candidateIndex => $candidate) {
-                if (call_user_func_array($predicate, [$reflectionClass, $candidate]) !== true) {
-                    continue;
+                if (call_user_func_array($predicate, [$parameter->getClass(), $candidate])) {
+                    $arguments[$num] = $candidate;
+
+                    $this->markArgumentDefined($num);
+
+                    unset($candidates[$candidateIndex]);
+
+                    break 1;
                 }
-
-                $arguments[$num] = $candidate;
-
-                $this->markArgumentDefined($num);
-
-                unset($candidates[$candidateIndex]);
-
-                break 1;
             }
         }
     }

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -236,7 +236,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
 
                 $arguments[$num] = $candidate;
 
-                $this->markArgumentDefined(true);
+                $this->markArgumentDefined($num);
 
                 unset($candidates[$candidateIndex]);
 

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -260,9 +260,9 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
         array &$arguments,
         callable $predicate
     ) {
-        $parameters = $this->filterApplicableTypehintedParameters($parameters);
+        $filtered = $this->filterApplicableTypehintedParameters($parameters);
 
-        foreach ($parameters as $num => $parameter) {
+        foreach ($filtered as $num => $parameter) {
             $reflectionClass = $parameter->getClass();
 
             foreach ($candidates as $candidateIndex => $candidate) {

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -228,6 +228,8 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
             }
 
             foreach ($candidates as $candidateIndex => $candidate) {
+                $reflectionClass = $parameter->getClass();
+
                 if (!$reflectionClass || !$reflectionClass->isInstance($candidate)) {
                     continue;
                 }

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -119,7 +119,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      *
      * @return Boolean
      */
-    public function isParameterTypehintedInArgumentList(array $parameters, $value)
+    private function isParameterTypehintedInArgumentList(array $parameters, $value)
     {
         if (!is_object($value)) {
             return false;


### PR DESCRIPTION
This PR updates the logic of the `MixedArgumentResolver@prepareTypehintedArguments` method to resolve an issue where a constructor asks for two typehinted arguments where one of the arguments is interchangeable with the other. A parent / child class relationship will cause this error.

See the original issue: behat/behat#1008

~~I have not added in any tests, as the unit tests were failing locally when I ran them on a fresh clone of master.~~
I have now added in a test case for the bug that I have fixed.