### PR TITLE
Remove short array syntax

### DIFF
--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -285,7 +285,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
         callable $predicate
     ) {
         foreach ($candidates as $candidateIndex => $candidate) {
-            if (call_user_func_array($predicate, [$parameter->getClass(), $candidate])) {
+            if (call_user_func_array($predicate, array($parameter->getClass(), $candidate))) {
                 $num = $parameter->getPosition();
 
                 $arguments[$num] = $candidate;


### PR DESCRIPTION
This contradicts the supported version declared in composer, and caused an issue with PhpSpec's legacy support branch (so might warrant a patch release)