### PR TITLE
Allow Behat to find feature files with specified line / range when not in the root folder

### DIFF
--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -225,6 +225,7 @@ final class GherkinExtension implements Extension
         }
 
         $definition->addMethodCall('setCache', array($cacheDefinition));
+        $definition->addMethodCall('setBasePath', array('%paths.base%'));
         $definition->addTag(self::LOADER_TAG, array('priority' => 50));
         $container->setDefinition('gherkin.loader.gherkin_file', $definition);
     }

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -225,7 +225,6 @@ final class GherkinExtension implements Extension
         }
 
         $definition->addMethodCall('setCache', array($cacheDefinition));
-        $definition->addMethodCall('setBasePath', array('%paths.base%'));
         $definition->addTag(self::LOADER_TAG, array('priority' => 50));
         $container->setDefinition('gherkin.loader.gherkin_file', $definition);
     }

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -182,7 +182,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
      * - example.feature:9
      * - example.feature:5-28
      *
-     *  This method will strip out everything preceeding the .feature if the next character is a colon.
+     * This method will strip out everything following the `.feature` extension in the filename if the next character is a colon.
      * This is required so that we can locate the file on the filesystem.
      *
      * @param  string $path Path to the feature file

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -121,6 +121,8 @@ final class FilesystemFeatureLocator implements SpecificationLocator
      */
     private function findFeatureFiles($path)
     {
+        $path = $this->sanitisePath($path);
+
         $absolutePath = $this->findAbsolutePath($path);
 
         if (!$absolutePath) {
@@ -172,5 +174,23 @@ final class FilesystemFeatureLocator implements SpecificationLocator
         }
 
         return false;
+    }
+
+    /**
+     * Sanitise the given path. The path may contain a line number or range,
+     * indicated by a colon followed by a number after the file extension, ex:
+     * - example.feature:9
+     * - example.feature:5-28
+     *
+     *  This method will strip out everything preceeding the .feature if the next character is a colon.
+     * This is required so that we can locate the file on the filesystem.
+     *
+     * @param  string $path Path to the feature file
+     *
+     * @return string       Path safe for searching the filesystem.
+     */
+    private function sanitisePath($path)
+    {
+        return preg_replace('/(.+\.feature)(?:\:.+?)?$/i', '$1', $path);
     }
 }

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -121,12 +121,12 @@ final class FilesystemFeatureLocator implements SpecificationLocator
      */
     private function findFeatureFiles($path)
     {
-        $path = $this->sanitisePath($path);
+        $sanitisedPath = $this->sanitisePath($path);
 
-        $absolutePath = $this->findAbsolutePath($path);
+        $absolutePath = $this->findAbsolutePath($sanitisedPath);
 
         if (!$absolutePath) {
-            return array($path);
+            return array($sanitisedPath);
         }
 
         if (is_file($absolutePath)) {


### PR DESCRIPTION
This is to resolve the bug raised in #1043.

In the scenario where you are running a specific Behat scenario whilst not in the project root (where `behat.yml` lives), Behat trips up as it cannot find the specified file, even if it has been passed properly.

To replicate the bug on master, change in to a sub directory, and call a specific scenario in a given feature file, example:
```
cd foo
../vendor/bin/behat -c ../behat.yml features/acme.feature:9
```

When running this, Behat will only look for `features/acme` in the `foo` directory, it will not try and look in the base path because the Gherkin loaders have not been told what the base path is, which causes a failure in the `behat\gherkin` repository (the `Behat\Gherkin\Loader\AbstractFileLoader@findAbsolutePath` method).

One line change to resolve it.