### PR TITLE
issue #982: support environment variable inside behat.yml

### DIFF
--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -184,7 +184,7 @@ final class Application extends BaseApplication
         $extension = new ContainerLoader($this->extensionManager);
         $extension->load($container, $this->loadConfiguration($input));
         $container->addObjectResource($extension);
-        $container->compile();
+        $container->compile(true);
 
         return $container;
     }


### PR DESCRIPTION
Issue #982 
With symfony/symfony#21460 fixed (>= 3.3.0, symfony/symfony@a3fd5122), this change allow the use of environment variables in any section of behat configuration file.
For example: `base_url: "http://%env(HOSTNAME)%"`
Don't forget, these variable must be exported for the container configuration to be resolved (otherwise the `default` [syntax must be used](https://symfony.com/doc/3.2/configuration/external_parameters.html))