### PR TITLE
Fix to inability to use LineFilter and LineRangefilter Filters

### DIFF
--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -64,13 +64,15 @@ final class LazyFeatureIterator implements SpecificationIterator
      * @param Gherkin           $gherkin
      * @param string[]          $paths
      * @param FilterInterface[] $filters
+     * @param string            $basePath
      */
-    public function __construct(Suite $suite, Gherkin $gherkin, array $paths, array $filters = array())
+    public function __construct(Suite $suite, Gherkin $gherkin, array $paths, array $filters = array(), $basePath = '')
     {
         $this->suite = $suite;
         $this->gherkin = $gherkin;
         $this->paths = array_values($paths);
         $this->filters = array_merge($this->getSuiteFilters($suite), $filters);
+        $gherkin->setBasePath($basePath);
     }
 
     /**

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -77,7 +77,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
         if ($locator) {
             $filters = array(new PathsFilter($suiteLocators));
 
-            return new LazyFeatureIterator($suite, $this->gherkin, $this->findFeatureFiles($locator), $filters);
+            return new LazyFeatureIterator($suite, $this->gherkin, $this->findFeatureFiles($locator), $filters, $this->basePath);
         }
 
         $featurePaths = array();
@@ -85,7 +85,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
             $featurePaths = array_merge($featurePaths, $this->findFeatureFiles($suiteLocator));
         }
 
-        return new LazyFeatureIterator($suite, $this->gherkin, $featurePaths);
+        return new LazyFeatureIterator($suite, $this->gherkin, $featurePaths, [], $this->basePath);
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where the user provides a line for a specific scenario(s). The AbstractFileLoader class doesn't find the basePath because FilesystemFeatureLocator doesn't set the $basePath via the _construct. It only sets the $basePath for the FilesystemFeatureLocator. Not sure if this is the best place for this. Without it any command for scenarios by line number fail due to the Gherkin class not having a basePath set.
````
bin/behat --suite=default features/donate.feature:61

