### PR TITLE
Make Gherkin aware of the base path so it can filter correctly

### DIFF
--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -225,6 +225,7 @@ final class GherkinExtension implements Extension
         }
 
         $definition->addMethodCall('setCache', array($cacheDefinition));
+        $definition->addMethodCall('setBasePath', ['%paths.base%']);
         $definition->addTag(self::LOADER_TAG, array('priority' => 50));
         $container->setDefinition('gherkin.loader.gherkin_file', $definition);
     }


### PR DESCRIPTION
Re-opened copy of #1046.

A PR in behat/Gherkin has been created, which is part 1 of this fix; it updates the PathFilter, so that the current path has the current working directory set on it.

That may / may not be correct. The CWD will be where the `behat.yml` file lives, and generally the feature files are relative to there (and the CWD should equal the 'base path'). Ideally, the `$file` property on `FeatureNode` should be given the absolute path, as that offers more flexibility later on down the line. That's a more fundamental change which will need discussed first.

Content copied from original PR:

This is to resolve the bug raised in #1043.

In the scenario where you are running a specific Behat scenario whilst not in the project root (where `behat.yml` lives), Behat trips up as it cannot find the specified file, even if it has been passed properly.

To replicate the bug on master, change in to a sub directory, and call a specific scenario in a given feature file, example:
```
cd foo
../vendor/bin/behat -c ../behat.yml features/acme.feature:9
```

When running this, Behat will only look for `features/acme` in the `foo` directory, it will not try and look in the base path because the Gherkin loaders have not been told what the base path is, which causes a failure in the `behat\gherkin` repository (the `Behat\Gherkin\Loader\AbstractFileLoader@findAbsolutePath` method).

One line change to resolve it.