### PR TITLE
Hold helper container on instances of Environment

### DIFF
--- a/src/Behat/Behat/Context/Argument/ArgumentResolverFactory.php
+++ b/src/Behat/Behat/Context/Argument/ArgumentResolverFactory.php
@@ -10,25 +10,23 @@
 
 namespace Behat\Behat\Context\Argument;
 
-use Behat\Testwork\Suite\Suite;
+use Behat\Testwork\Environment\Environment;
 
 /**
- * Creates argument resolvers for provided suite.
+ * Creates argument resolvers for provided environment.
  *
  * @see ContextEnvironmentHandler
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @deprecated since 3.4. Use `ArgumentResolverFactory` instead
  */
-interface SuiteScopedResolverFactory
+interface ArgumentResolverFactory
 {
     /**
-     * Creates argument resolvers for provided suite.
+     * Builds argument resolvers for provided suite.
      *
-     * @param Suite $suite
+     * @param Environment $environment
      *
      * @return ArgumentResolver[]
      */
-    public function generateArgumentResolvers(Suite $suite);
+    public function createArgumentResolvers(Environment $environment);
 }

--- a/src/Behat/Behat/Context/Argument/NullFactory.php
+++ b/src/Behat/Behat/Context/Argument/NullFactory.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Context\Argument;
 
+use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Suite\Suite;
 
 /**
@@ -19,12 +20,20 @@ use Behat\Testwork\Suite\Suite;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class NullFactory implements SuiteScopedResolverFactory
+final class NullFactory implements ArgumentResolverFactory, SuiteScopedResolverFactory
 {
     /**
      * {@inheritdoc}
      */
     public function generateArgumentResolvers(Suite $suite)
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createArgumentResolvers(Environment $environment)
     {
         return array();
     }

--- a/src/Behat/Behat/Context/Argument/SuiteScopedResolverFactoryAdapter.php
+++ b/src/Behat/Behat/Context/Argument/SuiteScopedResolverFactoryAdapter.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Argument;
+
+use Behat\Testwork\Environment\Environment;
+
+/**
+ * Adapts SuiteScopedResolverFactory to new ArgumentResolverFactory interface.
+ *
+ * @see ContextEnvironmentHandler
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @deprecated since 3.4. Use `ArgumentResolverFactory` instead
+ */
+final class SuiteScopedResolverFactoryAdapter implements ArgumentResolverFactory
+{
+    /**
+     * @var SuiteScopedResolverFactory
+     */
+    private $factory;
+
+    /**
+     * Initialises adapter.
+     *
+     * @param SuiteScopedResolverFactory $factory
+     */
+    public function __construct(SuiteScopedResolverFactory $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createArgumentResolvers(Environment $environment)
+    {
+        return $this->factory->generateArgumentResolvers($environment->getSuite());
+    }
+}

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -23,7 +23,6 @@ use Behat\Testwork\Environment\Exception\EnvironmentIsolationException;
 use Behat\Testwork\Environment\Handler\EnvironmentHandler;
 use Behat\Testwork\Suite\Exception\SuiteConfigurationException;
 use Behat\Testwork\Suite\Suite;
-use Webmozart\Assert\Assert;
 
 /**
  * Handles build and initialisation of the context-based environments.
@@ -58,12 +57,6 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
         $this->contextFactory = $factory;
 
         if ($resolverFactory && !$resolverFactory instanceof ArgumentResolverFactory) {
-            Assert::isInstanceOf(
-                $resolverFactory,
-                'Behat\Behat\Context\Argument\SuiteScopedResolverFactory',
-                'Argument resolver must implement ArgumentResolverFactory or SuiteScopedResolverFactory (deprecated)'
-            );
-
             $resolverFactory = new SuiteScopedResolverFactoryAdapter($resolverFactory);
         }
 

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -15,6 +15,7 @@ use Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler;
 use Behat\Behat\Context\Exception\ContextNotFoundException;
 use Behat\Testwork\Call\Callee;
 use Behat\Testwork\Suite\Suite;
+use Psr\Container\ContainerInterface;
 
 /**
  * Context environment based on a list of instantiated context objects.
@@ -23,12 +24,16 @@ use Behat\Testwork\Suite\Suite;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class InitializedContextEnvironment implements ContextEnvironment
+final class InitializedContextEnvironment implements ContextEnvironment, ServiceContainerEnvironment
 {
     /**
      * @var string
      */
     private $suite;
+    /**
+     * @var ContainerInterface
+     */
+    private $serviceContainer;
     /**
      * @var Context[]
      */
@@ -52,6 +57,14 @@ final class InitializedContextEnvironment implements ContextEnvironment
     public function registerContext(Context $context)
     {
         $this->contexts[get_class($context)] = $context;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setServiceContainer(ContainerInterface $container = null)
+    {
+        $this->serviceContainer = $container;
     }
 
     /**
@@ -115,6 +128,14 @@ final class InitializedContextEnvironment implements ContextEnvironment
         }
 
         return $this->contexts[$class];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServiceContainer()
+    {
+        return $this->serviceContainer;
     }
 
     /**

--- a/src/Behat/Behat/Context/Environment/ServiceContainerEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/ServiceContainerEnvironment.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Context\Environment;
+
+use Behat\Testwork\Environment\Environment;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Represents test environment based on a service locator pattern.
+ *
+ * @see ContextEnvironmentHandler
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+interface ServiceContainerEnvironment extends Environment
+{
+    /**
+     * Sets/unsets service container for the environment.
+     *
+     * @param ContainerInterface|null $container
+     */
+    public function setServiceContainer(ContainerInterface $container = null);
+
+    /**
+     * Returns environment service container if set.
+     *
+     * @return null|ContainerInterface
+     */
+    public function getServiceContainer();
+}

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
@@ -10,11 +10,14 @@
 
 namespace Behat\Behat\HelperContainer\Argument;
 
+use Behat\Behat\Context\Environment\ServiceContainerEnvironment;
+use Behat\Behat\Context\Argument\ArgumentResolverFactory;
 use Behat\Behat\Context\Argument\SuiteScopedResolverFactory;
 use Behat\Behat\HelperContainer\BuiltInServiceContainer;
 use Behat\Behat\HelperContainer\Exception\WrongContainerClassException;
 use Behat\Behat\HelperContainer\Exception\WrongServicesConfigurationException;
 use Behat\Behat\HelperContainer\ServiceContainer\HelperContainerExtension;
+use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Suite\Suite;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\TaggedContainerInterface;
@@ -26,7 +29,7 @@ use Symfony\Component\DependencyInjection\TaggedContainerInterface;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class ServicesResolverFactory implements SuiteScopedResolverFactory
+final class ServicesResolverFactory implements SuiteScopedResolverFactory, ArgumentResolverFactory
 {
     /**
      * @var TaggedContainerInterface
@@ -45,6 +48,8 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function generateArgumentResolvers(Suite $suite)
     {
@@ -53,6 +58,24 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory
         }
 
         $container = $this->createContainer($suite->getSetting('services'));
+
+        return array($this->createArgumentResolver($container));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createArgumentResolvers(Environment $environment)
+    {
+        if (!$environment->getSuite()->hasSetting('services')) {
+            return array();
+        }
+
+        $container = $this->createContainer($environment->getSuite()->getSetting('services'));
+
+        if ($environment instanceof ServiceContainerEnvironment) {
+            $environment->setServiceContainer($container);
+        }
 
         return array($this->createArgumentResolver($container));
     }

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
@@ -49,10 +49,15 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
     /**
      * {@inheritdoc}
      *
-     * @deprecated
+     * @deprecated as part of SuiteScopedResolverFactory deprecation. Would be removed in 4.0
      */
     public function generateArgumentResolvers(Suite $suite)
     {
+        @trigger_error(
+            'SuiteScopedResolverFactory::generateArgumentResolvers() was deprecated and will be removed in 4.0',
+            E_USER_DEPRECATED
+        );
+
         if (!$suite->hasSetting('services')) {
             return array();
         }


### PR DESCRIPTION
This is a second refactoring to enable us a bigger feature in upcoming release. However, despite aiming at supporting a bigger feature this refactoring brings value on its own - it exposes your preconfigured service-container via `Environment::getServiceContainer()`. Extension creators can use that to their own benefit.