### PR TITLE
Services autowiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+  * [#1071](https://github.com/Behat/Behat/pull/1071): Services auto-wiring
   * [#1054](https://github.com/Behat/Behat/pull/1054): [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md)
     support for helper containers.
   * Support for modern PHPUnit.

--- a/features/autowire.feature
+++ b/features/autowire.feature
@@ -1,0 +1,162 @@
+Feature: Helper services autowire
+  In order to speed up the development process at early stages
+  developers need to have a convenient way of requesting services without going through the explicit configuration layer
+
+  Rules:
+    - Autowiring only works with helper containers
+    - Autowiring is off by default
+    - Autowiring is enabled/disabled by a suite-level `autowire` flag
+    - It works for context constructor arguments
+    - It works for step definition arguments
+    - It works for transformation arguments
+    - It only wires arguments that weren't otherwise set
+
+  Background:
+    Given a file named "behat.yaml" with:
+      """
+      default:
+        suites:
+          default:
+            services: ServiceContainer
+            autowire: true
+      """
+    And a file named "features/bootstrap/ServiceContainer.php" with:
+      """
+      <?php use Psr\Container\ContainerInterface;
+
+      class Service1 {public $state;}
+      class Service2 {public $state;}
+      class Service3 {public $state;}
+
+      class ServiceContainer implements ContainerInterface {
+          private $services = array();
+
+          public function has($class) {
+              return in_array($class, array('Service1', 'Service2', 'Service3'));
+          }
+
+          public function get($class) {
+              return isset($this->services[$class])
+                   ? $this->services[$class]
+                   : $this->services[$class] = new $class;
+          }
+      }
+      """
+
+  Scenario: Constructor arguments
+    Given a file named "features/autowire.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given a step
+      """
+    And a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context {
+          public function __construct(Service2 $s1, Service1 $s2, Service3 $s3) {}
+
+          /** @Given a step */
+          public function aStep() {}
+      }
+      """
+    When I run "behat --no-colors -f progress features/autowire.feature"
+    Then it should pass
+
+  Scenario: Mixed constructor arguments
+    Given a file named "behat.yaml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - FeatureContext:
+                  name: "Konstantin"
+                  s2: "@Service2"
+            services: ServiceContainer
+            autowire: true
+      """
+    And a file named "features/autowire.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given a step
+      """
+    And a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context {
+          public function __construct(Service2 $s2, $name, Service1 $s1, Service3 $s3)
+          {
+              PHPUnit_Framework_Assert::assertEquals('Konstantin', $name);
+          }
+
+          /** @Given a step */
+          public function aStep() {}
+      }
+      """
+    When I run "behat --no-colors -f progress features/autowire.feature"
+    Then it should pass
+
+  Scenario: Step definition arguments
+
+  Scenario: Constructor arguments
+    Given a file named "features/autowire.feature" with:
+      """
+      Feature:
+        Scenario:
+          When I set the state to "isSet"
+          Then that state should be persisted as "isSet"
+      """
+    And a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context {
+          /** @When I set the state to :value */
+          public function setState($value, Service2 $s2) {
+              $s2->state = $value;
+          }
+
+          /** @Then that state should be persisted as :value */
+          public function checkState($val, Service2 $s2) {
+              PHPUnit_Framework_Assert::assertEquals($val, $s2->state);
+          }
+      }
+      """
+    When I run "behat --no-colors -f progress features/autowire.feature"
+    Then it should pass
+
+  Scenario: Transformation arguments
+    Given a file named "features/autowire.feature" with:
+      """
+      Feature:
+        Scenario:
+          When I set the "myFlag" flag to "isSet"
+          Then the "myFlag" flag should be persisted as "isSet"
+      """
+    And a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context {
+          /** @Transform :flag */
+          public function fromFlag($flag, Service2 $s2) {
+              return $s2->$flag;
+          }
+
+          /** @When I set the :flat flag to :value */
+          public function setState($flag, $value, Service2 $s2) {
+              $s2->$flag = $value;
+          }
+
+          /** @Then the :flag flag should be persisted as :value */
+          public function checkState($flag, $value) {
+              PHPUnit_Framework_Assert::assertEquals($value, $flag);
+          }
+      }
+      """
+    When I run "behat --no-colors -f progress features/autowire.feature"
+    Then it should pass

--- a/features/autowire.feature
+++ b/features/autowire.feature
@@ -127,8 +127,7 @@ Feature: Helper services autowire
     When I run "behat --no-colors -f progress features/autowire.feature"
     Then it should fail with:
       """
-      [Behat\Behat\HelperContainer\Exception\ServiceNotFoundException]
-        Service Service4 not found
+      Service Service4 not found
       """
 
   Scenario: Step definition arguments
@@ -177,13 +176,7 @@ Feature: Helper services autowire
     When I run "behat --no-colors -f progress features/autowire.feature"
     Then it should fail with:
       """
-      F
-
-      --- Failed steps:
-
-      001 Scenario:      # features/autowire.feature:2
-            Given a step # features/autowire.feature:3
-              Fatal error: Service Service4 not found (Behat\Testwork\Call\Exception\FatalThrowableError)
+      Service Service4 not found
       """
 
   Scenario: Transformation arguments

--- a/features/autowire.feature
+++ b/features/autowire.feature
@@ -10,6 +10,8 @@ Feature: Helper services autowire
     - It works for step definition arguments
     - It works for transformation arguments
     - It only wires arguments that weren't otherwise set
+    - Services must be last arguments in step definitions
+    - Services must be last arguments in transformations
 
   Background:
     Given a file named "behat.yaml" with:

--- a/features/autowire.feature
+++ b/features/autowire.feature
@@ -101,8 +101,6 @@ Feature: Helper services autowire
     Then it should pass
 
   Scenario: Step definition arguments
-
-  Scenario: Constructor arguments
     Given a file named "features/autowire.feature" with:
       """
       Feature:

--- a/features/helper_containers.feature
+++ b/features/helper_containers.feature
@@ -250,6 +250,44 @@ Feature: Per-suite helper containers
     When I run "behat --no-colors -f progress features/container.feature"
     Then it should pass
 
+  Scenario: Built-in container with class names as service IDs
+    Given a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - FirstContext:
+                - "@SharedService"
+              - SecondContext:
+                - "@SharedService"
+
+            services:
+              SharedService: ~
+      """
+    When I run "behat --no-colors -f progress features/container.feature"
+    Then it should pass
+
+  Scenario: Built-in container with class names as service IDs and arguments
+    Given a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - FirstContext:
+                - "@SharedServiceExpecting1"
+              - SecondContext:
+                - "@SharedServiceExpecting1"
+
+            services:
+              SharedServiceExpecting1:
+                arguments:
+                  - 1
+      """
+    When I run "behat --no-colors -f progress features/container.feature"
+    Then it should pass
+
   Scenario: Built-in container with factory-based services
     Given a file named "behat.yml" with:
       """

--- a/src/Behat/Behat/Context/Argument/CompositeArgumentResolverFactory.php
+++ b/src/Behat/Behat/Context/Argument/CompositeArgumentResolverFactory.php
@@ -10,7 +10,7 @@
 
 namespace Behat\Behat\Context\Argument;
 
-use Behat\Testwork\Suite\Suite;
+use Behat\Testwork\Environment\Environment;
 
 /**
  * Composite factory. Delegates to other (registered) factories to do the job.
@@ -18,22 +18,20 @@ use Behat\Testwork\Suite\Suite;
  * @see ContextEnvironmentHandler
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @deprecated and will be removed in 4.0. Use CompositeArgumentResolverFactory instead
  */
-final class CompositeFactory implements SuiteScopedResolverFactory
+final class CompositeArgumentResolverFactory implements ArgumentResolverFactory
 {
     /**
-     * @var SuiteScopedResolverFactory[]
+     * @var ArgumentResolverFactory[]
      */
     private $factories = array();
 
     /**
      * Registers factory.
      *
-     * @param SuiteScopedResolverFactory $factory
+     * @param ArgumentResolverFactory $factory
      */
-    public function registerFactory(SuiteScopedResolverFactory $factory)
+    public function registerFactory(ArgumentResolverFactory $factory)
     {
         $this->factories[] = $factory;
     }
@@ -41,12 +39,12 @@ final class CompositeFactory implements SuiteScopedResolverFactory
     /**
      * {@inheritdoc}
      */
-    public function generateArgumentResolvers(Suite $suite)
+    public function createArgumentResolvers(Environment $environment)
     {
         return array_reduce(
             $this->factories,
-            function (array $resolvers, SuiteScopedResolverFactory $factory) use ($suite) {
-                return array_merge($resolvers, $factory->generateArgumentResolvers($suite));
+            function (array $resolvers, ArgumentResolverFactory $factory) use ($environment) {
+                return array_merge($resolvers, $factory->createArgumentResolvers($environment));
             },
             array()
         );

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -13,6 +13,7 @@ namespace Behat\Behat\Context\Environment;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler;
 use Behat\Behat\Context\Exception\ContextNotFoundException;
+use Behat\Behat\HelperContainer\Environment\ServiceContainerEnvironment;
 use Behat\Testwork\Call\Callee;
 use Behat\Testwork\Suite\Suite;
 use Psr\Container\ContainerInterface;

--- a/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
+++ b/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
@@ -142,7 +142,7 @@ final class ContextExtension implements Extension
      */
     private function loadArgumentResolverFactory(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\Argument\CompositeFactory');
+        $definition = new Definition('Behat\Behat\Context\Argument\CompositeArgumentResolverFactory');
         $container->setDefinition(self::AGGREGATE_RESOLVER_FACTORY_ID, $definition);
     }
 

--- a/src/Behat/Behat/HelperContainer/Argument/AutowiringResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/AutowiringResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\HelperContainer\Argument;
+
+use Behat\Behat\Context\Argument\ArgumentResolver;
+use Behat\Behat\HelperContainer\ArgumentAutowirer;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+
+/**
+ * Resolves arguments that weren't resolved before by autowiring.
+ *
+ * @see ContextFactory
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class AutowiringResolver implements ArgumentResolver
+{
+    /**
+     * @var ArgumentAutowirer
+     */
+    private $autowirer;
+
+    /**
+     * Initialises resolver.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->autowirer = new ArgumentAutowirer($container);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveArguments(ReflectionClass $classReflection, array $arguments)
+    {
+        if ($constructor = $classReflection->getConstructor()) {
+            return $this->autowirer->autowireArguments($constructor, $arguments);
+        }
+
+        return $arguments;
+    }
+}

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
@@ -57,8 +57,8 @@ final class ServicesResolver implements ArgumentResolver
                     continue;
                 }
 
-                if ($parameter->hasType() && $this->container->has($parameter->getType()->getName())) {
-                    $newArguments[$index] = $this->container->get($parameter->getType()->getName());
+                if ($parameter->getClass() && $this->container->has($parameter->getClass()->getName())) {
+                    $newArguments[$index] = $this->container->get($parameter->getClass()->getName());
                 }
             }
         }

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
@@ -10,7 +10,7 @@
 
 namespace Behat\Behat\HelperContainer\Argument;
 
-use Behat\Behat\Context\Environment\ServiceContainerEnvironment;
+use Behat\Behat\HelperContainer\Environment\ServiceContainerEnvironment;
 use Behat\Behat\Context\Argument\ArgumentResolverFactory;
 use Behat\Behat\Context\Argument\SuiteScopedResolverFactory;
 use Behat\Behat\HelperContainer\BuiltInServiceContainer;

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
@@ -64,7 +64,7 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
 
         $container = $this->createContainer($suite->getSetting('services'));
 
-        return array($this->createArgumentResolver($container));
+        return array($this->createArgumentResolver($container, false));
     }
 
     /**
@@ -72,17 +72,20 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
      */
     public function createArgumentResolvers(Environment $environment)
     {
-        if (!$environment->getSuite()->hasSetting('services')) {
+        $suite = $environment->getSuite();
+
+        if (!$suite->hasSetting('services')) {
             return array();
         }
 
-        $container = $this->createContainer($environment->getSuite()->getSetting('services'));
+        $container = $this->createContainer($suite->getSetting('services'));
+        $autowire = $suite->hasSetting('autowire') && $suite->getSetting('autowire');
 
         if ($environment instanceof ServiceContainerEnvironment) {
             $environment->setServiceContainer($container);
         }
 
-        return array($this->createArgumentResolver($container));
+        return array($this->createArgumentResolver($container, $autowire));
     }
 
     /**
@@ -177,10 +180,11 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
      * Checks if container implements the correct interface and creates resolver using it.
      *
      * @param mixed $container
+     * @param bool  $autowire
      *
      * @return ServicesResolver
      */
-    private function createArgumentResolver($container)
+    private function createArgumentResolver($container, $autowire)
     {
         if (!$container instanceof ContainerInterface) {
             throw new WrongContainerClassException(
@@ -192,6 +196,6 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
             );
         }
 
-        return new ServicesResolver($container);
+        return new ServicesResolver($container, $autowire);
     }
 }

--- a/src/Behat/Behat/HelperContainer/ArgumentAutowirer.php
+++ b/src/Behat/Behat/HelperContainer/ArgumentAutowirer.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\HelperContainer;
 
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
@@ -37,12 +38,14 @@ final class ArgumentAutowirer
     }
 
     /**
-     * * Autowires given arguments using provided container.
+     * Autowires given arguments using provided container.
      *
      * @param ReflectionFunctionAbstract $reflection
-     * @param array                      $arguments
+     * @param array $arguments
      *
      * @return array
+     *
+     * @throws ContainerExceptionInterface if unset argument typehint can not be resolved from container
      */
     public function autowireArguments(ReflectionFunctionAbstract $reflection, array $arguments)
     {

--- a/src/Behat/Behat/HelperContainer/ArgumentAutowirer.php
+++ b/src/Behat/Behat/HelperContainer/ArgumentAutowirer.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\HelperContainer;
+
+use Psr\Container\ContainerInterface;
+use ReflectionFunctionAbstract;
+use ReflectionParameter;
+
+/**
+ * Automatically wires arguments of a given function from inside the container by using type-hitns.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class ArgumentAutowirer
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * Initialises wirer.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * * Autowires given arguments using provided container.
+     *
+     * @param ReflectionFunctionAbstract $reflection
+     * @param array                      $arguments
+     *
+     * @return array
+     */
+    public function autowireArguments(ReflectionFunctionAbstract $reflection, array $arguments)
+    {
+        $newArguments = $arguments;
+        foreach ($reflection->getParameters() as $index => $parameter) {
+            if ($this->isArgumentWireable($newArguments, $index, $parameter)) {
+                $newArguments[$index] = $this->container->get($parameter->getClass()->getName());
+            }
+        }
+
+        return $newArguments;
+    }
+
+    /**
+     * Checks if given argument is wireable.
+     *
+     * Argument is wireable if it was not previously set and it has a class type-hint.
+     *
+     * @param array               $arguments
+     * @param integer             $index
+     * @param ReflectionParameter $parameter
+     *
+     * @return bool
+     */
+    private function isArgumentWireable(array $arguments, $index, ReflectionParameter $parameter)
+    {
+        return !isset($arguments[$index]) && !isset($arguments[$parameter->getName()]) && $parameter->getClass();
+    }
+}

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -47,7 +47,7 @@ final class BuiltInServiceContainer implements ContainerInterface
      */
     public function has($id)
     {
-        return isset($this->schema[$id]);
+        return array_key_exists($id, $this->schema);
     }
 
     /**
@@ -98,6 +98,14 @@ final class BuiltInServiceContainer implements ContainerInterface
     private function getAndValidateServiceSchema($id)
     {
         $schema = $this->schema[$id];
+
+        if (null === $schema) {
+            $schema = array('class' => $id);
+        }
+
+        if (!isset($schema['class'])) {
+            $schema['class'] = $id;
+        }
 
         if (is_string($schema)) {
             $schema = array('class' => $schema);

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -103,7 +103,7 @@ final class BuiltInServiceContainer implements ContainerInterface
             $schema = array('class' => $id);
         }
 
-        if (!isset($schema['class'])) {
+        if (is_array($schema) && !array_key_exists('class', $schema)) {
             $schema['class'] = $id;
         }
 

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -103,10 +103,6 @@ final class BuiltInServiceContainer implements ContainerInterface
             $schema = array('class' => $id);
         }
 
-        if (is_array($schema) && !array_key_exists('class', $schema)) {
-            $schema['class'] = $id;
-        }
-
         if (is_string($schema)) {
             $schema = array('class' => $schema);
         }
@@ -128,10 +124,7 @@ final class BuiltInServiceContainer implements ContainerInterface
     private function getAndValidateClass($id, array $schema)
     {
         if (!isset($schema['class'])) {
-            throw new WrongServicesConfigurationException(sprintf(
-                'All services of the built-in `services` must have `class` option set, but `%s` does not.',
-                $id
-            ));
+            $schema['class'] = $id;
         }
 
         return $schema['class'];

--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -114,12 +114,12 @@ final class ServicesResolver implements CallFilter
     /**
      * Repackages old calls with new arguments.
      *
-     * @param Call  $call
-     * @param array $arguments
+     * @param DefinitionCall|TransformationCall $call
+     * @param array                             $arguments
      *
      * @return DefinitionCall|TransformationCall
      */
-    private function repackageCallWithNewArguments(Call $call, array $arguments)
+    private function repackageCallWithNewArguments($call, array $arguments)
     {
         if ($call instanceof DefinitionCall) {
             return new DefinitionCall(

--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\HelperContainer\Call\Filter;
+
+use Behat\Behat\Context\Environment\ServiceContainerEnvironment;
+use Behat\Behat\Definition\Call\DefinitionCall;
+use Behat\Behat\HelperContainer\Exception\UnsupportedCallException;
+use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Testwork\Call\Call;
+use Behat\Testwork\Call\Filter\CallFilter;
+use Behat\Testwork\Environment\Call\EnvironmentCall;
+
+/**
+ * Dynamically resolves call arguments using the service container.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class ServicesResolver implements CallFilter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsCall(Call $call)
+    {
+        return ($call instanceof DefinitionCall || $call instanceof TransformationCall)
+            && $call->getEnvironment() instanceof ServiceContainerEnvironment;
+    }
+
+    /**
+     * Filters a call and returns a new one.
+     *
+     * @param Call $call
+     *
+     * @return Call
+     */
+    public function filterCall(Call $call)
+    {
+        if (!$call instanceof EnvironmentCall || !$call->getEnvironment() instanceof ServiceContainerEnvironment) {
+            throw new UnsupportedCallException(sprintf(
+                'ServicesResolver can not filter `%s` call.',
+                get_class($call)
+            ), $call);
+        }
+
+        $container = $call->getEnvironment()->getServiceContainer();
+        $newArguments = $call->getArguments();
+
+        if ($container) {
+            foreach ($call->getCallee()->getReflection()->getParameters() as $index => $parameter) {
+                if (isset($newArguments[$index]) || isset($newArguments[$parameter->getName()])) {
+                    continue;
+                }
+
+                if ($parameter->hasType() && $container->has((string) $parameter->getType())) {
+                    $newArguments[$index] = $container->get((string) $parameter->getType());
+                }
+            }
+        }
+
+        if ($call instanceof DefinitionCall) {
+            return new DefinitionCall(
+                $call->getEnvironment(),
+                $call->getFeature(),
+                $call->getStep(),
+                $call->getCallee(),
+                $newArguments,
+                $call->getErrorReportingLevel()
+            );
+        }
+
+        if ($call instanceof TransformationCall) {
+            return new TransformationCall(
+                $call->getEnvironment(),
+                $call->getDefinition(),
+                $call->getCallee(),
+                $newArguments
+            );
+        }
+
+        return $call;
+    }
+}

--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -59,8 +59,8 @@ final class ServicesResolver implements CallFilter
                     continue;
                 }
 
-                if ($parameter->hasType() && $container->has((string) $parameter->getType())) {
-                    $newArguments[$index] = $container->get((string) $parameter->getType());
+                if ($parameter->getClass() && $container->has($parameter->getClass()->getName())) {
+                    $newArguments[$index] = $container->get($parameter->getClass()->getName());
                 }
             }
         }

--- a/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
+++ b/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Behat\Behat\Context\Environment;
+namespace Behat\Behat\HelperContainer\Environment;
 
 use Behat\Testwork\Environment\Environment;
 use Psr\Container\ContainerInterface;

--- a/src/Behat/Behat/HelperContainer/Exception/UnsupportedCallException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/UnsupportedCallException.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\HelperContainer\Exception;
+
+use Behat\Testwork\Call\Call;
+use InvalidArgumentException;
+
+/**
+ * Represents an exception caused by an attempt to filter an unsupported call.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class UnsupportedCallException extends InvalidArgumentException implements HelperContainerException
+{
+    /**
+     * @var Call
+     */
+    private $call;
+
+    /**
+     * Initializes exception.
+     *
+     * @param string $message
+     * @param Call   $call
+     */
+    public function __construct($message, Call $call)
+    {
+        parent::__construct($message);
+
+        $this->call = $call;
+    }
+
+    /**
+     * Returns a call that caused exception.
+     *
+     * @return Call
+     */
+    public function getCall()
+    {
+        return $this->call;
+    }
+}

--- a/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
+++ b/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\HelperContainer\ServiceContainer;
 
 use Behat\Behat\Context\ServiceContainer\ContextExtension;
 use Behat\Behat\HelperContainer\Exception\WrongServicesConfigurationException;
+use Behat\Testwork\Call\ServiceContainer\CallExtension;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Behat\Testwork\ServiceContainer\ServiceProcessor;
@@ -78,6 +79,10 @@ final class HelperContainerExtension implements Extension
         $definition = new Definition('Behat\Behat\HelperContainer\Argument\ServicesResolverFactory', array($container));
         $definition->addTag(ContextExtension::SUITE_SCOPED_RESOLVER_FACTORY_TAG, array('priority' => 0));
         $container->setDefinition(ContextExtension::SUITE_SCOPED_RESOLVER_FACTORY_TAG . '.helper_container', $definition);
+
+        $definition = new Definition('Behat\Behat\HelperContainer\Call\Filter\ServicesResolver');
+        $definition->addTag(CallExtension::CALL_FILTER_TAG, array('priority' => 0));
+        $container->setDefinition(CallExtension::CALL_FILTER_TAG . '.helper_container', $definition);
     }
 
     /**


### PR DESCRIPTION
# Services autowiring feature

This PR introduces new minor feature into Behat 3.x (planned for 3.4).

## Narrative

HelperContainers were introduced in 3.3 to help resolve particular case of sharing behaviour between contexts. But even before the problem of sharing behaviour there was always a problem of growing context classes. Everyone once stumbled into situation where you have tens of properties on your context class, most of which are used only once, in a single transformation or a step definition.

This is a very similar problem to what MVC users experience with their actions and controllers. For years my advice was similar to theirs - split your contexts down by lines of responsibility. This works well, but both adds additional weight to every decision at the beginning of the project, because splitting stateful classes later is harder than at the start.

Looking at MVC frameworks like Laravel and Symfony 4, they both now have an alternative solution to this problem, built on top of their service containers - auto-wiring. With auto-wiring framework can automatically inject the service your controller or action needs, just by reflecting upon the argument types you requested. From the user point of view this makes introducing dependency into your action as simple as just adding type-hinted argument. And actions created that way are easily transferrable across controllers with a simple cut-and-paste.

Imagine if you can do the same with your step definitions, transformations and event context constructors? With this PR merged, you can.

## Autowiring

Before starting with the spec and implementation, I set out on a list of basic rules that the implementation will follow:

- Autowiring only works with helper containers
- Autowiring is off by default
- Autowiring is enabled/disabled by a suite-level `autowire` flag
- It works for context constructor arguments
- It works for step definition arguments
- It works for transformation arguments
- It only wires arguments that weren't otherwise set
- Service arguments must be last in step definitions
- Service arguments must be last in transformations

## How to use service autowiring

The rest of this PR explains how to use autowiring. For more detailed info and examples, please read the feature attached to this PR.

### Enabling autowiring

Service auto-wiring only works with [helper containers](https://github.com/Behat/Behat/pull/974). So you need to enable them for your suite to benefit from the feature:

```yaml
default:
  suites:
    default:
      services:
        SharedService1: "SharedService1"
        SharedService2: "SharedService2"
```

Note that I use service class names as their names - without that auto-wiring wouldn't work. There's also a simpler notation now:

```yaml
default:
  suites:
    default:
      services:
        SharedService1: ~
        SharedService2: ~
```

After that is done, you'll need to explicitly enable auto-wiring (it is disable by default), again, at the suite level:

```yaml
default:
  suites:
    default:
      # ....
      autowire: true
```

With those two done, you're all set!

### Autowiring constructor arguments

As the name suggests, services can be wired into your context constructors. All you need to do is type-hint them:

```php
class MyContext implements Context {
    public function __construct(SharedService1 $s1, SharedService2 $s2) {
        // ...
    }
}
```

You might not expect it to, but auto-wiring works with mixing manual and automatic arguments:

```yaml
default:
  suites:
    default:
      contexts:
        - MyContext:
            name: "Konstantin"
      # ....
      autowire: true
```

```php
class MyContext implements Context {
    public function __construct(string $name, SharedService1 $s1, SharedService2 $s2) {
        // ...
    }
}
```

### Autowiring step definition arguments

Probably the most useful application is that you can use auto-wiring in step definitions. Yes, that means you don't need to inject your service into context constructor and store it on the context properties - you can just ask for it when and if you need it, straight inside the stepdef:

```php
    /** @When I set the state to :value */
    public function setState($value, Service2 $s2) {
        $s2->state = $value;
    }
```

**Note that service arguments should always go after all the other arguments in the stepdef.**

### Autowiring transformation arguments

Perhaps even more useful is the fact that you can do the same with transformations:

```php
    /** @Transform */
    public function usernameToUser(string $username, Users $repository): User {
        return $repository->findByUsername($username);
    }
```

**Note that service arguments should always go after all the other arguments in the transformations.**

## Further details

For further details, as usual, I advise you to dive into the feature file itself. It provides ultimate information, reasoining and examples behind this feature. Oh, yeah, it also is a stellar automated test to make sure I implemented feature correctly in the first place :)

As usual, feedback is greatly appreciated.