### PR TITLE
Fix PHP 5.3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+  * PHP 5.3 style cleanup.
 
 ## [3.4.0] - 2017-09-10
 ### Added

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -225,7 +225,7 @@ final class GherkinExtension implements Extension
         }
 
         $definition->addMethodCall('setCache', array($cacheDefinition));
-        $definition->addMethodCall('setBasePath', ['%paths.base%']);
+        $definition->addMethodCall('setBasePath', array('%paths.base%'));
         $definition->addTag(self::LOADER_TAG, array('priority' => 50));
         $container->setDefinition('gherkin.loader.gherkin_file', $definition);
     }


### PR DESCRIPTION
Removed short array syntax to maintain php 5.3 style. I believe this is a bug since composer.json still has a PHP requirement value of >= 5.3.3.