### PR TITLE
Allow to use latest PHPUnit but keep the compatibility with legacy versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 
     "require-dev": {
         "symfony/process": "~2.5|~3.0",
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "^4.8.36|^6.3",
         "herrera-io/box": "~1.6.1"
     },
 

--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -47,22 +47,22 @@ Feature: Append snippets option
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              \PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              \PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              \PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              \PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith() {}
@@ -162,22 +162,22 @@ Feature: Append snippets option
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              \PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              \PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              \PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              \PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith() {}
@@ -267,22 +267,22 @@ Feature: Append snippets option
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              \PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              \PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              \PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              \PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith() {}
@@ -332,22 +332,22 @@ Feature: Append snippets option
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              \PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              \PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              \PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              \PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith() {}
@@ -435,22 +435,22 @@ Feature: Append snippets option
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              \PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              \PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              \PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              \PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith() {}
@@ -500,22 +500,22 @@ Feature: Append snippets option
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              \PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              \PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              \PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              \PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith() {}

--- a/features/arguments.feature
+++ b/features/arguments.feature
@@ -44,22 +44,22 @@ Feature: Step Arguments
            * @Then /^it must be equals to string (\d+)$/
            */
           public function itMustBeEqualsToString($number) {
-              \PHPUnit_Framework_Assert::assertEquals($this->strings[intval($number)], (string) $this->input);
+              \PHPUnit\Framework\Assert::assertEquals($this->strings[intval($number)], (string) $this->input);
           }
 
           /**
            * @Then /^it must be equals to table (\d+)$/
            */
           public function itMustBeEqualsToTable($number) {
-              \PHPUnit_Framework_Assert::assertEquals($this->tables[intval($number)], $this->input->getHash());
+              \PHPUnit\Framework\Assert::assertEquals($this->tables[intval($number)], $this->input->getHash());
           }
 
           /**
            * @Given /^I have number2 = (?P<number2>\d+) and number1 = (?P<number1>\d+)$/
            */
           public function iHaveNumberAndNumber($number1, $number2) {
-              \PHPUnit_Framework_Assert::assertEquals(13, intval($number1));
-              \PHPUnit_Framework_Assert::assertEquals(243, intval($number2));
+              \PHPUnit\Framework\Assert::assertEquals(13, intval($number1));
+              \PHPUnit\Framework\Assert::assertEquals(243, intval($number2));
           }
       }
       """

--- a/features/autowire.feature
+++ b/features/autowire.feature
@@ -96,7 +96,7 @@ Feature: Helper services autowire
       class FeatureContext implements Context {
           public function __construct(Service2 $s2, $name, Service1 $s1, Service3 $s3)
           {
-              PHPUnit_Framework_Assert::assertEquals('Konstantin', $name);
+              PHPUnit\Framework\Assert::assertEquals('Konstantin', $name);
           }
 
           /** @Given a step */
@@ -150,7 +150,7 @@ Feature: Helper services autowire
 
           /** @Then that state should be persisted as :value */
           public function checkState($val, Service2 $s2) {
-              PHPUnit_Framework_Assert::assertEquals($val, $s2->state);
+              PHPUnit\Framework\Assert::assertEquals($val, $s2->state);
           }
       }
       """
@@ -204,7 +204,7 @@ Feature: Helper services autowire
 
           /** @Then the :flag flag should be persisted as :value */
           public function checkState($flag, $value) {
-              PHPUnit_Framework_Assert::assertEquals($value, $flag);
+              PHPUnit\Framework\Assert::assertEquals($value, $flag);
           }
       }
       """

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -10,6 +10,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -119,12 +120,12 @@ EOL;
         $this->createFile($this->workingDir . '/' . $filename, $content);
     }
 
-        /**
-         * Creates a noop feature in current workdir.
-         *
-         * @Given /^(?:there is )?a some feature scenarios/
-         */
-        public function aNoopFeature()
+    /**
+     * Creates a noop feature in current workdir.
+     *
+     * @Given /^(?:there is )?a some feature scenarios/
+     */
+    public function aNoopFeature()
     {
         $filename = 'features/bootstrap/FeatureContext.php';
         $content = <<<'EOL'
@@ -156,7 +157,7 @@ EOL;
      */
     public function fileShouldExist($path)
     {
-        PHPUnit_Framework_Assert::assertFileExists($this->workingDir . DIRECTORY_SEPARATOR . $path);
+        Assert::assertFileExists($this->workingDir . DIRECTORY_SEPARATOR . $path);
     }
 
     /**
@@ -258,7 +259,7 @@ EOL;
     public function itShouldPassWithNoOutput($success)
     {
         $this->itShouldFail($success);
-        PHPUnit_Framework_Assert::assertEmpty($this->getOutput());
+        Assert::assertEmpty($this->getOutput());
     }
 
     /**
@@ -272,7 +273,7 @@ EOL;
     public function fileShouldContain($path, PyStringNode $text)
     {
         $path = $this->workingDir . '/' . $path;
-        PHPUnit_Framework_Assert::assertFileExists($path);
+        Assert::assertFileExists($path);
 
         $fileContent = trim(file_get_contents($path));
         // Normalize the line endings in the output
@@ -280,7 +281,7 @@ EOL;
             $fileContent = str_replace(PHP_EOL, "\n", $fileContent);
         }
 
-        PHPUnit_Framework_Assert::assertEquals($this->getExpectedOutput($text), $fileContent);
+        Assert::assertEquals($this->getExpectedOutput($text), $fileContent);
     }
 
     /**
@@ -294,7 +295,7 @@ EOL;
     public function fileXmlShouldBeLike($path, PyStringNode $text)
     {
         $path = $this->workingDir . '/' . $path;
-        PHPUnit_Framework_Assert::assertFileExists($path);
+        Assert::assertFileExists($path);
 
         $fileContent = trim(file_get_contents($path));
 
@@ -302,7 +303,7 @@ EOL;
         $dom->loadXML($text);
         $dom->formatOutput = true;
 
-        PHPUnit_Framework_Assert::assertEquals(trim($dom->saveXML(null, LIBXML_NOEMPTYTAG)), $fileContent);
+        Assert::assertEquals(trim($dom->saveXML(null, LIBXML_NOEMPTYTAG)), $fileContent);
     }
 
 
@@ -315,7 +316,7 @@ EOL;
      */
     public function theOutputShouldContain(PyStringNode $text)
     {
-        PHPUnit_Framework_Assert::assertContains($this->getExpectedOutput($text), $this->getOutput());
+        Assert::assertContains($this->getExpectedOutput($text), $this->getOutput());
     }
 
     private function getExpectedOutput(PyStringNode $expectedText)
@@ -363,13 +364,13 @@ EOL;
                 echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            PHPUnit_Framework_Assert::assertNotEquals(0, $this->getExitCode());
+            Assert::assertNotEquals(0, $this->getExitCode());
         } else {
             if (0 !== $this->getExitCode()) {
                 echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            PHPUnit_Framework_Assert::assertEquals(0, $this->getExitCode());
+            Assert::assertEquals(0, $this->getExitCode());
         }
     }
 

--- a/features/config_inheritance.feature
+++ b/features/config_inheritance.feature
@@ -73,12 +73,12 @@ Feature: Config inheritance
 
           /** @Then the context parameters should be overwritten */
           public function theContextParametersOverwrite() {
-              \PHPUnit_Framework_Assert::assertEquals(array('param2' => 'val2'), $this->parameters);
+              \PHPUnit\Framework\Assert::assertEquals(array('param2' => 'val2'), $this->parameters);
           }
 
           /** @Then the extension config should be merged */
           public function theExtensionConfigMerge() {
-              \PHPUnit_Framework_Assert::assertEquals(array('param1' => 'val2', 'param2' => 'val1'), $this->extension);
+              \PHPUnit\Framework\Assert::assertEquals(array('param1' => 'val2', 'param2' => 'val1'), $this->extension);
           }
       }
       """

--- a/features/context.feature
+++ b/features/context.feature
@@ -47,22 +47,22 @@ Feature: Context consistency
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }
 

--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -158,8 +158,8 @@ Feature: Step Definition Pattern
            * @Given only second :second
            */
           public function invalidRegex($first = 'foo', $second = 'fiz') {
-            PHPUnit_Framework_Assert::assertEquals('foo', $first);
-            PHPUnit_Framework_Assert::assertEquals('bar', $second);
+            PHPUnit\Framework\Assert::assertEquals('foo', $first);
+            PHPUnit\Framework\Assert::assertEquals('bar', $second);
           }
       }
       """
@@ -192,7 +192,7 @@ Feature: Step Definition Pattern
            * @Given I can provide parameter :param
            */
           public function parameterCouldBeNull($param = null) {
-            PHPUnit_Framework_Assert::assertNull($param);
+            PHPUnit\Framework\Assert::assertNull($param);
           }
       }
       """
@@ -256,7 +256,7 @@ Feature: Step Definition Pattern
            *        parameter :param
            */
           public function parameterCouldBeNull($param = null) {
-            PHPUnit_Framework_Assert::assertNull($param);
+            PHPUnit\Framework\Assert::assertNull($param);
           }
       }
       """
@@ -295,8 +295,8 @@ Feature: Step Definition Pattern
            * @Given I can provide parameters :someParam and :someParam2
            */
           public function multipleWrongNamedParameters($param1, $param2) {
-            PHPUnit_Framework_Assert::assertEquals('one', $param1);
-            PHPUnit_Framework_Assert::assertEquals('two', $param2);
+            PHPUnit\Framework\Assert::assertEquals('one', $param1);
+            PHPUnit\Framework\Assert::assertEquals('two', $param2);
           }
       }
       """
@@ -328,8 +328,8 @@ Feature: Step Definition Pattern
            * @Given I can provide parameters :someParam and :someParam2
            */
           public function multipleWrongNamedParameters($param1, $someParam) {
-            PHPUnit_Framework_Assert::assertEquals('two', $param1);
-            PHPUnit_Framework_Assert::assertEquals('one', $someParam);
+            PHPUnit\Framework\Assert::assertEquals('two', $param1);
+            PHPUnit\Framework\Assert::assertEquals('one', $someParam);
           }
       }
       """
@@ -361,9 +361,9 @@ Feature: Step Definition Pattern
            * @Given I can provide :count parameters :firstParam and :otherParam
            */
           public function multipleWrongNamedParameters($param1, $firstParam, $count) {
-            PHPUnit_Framework_Assert::assertEquals('two', $param1);
-            PHPUnit_Framework_Assert::assertEquals('one', $firstParam);
-            PHPUnit_Framework_Assert::assertEquals(2, $count);
+            PHPUnit\Framework\Assert::assertEquals('two', $param1);
+            PHPUnit\Framework\Assert::assertEquals('one', $firstParam);
+            PHPUnit\Framework\Assert::assertEquals(2, $count);
           }
       }
       """
@@ -395,10 +395,10 @@ Feature: Step Definition Pattern
            * @Given I can provide :count parameters :firstParam and :otherParam with:
            */
           public function multipleWrongNamedParameters($param1, $firstParam, $count, $string) {
-            PHPUnit_Framework_Assert::assertEquals('two', $param1);
-            PHPUnit_Framework_Assert::assertEquals('one', $firstParam);
-            PHPUnit_Framework_Assert::assertEquals(2, $count);
-            PHPUnit_Framework_Assert::assertEquals("Test", (string) $string);
+            PHPUnit\Framework\Assert::assertEquals('two', $param1);
+            PHPUnit\Framework\Assert::assertEquals('one', $firstParam);
+            PHPUnit\Framework\Assert::assertEquals(2, $count);
+            PHPUnit\Framework\Assert::assertEquals("Test", (string) $string);
           }
       }
       """
@@ -433,9 +433,9 @@ Feature: Step Definition Pattern
            * @Given I can provide :count parameters for :name:
            */
           public function multipleWrongNamedParameters($count, $name, $string) {
-          PHPUnit_Framework_Assert::assertEquals('2', $count);
-            PHPUnit_Framework_Assert::assertEquals('thing', $name);
-            PHPUnit_Framework_Assert::assertEquals("Test", (string) $string);
+          PHPUnit\Framework\Assert::assertEquals('2', $count);
+            PHPUnit\Framework\Assert::assertEquals('thing', $name);
+            PHPUnit\Framework\Assert::assertEquals("Test", (string) $string);
           }
       }
       """
@@ -472,9 +472,9 @@ Feature: Step Definition Pattern
            */
           public function checkEquality($path = null, $isNegative = null, PyStringNode $json = null)
           {
-              PHPUnit_Framework_Assert::assertNull($path);
-              PHPUnit_Framework_Assert::assertNull($isNegative);
-              PHPUnit_Framework_Assert::assertNotNull($json);
+              PHPUnit\Framework\Assert::assertNull($path);
+              PHPUnit\Framework\Assert::assertNull($isNegative);
+              PHPUnit\Framework\Assert::assertNotNull($json);
           }
 
           /**
@@ -482,9 +482,9 @@ Feature: Step Definition Pattern
            */
           public function checkEquality2($json = null, $path = null, $isNegative = null)
           {
-              PHPUnit_Framework_Assert::assertNull($path);
-              PHPUnit_Framework_Assert::assertNull($isNegative);
-              PHPUnit_Framework_Assert::assertNotNull($json);
+              PHPUnit\Framework\Assert::assertNull($path);
+              PHPUnit\Framework\Assert::assertNull($isNegative);
+              PHPUnit\Framework\Assert::assertNotNull($json);
           }
       }
       """
@@ -523,7 +523,7 @@ Feature: Step Definition Pattern
            * @Given I have a package v:version
            */
           public function multipleWrongNamedParameters($version) {
-          PHPUnit_Framework_Assert::assertEquals('2.5', $version);
+          PHPUnit\Framework\Assert::assertEquals('2.5', $version);
           }
       }
       """
@@ -555,7 +555,7 @@ Feature: Step Definition Pattern
            * @When I enter the string :input
            */
           public function multipleWrongNamedParameters($input) {
-          PHPUnit_Framework_Assert::assertEquals('', $input);
+          PHPUnit\Framework\Assert::assertEquals('', $input);
           }
       }
       """
@@ -587,8 +587,8 @@ Feature: Step Definition Pattern
            * @Then images should be uploaded to web\/uploads\/media\/default\/:arg1\/:arg2\/
            */
           public function multipleWrongNamedParameters($arg1, $arg2) {
-          PHPUnit_Framework_Assert::assertEquals('0001', $arg1);
-          PHPUnit_Framework_Assert::assertEquals('01', $arg2);
+          PHPUnit\Framework\Assert::assertEquals('0001', $arg1);
+          PHPUnit\Framework\Assert::assertEquals('01', $arg2);
           }
       }
       """
@@ -620,7 +620,7 @@ Feature: Step Definition Pattern
            * @Given I have a negative number :num
            */
           public function multipleWrongNamedParameters($num) {
-          PHPUnit_Framework_Assert::assertEquals('-3', $num);
+          PHPUnit\Framework\Assert::assertEquals('-3', $num);
           }
       }
       """

--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -117,29 +117,29 @@ Feature: Step Arguments Transformations
            * @Then /Username must be "([^"]+)"/
            */
           public function usernameMustBe($username) {
-              PHPUnit_Framework_Assert::assertEquals($username, $this->user->getUsername());
+              PHPUnit\Framework\Assert::assertEquals($username, $this->user->getUsername());
           }
 
           /**
            * @Then /Age must be (\d+)/
            */
           public function ageMustBe($age) {
-              PHPUnit_Framework_Assert::assertEquals($age, $this->user->getAge());
-              PHPUnit_Framework_Assert::assertInternalType('int', $age);
+              PHPUnit\Framework\Assert::assertEquals($age, $this->user->getAge());
+              PHPUnit\Framework\Assert::assertInternalType('int', $age);
           }
 
           /**
            * @Then the Usernames must be:
            */
           public function usernamesMustBe(array $usernames) {
-              PHPUnit_Framework_Assert::assertEquals($usernames[0], $this->user->getUsername());
+              PHPUnit\Framework\Assert::assertEquals($usernames[0], $this->user->getUsername());
           }
 
           /**
            * @Then /^the boolean (no) should be transformed to false$/
            */
           public function theBooleanShouldBeTransformed($boolean) {
-              PHPUnit_Framework_Assert::assertSame(false, $boolean);
+              PHPUnit\Framework\Assert::assertSame(false, $boolean);
           }
       }
     """
@@ -289,7 +289,7 @@ Feature: Step Arguments Transformations
 
           /** @Then the :field should be :value */
           public function theFieldShouldBe($field, $value) {
-              PHPUnit_Framework_Assert::assertSame($value, $this->data[0][$field]);
+              PHPUnit\Framework\Assert::assertSame($value, $this->data[0][$field]);
           }
       }
       """

--- a/features/definitions_translations.feature
+++ b/features/definitions_translations.feature
@@ -47,7 +47,7 @@ Feature: Definitions translations
            * @Then /^I should see (\d+) on the screen$/
            */
           public function iShouldSeeOnTheScreen($result) {
-              PHPUnit_Framework_Assert::assertEquals(intval($result), $this->result);
+              PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
           }
 
           /** @Transform /"([^"]+)" user/ */
@@ -59,7 +59,7 @@ Feature: Definitions translations
            * @Then /^the ("[^"]+" user) name should be "([^"]*)"$/
            */
           public function theUserUsername($user, $username) {
-              PHPUnit_Framework_Assert::assertEquals($username, $user->name);
+              PHPUnit\Framework\Assert::assertEquals($username, $user->name);
           }
 
           public static function getTranslationResources() {
@@ -150,7 +150,7 @@ Feature: Definitions translations
            * @Then /^I should see (\d+) on the screen$/
            */
           public function iShouldSeeOnTheScreen($result) {
-              PHPUnit_Framework_Assert::assertEquals(intval($result), $this->result);
+              PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
           }
 
           /** @Transform /"([^"]+)" user/ */
@@ -162,7 +162,7 @@ Feature: Definitions translations
            * @Then /^the ("[^"]+" user) name should be "([^"]*)"$/
            */
           public function theUserUsername($user, $username) {
-              PHPUnit_Framework_Assert::assertEquals($username, $user->name);
+              PHPUnit\Framework\Assert::assertEquals($username, $user->name);
           }
 
           public static function getTranslationResources() {
@@ -231,7 +231,7 @@ Feature: Definitions translations
            * @Then /^I should see (\d+) on the screen$/
            */
           public function iShouldSeeOnTheScreen($result) {
-              PHPUnit_Framework_Assert::assertEquals(intval($result), $this->result);
+              PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
           }
 
           /** @Transform /"([^"]+)" user/ */
@@ -243,7 +243,7 @@ Feature: Definitions translations
            * @Then /^the ("[^"]+" user) name should be "([^"]*)"$/
            */
           public function theUserUsername($user, $username) {
-              PHPUnit_Framework_Assert::assertEquals($username, $user->name);
+              PHPUnit\Framework\Assert::assertEquals($username, $user->name);
           }
 
           public static function getTranslationResources() {
@@ -321,7 +321,7 @@ Feature: Definitions translations
            * @Then /^I should see (\d+) on the screen$/
            */
           public function iShouldSeeOnTheScreen($result) {
-              PHPUnit_Framework_Assert::assertEquals(intval($result), $this->result);
+              PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
           }
 
           /** @Transform /"([^"]+)" user/ */
@@ -333,7 +333,7 @@ Feature: Definitions translations
            * @Then /^the ("[^"]+" user) name should be "([^"]*)"$/
            */
           public function theUserUsername($user, $username) {
-              PHPUnit_Framework_Assert::assertEquals($username, $user->name);
+              PHPUnit\Framework\Assert::assertEquals($username, $user->name);
           }
 
           public static function getTranslationResources() {

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -37,7 +37,7 @@ Feature: Error Reporting
            */
           public function iShouldGetNull()
           {
-              PHPUnit_Framework_Assert::assertNull($this->result);
+              PHPUnit\Framework\Assert::assertNull($this->result);
           }
 
           /**
@@ -53,7 +53,7 @@ Feature: Error Reporting
            */
           public function iShouldGet($arg1)
           {
-              PHPUnit_Framework_Assert::assertEquals($arg1, $this->result);
+              PHPUnit\Framework\Assert::assertEquals($arg1, $this->result);
           }
 
       }

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -31,7 +31,7 @@ Feature: Extensions
 
           /** @Then the extension should be loaded */
           public function theExtensionLoaded() {
-              PHPUnit_Framework_Assert::assertEquals(array('param1' => 'val1', 'param2' => 'val2'), $this->extension);
+              PHPUnit\Framework\Assert::assertEquals(array('param1' => 'val1', 'param2' => 'val2'), $this->extension);
           }
       }
       """

--- a/features/format_options.feature
+++ b/features/format_options.feature
@@ -47,22 +47,22 @@ Feature: Format options
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }
       """

--- a/features/helper_containers.feature
+++ b/features/helper_containers.feature
@@ -47,7 +47,7 @@ Feature: Per-suite helper containers
 
           /** @Given service has no state */
           public function noState() {
-              PHPUnit_Framework_Assert::assertNull($this->service->number);
+              PHPUnit\Framework\Assert::assertNull($this->service->number);
           }
 
           /** @When service gets a state of :number in first context */
@@ -67,7 +67,7 @@ Feature: Per-suite helper containers
 
           /** @Then service should have a state of :number in second context */
           public function checkState($number) {
-              PHPUnit_Framework_Assert::assertSame($number, $this->service->number);
+              PHPUnit\Framework\Assert::assertSame($number, $this->service->number);
           }
       }
       """

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -101,7 +101,7 @@ Feature: hooks
            * @Then /^I must have (\d+)$/
            */
           public function iMustHave($number) {
-              \PHPUnit_Framework_Assert::assertEquals(intval($number), $this->number);
+              \PHPUnit\Framework\Assert::assertEquals(intval($number), $this->number);
           }
       }
       """

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -28,7 +28,7 @@ Feature: I18n
            * @Then /Я должен иметь (\d+)/
            */
           public function iShouldHave($number) {
-              PHPUnit_Framework_Assert::assertEquals(intval($number), $this->value);
+              PHPUnit\Framework\Assert::assertEquals(intval($number), $this->value);
           }
 
           /**

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -26,7 +26,7 @@
            * @Then /I must have (\d+)/
            */
           public function iMustHave($num) {
-              PHPUnit_Framework_Assert::assertEquals($num, $this->value);
+              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
           }
 
           /**
@@ -151,7 +151,7 @@
            * @Then /I must have (\d+)/
            */
           public function iMustHave($num) {
-              PHPUnit_Framework_Assert::assertEquals($num, $this->value);
+              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
           }
 
           /**
@@ -223,7 +223,7 @@
            * @Then /I must have (\d+)/
            */
           public function iMustHave($num) {
-              PHPUnit_Framework_Assert::assertEquals($num, $this->value);
+              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
           }
 
           /**
@@ -303,7 +303,7 @@
            * @Then /I will be stronger/
            */
           public function iWillBeStronger() {
-              PHPUnit_Framework_Assert::assertNotEquals(0, $this->strongLevel);
+              PHPUnit\Framework\Assert::assertNotEquals(0, $this->strongLevel);
           }
       }
       """
@@ -333,7 +333,7 @@
            * @Then /I will be stronger/
            */
           public function iWillBeStronger() {
-              PHPUnit_Framework_Assert::assertNotEquals(0, $this->strongLevel);
+              PHPUnit\Framework\Assert::assertNotEquals(0, $this->strongLevel);
           }
       }
       """
@@ -486,7 +486,7 @@
            * @Then /I must have (\d+)/
            */
           public function iMustHave($num) {
-              PHPUnit_Framework_Assert::assertEquals($num, $this->value);
+              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
           }
 
           /**
@@ -550,7 +550,7 @@
            * @Then /I must have (\d+)/
            */
           public function iMustHave($num) {
-              PHPUnit_Framework_Assert::assertEqual($num, $this->value);
+              PHPUnit\Framework\Assert::assertEqual($num, $this->value);
           }
 
           /**
@@ -578,7 +578,7 @@
     When I run "behat --no-colors -f junit -o junit"
     Then it should fail with:
       """
-      Call to undefined method PHPUnit_Framework_Assert::assertEqual
+      Call to undefined method PHPUnit\Framework\Assert::assertEqual
       """
     And "junit/default.xml" file xml should be like:
       """

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -47,22 +47,22 @@ Feature: Multiple formats
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }
       """

--- a/features/outlines.feature
+++ b/features/outlines.feature
@@ -80,7 +80,7 @@ Feature: Scenario Outlines
             * @Then /^The result should be (\d+)$/
             */
            public function theResultShouldBe($result) {
-              PHPUnit_Framework_Assert::assertEquals(intval($result), $this->result);
+              PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
            }
       }
       """
@@ -242,7 +242,7 @@ Feature: Scenario Outlines
             * @Then the result should be :result
             */
            public function theResultShouldBe($result) {
-              PHPUnit_Framework_Assert::assertEquals(intval($result), $this->number);
+              PHPUnit\Framework\Assert::assertEquals(intval($result), $this->number);
            }
       }
       """

--- a/features/parameters.feature
+++ b/features/parameters.feature
@@ -53,7 +53,7 @@ Feature: Parameters
            * @Then /The result should be (\d+)/
            */
           public function theResultShouldBe($result) {
-              PHPUnit_Framework_Assert::assertEquals($result, $this->result);
+              PHPUnit\Framework\Assert::assertEquals($result, $this->result);
           }
       }
       """

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -28,7 +28,7 @@ Feature: Pretty Formatter
            * @Then /I must have (\d+)/
            */
           public function iMustHave($num) {
-              PHPUnit_Framework_Assert::assertEquals($num, $this->value);
+              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
           }
 
           /**
@@ -163,7 +163,7 @@ Feature: Pretty Formatter
            * @Then /I must have (\d+)/
            */
           public function iMustHave($num) {
-              PHPUnit_Framework_Assert::assertEquals($num, $this->value);
+              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
           }
 
           /**
@@ -245,7 +245,7 @@ Feature: Pretty Formatter
              * @Then /I must have "([^"]+)"/
              */
             public function iMustHave($num) {
-                PHPUnit_Framework_Assert::assertEquals(intval(preg_replace('/[^\d]+/', '', $num)), $this->value);
+                PHPUnit\Framework\Assert::assertEquals(intval(preg_replace('/[^\d]+/', '', $num)), $this->value);
             }
 
             /**

--- a/features/profiles.feature
+++ b/features/profiles.feature
@@ -51,7 +51,7 @@ Feature: Profiles
            * @Then /The result should be (\d+)/
            */
           public function theResultShouldBe($result) {
-              PHPUnit_Framework_Assert::assertEquals($result, $this->result);
+              PHPUnit\Framework\Assert::assertEquals($result, $this->result);
           }
       }
       """

--- a/features/rerun.feature
+++ b/features/rerun.feature
@@ -44,22 +44,22 @@ Feature: Rerun
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }
       """

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -60,22 +60,22 @@ Feature: Rerun with multiple suite
            * @Then /^I should have (\d+) (apples|bananas)$/
            */
           public function iShouldHaveFruit($count, $fruit) {
-              PHPUnit_Framework_Assert::assertEquals(intval($count), $this->fruits[$fruit]);
+              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->fruits[$fruit]);
           }
 
           /**
            * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
            */
           public function contextParameterShouldBeEqualTo($key, $val) {
-              PHPUnit_Framework_Assert::assertEquals($val, $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           /**
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit_Framework_Assert::assertInternalType('array', $this->parameters[$key]);
-              PHPUnit_Framework_Assert::assertEquals(2, count($this->parameters[$key]));
+              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }
       """

--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -236,7 +236,7 @@ Feature: Different result types
            * @Then /^I should see (\d+)\$ on the screen$/
            */
           public function iShouldSee($money) {
-              PHPUnit_Framework_Assert::assertEquals($money, $this->money);
+              PHPUnit\Framework\Assert::assertEquals($money, $this->money);
           }
       }
       """
@@ -324,7 +324,7 @@ Feature: Different result types
            * @Then /^I should see (\d+)\$ on the screen$/
            */
           public function iShouldSee($money) {
-              PHPUnit_Framework_Assert::assertEquals($money, $this->money);
+              PHPUnit\Framework\Assert::assertEquals($money, $this->money);
           }
       }
       """

--- a/features/traits.feature
+++ b/features/traits.feature
@@ -49,7 +49,7 @@ Feature: Support php 5.4 traits
            * @Then /^I should have (\d+) apples$/
            */
           public function iShouldHaveApples($count) {
-              PHPUnit_Framework_Assert::assertEquals(intval($count), $this->apples);
+              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
           }
       }
       """

--- a/tests/Behat/Tests/Testwork/Subject/GroupedSubjectIteratorTest.php
+++ b/tests/Behat/Tests/Testwork/Subject/GroupedSubjectIteratorTest.php
@@ -5,8 +5,9 @@ namespace Behat\Tests\Testwork\Subject;
 use Behat\Testwork\Specification\GroupedSpecificationIterator;
 use Behat\Testwork\Specification\NoSpecificationsIterator;
 use Behat\Testwork\Specification\SpecificationArrayIterator;
+use PHPUnit\Framework\TestCase;
 
-class GroupedSubjectIteratorTest extends \PHPUnit_Framework_TestCase
+class GroupedSubjectIteratorTest extends TestCase
 {
     public function testIterationWithEmptyAtBeginning()
     {


### PR DESCRIPTION
Latest 4.8.36 comes with compatibility layer, so we can start using PHPUnit namespaces while continue using the 4.8 branch on legacy PHP versions. This will work even on PHP 5.3.

Note that [currently phpunit is not run on Travis](https://travis-ci.org/Behat/Behat/jobs/282180374#L519) with 7.x. phpunit can't find any tests.

<img width="815" alt="screen shot 2017-10-27 at 11 00 48" src="https://user-images.githubusercontent.com/190447/32098914-22868fcc-bb06-11e7-992f-c981c1aae9bc.png">
