### PR TITLE
symfony/class-loader 4.0 doesn't exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/event-dispatcher": "~2.1||~3.0||~4.0",
         "symfony/translation": "~2.3||~3.0||~4.0",
         "symfony/yaml": "~2.1||~3.0||~4.0",
-        "symfony/class-loader": "~2.1||~3.0||~4.0",
+        "symfony/class-loader": "~2.1||~3.0",
         "psr/container": "^1.0",
         "container-interop/container-interop": "^1.2"
     },


### PR DESCRIPTION
The Symfony's ClassLoader component has been deprecated in favor of Composer and doesn't exist in version 4.
This PR removes the invalid version, but some work need to be done to refactor classes using this component.