### PR TITLE
Fix the test suite by working around a Symfony problem

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ clone_folder: c:\projects\behat
 
 environment:
     matrix:
-        - PHP_DOWNLOAD_FILE: php-7.1.9-nts-Win32-VC14-x86.zip
+        - PHP_DOWNLOAD_FILE: php-7.2.1-nts-Win32-VC15-x86.zip
 
 branches:
   only:

--- a/features/execution_order.feature
+++ b/features/execution_order.feature
@@ -38,7 +38,7 @@ Feature: Setting order of execution
       """
 
   Scenario: No order specified
-    When I run "behat -fpretty"
+    When I run "behat -fpretty --no-colors"
     Then it should pass with:
       """
       Feature: Feature 1
@@ -65,7 +65,7 @@ Feature: Setting order of execution
       """
 
   Scenario: Reverse order
-    When I run "behat -fpretty --order=reverse"
+    When I run "behat -fpretty --order=reverse --no-colors"
     Then it should pass with:
       """
       Feature: Feature 2

--- a/features/suite.feature
+++ b/features/suite.feature
@@ -517,7 +517,7 @@ Feature: Suites
             filters:
               role:   big brother
       """
-    When I run "behat --no-colors -sbig_brother -fpretty --format-settings='{\"paths\": true}' features"
+    When I run "behat --no-colors -s big_brother -fpretty --format-settings='{\"paths\": true}' features"
     Then it should pass with:
       """
       Feature: Apples story


### PR DESCRIPTION
There is a Symfony BC break that broke the test suite: https://github.com/symfony/symfony/issues/25825

`-sbig_brother` is treated as a chain of options, and `h` makes the command display a help message. 

This change will at least make the build green again, before the issue is fixed in Symfony.