### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Installing Behat
 The easiest way to install Behat is by using [Composer](https://getcomposer.org):
 
 ```bash
-$> curl -sS https://getcomposer.org/installer | php
-$> php composer.phar require behat/behat
+$> composer require --dev behat/behat
 ```
 
 After that you'll be able to run Behat via:
@@ -30,8 +29,7 @@ Installing Development Version
 Clone the repository and install dependencies via [Composer](https://getcomposer.org):
 
 ```bash
-$> curl -sS https://getcomposer.org/installer | php
-$> php composer.phar install
+$> composer install
 ```
 
 After that you will be able to run development version of Behat via:


### PR DESCRIPTION
At the time these instructions were written it might've been necessary to explain how to install composer. With composer becoming a de-facto standard package manager for PHP I think it's now better to assume it's installed, and refer to composer's installation docs. The installation method we have here is outdated (and insecure) anyway.