### PR TITLE
Argument resolver arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+  * [#1144](https://github.com/Behat/Behat/pull/1144) : Allow to use arrays as context parameters
 
 ## [3.4.3] - 2017-11-27
 ### Fixed

--- a/features/context.feature
+++ b/features/context.feature
@@ -466,3 +466,42 @@ Feature: Context consistency
       2 scenarios (2 passed)
       2 steps (2 passed)
       """
+
+  Scenario: Array arguments
+    Given a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - FirstContext:
+                - [foo, bar]
+      """
+    And a file named "features/context-args-array.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given foo
+      """
+    And a file named "features/bootstrap/FirstContext.php" with:
+      """
+      <?php use Behat\Behat\Context\Context;
+
+      class FirstContext implements Context {
+          private $foo;
+
+          public function __construct(array $foo) {
+            $this->foo = $foo;
+          }
+
+          /** @Given foo */
+          public function foo() {
+            PHPUnit\Framework\Assert::assertInternalType('array', $this->foo);
+
+            PHPUnit\Framework\Assert::assertSame('foo', $this->foo[0]);
+            PHPUnit\Framework\Assert::assertSame('bar', $this->foo[1]);
+          }
+      }
+      """
+    When I run "behat --no-colors -f progress features/context-args-array.feature"
+    Then it should pass

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
@@ -63,7 +63,7 @@ final class ServicesResolver implements ArgumentResolver
      */
     private function resolveArgument($value)
     {
-        if (0 === mb_strpos($value, '@')) {
+        if (is_string($value) && 0 === mb_strpos($value, '@')) {
             return $this->container->get(mb_substr($value, 1));
         }
 


### PR DESCRIPTION
Currently, if using an array as a parameter of a context (with the help of a service container), an error pops up :

```
PHP Warning:  mb_strpos() expects parameter 1 to be string, array given in /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php on line 68
PHP Stack trace:
PHP   1. {main}() /home/talus/dev/Behapi/vendor/behat/behat/bin/behat:0
PHP   2. Behat\Testwork\Cli\Application->run() /home/talus/dev/Behapi/vendor/behat/behat/bin/behat:34
PHP   3. Behat\Testwork\Cli\Application->doRun() /home/talus/dev/test-behapi/vendor/symfony/console/Application.php:143
PHP   4. Behat\Testwork\Cli\Application->doRun() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Cli/Application.php:124
PHP   5. Behat\Testwork\Cli\Application->doRunCommand() /home/talus/dev/test-behapi/vendor/symfony/console/Application.php:241
PHP   6. Behat\Testwork\Cli\Command->run() /home/talus/dev/test-behapi/vendor/symfony/console/Application.php:865
PHP   7. Behat\Testwork\Cli\Command->execute() /home/talus/dev/test-behapi/vendor/symfony/console/Command/Command.php:252
PHP   8. Behat\Testwork\Tester\Cli\ExerciseController->execute() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Cli/Command.php:63
PHP   9. Behat\Testwork\Tester\Cli\ExerciseController->testSpecifications() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Tester/Cli/ExerciseController.php:108
PHP  10. Behat\Testwork\Ordering\OrderedExercise->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Tester/Cli/ExerciseController.php:149
PHP  11. Behat\Testwork\EventDispatcher\Tester\EventDispatchingExercise->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Ordering/OrderedExercise.php:80
PHP  12. Behat\Testwork\Tester\Runtime\RuntimeExercise->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php:70
PHP  13. Behat\Testwork\EventDispatcher\Tester\EventDispatchingSuiteTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php:71
PHP  14. Behat\Testwork\Hook\Tester\HookableSuiteTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php:72
PHP  15. Behat\Testwork\Tester\Runtime\RuntimeSuiteTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php:73
PHP  16. Behat\Behat\EventDispatcher\Tester\EventDispatchingFeatureTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Tester/Runtime/RuntimeSuiteTester.php:63
PHP  17. Behat\Behat\Hook\Tester\HookableFeatureTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php:71
PHP  18. Behat\Behat\Tester\Runtime\RuntimeFeatureTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php:72
PHP  19. Behat\Behat\EventDispatcher\Tester\EventDispatchingOutlineTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php:84
PHP  20. Behat\Behat\Tester\Runtime\RuntimeOutlineTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php:73
PHP  21. Behat\Behat\Tester\Runtime\IsolatingScenarioTester->test() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/Tester/Runtime/RuntimeOutlineTester.php:64
PHP  22. Behat\Testwork\Environment\EnvironmentManager->isolateEnvironment() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/Tester/Runtime/IsolatingScenarioTester.php:65
PHP  23. Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler->isolateEnvironment() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Testwork/Environment/EnvironmentManager.php:93
PHP  24. Behat\Behat\Context\ContextFactory->createContext() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php:121
PHP  25. Behat\Behat\Context\ContextFactory->resolveArguments() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/Context/ContextFactory.php:87
PHP  26. Behat\Behat\HelperContainer\Argument\ServicesResolver->resolveArguments() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/Context/ContextFactory.php:108
PHP  27. array_map() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php:49
PHP  28. Behat\Behat\HelperContainer\Argument\ServicesResolver->resolveArgument() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php:49
PHP  29. mb_strpos() /home/talus/dev/Behapi/vendor/behat/behat/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php:68
```

This PR aims to solve that. I wasn't sure whether we should iterate through arrays, or just test that the argument is a string. I first went for only the string check, then changed my mind.Still open to change it again, as I also think this is overkill. :}