### PR TITLE
Add local cache for transformPatternToRegex

### DIFF
--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -26,6 +26,8 @@ final class PatternTransformer
      */
     private $policies = array();
 
+    private $patternToRegexpCache = array();
+
     /**
      * Registers pattern policy.
      *
@@ -34,6 +36,7 @@ final class PatternTransformer
     public function registerPatternPolicy(PatternPolicy $policy)
     {
         $this->policies[] = $policy;
+        $this->patternToRegexpCache = array();
     }
 
     /**
@@ -68,11 +71,16 @@ final class PatternTransformer
      */
     public function transformPatternToRegex($pattern)
     {
-        foreach ($this->policies as $policy) {
-            if ($policy->supportsPattern($pattern)) {
-                return $policy->transformPatternToRegex($pattern);
+        if (!isset($this->patternToRegexpCache[$pattern])) {
+            foreach ($this->policies as $policy) {
+                if ($policy->supportsPattern($pattern)) {
+                    $this->patternToRegexpCache[$pattern] = $policy->transformPatternToRegex($pattern);
+                    break;
+                }
             }
         }
+        return $this->patternToRegexpCache[$pattern];
+
 
         throw new UnknownPatternException(sprintf('Can not find policy for a pattern `%s`.', $pattern), $pattern);
     }

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -79,9 +79,11 @@ final class PatternTransformer
                 }
             }
         }
+
+        if (!isset($this->patternToRegexpCache[$pattern])) {
+            throw new UnknownPatternException(sprintf('Can not find policy for a pattern `%s`.', $pattern), $pattern);
+        }
+
         return $this->patternToRegexpCache[$pattern];
-
-
-        throw new UnknownPatternException(sprintf('Can not find policy for a pattern `%s`.', $pattern), $pattern);
     }
 }

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -72,18 +72,20 @@ final class PatternTransformer
     public function transformPatternToRegex($pattern)
     {
         if (!isset($this->patternToRegexpCache[$pattern])) {
-            foreach ($this->policies as $policy) {
-                if ($policy->supportsPattern($pattern)) {
-                    $this->patternToRegexpCache[$pattern] = $policy->transformPatternToRegex($pattern);
-                    break;
-                }
-            }
-        }
-
-        if (!isset($this->patternToRegexpCache[$pattern])) {
-            throw new UnknownPatternException(sprintf('Can not find policy for a pattern `%s`.', $pattern), $pattern);
+            $this->patternToRegexpCache[$pattern] = $this->transformPatternToRegexWithSupportedPolicy($pattern);
         }
 
         return $this->patternToRegexpCache[$pattern];
+    }
+
+    private function transformPatternToRegexWithSupportedPolicy($pattern)
+    {
+        foreach ($this->policies as $policy) {
+            if ($policy->supportsPattern($pattern)) {
+                return $policy->transformPatternToRegex($pattern);
+            }
+        }
+
+        throw new UnknownPatternException(sprintf('Can not find policy for a pattern `%s`.', $pattern), $pattern);
     }
 }

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -26,6 +26,9 @@ final class PatternTransformer
      */
     private $policies = array();
 
+    /**
+     * @var string[]
+     */
     private $patternToRegexpCache = array();
 
     /**
@@ -78,6 +81,13 @@ final class PatternTransformer
         return $this->patternToRegexpCache[$pattern];
     }
 
+    /**
+     * @param string $pattern
+     *
+     * @return string
+     *
+     * @throws UnknownPatternException
+     */
     private function transformPatternToRegexWithSupportedPolicy($pattern)
     {
         foreach ($this->policies as $policy) {

--- a/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
+++ b/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
@@ -65,4 +65,22 @@ class PatternTransformerTest extends TestCase
         $this->assertEquals('/hello world/', $regex2);
         $this->assertEquals('/hello world/', $regex3);
     }
+
+    /**
+     * @expectedException \Behat\Behat\Definition\Exception\UnknownPatternException
+     * @expectedExceptionMessage Can not find policy for a pattern `hello world`.
+     */
+    public function testTransformPatternToRegexNoMatch()
+    {
+        // first pattern
+        $policy1Prophecy = $this->prophesize(PatternPolicy::class);
+        $policy1Prophecy->supportsPattern('hello world')->willReturn(false);
+        $policy1Prophecy->transformPatternToRegex('hello world')
+            ->shouldNotBeCalled();
+
+
+        $testedInstance = new PatternTransformer();
+        $testedInstance->registerPatternPolicy($policy1Prophecy->reveal());
+        $regex = $testedInstance->transformPatternToRegex('hello world');
+    }
 }

--- a/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
+++ b/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Behat\Tests\Definition\Pattern;
+
+use Behat\Behat\Definition\Pattern\PatternTransformer;
+use Behat\Behat\Definition\Pattern\Policy\PatternPolicy;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class PatternTransformerTest
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class PatternTransformerTest extends TestCase
+{
+    public function testTransformPatternToRegexCache()
+    {
+        $observer = $this->prophesize(PatternPolicy::class);
+        // first pattern
+        $observer->supportsPattern('hello world')->willReturn(true);
+        $observer->transformPatternToRegex('hello world')
+            ->shouldBeCalledTimes(1)
+            ->willReturn('/hello world/');
+
+        // second pattern
+        $observer->supportsPattern('hi world')->willReturn(true);
+        $observer->transformPatternToRegex('hi world')
+            ->shouldBeCalledTimes(1)
+            ->willReturn('/hi world/');
+
+        $testedInstance = new PatternTransformer();
+        $testedInstance->registerPatternPolicy($observer->reveal());
+        $regex = $testedInstance->transformPatternToRegex('hello world');
+        $regex2 = $testedInstance->transformPatternToRegex('hello world');
+
+        $regex3 = $testedInstance->transformPatternToRegex('hi world');
+
+        $this->assertEquals('/hello world/', $regex);
+        $this->assertEquals('/hello world/', $regex2);
+        $this->assertEquals('/hi world/', $regex3);
+    }
+
+    public function testTransformPatternToRegexCacheAndRegisterNewPolicy()
+    {
+        // first pattern
+        $policy1Prophecy = $this->prophesize(PatternPolicy::class);
+        $policy1Prophecy->supportsPattern('hello world')->willReturn(true);
+        $policy1Prophecy->transformPatternToRegex('hello world')
+            ->shouldBeCalledTimes(2)
+            ->willReturn('/hello world/');
+
+        // second pattern
+        $policy2Prophecy = $this->prophesize(PatternPolicy::class);
+        $policy1Prophecy->supportsPattern()->shouldNotBeCalled();
+        $policy1Prophecy->transformPatternToRegex()->shouldNotBeCalled();
+
+        $testedInstance = new PatternTransformer();
+        $testedInstance->registerPatternPolicy($policy1Prophecy->reveal());
+        $regex = $testedInstance->transformPatternToRegex('hello world');
+        $regex2 = $testedInstance->transformPatternToRegex('hello world');
+
+        $testedInstance->registerPatternPolicy($policy2Prophecy->reveal());
+        $regex3 = $testedInstance->transformPatternToRegex('hello world');
+
+        $this->assertEquals('/hello world/', $regex);
+        $this->assertEquals('/hello world/', $regex2);
+        $this->assertEquals('/hello world/', $regex3);
+    }
+}


### PR DESCRIPTION
This little cache helps us save 1,5 second on one file containing 2200 lines and "saved" nearly one billion call to `preg_match`