### PR TITLE
Remove suggestions from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,12 +35,6 @@
         "herrera-io/box": "~1.6.1"
     },
 
-    "suggest": {
-        "behat/symfony2-extension": "for integration with Symfony2 web framework",
-        "behat/yii-extension": "for integration with Yii web framework",
-        "behat/mink-extension": "for integration with Mink testing framework"
-    },
-
     "autoload": {
         "psr-0": {
             "Behat\\Behat": "src/",


### PR DESCRIPTION
As suggested in #1138, I propose to remove suggestions from the package.json. The utility of this was always questionable in the context information provide.

People who want Behat to integrate with Symfony2 OR Mink in most cases already know about the extensions they need to install. Even if they weren't there are better ways to instruct them.