### PR TITLE
Register cli input/output services as synthetic

### DIFF
--- a/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
+++ b/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
@@ -81,6 +81,7 @@ final class CliExtension implements Extension
     public function load(ContainerBuilder $container, array $config)
     {
         $this->loadCommand($container);
+        $this->loadSyntheticServices($container);
     }
 
     /**
@@ -101,6 +102,12 @@ final class CliExtension implements Extension
         $definition = new Definition('Behat\Testwork\Cli\Command', array('%cli.command.name%', array()));
         $definition->setPublic(true);
         $container->setDefinition(self::COMMAND_ID, $definition);
+    }
+
+    protected function loadSyntheticServices(ContainerBuilder $container)
+    {
+        $container->register(self::INPUT_ID)->setSynthetic(true)->setPublic(true);
+        $container->register(self::OUTPUT_ID)->setSynthetic(true)->setPublic(true);
     }
 
     /**


### PR DESCRIPTION
> Services that are set at runtime are called synthetic services. This service has to be configured so the container knows the service exists during compilation (otherwise, services depending on kernel will get a "service does not exist" error).

source: https://symfony.com/doc/current/service_container/synthetic_services.html

Fixes #1159