### PR TITLE
Fix for #1108: Serialization of 'Closure' is not allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+  * Serializable definitions for Symfony 4.x
 
 ## [3.4.3] - 2017-11-27
 ### Fixed

--- a/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
+++ b/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
@@ -19,6 +19,7 @@ use Behat\Testwork\ServiceContainer\ServiceProcessor;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Behat helper container extension.
@@ -76,7 +77,9 @@ final class HelperContainerExtension implements Extension
      */
     public function load(ContainerBuilder $container, array $config)
     {
-        $definition = new Definition('Behat\Behat\HelperContainer\Argument\ServicesResolverFactory', array($container));
+        $definition = new Definition('Behat\Behat\HelperContainer\Argument\ServicesResolverFactory', array(
+            new Reference('service_container')
+        ));
         $definition->addTag(ContextExtension::SUITE_SCOPED_RESOLVER_FACTORY_TAG, array('priority' => 0));
         $container->setDefinition(ContextExtension::SUITE_SCOPED_RESOLVER_FACTORY_TAG . '.helper_container', $definition);
 


### PR DESCRIPTION
Allows for changes in Symfony serialization in 4.x, where `json_encode` has been replaced by `serialize` and an error is thrown if a closure is found. This replaces the service container object as a Definition argument with a Symfony DI Reference that can be serialized.