### PR TITLE
Change specification for autoloading classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,12 +35,18 @@
     },
 
     "autoload": {
-        "psr-0": {
-            "Behat\\Behat": "src/",
-            "Behat\\Testwork": "src/"
+        "psr-4": {
+            "Behat\\Behat\\": "src/Behat/Behat/",
+            "Behat\\Testwork\\": "src/Behat/Testwork/"
         }
     },
-
+    
+    "autoload-dev": {
+        "psr-4": {
+            "Behat\\Tests\\": "tests/"
+        }
+    },
+    
     "extra": {
         "branch-alias": {
             "dev-master": "3.5.x-dev"


### PR DESCRIPTION
-  PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative. see https://www.php-fig.org/psr/psr-0/ 
- Added autoload-dev to define autoload rules for development purposes. see https://getcomposer.org/doc/04-schema.md#autoload-dev