### PR TITLE
Remove the dependency on Symfony's ClassLoader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "symfony/event-dispatcher": "~2.1||~3.0||~4.0",
         "symfony/translation": "~2.3||~3.0||~4.0",
         "symfony/yaml": "~2.1||~3.0||~4.0",
-        "symfony/class-loader": "~2.1||~3.0",
         "psr/container": "^1.0",
         "container-interop/container-interop": "^1.2"
     },

--- a/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
+++ b/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
@@ -16,7 +16,7 @@ use Behat\Testwork\Filesystem\FilesystemLogger;
 use Behat\Testwork\Suite\Exception\SuiteConfigurationException;
 use Behat\Testwork\Suite\Setup\SuiteSetup;
 use Behat\Testwork\Suite\Suite;
-use Symfony\Component\ClassLoader\ClassLoader;
+use Composer\Autoload\ClassLoader;
 
 /**
  * Generates classes for all contexts in the suite using autoloader.

--- a/src/Behat/Testwork/Autoloader/Cli/AutoloaderController.php
+++ b/src/Behat/Testwork/Autoloader/Cli/AutoloaderController.php
@@ -11,7 +11,7 @@
 namespace Behat\Testwork\Autoloader\Cli;
 
 use Behat\Testwork\Cli\Controller;
-use Symfony\Component\ClassLoader\ClassLoader;
+use Composer\Autoload\ClassLoader;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
+++ b/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
@@ -149,7 +149,7 @@ final class AutoloaderExtension implements Extension
         $prefixes = $container->getParameter('class_loader.prefixes');
 
         foreach ($prefixes as $prefix => $path) {
-            $loaderDefinition->addMethodCall('addPsr4', array($prefix, $path));
+            $loaderDefinition->addMethodCall('add', array($prefix, $path));
         }
     }
 }

--- a/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
+++ b/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
@@ -108,7 +108,7 @@ final class AutoloaderExtension implements Extension
      */
     private function loadAutoloader(ContainerBuilder $container)
     {
-        $definition = new Definition('Symfony\Component\ClassLoader\ClassLoader');
+        $definition = new Definition('Composer\Autoload\ClassLoader');
         $container->setDefinition(self::CLASS_LOADER_ID, $definition);
     }
 
@@ -146,6 +146,10 @@ final class AutoloaderExtension implements Extension
     private function processLoaderPrefixes(ContainerBuilder $container)
     {
         $loaderDefinition = $container->getDefinition(self::CLASS_LOADER_ID);
-        $loaderDefinition->addMethodCall('addPrefixes', array($container->getParameter('class_loader.prefixes')));
+        $prefixes = $container->getParameter('class_loader.prefixes');
+
+        foreach ($prefixes as $prefix => $path) {
+            $loaderDefinition->addMethodCall('addPsr4', array($prefix, $path));
+        }
     }
 }


### PR DESCRIPTION
It solves the issue #994 and allows installing Behat inside a Symfony 4 project.