### PR TITLE
Remove herrera-io/box as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
 
     "require-dev": {
         "symfony/process": "~2.5|~3.0|~4.0",
-        "phpunit/phpunit": "^4.8.36|^6.3",
-        "herrera-io/box": "~1.6.1"
+        "phpunit/phpunit": "^4.8.36|^6.3"
     },
 
     "autoload": {


### PR DESCRIPTION
This package was not being used directly in the code.

It cuts down on some packages, including two abandoned ones: `phine/exception` and `phine/path`.