### PR TITLE
Fix phar deployment on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-branches:
-  only:
-    - master
-
-matrix:
-  include:
-    - php: 5.6
-      env: DEPENDENCIES='low'
-    - php: 5.6
-      env: SYMFONY_VERSION='2.7.*'
-    - php: 5.6
-      env: SYMFONY_VERSION='2.8.*'
-    - php: 7.2
-      env: SYMFONY_VERSION='^3.4'
+if: branch = master OR tag IS present
 
 before_install:
   - phpenv config-rm xdebug.ini
@@ -37,18 +24,38 @@ script:
   - phpunit
   - behat -fprogress --strict --tags '~@php-version,'`php php_version_tags.php`
 
-before_deploy:
-  - curl -LSs https://box-project.github.io/box2/installer.php | php
-  - export PATH=.:$PATH
-  - rm -Rf ./vendor
-  - composer install --no-dev -o
-  - box.phar build
+stages:
+  - test
+  - name: deploy
+    if: tag IS present
 
-deploy:
-  provider: releases
-  api_key: $GITHUB_API_KEY
-  file: behat.phar
-  skip_cleanup: true
-  on:
-    tags: true
-    php: 5.6
+jobs:
+  include:
+    - stage: test
+      php: 5.6
+      env: DEPENDENCIES='low'
+    - php: 5.6
+      env: SYMFONY_VERSION='2.7.*'
+    - php: 5.6
+      env: SYMFONY_VERSION='2.8.*'
+    - php: 7.2
+      env: SYMFONY_VERSION='^3.4'
+
+    - stage: deploy
+      php: 7.2
+      before_script: skip
+      script: skip
+
+      before_deploy:
+        - curl -LSs https://box-project.github.io/box2/installer.php | php
+        - export PATH=.:$PATH
+        - composer install --no-dev -o
+        - box.phar build
+
+      deploy:
+        on:
+          tags: true
+        provider: releases
+        api_key: $GITHUB_API_KEY
+        file: behat.phar
+        skip_cleanup: true


### PR DESCRIPTION
Phar files were not built on Travis, because builds were enabled only on master branch, not on tags. You can see requests log here: [Requests](https://travis-ci.org/Behat/Behat/requests). So I have enabled builds on tags.

Enabling builds revealed another problem. In old Travis config (before my changes) deploy stage was executed on every of four PHP 5.6 jobs. This means that there could be zero to four deployments depending of how many jobs have failed. The result was unpredictable, because each upload was overwriting previous one. Final deploy was the result of the longest running job.

To solve those problems I've used Travis staged builds. There are two stages: test and deploy. Test stage consists of eight jobs running in parallel (the same jobs as before). Deploy stage has only one job and runs only on tagged commits and after all jobs from test stage have succeeded. 

This PR fixes #1078.