### PR TITLE
Get contexts via polymorphism

### DIFF
--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -97,7 +97,30 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
      */
     public function hasContextClass($class)
     {
-        return isset($this->contexts[$class]);
+        return (bool) $this->resolveContextClass($class);
+    }
+
+    /**
+     * Resolves the specified class to a registered context.
+     *
+     * Will return an instance of the specified class if it is registered directly,
+     * or any registered context that extends/implements the specified class/interface.
+     *
+     * @param  string       $class the fully qualified class name.
+     * @return Context|null The context class, or null if no matching context was found.
+     */
+    public function resolveContextClass($class) {
+        if (isset($this->contexts[$class])) {
+            return $this->contexts[$class];
+        }
+
+        foreach ($this->contexts as $context) {
+            if ($context instanceof $class) {
+                return $context;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -121,14 +144,14 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
      */
     public function getContext($class)
     {
-        if (!$this->hasContextClass($class)) {
+        if (!$context = $this->resolveContextClass($class)) {
             throw new ContextNotFoundException(sprintf(
                 '`%s` context is not found in the suite environment. Have you registered it?',
                 $class
             ), $class);
         }
 
-        return $this->contexts[$class];
+        return $context;
     }
 
     /**

--- a/tests/Behat/Tests/Context/Environment/InitializedContextEnvironmentTest.php
+++ b/tests/Behat/Tests/Context/Environment/InitializedContextEnvironmentTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Behat\Tests\Context\Environment;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Context\Exception\ContextNotFoundException;
+use Behat\Testwork\Suite\Suite;
+use PHPUnit\Framework\TestCase;
+
+interface ContextInterface {}
+class BaseContext implements Context {}
+class ExtendingContext extends BaseContext implements ContextInterface {}
+
+class InitializedContextEnvironmentTest extends TestCase
+{
+    public function testHasContextClassConcrete()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+      $environment->registerContext(new BaseContext());
+
+      self::assertTrue($environment->hasContextClass(BaseContext::class));
+    }
+
+    public function testHasContextClassExtended()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+      $environment->registerContext(new ExtendingContext());
+
+      self::assertTrue($environment->hasContextClass(BaseContext::class));
+    }
+
+    public function testHasContextClassInterface()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+      $environment->registerContext(new ExtendingContext());
+
+      self::assertTrue($environment->hasContextClass(ContextInterface::class));
+    }
+
+    public function testHasContextClassMissing()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+
+      self::assertFalse($environment->hasContextClass(ContextInterface::class));
+    }
+
+    public function testResolveContextClassConcrete()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+
+      $baseContext = new BaseContext();
+      $environment->registerContext($baseContext);
+
+      self::assertEquals($baseContext, $environment->resolveContextClass(BaseContext::class));
+    }
+
+    public function testResolveContextClassExtended()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+
+      $extendingContext = new ExtendingContext();
+      $environment->registerContext($extendingContext);
+
+      self::assertEquals($extendingContext, $environment->resolveContextClass(BaseContext::class));
+    }
+
+    public function testResolveContextClassInterface()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+
+      $extendingContext = new ExtendingContext();
+      $environment->registerContext($extendingContext);
+
+      self::assertEquals($extendingContext, $environment->resolveContextClass(ContextInterface::class));
+    }
+
+    public function testResolveContextClassMissing() {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+
+      self::assertNull($environment->resolveContextClass(BaseContext::class));
+    }
+
+    public function testGetContextConcrete()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+
+      $baseContext = new BaseContext();
+      $environment->registerContext($baseContext);
+
+      self::assertEquals($baseContext, $environment->getContext(BaseContext::class));
+    }
+
+    public function testGetContextExtended()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+
+      $extendingContext = new ExtendingContext();
+      $environment->registerContext($extendingContext);
+
+      self::assertEquals($extendingContext, $environment->getContext(BaseContext::class));
+    }
+
+    public function testGetContextInterface()
+    {
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+
+      $extendingContext = new ExtendingContext();
+      $environment->registerContext($extendingContext);
+
+      self::assertEquals($extendingContext, $environment->getContext(ContextInterface::class));
+    }
+
+    public function testGetContextMissing()
+    {
+      self::setExpectedException(
+          ContextNotFoundException::class,
+          '`' . BaseContext::class . '` context is not found in the suite environment. Have you registered it?'
+      );
+
+      $environment = new InitializedContextEnvironment(self::getMock(Suite::class));
+      $environment->getContext(BaseContext::class);
+    }
+}


### PR DESCRIPTION
## Scenario:
Given I have a context class MyContext
And I have a context class MyExtendingContext that extends MyContext
When I register MyExtendingContext in the Behat environment
And I try to use InitializedContextEnvironment::getContext to get MyContext

## Desired Behavior:
Then I should receive MyExtendingContext as it "is-a" MyContext

## Current Behavior:
Then I do not receive MyExtendingContext as it is not a MyContext

## Implementation:
I modified the hasContextClass and getContext methods to check for extending or implementation of the specified class or interface.