### PR TITLE
Nullable arguments

### DIFF
--- a/features/arguments.feature
+++ b/features/arguments.feature
@@ -181,3 +181,41 @@ Feature: Step Arguments
       1 scenario (1 passed)
       1 step (1 passed)
       """
+
+  @php-version @php7.1
+  Scenario: Nullable arguments
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @Given /^I do not match the nullable parameter$/
+           */
+          public function iHaveANullableArgument(?string $null)
+          {
+              \PHPUnit\Framework\Assert::assertNull($null);
+          }
+      }
+      """
+    And a file named "features/named_args.feature" with:
+      """
+      Feature: Nullable arguments
+        In order to maintain steps
+        As a step developer
+        I need to be able to declare regex with nullable matches
+
+        Scenario:
+          Given I do not match the nullable parameter
+      """
+    When I run "behat --no-colors -f progress features/named_args.feature "
+    Then it should pass with:
+      """
+      .
+
+      1 scenario (1 passed)
+      1 step (1 passed)
+      """

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -366,9 +366,11 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
                 continue;
             }
 
-            if ($parameter->isDefaultValueAvailable()) {
-                $arguments[$num] = $parameter->getDefaultValue();
+            if ($parameter->isDefaultValueAvailable() || $parameter->allowsNull()) {
+                $arguments[$num] = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
                 $this->markArgumentDefined($num);
+
+                continue;
             }
         }
 

--- a/src/Behat/Testwork/Argument/Validator.php
+++ b/src/Behat/Testwork/Argument/Validator.php
@@ -58,6 +58,10 @@ final class Validator
             return;
         }
 
+        if ($parameter->allowsNull()) {
+            return;
+        }
+
         throw new UnknownParameterValueException(sprintf(
             'Can not find a matching value for an argument `$%s` of the method `%s`.',
             $parameter->getName(),


### PR DESCRIPTION
Fix #1189 

If a parameter is nullable but doesn't have a `null` default value, it should IMO use `null` as a value. Not sure though if it's not better to leave it as it is currently, with nothing more than a default value detection.