### PR TITLE
Rerun should not write cache if it was explicitly set by user

### DIFF
--- a/features/rerun.feature
+++ b/features/rerun.feature
@@ -118,7 +118,7 @@ Feature: Rerun
       """
 
   Scenario: Rerun only failed scenarios
-    Given I run "behat --no-colors -f progress features/apples.feature"
+    Given I run "behat --no-colors -f progress features/apples.feature --rerun"
     When I run "behat --no-colors -f progress features/apples.feature --rerun"
     Then it should fail with:
     """
@@ -173,7 +173,7 @@ Feature: Rerun
             | 0   | 4     | 7      |
             | 2   | 2     | 3      |
       """
-    When I run "behat --no-colors -f progress features/apples.feature"
+    When I run "behat --no-colors -f progress features/apples.feature --rerun"
     And I run "behat --no-colors -f progress features/apples.feature --rerun"
     Then it should fail with:
     """

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -183,7 +183,7 @@ Feature: Rerun with multiple suite
       """
 
   Scenario: Rerun only failed scenarios, 4 from default suite and 2 from suite2
-    Given I run "behat --no-colors -f progress"
+    Given I run "behat --no-colors -f progress --rerun"
     When I run "behat --no-colors -f progress --rerun"
     Then it should fail with:
     """
@@ -254,7 +254,7 @@ Feature: Rerun with multiple suite
             | 0   | 4     | 7      |
             | 2   | 2     | 3      |
       """
-    When I run "behat --no-colors -f progress"
+    When I run "behat --no-colors -f progress --rerun"
     And I run "behat --no-colors -f progress --rerun"
     Then it should fail with:
     """
@@ -275,7 +275,7 @@ Feature: Rerun with multiple suite
     """
 
   Scenario: Rerun only suite failed scenarios from suite2 suite
-    Given I run "behat --no-colors -f progress --suite suite2"
+    Given I run "behat --no-colors -f progress --suite suite2 --rerun"
     When I run "behat --no-colors -f progress --suite suite2 --rerun"
     Then it should fail with:
     """

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -86,21 +86,26 @@ final class RerunController implements Controller
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->eventDispatcher->addListener(ScenarioTested::AFTER, array($this, 'collectFailedScenario'), -50);
-        $this->eventDispatcher->addListener(ExampleTested::AFTER, array($this, 'collectFailedScenario'), -50);
-        $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'writeCache'), -50);
-
-        $this->key = $this->generateKey($input);
-
         if (!$input->getOption('rerun')) {
             return;
         }
 
-        if (!$this->getFileName() || !file_exists($this->getFileName())) {
+        $this->key = $this->generateKey($input);
+        $filename = $this->getFileName();
+
+        if (!$filename) {
             return;
         }
 
-        $input->setArgument('paths', $this->getFileName());
+        $this->eventDispatcher->addListener(ScenarioTested::AFTER, array($this, 'collectFailedScenario'), -50);
+        $this->eventDispatcher->addListener(ExampleTested::AFTER, array($this, 'collectFailedScenario'), -50);
+        $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'writeCache'), -50);
+
+        if (!file_exists($filename)) {
+            return;
+        }
+
+        $input->setArgument('paths', $filename);
     }
 
     /**

--- a/tests/Behat/Tests/Behat/Tester/Cli/RerunControllerTest.php
+++ b/tests/Behat/Tests/Behat/Tester/Cli/RerunControllerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Behat\Tests\Behat\Tester\Cli;
+
+use Behat\Behat\EventDispatcher\Event\ExampleTested;
+use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use Behat\Behat\Tester\Cli\RerunController;
+use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class RerunControllerTest extends TestCase
+{
+    /** @var EventDispatcherInterface|MockObject */
+    private $eventDispatcher;
+
+    /** @var Input */
+    private $input;
+
+    /** @var string|null */
+    private $rerunCacheFile;
+
+    protected function setUp()
+    {
+        $this->eventDispatcher =
+            $this->getMockBuilder('\Symfony\Component\EventDispatcher\EventDispatcherInterface')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $inputDefinition = new InputDefinition();
+        $inputDefinition->setOptions(array(
+            new InputOption('rerun'),
+            new InputOption('profile'),
+            new InputOption('suite'),
+            new InputOption('name'),
+            new InputOption('tags'),
+            new InputOption('role'),
+        ));
+        $inputDefinition->setArguments(array(
+            new InputArgument('paths')
+        ));
+
+        $this->input = new ArrayInput(array('--profile' => 'behat'), $inputDefinition);
+    }
+
+    protected function tearDown()
+    {
+        if ($this->rerunCacheFile && file_exists($this->rerunCacheFile)) {
+            @unlink($this->rerunCacheFile);
+        }
+    }
+
+
+    public function testExecuteWithoutRerunOptionMustNotAddListeners()
+    {
+        $output = new BufferedOutput();
+
+        $cachePath = sys_get_temp_dir();
+        $basePath = sys_get_temp_dir();
+
+        $subject = new RerunController($this->eventDispatcher, $cachePath, $basePath);
+
+        $this->input->setOption('rerun', false);
+
+        // void
+        $this->assertNull($subject->execute($this->input, $output));
+    }
+
+    public function testExecuteWithoutCachePathMustNotAddListeners()
+    {
+
+        $output = new BufferedOutput();
+
+        $basePath = sys_get_temp_dir();
+
+        $subject = new RerunController($this->eventDispatcher, null, $basePath);
+
+        $this->input->setOption('rerun', true);
+        $this->input->setOption('suite', false);
+        $this->input->setOption('name', array(null, null));
+        $this->input->setOption('tags', array(null, null));
+        $this->input->setOption('role', false);
+        $this->input->setArgument('paths', false);
+
+        // void
+        $this->assertNull($subject->execute($this->input, $output));
+    }
+
+    public function testExecuteMustAddListenersAndMustNotRewritePathsArgument()
+    {
+        $output = new BufferedOutput();
+
+        $basePath = $cachePath = sys_get_temp_dir();
+
+        $subject = new RerunController($this->eventDispatcher, $cachePath, $basePath);
+
+        $this->input->setOption('rerun', true);
+        $this->input->setOption('suite', false);
+        $this->input->setOption('name', array(null, null));
+        $this->input->setOption('tags', array(null, null));
+        $this->input->setOption('role', false);
+        $this->input->setArgument('paths', false);
+
+        $this->eventDispatcher
+            ->expects($this->exactly(3))
+            ->method('addListener')
+            ->withConsecutive(
+                array(ScenarioTested::AFTER, array($subject, 'collectFailedScenario'), $this->anything()),
+                array(ExampleTested::AFTER, array($subject, 'collectFailedScenario'), $this->anything()),
+                array(ExerciseCompleted::AFTER, array($subject, 'writeCache'), $this->anything())
+            )
+        ;
+
+        // void
+        $this->assertNull($subject->execute($this->input, $output));
+        $this->assertFalse($this->input->getArgument('paths'));
+    }
+
+    public function testExecuteMustAddListenersAndMustRewritePathsArgumentIfFileExists()
+    {
+        $output = new BufferedOutput();
+
+        $basePath = $cachePath = sys_get_temp_dir();
+
+        $subject = new RerunController($this->eventDispatcher, $cachePath, $basePath);
+
+        $this->input->setOption('rerun', true);
+        $this->input->setOption('suite', false);
+        $this->input->setOption('name', array(null, null));
+        $this->input->setOption('tags', array(null, null));
+        $this->input->setOption('role', false);
+        $this->input->setArgument('paths', false);
+
+        $this->eventDispatcher
+            ->expects($this->exactly(3))
+            ->method('addListener')
+            ->withConsecutive(
+                array(ScenarioTested::AFTER, array($subject, 'collectFailedScenario'), $this->anything()),
+                array(ExampleTested::AFTER, array($subject, 'collectFailedScenario'), $this->anything()),
+                array(ExerciseCompleted::AFTER, array($subject, 'writeCache'), $this->anything())
+            )
+        ;
+
+        $key = md5(
+            'behat' .
+            false .
+            implode(' ', array(null, null)) .
+            implode(' ', array(null, null)) .
+            false .
+            false .
+            $basePath
+        );
+
+        $this->rerunCacheFile = $cachePath . DIRECTORY_SEPARATOR . $key . '.rerun';
+        touch($this->rerunCacheFile);
+
+        // void
+        $this->assertNull($subject->execute($this->input, $output));
+        $this->assertEquals($this->rerunCacheFile, $this->input->getArgument('paths'));
+    }
+}


### PR DESCRIPTION
By merging this PR `rerun` won't be enabled by default, which is minor behavior change.
To enable `rerun` user must explicitly define `--rerun` argument.

Issue #1194 