### PR TITLE
Update features to reflect new translations + remove deprecated phpunit annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-mbstring": "*",
-        "behat/gherkin": "^4.5.1",
+        "behat/gherkin": "^4.6.0",
         "behat/transliterator": "^1.2",
         "symfony/console": "~2.7.40||^2.8.33||~3.3.15||^3.4.3||^4.0.3",
         "symfony/config": "~2.3||~3.0||~4.0",

--- a/features/syntax_help.feature
+++ b/features/syntax_help.feature
@@ -20,7 +20,7 @@ Feature: Syntax helpers
           [Given|*] there is agent A
           [And|*] there is agent B
 
-        Scenario: Erasing agent memory
+        [Scenario|Example]: Erasing agent memory
           [Given|*] there is agent J
           [And|*] there is agent K
           [When|*] I erase agent K's memory
@@ -52,25 +52,25 @@ Feature: Syntax helpers
         In order to stay secret
         As a secret organization
         We need to be able to erase past agents' memory
-
+      
         [Предыстория|Контекст]:
-          [Допустим|Пусть|Дано|Если|*] there is agent A
+          [Допустим|Пусть|Дано|*] there is agent A
           [К тому же|Также|*|И] there is agent B
-
-        Сценарий: Erasing agent memory
-          [Допустим|Пусть|Дано|Если|*] there is agent J
+      
+        [Сценарий|Пример]: Erasing agent memory
+          [Допустим|Пусть|Дано|*] there is agent J
           [К тому же|Также|*|И] there is agent K
-          [Когда|*] I erase agent K's memory
+          [Когда|Если|*] I erase agent K's memory
           [Затем|Тогда|То|*] there should be agent J
-          [Но|*|А] there should not be agent K
-
+          [Иначе|Но|*|А] there should not be agent K
+      
         Структура сценария: Erasing other agents' memory
-          [Допустим|Пусть|Дано|Если|*] there is agent <agent1>
+          [Допустим|Пусть|Дано|*] there is agent <agent1>
           [К тому же|Также|*|И] there is agent <agent2>
-          [Когда|*] I erase agent <agent2>'s memory
+          [Когда|Если|*] I erase agent <agent2>'s memory
           [Затем|Тогда|То|*] there should be agent <agent1>
-          [Но|*|А] there should not be agent <agent2>
-
+          [Иначе|Но|*|А] there should not be agent <agent2>
+      
           Примеры:
             | agent1 | agent2 |
             | D      | M      |
@@ -399,6 +399,6 @@ Feature: Syntax helpers
     When I run "behat --no-colors --lang=ru -d 'нашел'"
     Then the output should contain:
       """
-      default | [Когда|*] /^Я нашел (\d+) яблоко?$/
+      default | [Когда|Если|*] /^Я нашел (\d+) яблоко?$/
               | at `FeatureContext::iFoundApples()`
       """

--- a/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
+++ b/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
@@ -2,6 +2,7 @@
 
 namespace Behat\Tests\Definition\Pattern;
 
+use Behat\Behat\Definition\Exception\UnknownPatternException;
 use Behat\Behat\Definition\Pattern\PatternTransformer;
 use Behat\Behat\Definition\Pattern\Policy\PatternPolicy;
 use PHPUnit\Framework\TestCase;
@@ -66,12 +67,12 @@ class PatternTransformerTest extends TestCase
         $this->assertEquals('/hello world/', $regex3);
     }
 
-    /**
-     * @expectedException \Behat\Behat\Definition\Exception\UnknownPatternException
-     * @expectedExceptionMessage Can not find policy for a pattern `hello world`.
-     */
     public function testTransformPatternToRegexNoMatch()
     {
+
+        $this->expectException(UnknownPatternException::class);
+        $this->expectExceptionMessage("Can not find policy for a pattern `hello world`.");
+
         // first pattern
         $policy1Prophecy = $this->prophesize(PatternPolicy::class);
         $policy1Prophecy->supportsPattern('hello world')->willReturn(false);


### PR DESCRIPTION
New translations in Behat/Gherkin have broken the tests

Additionally some PHPUnit deprecations are failing the build

We should probably make these less reliant on the real translations, seeing as they live in a different codebase