### PR TITLE
Allow multiple argumentTransformers to process the same argument

### DIFF
--- a/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
+++ b/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
@@ -100,7 +100,7 @@ final class DefinitionArgumentsTransformer implements CallFilter
                 continue;
             }
 
-            return $transformer->transformArgument($definitionCall, $index, $value);
+            $value = $transformer->transformArgument($definitionCall, $index, $value);
         }
 
         return $value;


### PR DESCRIPTION
Currently `DefinitionArgumentsTransformer::transformArgument()` bails after the first supported argumentTransformer processed the variable but in certain cases e.g. the argument is a TableNode you might have argumentTransformers that process different parts of an argument.
The made change allows all supported argumentTransformers to run on an argument.