### PR TITLE
Skipped tests should not be marked as fails

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -300,7 +300,7 @@ Feature: hooks
         Scenario: 130
           Given I must have 130
       """
-    When I run "behat --no-colors -f pretty"
+    When I run "behat --no-colors -f pretty --strict"
     Then it should fail with:
       """
       ┌─ @BeforeFeature # FeatureContext::doSomethingBeforeFeature()
@@ -426,7 +426,7 @@ Feature: hooks
           }
       }
       """
-    When I run "behat --no-colors -f pretty"
+    When I run "behat --no-colors -f pretty --strict"
     Then it should fail with:
       """
       Feature:

--- a/features/skipped_test.feature
+++ b/features/skipped_test.feature
@@ -1,0 +1,225 @@
+Feature: Skipped tests
+  In order to allow some tests to be excluded
+  As a features automator
+  I can exclude tests by my own criteria
+
+  Background:
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @Given /^I have (?:a|another) step that passes?$/
+           * @Then /^I should have a scenario that passed$/
+           */
+          public function passing() {
+          }
+
+          /**
+           * @Given /^I have (?:a|another) step that fails?$/
+           * @Then /^I should have a scenario that failed$/
+           */
+          public function failed() {
+              throw new Exception("step failed as supposed");
+          }
+
+          /**
+           * @BeforeScenario @skippedScenario
+           */
+          public function skippedScenario() {
+              throw new Exception("This Scenario should be skipped");
+          }
+
+          /**
+          * @BeforeFeature @skippedFeature
+           */
+          static public function skippedFeature() {
+              throw new Exception("This Feature should be skipped");
+          }
+
+      }
+      """
+    And a file named "features/skipped_feature.feature" with:
+      """
+      @skippedFeature
+      Feature: Feature with a skipped scenario
+        In order to test the Scenario Skipping feature
+        As a behat developer
+        I need to have a scenario that fails
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 2nd Passing
+          When I have a step that passes
+           And I have another step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 1st Skipped
+          When I have a step that fails
+          Then I should have a scenario that failed
+      """
+    And a file named "features/skipped_scenario.feature" with:
+      """
+      Feature: Feature with a skipped scenario
+        In order to test the Scenario Skipping feature
+        As a behat developer
+        I need to have a scenario that fails
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 2nd Passing
+          When I have a step that passes
+           And I have another step that passes
+          Then I should have a scenario that passed
+
+        @skippedScenario
+        Scenario: 1st Skipped
+          When I have a step that fails
+          Then I should have a scenario that failed
+      """
+
+  Scenario: Run feature containing a skipped scenario interpretting the results softly
+    When I run "behat --no-colors --format-settings='{\"paths\": false}' features/skipped_scenario.feature"
+    Then it should pass with:
+      """
+      Feature: Feature with a skipped scenario
+        In order to test the Scenario Skipping feature
+        As a behat developer
+        I need to have a scenario that fails
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 2nd Passing
+          When I have a step that passes
+          And I have another step that passes
+          Then I should have a scenario that passed
+
+        ┌─ @BeforeScenario @skippedScenario # FeatureContext::skippedScenario()
+        │
+        ╳  This Scenario should be skipped (Exception)
+        │
+        @skippedScenario
+        Scenario: 1st Skipped
+          When I have a step that fails
+          Then I should have a scenario that failed
+
+      --- Skipped scenarios:
+
+          features/skipped_scenario.feature:16
+
+      3 scenarios (2 passed, 1 skipped)
+      7 steps (5 passed, 2 skipped)
+      """
+
+  Scenario: Run feature containing a skipped scenario interpretting the results strictly
+    When I run "behat --no-colors --format-settings='{\"paths\": false}' features/skipped_scenario.feature --strict"
+    Then it should fail with:
+      """
+      Feature: Feature with a skipped scenario
+        In order to test the Scenario Skipping feature
+        As a behat developer
+        I need to have a scenario that fails
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 2nd Passing
+          When I have a step that passes
+          And I have another step that passes
+          Then I should have a scenario that passed
+
+        ┌─ @BeforeScenario @skippedScenario # FeatureContext::skippedScenario()
+        │
+        ╳  This Scenario should be skipped (Exception)
+        │
+        @skippedScenario
+        Scenario: 1st Skipped
+          When I have a step that fails
+          Then I should have a scenario that failed
+
+      --- Skipped scenarios:
+
+          features/skipped_scenario.feature:16
+
+      3 scenarios (2 passed, 1 skipped)
+      7 steps (5 passed, 2 skipped)
+      """
+
+  Scenario: Run skipped feature interpretting the results softly
+    When I run "behat --no-colors --format-settings='{\"paths\": false}' features/skipped_feature.feature"
+    Then it should pass with:
+      """
+      ┌─ @BeforeFeature @skippedFeature # FeatureContext::skippedFeature()
+      │
+      ╳  This Feature should be skipped (Exception)
+      │
+      @skippedFeature
+      Feature: Feature with a skipped scenario
+        In order to test the Scenario Skipping feature
+        As a behat developer
+        I need to have a scenario that fails
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 2nd Passing
+          When I have a step that passes
+          And I have another step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 1st Skipped
+          When I have a step that fails
+          Then I should have a scenario that failed
+
+      --- Skipped scenarios:
+
+          features/skipped_feature.feature:7
+          features/skipped_feature.feature:11
+          features/skipped_feature.feature:16
+      """
+
+  Scenario: Run skipped feature interpretting the results strictly
+    When I run "behat --no-colors --format-settings='{\"paths\": false}' features/skipped_feature.feature --strict"
+    Then it should fail with:
+      """
+      ┌─ @BeforeFeature @skippedFeature # FeatureContext::skippedFeature()
+      │
+      ╳  This Feature should be skipped (Exception)
+      │
+      @skippedFeature
+      Feature: Feature with a skipped scenario
+        In order to test the Scenario Skipping feature
+        As a behat developer
+        I need to have a scenario that fails
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 2nd Passing
+          When I have a step that passes
+          And I have another step that passes
+          Then I should have a scenario that passed
+
+        Scenario: 1st Skipped
+          When I have a step that fails
+          Then I should have a scenario that failed
+
+      --- Skipped scenarios:
+
+          features/skipped_feature.feature:7
+          features/skipped_feature.feature:11
+          features/skipped_feature.feature:16
+      """

--- a/src/Behat/Behat/Definition/Exception/BeforeStepException.php
+++ b/src/Behat/Behat/Definition/Exception/BeforeStepException.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Andrew Nicols <andrew@nicols.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Definition\Exception;
+
+use Behat\Behat\Definition\Definition;
+use RuntimeException;
+
+/**
+ * Represents an exception caused by a BeforeStepException.
+ *
+ * If multiple step definitions in the boundaries of the same suite use same regular expression, behat is not able
+ * to determine which one is better and thus this exception is thrown and test suite is stopped.
+ *
+ * @author Andrew Nicols <andrew@nicols.co.uk>
+ */
+final class BeforeStepException extends RuntimeException implements SearchException
+{
+    /**
+     * Initializes BeforeStepException.
+     */
+    public function __construct()
+    {
+        $message = sprintf(
+            "Step skipped due to failed BeforeStep setup"
+        );
+
+        parent::__construct($message);
+    }
+}

--- a/src/Behat/Behat/Definition/Exception/SkippedStepException.php
+++ b/src/Behat/Behat/Definition/Exception/SkippedStepException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Andrew Nicols <andrew@nicols.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Definition\Exception;
+
+use Behat\Behat\Definition\Definition;
+use RuntimeException;
+
+/**
+ * Represents an exception caused by a redundant step definition.
+ *
+ * If multiple step definitions in the boundaries of the same suite use same regular expression, behat is not able
+ * to determine which one is better and thus this exception is thrown and test suite is stopped.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class SkippedStepException extends RuntimeException implements SearchException
+{
+    /**
+     * Initializes redundant exception.
+     *
+     * @param Definition $step2 duplicate step definition
+     * @param Definition $step1 firstly matched step definition
+     */
+    public function __construct(Definition $step2, Definition $step1)
+    {
+        $message = sprintf(
+            "Step \"%s\" is already defined in %s\n\n%s\n%s",
+            $step2->getPattern(), $step1->getPath(), $step1->getPath(), $step2->getPath()
+        );
+
+        parent::__construct($message);
+    }
+}

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -13,6 +13,7 @@ namespace Behat\Behat\Tester\Runtime;
 use Behat\Behat\Definition\Call\DefinitionCall;
 use Behat\Behat\Definition\DefinitionFinder;
 use Behat\Behat\Definition\Exception\SearchException;
+use Behat\Behat\Definition\Exception\BeforeStepException;
 use Behat\Behat\Definition\SearchResult;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Behat\Tester\Result\FailedStepSearchResult;

--- a/src/Behat/Behat/Tester/StepContainerTester.php
+++ b/src/Behat/Behat/Tester/StepContainerTester.php
@@ -17,6 +17,10 @@ use Behat\Testwork\Tester\Result\IntegerTestResult;
 use Behat\Testwork\Tester\Result\TestResult;
 use Behat\Testwork\Tester\Result\TestWithSetupResult;
 
+use Behat\Testwork\Tester\Setup\FailedSetup;
+use Behat\Testwork\Tester\Setup\FailedTeardown;
+use Behat\Behat\Tester\Result\StepResult;
+
 /**
  * Tests provided collection of steps against provided environment.
  *
@@ -52,6 +56,7 @@ final class StepContainerTester
     public function test(Environment $env, FeatureNode $feature, StepContainerInterface $container, $skip)
     {
         $results = array();
+        $previousStageSkipped = $skip;
         foreach ($container->getSteps() as $step) {
             $setup = $this->stepTester->setUp($env, $feature, $step, $skip);
             $skipSetup = !$setup->isSuccessful() || $skip;
@@ -63,7 +68,8 @@ final class StepContainerTester
             $skip = $skip || $skipSetup || !$teardown->isSuccessful();
 
             $integerResult = new IntegerTestResult($testResult->getResultCode());
-            $results[] = new TestWithSetupResult($setup, $integerResult, $teardown);
+            $results[] = new TestWithSetupResult($setup, $integerResult, $teardown, $previousStageSkipped);
+            $previousStageSkipped = $skip;
         }
 
         return $results;

--- a/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
@@ -61,7 +61,7 @@ final class TestWithSetupResult implements TestResult
     public function getResultCode()
     {
         if (!$this->setup->isSuccessful()) {
-            return self::FAILED;
+            return self::SKIPPED;
         }
 
         if (!$this->teardown->isSuccessful()) {

--- a/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
@@ -32,6 +32,10 @@ final class TestWithSetupResult implements TestResult
      * @var Teardown
      */
     private $teardown;
+    /**
+     * @var bool
+     */
+    private $setupFailureCausesSkip;
 
     /**
      * Initializes test result.
@@ -39,12 +43,14 @@ final class TestWithSetupResult implements TestResult
      * @param Setup      $setup
      * @param TestResult $result
      * @param Teardown   $teardown
+     * @param bool       $setupFailureCausesSkip
      */
-    public function __construct(Setup $setup, TestResult $result, Teardown $teardown)
+    public function __construct(Setup $setup, TestResult $result, Teardown $teardown, $setupFailureCausesSkip = true)
     {
         $this->setup = $setup;
         $this->result = $result;
         $this->teardown = $teardown;
+        $this->setupFailureCausesSkip = $setupFailureCausesSkip;
     }
 
     /**
@@ -61,7 +67,11 @@ final class TestWithSetupResult implements TestResult
     public function getResultCode()
     {
         if (!$this->setup->isSuccessful()) {
-            return self::SKIPPED;
+            if ($this->setupFailureCausesSkip) {
+                return self::SKIPPED;
+            } else {
+                return self::FAILED;
+            }
         }
 
         if (!$this->teardown->isSuccessful()) {


### PR DESCRIPTION
By throwing an exception in any setUp hook (beforeSuite, beforeFeature, beforeScenario) a feature is marked as Skipped. This behaviour works as anticipated if you only consider the CLI output of the run.

However, the return status for skipped tests is incorrectly reported as being failed, regardless of whether strict mode is used.

According to the documentation for strict mode:
```
      --strict                           Passes only if all tests are explicitly passing.
```
This suggests that in soft mode, only _failing_ tests should be considered a fail, and that Pending and Skipped tests should not be considered to be a failure.

This has a knock-on effect that if using the `--rerun` option, if you have no failures, but one or more _skipped_ tests then the rerun file is empty, and the exit code is non-zero, and CI systems using the return status of the Behat CLI command will automatically attempt to rerun, causing the entire suite to be re-run.

This pull request changes the resultCode to be returned as SKIPPED for any test which was not successful in the _setup_ phase. This means that soft mode only regards FAILED tests as being Failed as intended. This change does not affect the result when strict mode is used.

This change is accompanied by a four new test which ensure that both soft, and strict mode give the correct return code and result (including exit code) for both a skipped Feature, and a skipped Scenario. Since it does not make sense to skip an entire suite I have not added a test to cover this case.