### PR TITLE
Lowercase `Boolean`

### DIFF
--- a/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
+++ b/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
@@ -98,7 +98,7 @@ final class InteractiveContextIdentifier implements TargetContextIdentifier
     /**
      * Checks if interactive mode is supported.
      *
-     * @return boolean
+     * @return bool
      *
      * @deprecated there is a better way to do it - `InputInterface::isInteractive()` method.
      *             Sadly, this doesn't work properly prior Symfony\Console 2.7 and as we need

--- a/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
+++ b/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
@@ -98,7 +98,7 @@ final class InteractiveContextIdentifier implements TargetContextIdentifier
     /**
      * Checks if interactive mode is supported.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @deprecated there is a better way to do it - `InputInterface::isInteractive()` method.
      *             Sadly, this doesn't work properly prior Symfony\Console 2.7 and as we need

--- a/src/Behat/Behat/Context/ContextClass/ClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/ClassGenerator.php
@@ -28,7 +28,7 @@ interface ClassGenerator
      * @param Suite  $suite
      * @param string $contextClass
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsSuiteAndClass(Suite $suite, $contextClass);
 

--- a/src/Behat/Behat/Context/ContextClass/ClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/ClassGenerator.php
@@ -28,7 +28,7 @@ interface ClassGenerator
      * @param Suite  $suite
      * @param string $contextClass
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsSuiteAndClass(Suite $suite, $contextClass);
 

--- a/src/Behat/Behat/Context/ContextClass/ClassResolver.php
+++ b/src/Behat/Behat/Context/ContextClass/ClassResolver.php
@@ -26,7 +26,7 @@ interface ClassResolver
      *
      * @param string $contextString
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsClass($contextString);
 

--- a/src/Behat/Behat/Context/ContextClass/ClassResolver.php
+++ b/src/Behat/Behat/Context/ContextClass/ClassResolver.php
@@ -26,7 +26,7 @@ interface ClassResolver
      *
      * @param string $contextString
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsClass($contextString);
 

--- a/src/Behat/Behat/Context/Environment/ContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/ContextEnvironment.php
@@ -25,7 +25,7 @@ interface ContextEnvironment extends Environment
     /**
      * Checks if environment has any contexts registered.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasContexts();
 
@@ -41,7 +41,7 @@ interface ContextEnvironment extends Environment
      *
      * @param string $class
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasContextClass($class);
 }

--- a/src/Behat/Behat/Context/Environment/ContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/ContextEnvironment.php
@@ -25,7 +25,7 @@ interface ContextEnvironment extends Environment
     /**
      * Checks if environment has any contexts registered.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasContexts();
 
@@ -41,7 +41,7 @@ interface ContextEnvironment extends Environment
      *
      * @param string $class
      *
-     * @return boolean
+     * @return bool
      */
     public function hasContextClass($class);
 }

--- a/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
@@ -180,7 +180,7 @@ final class AnnotatedContextReader implements ContextReader
      *
      * @param string $docLine
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isEmpty($docLine)
     {
@@ -192,7 +192,7 @@ final class AnnotatedContextReader implements ContextReader
      *
      * @param string $docLine
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isNotAnnotation($docLine)
     {
@@ -229,7 +229,7 @@ final class AnnotatedContextReader implements ContextReader
      *
      * @param string $docLine
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isIgnoredAnnotation($docLine)
     {

--- a/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
@@ -180,7 +180,7 @@ final class AnnotatedContextReader implements ContextReader
      *
      * @param string $docLine
      *
-     * @return boolean
+     * @return bool
      */
     private function isEmpty($docLine)
     {
@@ -192,7 +192,7 @@ final class AnnotatedContextReader implements ContextReader
      *
      * @param string $docLine
      *
-     * @return boolean
+     * @return bool
      */
     private function isNotAnnotation($docLine)
     {
@@ -229,7 +229,7 @@ final class AnnotatedContextReader implements ContextReader
      *
      * @param string $docLine
      *
-     * @return boolean
+     * @return bool
      */
     private function isIgnoredAnnotation($docLine)
     {

--- a/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
+++ b/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
@@ -81,7 +81,7 @@ final class ContextSnippetAppender implements SnippetAppender
      * @param string $class
      * @param string $contextFileContent
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isClassImported($class, $contextFileContent)
     {

--- a/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
+++ b/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
@@ -81,7 +81,7 @@ final class ContextSnippetAppender implements SnippetAppender
      * @param string $class
      * @param string $contextFileContent
      *
-     * @return boolean
+     * @return bool
      */
     private function isClassImported($class, $contextFileContent)
     {

--- a/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
@@ -27,7 +27,7 @@ interface PatternPolicy
      *
      * @param string $type
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsPatternType($type);
 
@@ -45,7 +45,7 @@ interface PatternPolicy
      *
      * @param string $pattern
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsPattern($pattern);
 

--- a/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
@@ -27,7 +27,7 @@ interface PatternPolicy
      *
      * @param string $type
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsPatternType($type);
 
@@ -45,7 +45,7 @@ interface PatternPolicy
      *
      * @param string $pattern
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsPattern($pattern);
 

--- a/src/Behat/Behat/Definition/SearchResult.php
+++ b/src/Behat/Behat/Definition/SearchResult.php
@@ -47,7 +47,7 @@ final class SearchResult
     /**
      * Checks if result contains a match.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasMatch()
     {

--- a/src/Behat/Behat/Definition/SearchResult.php
+++ b/src/Behat/Behat/Definition/SearchResult.php
@@ -47,7 +47,7 @@ final class SearchResult
     /**
      * Checks if result contains a match.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasMatch()
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
@@ -86,7 +86,7 @@ final class AfterStepSetup extends StepTested implements AfterSetup
     /**
      * Checks if step call, setup or teardown produced any output (stdOut or exception).
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOutput()
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
@@ -86,7 +86,7 @@ final class AfterStepSetup extends StepTested implements AfterSetup
     /**
      * Checks if step call, setup or teardown produced any output (stdOut or exception).
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasOutput()
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
@@ -111,7 +111,7 @@ final class AfterStepTested extends StepTested implements AfterTested
     /**
      * Checks if step call, setup or teardown produced any output (stdOut or exception).
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOutput()
     {
@@ -121,7 +121,7 @@ final class AfterStepTested extends StepTested implements AfterTested
     /**
      * Checks if step teardown has output.
      *
-     * @return boolean
+     * @return bool
      */
     private function teardownHasOutput()
     {
@@ -131,7 +131,7 @@ final class AfterStepTested extends StepTested implements AfterTested
     /**
      * Checks if result has produced exception.
      *
-     * @return boolean
+     * @return bool
      */
     private function resultHasException()
     {
@@ -141,7 +141,7 @@ final class AfterStepTested extends StepTested implements AfterTested
     /**
      * Checks if result is executed and call result has produced exception or stdOut.
      *
-     * @return boolean
+     * @return bool
      */
     private function resultCallHasOutput()
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
@@ -111,7 +111,7 @@ final class AfterStepTested extends StepTested implements AfterTested
     /**
      * Checks if step call, setup or teardown produced any output (stdOut or exception).
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasOutput()
     {
@@ -121,7 +121,7 @@ final class AfterStepTested extends StepTested implements AfterTested
     /**
      * Checks if step teardown has output.
      *
-     * @return Boolean
+     * @return boolean
      */
     private function teardownHasOutput()
     {
@@ -131,7 +131,7 @@ final class AfterStepTested extends StepTested implements AfterTested
     /**
      * Checks if result has produced exception.
      *
-     * @return Boolean
+     * @return boolean
      */
     private function resultHasException()
     {
@@ -141,7 +141,7 @@ final class AfterStepTested extends StepTested implements AfterTested
     /**
      * Checks if result is executed and call result has produced exception or stdOut.
      *
-     * @return Boolean
+     * @return boolean
      */
     private function resultCallHasOutput()
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
@@ -93,7 +93,7 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
     /**
      * Checks if step call produced any output (stdOut or exception).
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOutput()
     {
@@ -103,7 +103,7 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
     /**
      * Checks if result has produced exception.
      *
-     * @return boolean
+     * @return bool
      */
     private function resultHasException()
     {
@@ -113,7 +113,7 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
     /**
      * Checks if result is executed and call result has produced exception or stdOut.
      *
-     * @return boolean
+     * @return bool
      */
     private function resultCallHasOutput()
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
@@ -93,7 +93,7 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
     /**
      * Checks if step call produced any output (stdOut or exception).
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasOutput()
     {
@@ -103,7 +103,7 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
     /**
      * Checks if result has produced exception.
      *
-     * @return Boolean
+     * @return boolean
      */
     private function resultHasException()
     {
@@ -113,7 +113,7 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
     /**
      * Checks if result is executed and call result has produced exception or stdOut.
      *
-     * @return Boolean
+     * @return boolean
      */
     private function resultCallHasOutput()
     {

--- a/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
+++ b/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
@@ -97,7 +97,7 @@ final class SuiteWithPathsSetup implements SuiteSetup
      *
      * @param string $file A file path
      *
-     * @return boolean
+     * @return bool
      */
     private function isAbsolutePath($file)
     {

--- a/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
+++ b/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
@@ -97,7 +97,7 @@ final class SuiteWithPathsSetup implements SuiteSetup
      *
      * @param string $file A file path
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isAbsolutePath($file)
     {

--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -68,7 +68,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
      * @param FeatureNode $feature
      * @param string      $filterString
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isMatch(FeatureNode $feature, $filterString)
     {
@@ -89,7 +89,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
      * @param FeatureNode $feature
      * @param string      $filterString
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isMatchTagFilter(FeatureNode $feature, $filterString)
     {
@@ -104,7 +104,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
      * @param FeatureNode $feature
      * @param string      $filterString
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isMatchNameFilter(FeatureNode $feature, $filterString)
     {

--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -68,7 +68,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
      * @param FeatureNode $feature
      * @param string      $filterString
      *
-     * @return boolean
+     * @return bool
      */
     private function isMatch(FeatureNode $feature, $filterString)
     {
@@ -89,7 +89,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
      * @param FeatureNode $feature
      * @param string      $filterString
      *
-     * @return boolean
+     * @return bool
      */
     private function isMatchTagFilter(FeatureNode $feature, $filterString)
     {
@@ -104,7 +104,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
      * @param FeatureNode $feature
      * @param string      $filterString
      *
-     * @return boolean
+     * @return bool
      */
     private function isMatchNameFilter(FeatureNode $feature, $filterString)
     {

--- a/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
@@ -48,7 +48,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
      * @param ScenarioInterface $scenario
      * @param string            $filterString
      *
-     * @return boolean
+     * @return bool
      */
     protected function isMatch(FeatureNode $feature, ScenarioInterface $scenario, $filterString)
     {
@@ -70,7 +70,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
      * @param ScenarioInterface $scenario
      * @param string            $filterString
      *
-     * @return boolean
+     * @return bool
      */
     protected function isMatchTagFilter(FeatureNode $feature, ScenarioInterface $scenario, $filterString)
     {
@@ -89,7 +89,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
      * @param ScenarioInterface $scenario
      * @param string            $filterString
      *
-     * @return boolean
+     * @return bool
      */
     protected function isMatchNameFilter(ScenarioInterface $scenario, $filterString)
     {

--- a/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
@@ -48,7 +48,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
      * @param ScenarioInterface $scenario
      * @param string            $filterString
      *
-     * @return Boolean
+     * @return boolean
      */
     protected function isMatch(FeatureNode $feature, ScenarioInterface $scenario, $filterString)
     {
@@ -70,7 +70,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
      * @param ScenarioInterface $scenario
      * @param string            $filterString
      *
-     * @return Boolean
+     * @return boolean
      */
     protected function isMatchTagFilter(FeatureNode $feature, ScenarioInterface $scenario, $filterString)
     {
@@ -89,7 +89,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
      * @param ScenarioInterface $scenario
      * @param string            $filterString
      *
-     * @return Boolean
+     * @return boolean
      */
     protected function isMatchNameFilter(ScenarioInterface $scenario, $filterString)
     {

--- a/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
@@ -55,7 +55,7 @@ abstract class RuntimeStepHook extends RuntimeFilterableHook
      * @param StepNode $step
      * @param string   $filterString
      *
-     * @return boolean
+     * @return bool
      */
     private function isStepMatch(StepNode $step, $filterString)
     {

--- a/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
@@ -55,7 +55,7 @@ abstract class RuntimeStepHook extends RuntimeFilterableHook
      * @param StepNode $step
      * @param string   $filterString
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isStepMatch(StepNode $step, $filterString)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
@@ -61,7 +61,7 @@ final class OutlineTableListener implements EventListener
      */
     private $exampleSetup;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $headerPrinted = false;
     /**

--- a/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
@@ -61,7 +61,7 @@ final class OutlineTableListener implements EventListener
      */
     private $exampleSetup;
     /**
-     * @var boolean
+     * @var bool
      */
     private $headerPrinted = false;
     /**

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
@@ -37,7 +37,7 @@ class FireOnlySiblingsListener implements EventListener
      */
     private $descendant;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $inContext = false;
 

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
@@ -37,7 +37,7 @@ class FireOnlySiblingsListener implements EventListener
      */
     private $descendant;
     /**
-     * @var boolean
+     * @var bool
      */
     private $inContext = false;
 

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
@@ -34,7 +34,7 @@ class FirstBackgroundFiresFirstListener implements EventListener
      */
     private $descendant;
     /**
-     * @var boolean
+     * @var bool
      */
     private $firstBackgroundEnded = false;
     /**
@@ -103,7 +103,7 @@ class FirstBackgroundFiresFirstListener implements EventListener
      *
      * @param Event $event
      *
-     * @return boolean
+     * @return bool
      */
     private function isEventDelayedUntilFirstBackgroundPrinted(Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
@@ -34,7 +34,7 @@ class FirstBackgroundFiresFirstListener implements EventListener
      */
     private $descendant;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $firstBackgroundEnded = false;
     /**
@@ -103,7 +103,7 @@ class FirstBackgroundFiresFirstListener implements EventListener
      *
      * @param Event $event
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isEventDelayedUntilFirstBackgroundPrinted(Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
@@ -36,15 +36,15 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      */
     private $descendant;
     /**
-     * @var boolean
+     * @var bool
      */
     private $firstBackgroundEnded = false;
     /**
-     * @var boolean
+     * @var bool
      */
     private $inBackground = false;
     /**
-     * @var boolean
+     * @var bool
      */
     private $stepSetupHadOutput = false;
 
@@ -125,7 +125,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return boolean
+     * @return bool
      */
     private function isSkippableEvent(Event $event)
     {
@@ -141,7 +141,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return boolean
+     * @return bool
      */
     private function isNonFailingConsequentBackgroundStep(Event $event)
     {
@@ -157,7 +157,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return boolean
+     * @return bool
      */
     private function isStepEventWithOutput(Event $event)
     {
@@ -169,7 +169,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return boolean
+     * @return bool
      */
     private function isBeforeStepEventWithOutput(Event $event)
     {
@@ -187,7 +187,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return boolean
+     * @return bool
      */
     private function isAfterStepWithOutput(Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
@@ -36,15 +36,15 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      */
     private $descendant;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $firstBackgroundEnded = false;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $inBackground = false;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $stepSetupHadOutput = false;
 
@@ -125,7 +125,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isSkippableEvent(Event $event)
     {
@@ -141,7 +141,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isNonFailingConsequentBackgroundStep(Event $event)
     {
@@ -157,7 +157,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isStepEventWithOutput(Event $event)
     {
@@ -169,7 +169,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isBeforeStepEventWithOutput(Event $event)
     {
@@ -187,7 +187,7 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      *
      * @param Event $event
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isAfterStepWithOutput(Event $event)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
@@ -56,8 +56,8 @@ final class PrettySetupPrinter implements SetupPrinter
      * @param ResultToStringConverter $resultConverter
      * @param ExceptionPresenter      $exceptionPresenter
      * @param integer                 $indentation
-     * @param boolean                 $newlineBefore
-     * @param boolean                 $newlineAfter
+     * @param bool                 $newlineBefore
+     * @param bool                 $newlineAfter
      */
     public function __construct(
         ResultToStringConverter $resultConverter,

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
@@ -56,8 +56,8 @@ final class PrettySetupPrinter implements SetupPrinter
      * @param ResultToStringConverter $resultConverter
      * @param ExceptionPresenter      $exceptionPresenter
      * @param integer                 $indentation
-     * @param Boolean                 $newlineBefore
-     * @param Boolean                 $newlineAfter
+     * @param boolean                 $newlineBefore
+     * @param boolean                 $newlineAfter
      */
     public function __construct(
         ResultToStringConverter $resultConverter,

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -129,7 +129,7 @@ final class PrettySkippedStepPrinter implements StepPrinter
      * Returns argument string for provided argument.
      *
      * @param ArgumentInterface $argument
-     * @param boolean           $collapse
+     * @param bool           $collapse
      *
      * @return string
      */

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -129,7 +129,7 @@ final class PrettySkippedStepPrinter implements StepPrinter
      * Returns argument string for provided argument.
      *
      * @param ArgumentInterface $argument
-     * @param Boolean           $collapse
+     * @param boolean           $collapse
      *
      * @return string
      */

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -180,7 +180,7 @@ final class PrettyStepPrinter implements StepPrinter
      * Returns argument string for provided argument.
      *
      * @param ArgumentInterface $argument
-     * @param boolean           $collapse
+     * @param bool           $collapse
      *
      * @return string
      */

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -180,7 +180,7 @@ final class PrettyStepPrinter implements StepPrinter
      * Returns argument string for provided argument.
      *
      * @param ArgumentInterface $argument
-     * @param Boolean           $collapse
+     * @param boolean           $collapse
      *
      * @return string
      */

--- a/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
+++ b/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
@@ -27,7 +27,7 @@ interface SnippetAppender
      *
      * @param AggregateSnippet $snippet
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsSnippet(AggregateSnippet $snippet);
 

--- a/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
+++ b/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
@@ -27,7 +27,7 @@ interface SnippetAppender
      *
      * @param AggregateSnippet $snippet
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsSnippet(AggregateSnippet $snippet);
 

--- a/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
+++ b/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
@@ -30,7 +30,7 @@ interface SnippetGenerator
      * @param Environment $environment
      * @param StepNode    $step
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsEnvironmentAndStep(Environment $environment, StepNode $step);
 

--- a/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
+++ b/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
@@ -30,7 +30,7 @@ interface SnippetGenerator
      * @param Environment $environment
      * @param StepNode    $step
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsEnvironmentAndStep(Environment $environment, StepNode $step);
 

--- a/src/Behat/Behat/Snippet/SnippetRegistry.php
+++ b/src/Behat/Behat/Snippet/SnippetRegistry.php
@@ -34,7 +34,7 @@ final class SnippetRegistry implements SnippetRepository
      */
     private $snippets = array();
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $snippetsGenerated = false;
 

--- a/src/Behat/Behat/Snippet/SnippetRegistry.php
+++ b/src/Behat/Behat/Snippet/SnippetRegistry.php
@@ -34,7 +34,7 @@ final class SnippetRegistry implements SnippetRepository
      */
     private $snippets = array();
     /**
-     * @var boolean
+     * @var bool
      */
     private $snippetsGenerated = false;
 

--- a/src/Behat/Behat/Tester/BackgroundTester.php
+++ b/src/Behat/Behat/Tester/BackgroundTester.php
@@ -28,7 +28,7 @@ interface BackgroundTester
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return Setup
      */
@@ -39,7 +39,7 @@ interface BackgroundTester
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return TestResult
      */
@@ -50,7 +50,7 @@ interface BackgroundTester
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param boolean     $skip
+     * @param bool     $skip
      * @param TestResult  $result
      *
      * @return Teardown

--- a/src/Behat/Behat/Tester/BackgroundTester.php
+++ b/src/Behat/Behat/Tester/BackgroundTester.php
@@ -28,7 +28,7 @@ interface BackgroundTester
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return Setup
      */
@@ -39,7 +39,7 @@ interface BackgroundTester
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return TestResult
      */
@@ -50,7 +50,7 @@ interface BackgroundTester
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param Boolean     $skip
+     * @param boolean     $skip
      * @param TestResult  $result
      *
      * @return Teardown

--- a/src/Behat/Behat/Tester/OutlineTester.php
+++ b/src/Behat/Behat/Tester/OutlineTester.php
@@ -30,7 +30,7 @@ interface OutlineTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param OutlineNode $outline
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return Setup
      */
@@ -42,7 +42,7 @@ interface OutlineTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param OutlineNode $outline
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return TestResult
      */
@@ -54,7 +54,7 @@ interface OutlineTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param OutlineNode $outline
-     * @param boolean     $skip
+     * @param bool     $skip
      * @param TestResult  $result
      *
      * @return Teardown

--- a/src/Behat/Behat/Tester/OutlineTester.php
+++ b/src/Behat/Behat/Tester/OutlineTester.php
@@ -30,7 +30,7 @@ interface OutlineTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param OutlineNode $outline
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return Setup
      */
@@ -42,7 +42,7 @@ interface OutlineTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param OutlineNode $outline
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return TestResult
      */
@@ -54,7 +54,7 @@ interface OutlineTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param OutlineNode $outline
-     * @param Boolean     $skip
+     * @param boolean     $skip
      * @param TestResult  $result
      *
      * @return Teardown

--- a/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
@@ -91,7 +91,7 @@ final class RuntimeScenarioTester implements ScenarioTester
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return TestResult
      */

--- a/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
@@ -91,7 +91,7 @@ final class RuntimeScenarioTester implements ScenarioTester
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return TestResult
      */

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -107,7 +107,7 @@ final class RuntimeStepTester implements StepTester
      * @param FeatureNode  $feature
      * @param StepNode     $step
      * @param SearchResult $search
-     * @param boolean      $skip
+     * @param bool      $skip
      *
      * @return StepResult
      */

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -107,7 +107,7 @@ final class RuntimeStepTester implements StepTester
      * @param FeatureNode  $feature
      * @param StepNode     $step
      * @param SearchResult $search
-     * @param Boolean      $skip
+     * @param boolean      $skip
      *
      * @return StepResult
      */

--- a/src/Behat/Behat/Tester/ScenarioTester.php
+++ b/src/Behat/Behat/Tester/ScenarioTester.php
@@ -30,7 +30,7 @@ interface ScenarioTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param Scenario    $scenario
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return Setup
      */
@@ -42,7 +42,7 @@ interface ScenarioTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param Scenario    $scenario
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return TestResult
      */
@@ -54,7 +54,7 @@ interface ScenarioTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param Scenario    $scenario
-     * @param boolean     $skip
+     * @param bool     $skip
      * @param TestResult  $result
      *
      * @return Teardown

--- a/src/Behat/Behat/Tester/ScenarioTester.php
+++ b/src/Behat/Behat/Tester/ScenarioTester.php
@@ -30,7 +30,7 @@ interface ScenarioTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param Scenario    $scenario
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return Setup
      */
@@ -42,7 +42,7 @@ interface ScenarioTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param Scenario    $scenario
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return TestResult
      */
@@ -54,7 +54,7 @@ interface ScenarioTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param Scenario    $scenario
-     * @param Boolean     $skip
+     * @param boolean     $skip
      * @param TestResult  $result
      *
      * @return Teardown

--- a/src/Behat/Behat/Tester/StepContainerTester.php
+++ b/src/Behat/Behat/Tester/StepContainerTester.php
@@ -45,7 +45,7 @@ final class StepContainerTester
      * @param Environment            $env
      * @param FeatureNode            $feature
      * @param StepContainerInterface $container
-     * @param boolean                $skip
+     * @param bool                $skip
      *
      * @return TestResult[]
      */

--- a/src/Behat/Behat/Tester/StepContainerTester.php
+++ b/src/Behat/Behat/Tester/StepContainerTester.php
@@ -45,7 +45,7 @@ final class StepContainerTester
      * @param Environment            $env
      * @param FeatureNode            $feature
      * @param StepContainerInterface $container
-     * @param Boolean                $skip
+     * @param boolean                $skip
      *
      * @return TestResult[]
      */

--- a/src/Behat/Behat/Tester/StepTester.php
+++ b/src/Behat/Behat/Tester/StepTester.php
@@ -30,7 +30,7 @@ interface StepTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param StepNode    $step
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return Setup
      */
@@ -42,7 +42,7 @@ interface StepTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param StepNode    $step
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return StepResult
      */
@@ -54,7 +54,7 @@ interface StepTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param StepNode    $step
-     * @param Boolean     $skip
+     * @param boolean     $skip
      * @param StepResult  $result
      *
      * @return Teardown

--- a/src/Behat/Behat/Tester/StepTester.php
+++ b/src/Behat/Behat/Tester/StepTester.php
@@ -30,7 +30,7 @@ interface StepTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param StepNode    $step
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return Setup
      */
@@ -42,7 +42,7 @@ interface StepTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param StepNode    $step
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return StepResult
      */
@@ -54,7 +54,7 @@ interface StepTester
      * @param Environment $env
      * @param FeatureNode $feature
      * @param StepNode    $step
-     * @param boolean     $skip
+     * @param bool     $skip
      * @param StepResult  $result
      *
      * @return Teardown

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -45,7 +45,7 @@ interface SimpleArgumentTransformation extends Transformation
      * @param integer|string $argumentIndex
      * @param mixed          $argumentValue
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue);
 

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -45,7 +45,7 @@ interface SimpleArgumentTransformation extends Transformation
      * @param integer|string $argumentIndex
      * @param mixed          $argumentValue
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue);
 

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -26,7 +26,7 @@ interface ArgumentTransformer
      * @param integer|string $argumentIndex
      * @param mixed          $argumentValue
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue);
 

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -26,7 +26,7 @@ interface ArgumentTransformer
      * @param integer|string $argumentIndex
      * @param mixed          $argumentValue
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue);
 

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -99,7 +99,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * @param mixed    $argumentKey
      * @param string[] $parameterNames
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isStringKeyAndExistsInParameters($argumentKey, $parameterNames)
     {
@@ -112,7 +112,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * @param  ReflectionParameter[] $parameters
      * @param  mixed                 $value
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isParameterTypehintedInArgumentList(array $parameters, $value)
     {
@@ -135,7 +135,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * @param object              $value
      * @param ReflectionParameter $parameter
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isValueMatchesTypehintedParameter($value, ReflectionParameter $parameter)
     {
@@ -425,7 +425,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      *
      * @param integer $position
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isArgumentDefined($position)
     {

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -99,7 +99,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * @param mixed    $argumentKey
      * @param string[] $parameterNames
      *
-     * @return boolean
+     * @return bool
      */
     private function isStringKeyAndExistsInParameters($argumentKey, $parameterNames)
     {
@@ -112,7 +112,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * @param  ReflectionParameter[] $parameters
      * @param  mixed                 $value
      *
-     * @return boolean
+     * @return bool
      */
     private function isParameterTypehintedInArgumentList(array $parameters, $value)
     {
@@ -135,7 +135,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * @param object              $value
      * @param ReflectionParameter $parameter
      *
-     * @return boolean
+     * @return bool
      */
     private function isValueMatchesTypehintedParameter($value, ReflectionParameter $parameter)
     {
@@ -274,7 +274,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * @param  mixed[]             &$candidates Resolved arguments
      * @param  mixed[]             &$arguments  Argument mapping
      * @param  callable            $predicate   Callable predicate to apply to each candidate
-     * @return boolean Returns true if a candidate has been matched to the given parameter, otherwise false
+     * @return bool Returns true if a candidate has been matched to the given parameter, otherwise false
      */
     public function matchParameterToCandidateUsingPredicate(
         ReflectionParameter $parameter,
@@ -304,7 +304,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      *
      * @param  ReflectionClass $reflectionClass Typehinted argument
      * @param  mixed           $candidate       Resolved argument
-     * @return boolean
+     * @return bool
      */
     private function classMatchingPredicateForTypehintedArguments(ReflectionClass $reflectionClass, $candidate)
     {
@@ -316,7 +316,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      *
      * @param  ReflectionClass $reflectionClass Typehinted argument
      * @param  mixed           $candidate       Resolved argument
-     * @return boolean
+     * @return bool
      */
     private function isInstancePredicateForTypehintedArguments(ReflectionClass $reflectionClass, $candidate)
     {
@@ -425,7 +425,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      *
      * @param integer $position
      *
-     * @return boolean
+     * @return bool
      */
     private function isArgumentDefined($position)
     {

--- a/src/Behat/Testwork/Argument/PregMatchArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/PregMatchArgumentOrganiser.php
@@ -81,7 +81,7 @@ final class PregMatchArgumentOrganiser implements ArgumentOrganiser
      * @param integer $keyIndex
      * @param mixed[] $keys
      *
-     * @return boolean
+     * @return bool
      */
     private function isKeyAStringAndNexOneIsAnInteger($keyIndex, array $keys)
     {

--- a/src/Behat/Testwork/Argument/PregMatchArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/PregMatchArgumentOrganiser.php
@@ -81,7 +81,7 @@ final class PregMatchArgumentOrganiser implements ArgumentOrganiser
      * @param integer $keyIndex
      * @param mixed[] $keys
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isKeyAStringAndNexOneIsAnInteger($keyIndex, array $keys)
     {

--- a/src/Behat/Testwork/Call/CallResult.php
+++ b/src/Behat/Testwork/Call/CallResult.php
@@ -75,7 +75,7 @@ final class CallResult
     /**
      * Check if call thrown exception.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasException()
     {
@@ -95,7 +95,7 @@ final class CallResult
     /**
      * Checks if call produced stdOut.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasStdOut()
     {

--- a/src/Behat/Testwork/Call/CallResult.php
+++ b/src/Behat/Testwork/Call/CallResult.php
@@ -75,7 +75,7 @@ final class CallResult
     /**
      * Check if call thrown exception.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasException()
     {
@@ -95,7 +95,7 @@ final class CallResult
     /**
      * Checks if call produced stdOut.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasStdOut()
     {

--- a/src/Behat/Testwork/Call/CallResults.php
+++ b/src/Behat/Testwork/Call/CallResults.php
@@ -53,7 +53,7 @@ final class CallResults implements Countable, IteratorAggregate
     /**
      * Checks if any call in collection throws an exception.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasExceptions()
     {
@@ -69,7 +69,7 @@ final class CallResults implements Countable, IteratorAggregate
     /**
      * Checks if any call in collection produces an output.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasStdOuts()
     {

--- a/src/Behat/Testwork/Call/CallResults.php
+++ b/src/Behat/Testwork/Call/CallResults.php
@@ -53,7 +53,7 @@ final class CallResults implements Countable, IteratorAggregate
     /**
      * Checks if any call in collection throws an exception.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasExceptions()
     {
@@ -69,7 +69,7 @@ final class CallResults implements Countable, IteratorAggregate
     /**
      * Checks if any call in collection produces an output.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasStdOuts()
     {

--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -36,14 +36,14 @@ interface Callee
     /**
      * Returns true if callee is a method, false otherwise.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isAMethod();
 
     /**
      * Returns true if callee is an instance (non-static) method, false otherwise.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isAnInstanceMethod();
 

--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -36,14 +36,14 @@ interface Callee
     /**
      * Returns true if callee is a method, false otherwise.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAMethod();
 
     /**
      * Returns true if callee is an instance (non-static) method, false otherwise.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAnInstanceMethod();
 

--- a/src/Behat/Testwork/Call/Filter/CallFilter.php
+++ b/src/Behat/Testwork/Call/Filter/CallFilter.php
@@ -27,7 +27,7 @@ interface CallFilter
      *
      * @param Call $call
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsCall(Call $call);
 

--- a/src/Behat/Testwork/Call/Filter/CallFilter.php
+++ b/src/Behat/Testwork/Call/Filter/CallFilter.php
@@ -27,7 +27,7 @@ interface CallFilter
      *
      * @param Call $call
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsCall(Call $call);
 

--- a/src/Behat/Testwork/Call/Filter/ResultFilter.php
+++ b/src/Behat/Testwork/Call/Filter/ResultFilter.php
@@ -27,7 +27,7 @@ interface ResultFilter
      *
      * @param CallResult $result
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsResult(CallResult $result);
 

--- a/src/Behat/Testwork/Call/Filter/ResultFilter.php
+++ b/src/Behat/Testwork/Call/Filter/ResultFilter.php
@@ -27,7 +27,7 @@ interface ResultFilter
      *
      * @param CallResult $result
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsResult(CallResult $result);
 

--- a/src/Behat/Testwork/Call/Handler/CallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/CallHandler.php
@@ -28,7 +28,7 @@ interface CallHandler
      *
      * @param Call $call
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsCall(Call $call);
 

--- a/src/Behat/Testwork/Call/Handler/CallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/CallHandler.php
@@ -28,7 +28,7 @@ interface CallHandler
      *
      * @param Call $call
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsCall(Call $call);
 

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -77,7 +77,7 @@ final class RuntimeCallHandler implements CallHandler
      * @param string  $file
      * @param integer $line
      *
-     * @return Boolean
+     * @return boolean
      *
      * @throws CallErrorException
      */
@@ -154,7 +154,7 @@ final class RuntimeCallHandler implements CallHandler
      *
      * @param integer $level
      *
-     * @return Boolean
+     * @return boolean
      */
     private function errorLevelIsNotReportable($level)
     {

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -77,7 +77,7 @@ final class RuntimeCallHandler implements CallHandler
      * @param string  $file
      * @param integer $line
      *
-     * @return boolean
+     * @return bool
      *
      * @throws CallErrorException
      */
@@ -154,7 +154,7 @@ final class RuntimeCallHandler implements CallHandler
      *
      * @param integer $level
      *
-     * @return boolean
+     * @return bool
      */
     private function errorLevelIsNotReportable($level)
     {

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -112,7 +112,7 @@ class RuntimeCallee implements Callee
     /**
      * Returns true if callee is a method, false otherwise.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAMethod()
     {
@@ -122,7 +122,7 @@ class RuntimeCallee implements Callee
     /**
      * Returns true if callee is an instance (non-static) method, false otherwise.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAnInstanceMethod()
     {

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -112,7 +112,7 @@ class RuntimeCallee implements Callee
     /**
      * Returns true if callee is a method, false otherwise.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isAMethod()
     {
@@ -122,7 +122,7 @@ class RuntimeCallee implements Callee
     /**
      * Returns true if callee is an instance (non-static) method, false otherwise.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isAnInstanceMethod()
     {

--- a/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
+++ b/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
@@ -28,7 +28,7 @@ interface EnvironmentHandler
      *
      * @param Suite $suite
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsSuite(Suite $suite);
 
@@ -47,7 +47,7 @@ interface EnvironmentHandler
      * @param Environment $environment
      * @param mixed       $testSubject
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsEnvironmentAndSubject(Environment $environment, $testSubject = null);
 

--- a/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
+++ b/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
@@ -28,7 +28,7 @@ interface EnvironmentHandler
      *
      * @param Suite $suite
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsSuite(Suite $suite);
 
@@ -47,7 +47,7 @@ interface EnvironmentHandler
      * @param Environment $environment
      * @param mixed       $testSubject
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsEnvironmentAndSubject(Environment $environment, $testSubject = null);
 

--- a/src/Behat/Testwork/Environment/Reader/EnvironmentReader.php
+++ b/src/Behat/Testwork/Environment/Reader/EnvironmentReader.php
@@ -28,7 +28,7 @@ interface EnvironmentReader
      *
      * @param Environment $environment
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsEnvironment(Environment $environment);
 

--- a/src/Behat/Testwork/Environment/Reader/EnvironmentReader.php
+++ b/src/Behat/Testwork/Environment/Reader/EnvironmentReader.php
@@ -28,7 +28,7 @@ interface EnvironmentReader
      *
      * @param Environment $environment
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsEnvironment(Environment $environment);
 

--- a/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
@@ -27,7 +27,7 @@ interface ExceptionStringer
      *
      * @param Exception $exception
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsException(Exception $exception);
 

--- a/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
@@ -27,7 +27,7 @@ interface ExceptionStringer
      *
      * @param Exception $exception
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsException(Exception $exception);
 

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -70,7 +70,7 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
      * @param Suite  $suite
      * @param string $filterString
      *
-     * @return boolean
+     * @return bool
      */
     private function isSuiteMatch(Suite $suite, $filterString)
     {

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -70,7 +70,7 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
      * @param Suite  $suite
      * @param string $filterString
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isSuiteMatch(Suite $suite, $filterString)
     {

--- a/src/Behat/Testwork/Hook/FilterableHook.php
+++ b/src/Behat/Testwork/Hook/FilterableHook.php
@@ -24,7 +24,7 @@ interface FilterableHook extends Hook
      *
      * @param HookScope $scope
      *
-     * @return boolean
+     * @return bool
      */
     public function filterMatches(HookScope $scope);
 }

--- a/src/Behat/Testwork/Hook/FilterableHook.php
+++ b/src/Behat/Testwork/Hook/FilterableHook.php
@@ -24,7 +24,7 @@ interface FilterableHook extends Hook
      *
      * @param HookScope $scope
      *
-     * @return Boolean
+     * @return boolean
      */
     public function filterMatches(HookScope $scope);
 }

--- a/src/Behat/Testwork/Ordering/OrderedExercise.php
+++ b/src/Behat/Testwork/Ordering/OrderedExercise.php
@@ -58,7 +58,7 @@ final class OrderedExercise implements Exercise
      * Sets up exercise for a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param boolean $skip
+     * @param bool $skip
      *
      * @return Setup
      */
@@ -71,7 +71,7 @@ final class OrderedExercise implements Exercise
      * Tests suites specifications.
      *
      * @param SpecificationIterator[] $iterators
-     * @param boolean $skip
+     * @param bool $skip
      *
      * @return TestResult
      */
@@ -84,7 +84,7 @@ final class OrderedExercise implements Exercise
      * Tears down exercise after a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param boolean $skip
+     * @param bool $skip
      * @param TestResult $result
      *
      * @return Teardown

--- a/src/Behat/Testwork/Ordering/OrderedExercise.php
+++ b/src/Behat/Testwork/Ordering/OrderedExercise.php
@@ -58,7 +58,7 @@ final class OrderedExercise implements Exercise
      * Sets up exercise for a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param Boolean $skip
+     * @param boolean $skip
      *
      * @return Setup
      */
@@ -71,7 +71,7 @@ final class OrderedExercise implements Exercise
      * Tests suites specifications.
      *
      * @param SpecificationIterator[] $iterators
-     * @param Boolean $skip
+     * @param boolean $skip
      *
      * @return TestResult
      */
@@ -84,7 +84,7 @@ final class OrderedExercise implements Exercise
      * Tears down exercise after a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param Boolean $skip
+     * @param boolean $skip
      * @param TestResult $result
      *
      * @return Teardown

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -153,7 +153,7 @@ class OutputController implements Controller
      *
      * @param array   $formats
      * @param array   $outputs
-     * @param boolean $decorated
+     * @param bool $decorated
      */
     private function configureOutputs(array $formats, array $outputs, $decorated = false)
     {
@@ -184,7 +184,7 @@ class OutputController implements Controller
      *
      * @param string $outputId
      *
-     * @return boolean
+     * @return bool
      */
     private function isStandardOutput($outputId)
     {
@@ -196,7 +196,7 @@ class OutputController implements Controller
      *
      * @param string $file A file path
      *
-     * @return boolean
+     * @return bool
      */
     private function isAbsolutePath($file)
     {

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -153,7 +153,7 @@ class OutputController implements Controller
      *
      * @param array   $formats
      * @param array   $outputs
-     * @param Boolean $decorated
+     * @param boolean $decorated
      */
     private function configureOutputs(array $formats, array $outputs, $decorated = false)
     {
@@ -184,7 +184,7 @@ class OutputController implements Controller
      *
      * @param string $outputId
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isStandardOutput($outputId)
     {
@@ -196,7 +196,7 @@ class OutputController implements Controller
      *
      * @param string $file A file path
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isAbsolutePath($file)
     {

--- a/src/Behat/Testwork/Output/OutputManager.php
+++ b/src/Behat/Testwork/Output/OutputManager.php
@@ -58,7 +58,7 @@ final class OutputManager
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function isFormatterRegistered($name)
     {

--- a/src/Behat/Testwork/Output/OutputManager.php
+++ b/src/Behat/Testwork/Output/OutputManager.php
@@ -58,7 +58,7 @@ final class OutputManager
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isFormatterRegistered($name)
     {

--- a/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
@@ -83,7 +83,7 @@ abstract class OutputFactory
     /**
      * Forces output to be decorated.
      *
-     * @param boolean $decorated
+     * @param bool $decorated
      */
     public function setOutputDecorated($decorated)
     {

--- a/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
@@ -83,7 +83,7 @@ abstract class OutputFactory
     /**
      * Forces output to be decorated.
      *
-     * @param Boolean $decorated
+     * @param boolean $decorated
      */
     public function setOutputDecorated($decorated)
     {

--- a/src/Behat/Testwork/Output/Printer/OutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/OutputPrinter.php
@@ -69,7 +69,7 @@ interface OutputPrinter
     /**
      * Forces output to be decorated.
      *
-     * @param Boolean $decorated
+     * @param boolean $decorated
      */
     public function setOutputDecorated($decorated);
 

--- a/src/Behat/Testwork/Output/Printer/OutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/OutputPrinter.php
@@ -69,7 +69,7 @@ interface OutputPrinter
     /**
      * Forces output to be decorated.
      *
-     * @param boolean $decorated
+     * @param bool $decorated
      */
     public function setOutputDecorated($decorated);
 

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -29,7 +29,7 @@ final class ConfigurationLoader
      */
     private $environmentVariable;
     /**
-     * @var boolean
+     * @var bool
      */
     private $profileFound;
     /**

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -29,7 +29,7 @@ final class ConfigurationLoader
      */
     private $environmentVariable;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $profileFound;
     /**

--- a/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
+++ b/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
@@ -28,7 +28,7 @@ interface SuiteGenerator
      * @param string $type
      * @param array  $settings
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsTypeAndSettings($type, array $settings);
 

--- a/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
+++ b/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
@@ -28,7 +28,7 @@ interface SuiteGenerator
      * @param string $type
      * @param array  $settings
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsTypeAndSettings($type, array $settings);
 

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -65,7 +65,7 @@ final class GenericSuite implements Suite
      *
      * @param string $key
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasSetting($key)
     {

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -65,7 +65,7 @@ final class GenericSuite implements Suite
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function hasSetting($key)
     {

--- a/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
+++ b/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
@@ -27,7 +27,7 @@ interface SuiteSetup
      *
      * @param Suite $suite
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsSuite(Suite $suite);
 

--- a/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
+++ b/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
@@ -27,7 +27,7 @@ interface SuiteSetup
      *
      * @param Suite $suite
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsSuite(Suite $suite);
 

--- a/src/Behat/Testwork/Suite/Suite.php
+++ b/src/Behat/Testwork/Suite/Suite.php
@@ -36,7 +36,7 @@ interface Suite
      *
      * @param string $key
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasSetting($key);
 

--- a/src/Behat/Testwork/Suite/Suite.php
+++ b/src/Behat/Testwork/Suite/Suite.php
@@ -36,7 +36,7 @@ interface Suite
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function hasSetting($key);
 

--- a/src/Behat/Testwork/Suite/SuiteRegistry.php
+++ b/src/Behat/Testwork/Suite/SuiteRegistry.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Suite\Generator\SuiteGenerator;
 final class SuiteRegistry implements SuiteRepository
 {
     /**
-     * @var boolean
+     * @var bool
      */
     private $suitesGenerated = false;
     /**

--- a/src/Behat/Testwork/Suite/SuiteRegistry.php
+++ b/src/Behat/Testwork/Suite/SuiteRegistry.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Suite\Generator\SuiteGenerator;
 final class SuiteRegistry implements SuiteRepository
 {
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $suitesGenerated = false;
     /**

--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -52,7 +52,7 @@ final class ExerciseController implements Controller
      */
     private $resultInterpreter;
     /**
-     * @var boolean
+     * @var bool
      */
     private $skip;
 
@@ -63,7 +63,7 @@ final class ExerciseController implements Controller
      * @param SpecificationFinder $specificationFinder
      * @param Exercise            $exercise
      * @param ResultInterpreter   $resultInterpreter
-     * @param boolean             $skip
+     * @param bool             $skip
      */
     public function __construct(
         SuiteRepository $suiteRepository,

--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -52,7 +52,7 @@ final class ExerciseController implements Controller
      */
     private $resultInterpreter;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $skip;
 
@@ -63,7 +63,7 @@ final class ExerciseController implements Controller
      * @param SpecificationFinder $specificationFinder
      * @param Exercise            $exercise
      * @param ResultInterpreter   $resultInterpreter
-     * @param Boolean             $skip
+     * @param boolean             $skip
      */
     public function __construct(
         SuiteRepository $suiteRepository,

--- a/src/Behat/Testwork/Tester/Cli/StrictController.php
+++ b/src/Behat/Testwork/Tester/Cli/StrictController.php
@@ -30,7 +30,7 @@ final class StrictController implements Controller
      */
     private $resultInterpreter;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $strict;
 
@@ -38,7 +38,7 @@ final class StrictController implements Controller
      * Initializes controller.
      *
      * @param ResultInterpreter $resultInterpreter
-     * @param Boolean           $strict
+     * @param boolean           $strict
      */
     public function __construct(ResultInterpreter $resultInterpreter, $strict = false)
     {

--- a/src/Behat/Testwork/Tester/Cli/StrictController.php
+++ b/src/Behat/Testwork/Tester/Cli/StrictController.php
@@ -30,7 +30,7 @@ final class StrictController implements Controller
      */
     private $resultInterpreter;
     /**
-     * @var boolean
+     * @var bool
      */
     private $strict;
 
@@ -38,7 +38,7 @@ final class StrictController implements Controller
      * Initializes controller.
      *
      * @param ResultInterpreter $resultInterpreter
-     * @param boolean           $strict
+     * @param bool           $strict
      */
     public function __construct(ResultInterpreter $resultInterpreter, $strict = false)
     {

--- a/src/Behat/Testwork/Tester/Exercise.php
+++ b/src/Behat/Testwork/Tester/Exercise.php
@@ -26,7 +26,7 @@ interface Exercise
      * Sets up exercise for a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param boolean                 $skip
+     * @param bool                 $skip
      *
      * @return Setup
      */
@@ -36,7 +36,7 @@ interface Exercise
      * Tests suites specifications.
      *
      * @param SpecificationIterator[] $iterators
-     * @param boolean                 $skip
+     * @param bool                 $skip
      *
      * @return TestResult
      */
@@ -46,7 +46,7 @@ interface Exercise
      * Tears down exercise after a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param boolean                 $skip
+     * @param bool                 $skip
      * @param TestResult              $result
      *
      * @return Teardown

--- a/src/Behat/Testwork/Tester/Exercise.php
+++ b/src/Behat/Testwork/Tester/Exercise.php
@@ -26,7 +26,7 @@ interface Exercise
      * Sets up exercise for a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param Boolean                 $skip
+     * @param boolean                 $skip
      *
      * @return Setup
      */
@@ -36,7 +36,7 @@ interface Exercise
      * Tests suites specifications.
      *
      * @param SpecificationIterator[] $iterators
-     * @param Boolean                 $skip
+     * @param boolean                 $skip
      *
      * @return TestResult
      */
@@ -46,7 +46,7 @@ interface Exercise
      * Tears down exercise after a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param Boolean                 $skip
+     * @param boolean                 $skip
      * @param TestResult              $result
      *
      * @return Teardown

--- a/src/Behat/Testwork/Tester/Result/ExceptionResult.php
+++ b/src/Behat/Testwork/Tester/Result/ExceptionResult.php
@@ -22,7 +22,7 @@ interface ExceptionResult extends TestResult
     /**
      * Checks that the test result has exception.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasException();
 

--- a/src/Behat/Testwork/Tester/Result/ExceptionResult.php
+++ b/src/Behat/Testwork/Tester/Result/ExceptionResult.php
@@ -22,7 +22,7 @@ interface ExceptionResult extends TestResult
     /**
      * Checks that the test result has exception.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasException();
 

--- a/src/Behat/Testwork/Tester/Result/Interpretation/ResultInterpretation.php
+++ b/src/Behat/Testwork/Tester/Result/Interpretation/ResultInterpretation.php
@@ -27,7 +27,7 @@ interface ResultInterpretation
      *
      * @param TestResult $result
      *
-     * @return boolean
+     * @return bool
      */
     public function isFailure(TestResult $result);
 }

--- a/src/Behat/Testwork/Tester/Result/Interpretation/ResultInterpretation.php
+++ b/src/Behat/Testwork/Tester/Result/Interpretation/ResultInterpretation.php
@@ -27,7 +27,7 @@ interface ResultInterpretation
      *
      * @param TestResult $result
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isFailure(TestResult $result);
 }

--- a/src/Behat/Testwork/Tester/Result/TestResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestResult.php
@@ -25,7 +25,7 @@ interface TestResult
     /**
      * Checks that test has passed.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPassed();
 

--- a/src/Behat/Testwork/Tester/Result/TestResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestResult.php
@@ -25,7 +25,7 @@ interface TestResult
     /**
      * Checks that test has passed.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isPassed();
 

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -123,7 +123,7 @@ abstract class TesterExtension implements Extension
      * Loads exercise cli controllers.
      *
      * @param ContainerBuilder $container
-     * @param Boolean          $skip
+     * @param boolean          $skip
      */
     protected function loadExerciseController(ContainerBuilder $container, $skip = false)
     {
@@ -142,7 +142,7 @@ abstract class TesterExtension implements Extension
      * Loads exercise cli controllers.
      *
      * @param ContainerBuilder $container
-     * @param Boolean          $strict
+     * @param boolean          $strict
      */
     protected function loadStrictController(ContainerBuilder $container, $strict = false)
     {

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -123,7 +123,7 @@ abstract class TesterExtension implements Extension
      * Loads exercise cli controllers.
      *
      * @param ContainerBuilder $container
-     * @param boolean          $skip
+     * @param bool          $skip
      */
     protected function loadExerciseController(ContainerBuilder $container, $skip = false)
     {
@@ -142,7 +142,7 @@ abstract class TesterExtension implements Extension
      * Loads exercise cli controllers.
      *
      * @param ContainerBuilder $container
-     * @param boolean          $strict
+     * @param bool          $strict
      */
     protected function loadStrictController(ContainerBuilder $container, $strict = false)
     {

--- a/src/Behat/Testwork/Tester/Setup/Setup.php
+++ b/src/Behat/Testwork/Tester/Setup/Setup.php
@@ -20,14 +20,14 @@ interface Setup
     /**
      * Returns true if fixtures have been handled successfully.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isSuccessful();
 
     /**
      * Checks if setup has produced any output.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasOutput();
 }

--- a/src/Behat/Testwork/Tester/Setup/Setup.php
+++ b/src/Behat/Testwork/Tester/Setup/Setup.php
@@ -20,14 +20,14 @@ interface Setup
     /**
      * Returns true if fixtures have been handled successfully.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSuccessful();
 
     /**
      * Checks if setup has produced any output.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOutput();
 }

--- a/src/Behat/Testwork/Tester/Setup/Teardown.php
+++ b/src/Behat/Testwork/Tester/Setup/Teardown.php
@@ -20,14 +20,14 @@ interface Teardown
     /**
      * Returns true if fixtures have been handled successfully.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isSuccessful();
 
     /**
      * Checks if tear down has produced any output.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasOutput();
 }

--- a/src/Behat/Testwork/Tester/Setup/Teardown.php
+++ b/src/Behat/Testwork/Tester/Setup/Teardown.php
@@ -20,14 +20,14 @@ interface Teardown
     /**
      * Returns true if fixtures have been handled successfully.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSuccessful();
 
     /**
      * Checks if tear down has produced any output.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOutput();
 }

--- a/src/Behat/Testwork/Tester/SpecificationTester.php
+++ b/src/Behat/Testwork/Tester/SpecificationTester.php
@@ -27,7 +27,7 @@ interface SpecificationTester
      *
      * @param Environment $env
      * @param mixed       $spec
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return Setup
      */
@@ -38,7 +38,7 @@ interface SpecificationTester
      *
      * @param Environment $env
      * @param mixed       $spec
-     * @param Boolean     $skip
+     * @param boolean     $skip
      *
      * @return TestResult
      */
@@ -49,7 +49,7 @@ interface SpecificationTester
      *
      * @param Environment $env
      * @param mixed       $spec
-     * @param Boolean     $skip
+     * @param boolean     $skip
      * @param TestResult  $result
      *
      * @return Teardown

--- a/src/Behat/Testwork/Tester/SpecificationTester.php
+++ b/src/Behat/Testwork/Tester/SpecificationTester.php
@@ -27,7 +27,7 @@ interface SpecificationTester
      *
      * @param Environment $env
      * @param mixed       $spec
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return Setup
      */
@@ -38,7 +38,7 @@ interface SpecificationTester
      *
      * @param Environment $env
      * @param mixed       $spec
-     * @param boolean     $skip
+     * @param bool     $skip
      *
      * @return TestResult
      */
@@ -49,7 +49,7 @@ interface SpecificationTester
      *
      * @param Environment $env
      * @param mixed       $spec
-     * @param boolean     $skip
+     * @param bool     $skip
      * @param TestResult  $result
      *
      * @return Teardown

--- a/src/Behat/Testwork/Tester/SuiteTester.php
+++ b/src/Behat/Testwork/Tester/SuiteTester.php
@@ -28,7 +28,7 @@ interface SuiteTester
      *
      * @param Environment           $env
      * @param SpecificationIterator $iterator
-     * @param Boolean               $skip
+     * @param boolean               $skip
      *
      * @return Setup
      */
@@ -39,7 +39,7 @@ interface SuiteTester
      *
      * @param Environment           $env
      * @param SpecificationIterator $iterator
-     * @param Boolean               $skip
+     * @param boolean               $skip
      *
      * @return TestResult
      */
@@ -50,7 +50,7 @@ interface SuiteTester
      *
      * @param Environment           $env
      * @param SpecificationIterator $iterator
-     * @param Boolean               $skip
+     * @param boolean               $skip
      * @param TestResult            $result
      *
      * @return Teardown

--- a/src/Behat/Testwork/Tester/SuiteTester.php
+++ b/src/Behat/Testwork/Tester/SuiteTester.php
@@ -28,7 +28,7 @@ interface SuiteTester
      *
      * @param Environment           $env
      * @param SpecificationIterator $iterator
-     * @param boolean               $skip
+     * @param bool               $skip
      *
      * @return Setup
      */
@@ -39,7 +39,7 @@ interface SuiteTester
      *
      * @param Environment           $env
      * @param SpecificationIterator $iterator
-     * @param boolean               $skip
+     * @param bool               $skip
      *
      * @return TestResult
      */
@@ -50,7 +50,7 @@ interface SuiteTester
      *
      * @param Environment           $env
      * @param SpecificationIterator $iterator
-     * @param boolean               $skip
+     * @param bool               $skip
      * @param TestResult            $result
      *
      * @return Teardown


### PR DESCRIPTION
`Bool` type should be written by lowercase, because some tools (like psalm) trying to recognize this name as class name.