### PR TITLE
The PHP DOM extension is required for JUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
         "ext-mbstring": "*",
         "behat/gherkin": "^4.6.0",
         "behat/transliterator": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
 
     "require": {
         "php": ">=5.3.3",
-        "ext-dom": "*",
         "ext-mbstring": "*",
         "behat/gherkin": "^4.6.0",
         "behat/transliterator": "^1.2",
@@ -33,6 +32,10 @@
         "symfony/process": "~2.5|~3.0|~4.0",
         "phpunit/phpunit": "^4.8.36|^6.3",
         "herrera-io/box": "~1.6.1"
+    },
+
+    "suggest": {
+        "ext-dom": "Needed to output test results in JUnit format."
     },
 
     "autoload": {

--- a/src/Behat/Testwork/Output/Exception/MissingExtensionException.php
+++ b/src/Behat/Testwork/Output/Exception/MissingExtensionException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\Output\Exception;
+
+use RuntimeException;
+
+/**
+ * Represents an exception thrown when a required extension is missing.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+class MissingExtensionException extends RuntimeException implements PrinterException
+{
+}

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\Output\Printer;
 
+use Behat\Testwork\Output\Exception\MissingExtensionException;
 use Behat\Testwork\Output\Printer\Factory\FilesystemOutputFactory;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -59,7 +60,7 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
     {
         // This requires the DOM extension to be enabled.
         if (!extension_loaded('dom')) {
-            throw new \Exception('The PHP DOM extension is required to generate JUnit reports.');
+            throw new MissingExtensionException('The PHP DOM extension is required to generate JUnit reports.');
         }
         $this->setFileName(strtolower(trim(preg_replace('/[^[:alnum:]_]+/', '_', $name), '_')));
 

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -57,6 +57,10 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
      */
     public function createNewFile($name, array $testsuitesAttributes = array())
     {
+        // This requires the DOM extension to be enabled.
+        if (!extension_loaded('dom')) {
+            throw new \Exception('The PHP DOM extension is required to generate JUnit reports.');
+        }
         $this->setFileName(strtolower(trim(preg_replace('/[^[:alnum:]_]+/', '_', $name), '_')));
 
         $this->domDocument = new \DOMDocument(self::XML_VERSION, self::XML_ENCODING);


### PR DESCRIPTION
I'm getting the following error when running a test scenario on a minimal Ubuntu Bionic image:

```
Fatal error: Class 'DOMDocument' not found (Behat\Testwork\Call\Exception\FatalThrowableError)
```

It is thrown in [`Behat\Testwork\Output\Printer\JUnitOutputPrinter`](https://github.com/Behat/Behat/blob/master/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php#L62).