### PR TITLE
Fix specifications locator to find feature files

### DIFF
--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -64,12 +64,14 @@ final class LazyFeatureIterator implements SpecificationIterator
      * @param Gherkin           $gherkin
      * @param string[]          $paths
      * @param FilterInterface[] $filters
+     * @param FeatureNode[]     $features
      */
-    public function __construct(Suite $suite, Gherkin $gherkin, array $paths, array $filters = array())
+    public function __construct(Suite $suite, Gherkin $gherkin, array $paths, array $filters = array(), $features = array())
     {
         $this->suite = $suite;
         $this->gherkin = $gherkin;
         $this->paths = array_values($paths);
+        $this->features = $features;
         $this->filters = array_merge($this->getSuiteFilters($suite), $filters);
     }
 

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -76,8 +76,13 @@ final class FilesystemFeatureLocator implements SpecificationLocator
 
         if ($locator) {
             $filters = array(new PathsFilter($suiteLocators));
+            $features = array();
+            foreach ($this->findFeatureFiles($locator) as $featureFile) {
+                // Collect all the feature specification files.
+                $features = array_merge($features, $this->gherkin->load($featureFile, $filters));
+            }
 
-            return new LazyFeatureIterator($suite, $this->gherkin, $this->findFeatureFiles($locator), $filters);
+            return new LazyFeatureIterator($suite, $this->gherkin, [], $filters, $features);
         }
 
         $featurePaths = array();


### PR DESCRIPTION
This is my fix for the https://github.com/Behat/Behat/issues/1076 issue.
Looks like feature files were not discovered properly. I have extended the locator and iterator for this.

Before:
```
./bin/behat features/migrate/articles.feature
...
No specifications found at path(s) `features/migrate/articles.feature`. This might be because of incorrect paths configuration in your `suites`.
```

After:
```
./bin/behat features/migrate/articles.feature
...
1 scenario (1 passed)
2 steps (2 passed)
```

P.S. Tests\Behat\Gherkin\Loader\GherkinFileLoaderTest shows no errors.