### PR TITLE
Disable XDebug only if it is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
       env: SYMFONY_VERSION='^4.2'
 
 before_install:
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || echo "XDebug is not enabled"
 
 before_script:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update "symfony/symfony:${SYMFONY_VERSION}"; fi;


### PR DESCRIPTION
This will prevent failures on PHP versions that don't have a working version of XDebug yet.