### PR TITLE
removal of old versions for the update to sf5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: [5.6, 7.0, 7.1, 7.2, 7.3]
+php: [7.1, 7.2, 7.3]
 
 sudo: false
 
@@ -14,12 +14,8 @@ branches:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: DEPENDENCIES='low'
-    - php: 5.6
-      env: SYMFONY_VERSION='2.7.*'
-    - php: 5.6
-      env: SYMFONY_VERSION='2.8.*'
     - php: 7.2
       env: SYMFONY_VERSION='^3.4'
     - php: 7.3
@@ -35,11 +31,10 @@ before_script:
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-lowest; fi;
   - export PATH=./bin:$PATH
-  - echo "<?php echo '@php5' . implode(',@php5.', range(3, PHP_MINOR_VERSION));" > php_version_tags.php
 
 script:
   - ./vendor/bin/phpunit
-  - behat -fprogress --strict --tags '~@php-version,'`php php_version_tags.php`
+  - behat -fprogress --strict
 
 before_deploy:
   - curl -LSs https://box-project.github.io/box2/installer.php | php
@@ -55,4 +50,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    php: 5.6
+    php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
 
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-mbstring": "*",
         "behat/gherkin": "^4.6.0",
         "behat/transliterator": "^1.2",

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -526,66 +526,6 @@
       """
     And the file "junit/default.xml" should be a valid document according to "junit.xsd"
 
-  @php-version @php5.3 @php5.4
-  Scenario: Aborting due to PHP error
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context,
-          Behat\Behat\Tester\Exception\PendingException;
-
-      class FeatureContext implements Context
-      {
-          private $value;
-
-          /**
-           * @Given /I have entered (\d+)/
-           */
-          public function iHaveEntered($num) {
-              $this->value = $num;
-          }
-
-          /**
-           * @Then /I must have (\d+)/
-           */
-          public function iMustHave($num) {
-              PHPUnit\Framework\Assert::assertEqual($num, $this->value);
-          }
-
-          /**
-           * @When /I add (\d+)/
-           */
-          public function iAdd($num) {
-              $this->value += $num;
-          }
-      }
-      """
-    And a file named "features/World.feature" with:
-      """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-
-        Background:
-          Given I have entered 10
-
-        Scenario: Failed
-          When I add 4
-          Then I must have 14
-      """
-    When I run "behat --no-colors -f junit -o junit"
-    Then it should fail with:
-      """
-      Call to undefined method PHPUnit\Framework\Assert::assertEqual
-      """
-    And "junit/default.xml" file xml should be like:
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default"/>
-      """
-
   Scenario: Aborting due invalid output path
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """


### PR DESCRIPTION
pre-pull-request for the removal of versions not maintained by symfony and the removal of old versions of php that are no longer maintained. This will facilitate the migration of behat code to the latest symfony 5 components. 

pr ref : https://github.com/Behat/Behat/pull/1247