### PR TITLE
Enable env placeholder resolution

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -170,11 +170,21 @@ EOL;
     /**
      * Sets specified ENV variable
      *
+     * @When /^the "([^"]*)" environment variable is set to "([^"]*)"$/
+     */
+    public function iSetEnvironmentVariable($name, $value)
+    {
+        $this->env = array($name => (string) $value);
+    }
+
+    /**
+     * Sets the BEHAT_PARAMS env variable
+     *
      * @When /^"BEHAT_PARAMS" environment variable is set to:$/
      *
      * @param PyStringNode $value
      */
-    public function iSetEnvironmentVariable(PyStringNode $value)
+    public function iSetBehatParamsEnvironmentVariable(PyStringNode $value)
     {
         $this->env = array('BEHAT_PARAMS' => (string) $value);
     }

--- a/features/env_var_placeholders.feature
+++ b/features/env_var_placeholders.feature
@@ -1,0 +1,52 @@
+Feature: Symfony Env Var Placeholders
+  In order to support different setups
+  As a tester
+  I need to be able to use environment variables in the behat.yml configuration file
+
+  Background:
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          private $value;
+
+          public function __construct($value) {
+              $this->value = $value;
+          }
+
+          /**
+           * @Then /the value should be configured as "([^"]+)"/
+           */
+          public function theValueShouldBeConfiguredAs($expected) {
+              PHPUnit\Framework\Assert::assertEquals($expected, $this->value);
+          }
+      }
+      """
+    And a file named "features/env_var.feature" with:
+      """
+      Feature: Environment variables
+
+        Scenario:
+          Then the value should be configured as "some environment variable value"
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - FeatureContext:
+                - '%env(MY_ENV_VAR)%'
+      """
+
+  Scenario:
+    When the "MY_ENV_VAR" environment variable is set to "some environment variable value"
+    And I run "behat --no-colors"
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -184,7 +184,7 @@ final class Application extends BaseApplication
         $extension = new ContainerLoader($this->extensionManager);
         $extension->load($container, $this->loadConfiguration($input));
         $container->addObjectResource($extension);
-        $container->compile();
+        $container->compile(true);
 
         return $container;
     }


### PR DESCRIPTION
With this change, [env placeholders](https://symfony.com/blog/new-in-symfony-3-4-advanced-environment-variables) can be used in `behat.yml`.

For example, when using Mink, you can write 

```yaml
default:
    extensions:
        Behat\MinkExtension:
            base_url: '%env(BEHAT_BASE_URL)%'

```

... and then use the environment variable `BEHAT_BASE_URL` to control the Mink setting.
