### PR TITLE
Drop container-interop/container-interop from required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "symfony/event-dispatcher": "~2.1||~3.0||~4.0",
         "symfony/translation": "~2.3||~3.0||~4.0",
         "symfony/yaml": "~2.1||~3.0||~4.0",
-        "psr/container": "^1.0",
-        "container-interop/container-interop": "^1.2"
+        "psr/container": "^1.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
As noted in #1110 and #1255 this package has been abandoned and
replaced with psr/container.

I understand that this is a BC break, but once the changes for Symfony 5 get merged in maybe a new version could be released.