### PR TITLE
Fix issues with PHP version handling in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.tgz
 *.phar
 *.phar.asc
-php_version_tags.php
 behat.yml
 vendor
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-lowest; fi;
   - export PATH=./bin:$PATH
-  - echo "<?php echo '@php5.' . implode(',@php5.', range(3, PHP_MINOR_VERSION));" > php_version_tags.php
+  - echo "<?php echo '@php' . PHP_MAJOR_VERSION . '.' . implode(',@php' . PHP_MAJOR_VERSION, range(0, PHP_MINOR_VERSION));" > php_version_tags.php
 
 script:
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-lowest; fi;
   - export PATH=./bin:$PATH
-  - echo "<?php echo '@php5' . implode(',@php5.', range(3, PHP_MINOR_VERSION));" > php_version_tags.php
+  - echo "<?php echo '@php5.' . implode(',@php5.', range(3, PHP_MINOR_VERSION));" > php_version_tags.php
 
 script:
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,10 @@ before_script:
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-lowest; fi;
   - export PATH=./bin:$PATH
-  - echo "<?php echo '@php' . PHP_MAJOR_VERSION . '.' . implode(',@php' . PHP_MAJOR_VERSION, range(0, PHP_MINOR_VERSION));" > php_version_tags.php
 
 script:
   - ./vendor/bin/phpunit
-  - behat -fprogress --strict --tags '~@php-version,'`php php_version_tags.php`
+  - behat -fprogress --strict --tags '~@php-version,@php'`php -r 'echo PHP_MAJOR_VERSION;'`
 
 before_deploy:
   - curl -LSs https://box-project.github.io/box2/installer.php | php

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,5 +57,5 @@ install:
 
 test_script:
     - cd c:\projects\behat
-    - php bin\behat --tags="~@php-version,@php53,@php5.2,@php5.1,@php5.0" --format=progress
+    - php bin\behat --tags="~@php-version,@php7" --format=progress
     - php vendor\phpunit\phpunit\phpunit --testdox

--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -420,7 +420,7 @@ Feature: Step Arguments Transformations
       8 steps (8 passed)
       """
 
-  @php-version @php7.0
+  @php-version @php7
   Scenario: By-type object transformations
     Given a file named "features/my.feature" with:
       """
@@ -488,7 +488,7 @@ Feature: Step Arguments Transformations
       4 steps (4 passed)
       """
 
-  @php-version @php7.0
+  @php-version @php7
   Scenario: By-type and by-name object transformations
     Given a file named "features/my.feature" with:
       """

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -122,7 +122,7 @@ Feature: Extensions
       `inexistent_extension` extension file or class could not be located.
       """
 
-  @php-version @php7.0
+  @php-version @php7
   Scenario: Exception handlers extension
     Given a file named "behat.yml" with:
       """

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -526,7 +526,7 @@
       """
     And the file "junit/default.xml" should be a valid document according to "junit.xsd"
 
-  @php-version @php5.3 @php5.4
+  @php-version @php5
   Scenario: Aborting due to PHP error
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """

--- a/features/traits.feature
+++ b/features/traits.feature
@@ -1,5 +1,4 @@
-@php-version @php5.4
-Feature: Support php 5.4 traits
+Feature: Support traits
   In order to have much cleaner horizontal reusability
   As a context developer
   I need to be able to use definition traits in my context


### PR DESCRIPTION
Builds are failing in PHP7.4, because of an issue with the build scripts.

Tests tagged as`php5.4` are running in 7.4, because only the minor version is checked.

This pull request fixes these issues, and simplifies the handling of language version numbers generally.