### PR TITLE
ReturnTypeTransformation: Add support for php 7.4

### DIFF
--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -130,7 +130,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
             return null;
         }
 
-        return $type->getName();
+        return method_exists($type, 'getName') ? $type->getName(); : (string) $type;
     }
 
     /**

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -130,7 +130,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
             return null;
         }
 
-        return (string) $type;
+        return $type->getName();
     }
 
     /**


### PR DESCRIPTION
> Fatal error: 8192: Function ReflectionType::__toString() is deprecated in vendor/behat/behat/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php line 133

Since getName() is not documented, I am not sure from which PHP version it is available.

Behat 3.5 is for PHP 5.6+, is that correct ?

In case `getName()` is missing in some PHP version it would require a : 

```
return method_exists($type, 'getName') ? $type->getName(); : (string) $type;
```