### PR TITLE
Drop container-interop/container-interop from required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "symfony/event-dispatcher": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
         "symfony/translation": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
         "symfony/yaml": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-        "psr/container": "^1.0",
-        "container-interop/container-interop": "^1.2"
+        "psr/container": "^1.0"
     },
 
     "require-dev": {

--- a/features/helper_containers.feature
+++ b/features/helper_containers.feature
@@ -193,7 +193,7 @@ Feature: Per-suite helper containers
       """
     And a file named "features/bootstrap/MyContainer.php" with:
       """
-      <?php use Interop\Container\ContainerInterface;
+      <?php use Psr\Container\ContainerInterface;
 
       class MyContainer implements ContainerInterface {
           private $service;

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -12,7 +12,7 @@ namespace Behat\Behat\HelperContainer;
 
 use Behat\Behat\HelperContainer\Exception\ServiceNotFoundException;
 use Behat\Behat\HelperContainer\Exception\WrongServicesConfigurationException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionMethod;
 

--- a/src/Behat/Behat/HelperContainer/Exception/HelperContainerException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/HelperContainerException.php
@@ -11,13 +11,13 @@
 namespace Behat\Behat\HelperContainer\Exception;
 
 use Behat\Testwork\Environment\Exception\EnvironmentException;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * All HelperContainer exceptions implement this interface.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-interface HelperContainerException extends ContainerException, EnvironmentException
+interface HelperContainerException extends ContainerExceptionInterface, EnvironmentException
 {
 }

--- a/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
@@ -10,7 +10,7 @@
 
 namespace Behat\Behat\HelperContainer\Exception;
 
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 use InvalidArgumentException;
 
 /**
@@ -18,7 +18,7 @@ use InvalidArgumentException;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class ServiceNotFoundException extends InvalidArgumentException implements HelperContainerException, NotFoundException
+final class ServiceNotFoundException extends InvalidArgumentException implements HelperContainerException, NotFoundExceptionInterface
 {
     /**
      * @var string


### PR DESCRIPTION
The package has been abandoned and replaced with psr/container.

Related issues:  #1110, #1255