### PR TITLE
Restore PHP 5.3/5.4 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ branches:
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
+      env: DEPENDENCIES='low'
+    - php: 5.4
+      dist: trusty
+      env: DEPENDENCIES='low'
+    - php: 5.5
+      dist: trusty
+      env: DEPENDENCIES='low'
     - php: 5.6
       env: DEPENDENCIES='low'
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,10 @@ matrix:
   include:
     - php: 5.3
       dist: precise
-      env: DEPENDENCIES='low'
     - php: 5.4
       dist: trusty
-      env: DEPENDENCIES='low'
     - php: 5.5
       dist: trusty
-      env: DEPENDENCIES='low'
     - php: 5.6
       env: DEPENDENCIES='low'
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,20 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-branches:
-  only:
-    - master
-
 matrix:
   include:
     - php: 5.3
       dist: precise
+      env: PHP_VERSION=53
     - php: 5.4
       dist: trusty
+      env: PHP_VERSION=54+
     - php: 5.5
       dist: trusty
+      env: PHP_VERSION=54+
     - php: 5.6
       env: DEPENDENCIES='low'
+      env: PHP_VERSION=54+
     - php: 5.6
       env: SKIP_INTEROP='~@interop&&'
     - php: 5.6
@@ -45,11 +45,12 @@ before_script:
   - if [ "$SKIP_INTEROP" != "" ]; then composer remove --dev --no-update container-interop/container-interop; fi;
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-lowest; fi;
+  - if [ ! "$PHP_VERSION" ]; then export PHP_VERSION=`php -r 'echo PHP_MAJOR_VERSION;'`; fi;
   - export PATH=./bin:$PATH
 
 script:
   - ./vendor/bin/phpunit
-  - behat -fprogress --strict --tags "$SKIP_INTEROP"'~@php-version,@php'`php -r 'echo PHP_MAJOR_VERSION;'`
+  - behat -fprogress --strict --tags '~@php-version,@php'$PHP_VERSION
 
 before_deploy:
   - curl -LSs https://box-project.github.io/box2/installer.php | php

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit
-  - behat -fprogress --strict --tags '~@php-version,@php'$PHP_VERSION
+  - behat -fprogress --strict --tags "${SKIP_INTEROP}~@php-version,@php${PHP_VERSION}"
 
 before_deploy:
   - curl -LSs https://box-project.github.io/box2/installer.php | php

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -41,7 +41,7 @@ class FeatureContext implements Context
     /**
      * @var array
      */
-    private $env = [];
+    private $env = array();
     /**
      * @var string
      */

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -526,7 +526,7 @@
       """
     And the file "junit/default.xml" should be a valid document according to "junit.xsd"
 
-  @php-version @php5
+  @php-version @php53 @php54+
   Scenario: Aborting due to PHP error
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """

--- a/features/traits.feature
+++ b/features/traits.feature
@@ -86,6 +86,7 @@ Feature: Support traits
             | 2   | 2     | 3      |
       """
 
+  @php-version @php54+ @php7
   Scenario: Run feature with failing scenarios
     When I run "behat --no-colors -f progress"
     Then it should pass with:

--- a/src/Behat/Behat/Definition/Translator/TranslatorInterface.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatorInterface.php
@@ -2,11 +2,11 @@
 
 namespace Behat\Behat\Definition\Translator;
 
-if (interface_exists('\Symfony\Contracts\Translation\TranslatorInterface')) {
+if (interface_exists('Symfony\Contracts\Translation\TranslatorInterface')) {
     interface TranslatorInterface extends \Symfony\Contracts\Translation\TranslatorInterface
     {
     }
-} elseif (interface_exists('\Symfony\Component\Translation\TranslatorInterface')) {
+} elseif (interface_exists('Symfony\Component\Translation\TranslatorInterface')) {
     interface TranslatorInterface extends \Symfony\Component\Translation\TranslatorInterface
     {
     }

--- a/src/Behat/Behat/Definition/Translator/TranslatorInterface.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatorInterface.php
@@ -2,11 +2,11 @@
 
 namespace Behat\Behat\Definition\Translator;
 
-if (interface_exists(\Symfony\Contracts\Translation\TranslatorInterface::class)) {
+if (interface_exists('\Symfony\Contracts\Translation\TranslatorInterface')) {
     interface TranslatorInterface extends \Symfony\Contracts\Translation\TranslatorInterface
     {
     }
-} elseif (interface_exists(\Symfony\Component\Translation\TranslatorInterface::class)) {
+} elseif (interface_exists('\Symfony\Component\Translation\TranslatorInterface')) {
     interface TranslatorInterface extends \Symfony\Component\Translation\TranslatorInterface
     {
     }

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
 $identifyEventDispatcherClassVersion = function() {
-    $reflection  = new \ReflectionClass(\Symfony\Component\EventDispatcher\EventDispatcher::class);
+    $reflection  = new \ReflectionClass('\Symfony\Component\EventDispatcher\EventDispatcher');
     $dispatch    = $reflection->getMethod('dispatch');
 
     if ($dispatch->getNumberOfParameters() === 1) {
@@ -26,7 +26,7 @@ $identifyEventDispatcherClassVersion = function() {
         // internally uses func_get_args to work parameters it got in what order. The legacy Testwork class can still
         // extend this because its signature only adds an extra optional param. It may however produce unexpected
         // results as it assumes all dispatch calls are with the legacy sequence of $eventName, $event.
-        return TestworkEventDispatcherSymfonyLegacy::class;
+        return 'Behat\Testwork\EventDispatcher\TestworkEventDispatcherSymfonyLegacy';
     }
 
     $first_param = $dispatch->getParameters()[0];
@@ -34,19 +34,19 @@ $identifyEventDispatcherClassVersion = function() {
         case 'event':
             // This is the new Symfony 5 event dispatcher interface
             // public function dispatch(object $event, string $eventName = null): object
-            return TestworkEventDispatcherSymfony5::class;
+            return 'Behat\Testwork\EventDispatcher\TestworkEventDispatcherSymfony5';
 
         case 'eventName':
             // This is the Symfony <= 4.2 version
             // public function dispatch($eventName, Event $event = null)
-            return TestworkEventDispatcherSymfonyLegacy::class;
+            return 'Behat\Testwork\EventDispatcher\TestworkEventDispatcherSymfonyLegacy';
 
         default:
             throw new \UnexpectedValueException('Could not identify which version of symfony/event-dispatcher is in use, could not define a compatible TestworkEventDispatcher');
     }
 };
 
-class_alias($identifyEventDispatcherClassVersion(), \Behat\Testwork\EventDispatcher\TestworkEventDispatcher::class);
+class_alias($identifyEventDispatcherClassVersion(), '\Behat\Testwork\EventDispatcher\TestworkEventDispatcher');
 unset($identifyEventDispatcherClassVersion);
 
 

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
 $identifyEventDispatcherClassVersion = function() {
-    $reflection  = new \ReflectionClass('\Symfony\Component\EventDispatcher\EventDispatcher');
+    $reflection  = new \ReflectionClass('Symfony\Component\EventDispatcher\EventDispatcher');
     $dispatch    = $reflection->getMethod('dispatch');
 
     if ($dispatch->getNumberOfParameters() === 1) {
@@ -47,7 +47,7 @@ $identifyEventDispatcherClassVersion = function() {
     }
 };
 
-class_alias($identifyEventDispatcherClassVersion(), '\Behat\Testwork\EventDispatcher\TestworkEventDispatcher');
+class_alias($identifyEventDispatcherClassVersion(), 'Behat\Testwork\EventDispatcher\TestworkEventDispatcher');
 unset($identifyEventDispatcherClassVersion);
 
 

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
@@ -29,7 +29,8 @@ $identifyEventDispatcherClassVersion = function() {
         return 'Behat\Testwork\EventDispatcher\TestworkEventDispatcherSymfonyLegacy';
     }
 
-    $first_param = $dispatch->getParameters()[0];
+    $params = $dispatch->getParameters();
+    $first_param = reset($params);
     switch ($first_param->getName()) {
         case 'event':
             // This is the new Symfony 5 event dispatcher interface

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationTree.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationTree.php
@@ -31,7 +31,7 @@ final class ConfigurationTree
      */
     public function getConfigTree(array $extensions)
     {
-        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+        if (method_exists('Symfony\Component\Config\Definition\Builder\TreeBuilder', 'getRootNode')) {
             $treeBuilder = new TreeBuilder('testwork');
             /** @var ArrayNodeDefinition $rootNode */
             $rootNode = $treeBuilder->getRootNode();

--- a/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
+++ b/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
@@ -14,7 +14,7 @@ class PatternTransformerTest extends TestCase
 {
     public function testTransformPatternToRegexCache()
     {
-        $observer = $this->prophesize(PatternPolicy::class);
+        $observer = $this->prophesize('Behat\Behat\Definition\Pattern\Policy\PatternPolicy');
         // first pattern
         $observer->supportsPattern('hello world')->willReturn(true);
         $observer->transformPatternToRegex('hello world')
@@ -42,14 +42,14 @@ class PatternTransformerTest extends TestCase
     public function testTransformPatternToRegexCacheAndRegisterNewPolicy()
     {
         // first pattern
-        $policy1Prophecy = $this->prophesize(PatternPolicy::class);
+        $policy1Prophecy = $this->prophesize('Behat\Behat\Definition\Pattern\Policy\PatternPolicy');
         $policy1Prophecy->supportsPattern('hello world')->willReturn(true);
         $policy1Prophecy->transformPatternToRegex('hello world')
             ->shouldBeCalledTimes(2)
             ->willReturn('/hello world/');
 
         // second pattern
-        $policy2Prophecy = $this->prophesize(PatternPolicy::class);
+        $policy2Prophecy = $this->prophesize('Behat\Behat\Definition\Pattern\Policy\PatternPolicy');
         $policy1Prophecy->supportsPattern()->shouldNotBeCalled();
         $policy1Prophecy->transformPatternToRegex()->shouldNotBeCalled();
 
@@ -73,7 +73,7 @@ class PatternTransformerTest extends TestCase
     public function testTransformPatternToRegexNoMatch()
     {
         // first pattern
-        $policy1Prophecy = $this->prophesize(PatternPolicy::class);
+        $policy1Prophecy = $this->prophesize('Behat\Behat\Definition\Pattern\Policy\PatternPolicy');
         $policy1Prophecy->supportsPattern('hello world')->willReturn(false);
         $policy1Prophecy->transformPatternToRegex('hello world')
             ->shouldNotBeCalled();


### PR DESCRIPTION
Behat 3.6 has broken support for PHP <5.5 even though `composer.json` is still claiming to support PHP >= 5.3.3.

This PR hopefully fixes that and adds PHP 5.3, 5.4 and 5.5 to CI as it currently doesn't seem to test these older versions 🤔 

Fully behind you guys dropping support for older PHP in the future, just please update `composer.json` first 😉 