### PR TITLE
Bump requirements to PHP ^7.2 and Symfony ^4.4|^5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: php
 
+os: linux
+
+dist: xenial
+
 php: [7.2, 7.3, 7.4]
 
 cache:
   directories:
     - $HOME/.composer/cache
 
-matrix:
+jobs:
   include:
     - php: 7.2
       env: SKIP_INTEROP='~@interop&&'
@@ -38,9 +42,9 @@ before_deploy:
 
 deploy:
   provider: releases
-  api_key: $GITHUB_API_KEY
+  token: $GITHUB_API_KEY
   file: behat.phar
-  skip_cleanup: true
+  cleanup: false
   on:
     tags: true
     php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ matrix:
       env: SKIP_INTEROP='~@interop&&'
     - php: 7.2
       env: DEPENDENCIES='low'
-    - php: 7.2
-      env: SYMFONY_VERSION='^4.4'
-    - php: 7.3
-      env: SYMFONY_VERSION='^4.4'
     - php: 7.4
       env: SYMFONY_VERSION='^4.4'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 jobs:
   include:
     - php: 7.2
-      env: SKIP_INTEROP='~@interop&&'
+      env: SKIP_INTEROP=true
     - php: 7.2
       env: DEPENDENCIES='low'
     - php: 7.4
@@ -31,7 +31,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit
-  - behat -fprogress --strict --tags "${SKIP_INTEROP}~@random"
+  - behat -fprogress --strict $([ -z "$SKIP_INTEROP" ] || echo "--tags ~@interop")
 
 before_deploy:
   - curl -LSs https://box-project.github.io/box2/installer.php | php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
-php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
-
-sudo: false
+php: [7.2, 7.3, 7.4]
 
 cache:
   directories:
@@ -10,32 +8,16 @@ cache:
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-      env: PHP_VERSION=53
-    - php: 5.4
-      dist: trusty
-      env: PHP_VERSION=54+
-    - php: 5.5
-      dist: trusty
-      env: PHP_VERSION=54+
-    - php: 5.6
-      env: DEPENDENCIES='low'
-      env: PHP_VERSION=54+
-    - php: 5.6
-      env: SKIP_INTEROP='~@interop&&'
-    - php: 5.6
-      env: SYMFONY_VERSION='2.7.*'
-    - php: 5.6
-      env: SYMFONY_VERSION='2.8.*'
     - php: 7.2
-      env: SYMFONY_VERSION='^3.4'
+      env: SKIP_INTEROP='~@interop&&'
+    - php: 7.2
+      env: DEPENDENCIES='low'
+    - php: 7.2
+      env: SYMFONY_VERSION='^4.4'
     - php: 7.3
-      env: SYMFONY_VERSION='^3.4'
-    - php: 7.3
-      env: SYMFONY_VERSION='^4.3'
-    - php: 7.3
-      env: SYMFONY_VERSION='^5.0'
+      env: SYMFONY_VERSION='^4.4'
+    - php: 7.4
+      env: SYMFONY_VERSION='^4.4'
 
 before_install:
   - phpenv config-rm xdebug.ini || echo "XDebug is not enabled"
@@ -45,12 +27,11 @@ before_script:
   - if [ "$SKIP_INTEROP" != "" ]; then composer remove --dev --no-update container-interop/container-interop; fi;
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-lowest; fi;
-  - if [ ! "$PHP_VERSION" ]; then export PHP_VERSION=`php -r 'echo PHP_MAJOR_VERSION;'`; fi;
   - export PATH=./bin:$PATH
 
 script:
   - ./vendor/bin/phpunit
-  - behat -fprogress --strict --tags "${SKIP_INTEROP}~@php-version,@php${PHP_VERSION}"
+  - behat -fprogress --strict --tags "${SKIP_INTEROP}~@random"
 
 before_deploy:
   - curl -LSs https://box-project.github.io/box2/installer.php | php

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,5 +57,5 @@ install:
 
 test_script:
     - cd c:\projects\behat
-    - php bin\behat --tags="~@php-version,@php7" --format=progress
+    - php bin\behat --format=progress
     - php vendor\phpunit\phpunit\phpunit --testdox

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "behat/behat",
-    "description": "Scenario-oriented BDD framework for PHP 5.3",
+    "description": "Scenario-oriented BDD framework for PHP",
     "keywords": ["BDD", "ScenarioBDD", "StoryBDD", "Examples", "Scrum", "Agile", "User story", "Symfony", "business", "development", "testing", "documentation"],
     "homepage": "http://behat.org/",
     "type": "library",
@@ -14,22 +14,22 @@
     ],
 
     "require": {
-        "php": ">=5.3.3",
+        "php": "^7.2",
         "ext-mbstring": "*",
         "behat/gherkin": "^4.6.0",
         "behat/transliterator": "^1.2",
-        "symfony/console": "^2.7.51 || ^2.8.33 || ^3.3.15 || ^3.4.3 || ^4.0.3 || ^5.0",
-        "symfony/config": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/dependency-injection": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/event-dispatcher": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/translation": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/yaml": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/console": "^4.4 || ^5.0",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0",
+        "symfony/translation": "^4.4 || ^5.0",
+        "symfony/yaml": "^4.4 || ^5.0",
         "psr/container": "^1.0"
     },
 
     "require-dev": {
-        "symfony/process": "~2.5 || ^3.0 || ^4.0 || ^5.0",
-        "phpunit/phpunit": "^4.8.36 || ^6.5.14 || ^7.5.20",
+        "symfony/process": "^4.4 || ^5.0",
+        "phpunit/phpunit": "^7.5.20",
         "herrera-io/box": "~1.6.1",
         "container-interop/container-interop": "^1.2"
     },
@@ -53,7 +53,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "3.6.x-dev"
+            "dev-master": "3.8.x-dev"
         }
     },
 

--- a/features/catch_throwable.feature
+++ b/features/catch_throwable.feature
@@ -1,4 +1,3 @@
-@php-version @php7
 Feature: Support PHP 7 Throwable
   In order for my test suite to continue running despite fatal errors in my code
   As a feature developer

--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -420,7 +420,6 @@ Feature: Step Arguments Transformations
       8 steps (8 passed)
       """
 
-  @php-version @php7
   Scenario: By-type object transformations
     Given a file named "features/my.feature" with:
       """
@@ -488,7 +487,6 @@ Feature: Step Arguments Transformations
       4 steps (4 passed)
       """
 
-  @php-version @php7
   Scenario: By-type and by-name object transformations
     Given a file named "features/my.feature" with:
       """

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -121,7 +121,6 @@ Feature: Error Reporting
     When I run "behat -f progress --no-colors features/e_notice_in_scenario.feature"
     Then it should pass
 
-  @php-version @php7
   Scenario: With very verbose error reporting
     When I run "behat -f progress --no-colors -vv features/exception_in_scenario.feature"
     Then it should fail
@@ -139,7 +138,6 @@ Feature: Error Reporting
     1 step (1 failed)
     """
 
-  @php-version @php7
   Scenario: With debug verbose error reporting
     When I run "behat -f progress --no-colors -vvv features/exception_in_scenario.feature"
     Then it should fail

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -122,7 +122,6 @@ Feature: Extensions
       `inexistent_extension` extension file or class could not be located.
       """
 
-  @php-version @php7
   Scenario: Exception handlers extension
     Given a file named "behat.yml" with:
       """

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -526,66 +526,6 @@
       """
     And the file "junit/default.xml" should be a valid document according to "junit.xsd"
 
-  @php-version @php53 @php54+
-  Scenario: Aborting due to PHP error
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context,
-          Behat\Behat\Tester\Exception\PendingException;
-
-      class FeatureContext implements Context
-      {
-          private $value;
-
-          /**
-           * @Given /I have entered (\d+)/
-           */
-          public function iHaveEntered($num) {
-              $this->value = $num;
-          }
-
-          /**
-           * @Then /I must have (\d+)/
-           */
-          public function iMustHave($num) {
-              PHPUnit\Framework\Assert::assertEqual($num, $this->value);
-          }
-
-          /**
-           * @When /I add (\d+)/
-           */
-          public function iAdd($num) {
-              $this->value += $num;
-          }
-      }
-      """
-    And a file named "features/World.feature" with:
-      """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-
-        Background:
-          Given I have entered 10
-
-        Scenario: Failed
-          When I add 4
-          Then I must have 14
-      """
-    When I run "behat --no-colors -f junit -o junit"
-    Then it should fail with:
-      """
-      Call to undefined method PHPUnit\Framework\Assert::assertEqual
-      """
-    And "junit/default.xml" file xml should be like:
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default"/>
-      """
-
   Scenario: Aborting due invalid output path
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """

--- a/features/traits.feature
+++ b/features/traits.feature
@@ -86,7 +86,6 @@ Feature: Support traits
             | 2   | 2     | 3      |
       """
 
-  @php-version @php54+ @php7
   Scenario: Run feature with failing scenarios
     When I run "behat --no-colors -f progress"
     Then it should pass with:


### PR DESCRIPTION
Fixes #1258.

This PR does not remove any dead code, just bumps up requirements and adjusts CI configs.

What to do later?
 - Remove dead code that brings compatibility for Symfony <4.4
 - Remove dead code that brings compatibility for PHP <7.2
 - Setup some coding standard tool in order to maintain a consistent code style (and replace those `array()` with `[]`)
 - Merge some cool stuff 🎉 