### PR TITLE
Add "return 0" in DebugCommand.php

### DIFF
--- a/features/debug.feature
+++ b/features/debug.feature
@@ -1,0 +1,16 @@
+Feature: Debug info
+  In order to know more about current environment
+  As a Behat user
+  I need an ability to get debugging information
+
+  Scenario: Debug
+    When I run behat in debug mode
+    Then it should pass
+    And the output should contain:
+      """
+      --- configuration
+      """
+    And the output should contain:
+      """
+      --- extensions
+      """

--- a/src/Behat/Testwork/Cli/DebugCommand.php
+++ b/src/Behat/Testwork/Cli/DebugCommand.php
@@ -76,5 +76,7 @@ final class DebugCommand extends BaseCommand
         $output->writeln(sprintf('    extensions loaded: %s', count($debug['extensions_list']) ? implode(', ', $debug['extensions_list']) : 'none'));
 
         $output->writeln('');
+
+        return 0;
     }
 }


### PR DESCRIPTION
I added "return 0" to fix this error message:

```
$ vendor/bin/behat --debug

behat version 3.7.0

--- configuration
    environment variable (BEHAT_PARAMS): none
    configuration file: /home/jawira/PhpstormProjects/xxxxxxxx/behat.yml

--- extensions
    extensions loaded: api_extension

PHP Fatal error:  Uncaught TypeError: Return value of "Behat\Testwork\Cli\DebugCommand::execute()" must be of the type int, NULL returned. in /home/jawira/PhpstormProjects/xxxxxxxx/vendor/symfony/console/Command/Command.php:258
Stack trace:
#0 /home/jawira/PhpstormProjects/xxxxxxxx/vendor/symfony/console/Application.php(912): Symfony\Component\Console\Command\Command->run()
#1 /home/jawira/PhpstormProjects/xxxxxxxx/vendor/symfony/console/Application.php(264): Symfony\Component\Console\Application->doRunCommand()
#2 /home/jawira/PhpstormProjects/xxxxxxxx/vendor/behat/behat/src/Behat/Testwork/Cli/Application.php(124): Symfony\Component\Console\Application->doRun()
#3 /home/jawira/PhpstormProjects/xxxxxxxx/vendor/symfony/console/Application.php(140): Behat\Testwork\Cli\Application->doRun()
#4 /home/jawira/PhpstormProjects/xxxxxxxx/vendor/behat/behat/bin/behat(34): Symfony\Component\Console\Application->run()
#5 {main}
  thrown in /home/jawira/PhpstormProjects/xxxxxxxx/vendor/symfony/console/Command/Command.php on line 258
```