### PR TITLE
Use new PHP > 5.3 features

### DIFF
--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -148,7 +148,6 @@ Feature: Error Reporting
           When an exception is thrown # features/exception_in_scenario.feature:7
             Exception: Exception is thrown in features/bootstrap/FeatureContext.php:56
             Stack trace:
-            #0 [internal function]: FeatureContext->anExceptionIsThrown()
-            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(109): call_user_func_array(Array, Array)
-            #2 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(Object(Behat\Behat\Definition\Call\DefinitionCall))
+            #0 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(109): FeatureContext->anExceptionIsThrown()
+            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall()
     """

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -132,7 +132,6 @@ Feature: Error Reporting
           When an exception is thrown # features/exception_in_scenario.feature:7
             Exception: Exception is thrown in features/bootstrap/FeatureContext.php:56
             Stack trace:
-            #0 [internal function]: FeatureContext->anExceptionIsThrown()
 
     1 scenario (1 failed)
     1 step (1 failed)

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -149,5 +149,5 @@ Feature: Error Reporting
             Exception: Exception is thrown in features/bootstrap/FeatureContext.php:56
             Stack trace:
             #0 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(109): FeatureContext->anExceptionIsThrown()
-            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall()
+            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(Object(Behat\Behat\Definition\Call\DefinitionCall))
     """

--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -46,7 +46,7 @@ use Behat\Testwork\Translator\ServiceContainer\TranslatorExtension;
  */
 final class ApplicationFactory extends BaseFactory
 {
-    const VERSION = '3.7.0';
+    public const VERSION = '3.7.0';
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
@@ -24,7 +24,7 @@ use ReflectionMethod;
  */
 final class AnnotatedContextReader implements ContextReader
 {
-    const DOCLINE_TRIMMER_REGEX = '/^\/\*\*\s*|^\s*\*\s*|\s*\*\/$|\s*$/';
+    public const DOCLINE_TRIMMER_REGEX = '/^\/\*\*\s*|^\s*\*\s*|\s*\*\/$|\s*$/';
 
     /**
      * @var string[]

--- a/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
+++ b/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
@@ -42,6 +42,11 @@ final class ContextExtension implements Extension
     public const FACTORY_ID = 'context.factory';
     public const CONTEXT_SNIPPET_GENERATOR_ID = 'snippet.generator.context';
     public const AGGREGATE_RESOLVER_FACTORY_ID = 'context.argument.aggregate_resolver_factory';
+    private const ENVIRONMENT_HANDLER_ID = EnvironmentExtension::HANDLER_TAG . '.context';
+    private const ENVIRONMENT_READER_ID = EnvironmentExtension::READER_TAG . '.context';
+    private const SUITE_SETUP_ID = SuiteExtension::SETUP_TAG . '.suite_with_contexts';
+    private const ANNOTATED_CONTEXT_READER_ID = self::READER_TAG . '.annotated';
+
 
     /*
      * Available extension points
@@ -158,7 +163,7 @@ final class ContextExtension implements Extension
             new Reference(self::AGGREGATE_RESOLVER_FACTORY_ID)
         ));
         $definition->addTag(EnvironmentExtension::HANDLER_TAG, array('priority' => 50));
-        $container->setDefinition(self::getEnvironmentHandlerId(), $definition);
+        $container->setDefinition(self::ENVIRONMENT_HANDLER_ID, $definition);
     }
 
     /**
@@ -170,7 +175,7 @@ final class ContextExtension implements Extension
     {
         $definition = new Definition('Behat\Behat\Context\Environment\Reader\ContextEnvironmentReader');
         $definition->addTag(EnvironmentExtension::READER_TAG, array('priority' => 50));
-        $container->setDefinition(self::getEnvironmentReaderId(), $definition);
+        $container->setDefinition(self::ENVIRONMENT_READER_ID, $definition);
     }
 
     /**
@@ -185,7 +190,7 @@ final class ContextExtension implements Extension
             new Reference(FilesystemExtension::LOGGER_ID)
         ));
         $definition->addTag(SuiteExtension::SETUP_TAG, array('priority' => 20));
-        $container->setDefinition(self::getSuiteSetupId(), $definition);
+        $container->setDefinition(self::SUITE_SETUP_ID, $definition);
     }
 
     /**
@@ -249,13 +254,13 @@ final class ContextExtension implements Extension
     private function loadDefaultContextReaders(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Context\Reader\AnnotatedContextReader');
-        $container->setDefinition(self::getAnnotatedContextReaderId(), $definition);
+        $container->setDefinition(self::ANNOTATED_CONTEXT_READER_ID, $definition);
 
         $definition = new Definition('Behat\Behat\Context\Reader\ContextReaderCachedPerContext', array(
-            new Reference(self::getAnnotatedContextReaderId())
+            new Reference(self::ANNOTATED_CONTEXT_READER_ID)
         ));
         $definition->addTag(self::READER_TAG, array('priority' => 50));
-        $container->setDefinition(self::getAnnotatedContextReaderId() . '.cached', $definition);
+        $container->setDefinition(self::ANNOTATED_CONTEXT_READER_ID . '.cached', $definition);
 
         $definition = new Definition('Behat\Behat\Context\Reader\TranslatableContextReader', array(
             new Reference(TranslatorExtension::TRANSLATOR_ID)
@@ -277,7 +282,7 @@ final class ContextExtension implements Extension
     private function processClassResolvers(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::CLASS_RESOLVER_TAG);
-        $definition = $container->getDefinition(self::getEnvironmentHandlerId());
+        $definition = $container->getDefinition(self::ENVIRONMENT_HANDLER_ID);
 
         foreach ($references as $reference) {
             $definition->addMethodCall('registerClassResolver', array($reference));
@@ -337,7 +342,7 @@ final class ContextExtension implements Extension
     private function processContextReaders(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::READER_TAG);
-        $definition = $container->getDefinition(self::getEnvironmentReaderId());
+        $definition = $container->getDefinition(self::ENVIRONMENT_READER_ID);
 
         foreach ($references as $reference) {
             $definition->addMethodCall('registerContextReader', array($reference));
@@ -352,7 +357,7 @@ final class ContextExtension implements Extension
     private function processClassGenerators(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::CLASS_GENERATOR_TAG);
-        $definition = $container->getDefinition(self::getSuiteSetupId());
+        $definition = $container->getDefinition(self::SUITE_SETUP_ID);
 
         foreach ($references as $reference) {
             $definition->addMethodCall('registerClassGenerator', array($reference));
@@ -367,50 +372,10 @@ final class ContextExtension implements Extension
     private function processAnnotationReaders(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::ANNOTATION_READER_TAG);
-        $definition = $container->getDefinition(self::getAnnotatedContextReaderId());
+        $definition = $container->getDefinition(self::ANNOTATED_CONTEXT_READER_ID);
 
         foreach ($references as $reference) {
             $definition->addMethodCall('registerAnnotationReader', array($reference));
         }
-    }
-
-    /**
-     * Returns context environment handler service id.
-     *
-     * @return string
-     */
-    private static function getEnvironmentHandlerId()
-    {
-        return EnvironmentExtension::HANDLER_TAG . '.context';
-    }
-
-    /**
-     * Returns context environment reader id.
-     *
-     * @return string
-     */
-    private static function getEnvironmentReaderId()
-    {
-        return EnvironmentExtension::READER_TAG . '.context';
-    }
-
-    /**
-     * Returns context suite setup id.
-     *
-     * @return string
-     */
-    private static function getSuiteSetupId()
-    {
-        return SuiteExtension::SETUP_TAG . '.suite_with_contexts';
-    }
-
-    /**
-     * Returns annotated context reader id.
-     *
-     * @return string
-     */
-    private static function getAnnotatedContextReaderId()
-    {
-        return self::READER_TAG . '.annotated';
     }
 }

--- a/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
+++ b/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
@@ -39,20 +39,20 @@ final class ContextExtension implements Extension
     /**
      * Available services
      */
-    const FACTORY_ID = 'context.factory';
-    const CONTEXT_SNIPPET_GENERATOR_ID = 'snippet.generator.context';
-    const AGGREGATE_RESOLVER_FACTORY_ID = 'context.argument.aggregate_resolver_factory';
+    public const FACTORY_ID = 'context.factory';
+    public const CONTEXT_SNIPPET_GENERATOR_ID = 'snippet.generator.context';
+    public const AGGREGATE_RESOLVER_FACTORY_ID = 'context.argument.aggregate_resolver_factory';
 
     /*
      * Available extension points
      */
-    const CLASS_RESOLVER_TAG = 'context.class_resolver';
-    const ARGUMENT_RESOLVER_TAG = 'context.argument_resolver';
-    const INITIALIZER_TAG = 'context.initializer';
-    const READER_TAG = 'context.reader';
-    const ANNOTATION_READER_TAG = 'context.annotation_reader';
-    const CLASS_GENERATOR_TAG = 'context.class_generator';
-    const SUITE_SCOPED_RESOLVER_FACTORY_TAG = 'context.argument.suite_resolver_factory';
+    public const CLASS_RESOLVER_TAG = 'context.class_resolver';
+    public const ARGUMENT_RESOLVER_TAG = 'context.argument_resolver';
+    public const INITIALIZER_TAG = 'context.initializer';
+    public const READER_TAG = 'context.reader';
+    public const ANNOTATION_READER_TAG = 'context.annotation_reader';
+    public const CLASS_GENERATOR_TAG = 'context.class_generator';
+    public const SUITE_SCOPED_RESOLVER_FACTORY_TAG = 'context.argument.suite_resolver_factory';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
+++ b/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
@@ -25,7 +25,7 @@ final class ContextSnippetAppender implements SnippetAppender
     /**
      * @const PendingException class
      */
-    const PENDING_EXCEPTION_CLASS = 'Behat\Behat\Tester\Exception\PendingException';
+    public const PENDING_EXCEPTION_CLASS = 'Behat\Behat\Tester\Exception\PendingException';
 
     /**
      * @var FilesystemLogger

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -324,7 +324,7 @@ TPL;
      */
     private function getAlreadyProposedMethods($contextClass)
     {
-        return isset(self::$proposedMethods[$contextClass]) ? self::$proposedMethods[$contextClass] : array();
+        return self::$proposedMethods[$contextClass] ?? array();
     }
 
     /**

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -65,7 +65,7 @@ final class RegexPatternPolicy implements PatternPolicy
     {
         if (false === @preg_match($pattern, 'anything')) {
             $error = error_get_last();
-            $errorMessage = isset($error['message']) ? $error['message'] : '';
+            $errorMessage = $error['message'] ?? '';
 
             throw new InvalidPatternException(sprintf('The regex `%s` is invalid: %s', $pattern, $errorMessage));
         }

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -21,11 +21,11 @@ use Behat\Transliterator\Transliterator;
  */
 final class TurnipPatternPolicy implements PatternPolicy
 {
-    const TOKEN_REGEX = "[\"']?(?P<%s>(?<=\")[^\"]*(?=\")|(?<=')[^']*(?=')|\-?[\w\.\,]+)['\"]?";
+    public const TOKEN_REGEX = "[\"']?(?P<%s>(?<=\")[^\"]*(?=\")|(?<=')[^']*(?=')|\-?[\w\.\,]+)['\"]?";
 
-    const PLACEHOLDER_REGEXP = "/\\\:(\w+)/";
-    const OPTIONAL_WORD_REGEXP = '/(\s)?\\\\\(([^\\\]+)\\\\\)(\s)?/';
-    const ALTERNATIVE_WORD_REGEXP = '/(\w+)\\\\\/(\w+)/';
+    public const PLACEHOLDER_REGEXP = "/\\\:(\w+)/";
+    public const OPTIONAL_WORD_REGEXP = '/(\s)?\\\\\(([^\\\]+)\\\\\)(\s)?/';
+    public const ALTERNATIVE_WORD_REGEXP = '/(\w+)\\\\\/(\w+)/';
 
     /**
      * @var string[]

--- a/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
+++ b/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
@@ -35,17 +35,17 @@ final class DefinitionExtension implements Extension
     /*
      * Available services
      */
-    const FINDER_ID = 'definition.finder';
-    const REPOSITORY_ID = 'definition.repository';
-    const PATTERN_TRANSFORMER_ID = 'definition.pattern_transformer';
-    const WRITER_ID = 'definition.writer';
-    const DEFINITION_TRANSLATOR_ID = 'definition.translator';
+    public const FINDER_ID = 'definition.finder';
+    public const REPOSITORY_ID = 'definition.repository';
+    public const PATTERN_TRANSFORMER_ID = 'definition.pattern_transformer';
+    public const WRITER_ID = 'definition.writer';
+    public const DEFINITION_TRANSLATOR_ID = 'definition.translator';
 
     /*
      * Available extension points
      */
-    const SEARCH_ENGINE_TAG = 'definition.search_engine';
-    const PATTERN_POLICY_TAG = 'definition.pattern_policy';
+    public const SEARCH_ENGINE_TAG = 'definition.search_engine';
+    public const PATTERN_POLICY_TAG = 'definition.pattern_policy';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
@@ -21,10 +21,10 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  */
 abstract class BackgroundTested extends LifecycleEvent implements ScenarioLikeTested
 {
-    const BEFORE = 'tester.background_tested.before';
-    const AFTER_SETUP = 'tester.background_tested.after_setup';
-    const BEFORE_TEARDOWN = 'tester.background_tested.before_teardown';
-    const AFTER = 'tester.background_tested.after';
+    public const BEFORE = 'tester.background_tested.before';
+    public const AFTER_SETUP = 'tester.background_tested.after_setup';
+    public const BEFORE_TEARDOWN = 'tester.background_tested.before_teardown';
+    public const AFTER = 'tester.background_tested.after';
 
     /**
      * Returns background node.

--- a/src/Behat/Behat/EventDispatcher/Event/ExampleTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ExampleTested.php
@@ -17,8 +17,8 @@ namespace Behat\Behat\EventDispatcher\Event;
  */
 interface ExampleTested
 {
-    const BEFORE = 'tester.example_tested.before';
-    const AFTER_SETUP = 'tester.example_tested.after_setup';
-    const BEFORE_TEARDOWN = 'tester.example_tested.before_teardown';
-    const AFTER = 'tester.example_tested.after';
+    public const BEFORE = 'tester.example_tested.before';
+    public const AFTER_SETUP = 'tester.example_tested.after_setup';
+    public const BEFORE_TEARDOWN = 'tester.example_tested.before_teardown';
+    public const AFTER = 'tester.example_tested.after';
 }

--- a/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
@@ -21,10 +21,10 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  */
 abstract class FeatureTested extends LifecycleEvent implements GherkinNodeTested
 {
-    const BEFORE = 'tester.feature_tested.before';
-    const AFTER_SETUP = 'tester.feature_tested.after_setup';
-    const BEFORE_TEARDOWN = 'tester.feature_tested.before_teardown';
-    const AFTER = 'tester.feature_tested.after';
+    public const BEFORE = 'tester.feature_tested.before';
+    public const AFTER_SETUP = 'tester.feature_tested.after_setup';
+    public const BEFORE_TEARDOWN = 'tester.feature_tested.before_teardown';
+    public const AFTER = 'tester.feature_tested.after';
 
     /**
      * Returns feature.

--- a/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
@@ -22,10 +22,10 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  */
 abstract class OutlineTested extends LifecycleEvent implements GherkinNodeTested
 {
-    const BEFORE = 'tester.outline_tested.before';
-    const AFTER_SETUP = 'tester.outline_tested.after_setup';
-    const BEFORE_TEARDOWN = 'tester.outline_tested.before_teardown';
-    const AFTER = 'tester.outline_tested.after';
+    public const BEFORE = 'tester.outline_tested.before';
+    public const AFTER_SETUP = 'tester.outline_tested.after_setup';
+    public const BEFORE_TEARDOWN = 'tester.outline_tested.before_teardown';
+    public const AFTER = 'tester.outline_tested.after';
 
     /**
      * Returns feature.

--- a/src/Behat/Behat/EventDispatcher/Event/ScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ScenarioTested.php
@@ -19,10 +19,10 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  */
 abstract class ScenarioTested extends LifecycleEvent implements ScenarioLikeTested
 {
-    const BEFORE = 'tester.scenario_tested.before';
-    const AFTER_SETUP = 'tester.scenario_tested.after_setup';
-    const BEFORE_TEARDOWN = 'tester.scenario_tested.before_teardown';
-    const AFTER = 'tester.scenario_tested.after';
+    public const BEFORE = 'tester.scenario_tested.before';
+    public const AFTER_SETUP = 'tester.scenario_tested.after_setup';
+    public const BEFORE_TEARDOWN = 'tester.scenario_tested.before_teardown';
+    public const AFTER = 'tester.scenario_tested.after';
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Behat/EventDispatcher/Event/StepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/StepTested.php
@@ -21,10 +21,10 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  */
 abstract class StepTested extends LifecycleEvent implements GherkinNodeTested
 {
-    const BEFORE = 'tester.step_tested.before';
-    const AFTER_SETUP = 'tester.step_tested.after_setup';
-    const BEFORE_TEARDOWN = 'tester.step_tested.before_teardown';
-    const AFTER = 'tester.step_tested.after';
+    public const BEFORE = 'tester.step_tested.before';
+    public const AFTER_SETUP = 'tester.step_tested.after_setup';
+    public const BEFORE_TEARDOWN = 'tester.step_tested.before_teardown';
+    public const AFTER = 'tester.step_tested.after';
 
     /**
      * Returns feature.

--- a/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -156,20 +156,18 @@ class EventDispatcherExtension extends BaseExtension
     }
 
     /**
-     * Loads ticking step tester.
+     * This method used in the past to load the TickingStepTester to work around
+     * a bug with the scope of declare(ticks) in PHP < 7.1. Since we don't
+     * support those PHP versions anymore loading the TickingStepTester is
+     * no longer needed. This method is left here to prevent breaking BC.
+     *
+     * @todo Remove this method in next major
+     *
+     * @deprecated
      *
      * @param ContainerBuilder $container
      */
     protected function loadTickingStepTester(ContainerBuilder $container)
     {
-        if (!function_exists('pcntl_signal')) {
-            return;
-        }
-
-        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\TickingStepTester', array(
-            new Reference(TesterExtension::STEP_TESTER_ID)
-        ));
-        $definition->addTag(TesterExtension::STEP_TESTER_WRAPPER_TAG, array('priority' => 9999));
-        $container->setDefinition(TesterExtension::STEP_TESTER_WRAPPER_TAG . '.ticking', $definition);
     }
 }

--- a/src/Behat/Behat/EventDispatcher/Tester/TickingStepTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/TickingStepTester.php
@@ -21,6 +21,11 @@ use Behat\Testwork\Environment\Environment;
  * to handle an interupt (on PHP7)
  *
  * @see Behat\Testwork\EventDispatcher\Cli\SigintController
+ * 
+ * @deprecated Since the way signals are handled changed to use pcntl_signal_dispatch
+ *   this class is no longer needed.
+ * 
+ * @todo Remove this class in the next major version
  *
  * @author Peter Mitchell <peterjmit@gmail.com>
  */

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -35,14 +35,14 @@ final class GherkinExtension implements Extension
     /*
      * Available services
      */
-    const MANAGER_ID = 'gherkin';
-    const KEYWORDS_DUMPER_ID = 'gherkin.keywords_dumper';
-    const KEYWORDS_ID = 'gherkin.keywords';
+    public const MANAGER_ID = 'gherkin';
+    public const KEYWORDS_DUMPER_ID = 'gherkin.keywords_dumper';
+    public const KEYWORDS_ID = 'gherkin.keywords';
 
     /*
      * Available extension points
      */
-    const LOADER_TAG = 'gherkin.loader';
+    public const LOADER_TAG = 'gherkin.loader';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -61,7 +61,7 @@ final class BuiltInServiceContainer implements ContainerInterface
             );
         }
 
-        return $this->instances[$id] = isset($this->instances[$id]) ? $this->instances[$id] : $this->createInstance($id);
+        return $this->instances[$id] = $this->instances[$id] ?? $this->createInstance($id);
     }
 
     /**

--- a/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
+++ b/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
@@ -33,7 +33,7 @@ final class HelperContainerExtension implements Extension
     /*
      * Available extension points
      */
-    const HELPER_CONTAINER_TAG = 'helper_container.container';
+    public const HELPER_CONTAINER_TAG = 'helper_container.container';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Behat/Hook/Context/Annotation/HookAnnotationReader.php
+++ b/src/Behat/Behat/Hook/Context/Annotation/HookAnnotationReader.php
@@ -57,7 +57,7 @@ final class HookAnnotationReader implements AnnotationReader
 
         $type = strtolower($match[1]);
         $class = self::$classes[$type];
-        $pattern = isset($match[2]) ? $match[2] : null;
+        $pattern = $match[2] ?? null;
         $callable = array($contextClass, $method->getName());
 
         return new $class($pattern, $callable, $description);

--- a/src/Behat/Behat/Hook/Scope/FeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/FeatureScope.php
@@ -20,8 +20,8 @@ use Behat\Testwork\Hook\Scope\HookScope;
  */
 interface FeatureScope extends HookScope
 {
-    const BEFORE = 'feature.before';
-    const AFTER = 'feature.after';
+    public const BEFORE = 'feature.before';
+    public const AFTER = 'feature.after';
 
     /**
      * Returns scope feature.

--- a/src/Behat/Behat/Hook/Scope/ScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/ScenarioScope.php
@@ -21,8 +21,8 @@ use Behat\Testwork\Hook\Scope\HookScope;
  */
 interface ScenarioScope extends HookScope
 {
-    const BEFORE = 'scenario.before';
-    const AFTER = 'scenario.after';
+    public const BEFORE = 'scenario.before';
+    public const AFTER = 'scenario.after';
 
     /**
      * Returns scope feature.

--- a/src/Behat/Behat/Hook/Scope/StepScope.php
+++ b/src/Behat/Behat/Hook/Scope/StepScope.php
@@ -21,8 +21,8 @@ use Behat\Testwork\Hook\Scope\HookScope;
  */
 interface StepScope extends HookScope
 {
-    const BEFORE = 'step.before';
-    const AFTER = 'step.after';
+    public const BEFORE = 'step.before';
+    public const AFTER = 'step.after';
 
     /**
      * Returns scope feature.

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Formatter\OutputFormatter as BaseOutputFormatter;
  */
 final class ConsoleFormatter extends BaseOutputFormatter
 {
-    const CUSTOM_PATTERN = '/{\+([a-z-_]+)}(.*?){\-\\1}/si';
+    public const CUSTOM_PATTERN = '/{\+([a-z-_]+)}(.*?){\-\\1}/si';
 
     /**
      * Formats a message according to the given styles.

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
@@ -27,8 +27,8 @@ final class JUnitFormatterFactory implements FormatterFactory
     /*
      * Available services
      */
-    const ROOT_LISTENER_ID = 'output.node.listener.junit';
-    const RESULT_TO_STRING_CONVERTER_ID = 'output.node.printer.result_to_string';
+    public const ROOT_LISTENER_ID = 'output.node.listener.junit';
+    public const RESULT_TO_STRING_CONVERTER_ID = 'output.node.printer.result_to_string';
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -38,13 +38,13 @@ class PrettyFormatterFactory implements FormatterFactory
     /*
      * Available services
      */
-    const ROOT_LISTENER_ID = 'output.node.listener.pretty';
-    const RESULT_TO_STRING_CONVERTER_ID = 'output.node.printer.result_to_string';
+    public const ROOT_LISTENER_ID = 'output.node.listener.pretty';
+    public const RESULT_TO_STRING_CONVERTER_ID = 'output.node.printer.result_to_string';
 
     /*
      * Available extension points
      */
-    const ROOT_LISTENER_WRAPPER_TAG = 'output.node.listener.pretty.wrapper';
+    public const ROOT_LISTENER_WRAPPER_TAG = 'output.node.listener.pretty.wrapper';
 
     /**
      * Initializes extension.

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -34,13 +34,13 @@ class ProgressFormatterFactory implements FormatterFactory
     /*
      * Available services
      */
-    const ROOT_LISTENER_ID = 'output.node.listener.progress';
-    const RESULT_TO_STRING_CONVERTER_ID = 'output.node.printer.result_to_string';
+    public const ROOT_LISTENER_ID = 'output.node.listener.progress';
+    public const RESULT_TO_STRING_CONVERTER_ID = 'output.node.printer.result_to_string';
 
     /*
      * Available extension points
      */
-    const ROOT_LISTENER_WRAPPER_TAG = 'output.node.listener.progress.wrapper';
+    public const ROOT_LISTENER_WRAPPER_TAG = 'output.node.listener.progress.wrapper';
 
     /**
      * Initializes extension.

--- a/src/Behat/Behat/Snippet/AggregateSnippet.php
+++ b/src/Behat/Behat/Snippet/AggregateSnippet.php
@@ -112,9 +112,8 @@ final class AggregateSnippet
         }
 
         return array_unique(
-            call_user_func_array(
-                'array_merge',
-                array_map(
+            array_merge(
+                ...array_map(
                     function (Snippet $snippet) {
                         if (!$snippet instanceof ContextSnippet) {
                             return array();

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -31,14 +31,14 @@ class SnippetExtension implements Extension
     /*
      * Available services
      */
-    const REGISTRY_ID = 'snippet.registry';
-    const WRITER_ID = 'snippet.writer';
+    public const REGISTRY_ID = 'snippet.registry';
+    public const WRITER_ID = 'snippet.writer';
 
     /*
      * Available extension points
      */
-    const GENERATOR_TAG = 'snippet.generator';
-    const APPENDER_TAG = 'snippet.appender';
+    public const GENERATOR_TAG = 'snippet.generator';
+    public const APPENDER_TAG = 'snippet.appender';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Behat/Tester/Result/StepResult.php
+++ b/src/Behat/Behat/Tester/Result/StepResult.php
@@ -19,5 +19,5 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 interface StepResult extends TestResult
 {
-    const UNDEFINED = 30;
+    public const UNDEFINED = 30;
 }

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -33,20 +33,20 @@ class TesterExtension extends BaseExtension
     /*
      * Available services
      */
-    const SCENARIO_TESTER_ID = 'tester.scenario';
-    const OUTLINE_TESTER_ID = 'tester.outline';
-    const EXAMPLE_TESTER_ID = 'tester.example';
-    const BACKGROUND_TESTER_ID = 'tester.background';
-    const STEP_TESTER_ID = 'tester.step';
+    public const SCENARIO_TESTER_ID = 'tester.scenario';
+    public const OUTLINE_TESTER_ID = 'tester.outline';
+    public const EXAMPLE_TESTER_ID = 'tester.example';
+    public const BACKGROUND_TESTER_ID = 'tester.background';
+    public const STEP_TESTER_ID = 'tester.step';
 
     /**
      * Available extension points
      */
-    const SCENARIO_TESTER_WRAPPER_TAG = 'tester.scenario.wrapper';
-    const OUTLINE_TESTER_WRAPPER_TAG = 'tester.outline.wrapper';
-    const EXAMPLE_TESTER_WRAPPER_TAG = 'tester.example.wrapper';
-    const BACKGROUND_TESTER_WRAPPER_TAG = 'tester.background.wrapper';
-    const STEP_TESTER_WRAPPER_TAG = 'tester.step.wrapper';
+    public const SCENARIO_TESTER_WRAPPER_TAG = 'tester.scenario.wrapper';
+    public const OUTLINE_TESTER_WRAPPER_TAG = 'tester.outline.wrapper';
+    public const EXAMPLE_TESTER_WRAPPER_TAG = 'tester.example.wrapper';
+    public const BACKGROUND_TESTER_WRAPPER_TAG = 'tester.background.wrapper';
+    public const STEP_TESTER_WRAPPER_TAG = 'tester.step.wrapper';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Behat/Transformation/Context/Annotation/TransformationAnnotationReader.php
+++ b/src/Behat/Behat/Transformation/Context/Annotation/TransformationAnnotationReader.php
@@ -64,18 +64,13 @@ class TransformationAnnotationReader implements AnnotationReader
      */
     private function simpleTransformations()
     {
-        $transformations = array();
-        $transformations[] = 'Behat\Behat\Transformation\Transformation\RowBasedTableTransformation';
-        $transformations[] = 'Behat\Behat\Transformation\Transformation\ColumnBasedTableTransformation';
-        $transformations[] = 'Behat\Behat\Transformation\Transformation\TableRowTransformation';
-
-        if (PHP_VERSION_ID >= 70000) {
-            $transformations[] = 'Behat\Behat\Transformation\Transformation\TokenNameAndReturnTypeTransformation';
-            $transformations[] = 'Behat\Behat\Transformation\Transformation\ReturnTypeTransformation';
-        }
-
-        $transformations[] = 'Behat\Behat\Transformation\Transformation\TokenNameTransformation';
-
-        return $transformations;
+        return array(
+            'Behat\Behat\Transformation\Transformation\RowBasedTableTransformation',
+            'Behat\Behat\Transformation\Transformation\ColumnBasedTableTransformation',
+            'Behat\Behat\Transformation\Transformation\TableRowTransformation',
+            'Behat\Behat\Transformation\Transformation\TokenNameAndReturnTypeTransformation',
+            'Behat\Behat\Transformation\Transformation\ReturnTypeTransformation',
+            'Behat\Behat\Transformation\Transformation\TokenNameTransformation'
+        );
     }
 }

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -33,12 +33,12 @@ class TransformationExtension implements Extension
     /*
      * Available services
      */
-    const REPOSITORY_ID = 'transformation.repository';
+    public const REPOSITORY_ID = 'transformation.repository';
 
     /*
      * Available extension points
      */
-    const ARGUMENT_TRANSFORMER_TAG = 'transformation.argument_transformer';
+    public const ARGUMENT_TRANSFORMER_TAG = 'transformation.argument_transformer';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -40,6 +40,8 @@ class TransformationExtension implements Extension
      */
     public const ARGUMENT_TRANSFORMER_TAG = 'transformation.argument_transformer';
 
+    protected const DEFINITION_ARGUMENT_TRANSFORMER_ID = CallExtension::CALL_FILTER_TAG . '.definition_argument_transformer';
+
     /**
      * @var ServiceProcessor
      */
@@ -105,7 +107,7 @@ class TransformationExtension implements Extension
     {
         $definition = new Definition('Behat\Behat\Transformation\Call\Filter\DefinitionArgumentsTransformer');
         $definition->addTag(CallExtension::CALL_FILTER_TAG, array('priority' => 200));
-        $container->setDefinition($this->getDefinitionArgumentTransformerId(), $definition);
+        $container->setDefinition(self::DEFINITION_ARGUMENT_TRANSFORMER_ID, $definition);
     }
 
     /**
@@ -158,7 +160,7 @@ class TransformationExtension implements Extension
     protected function processArgumentsTransformers(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::ARGUMENT_TRANSFORMER_TAG);
-        $definition = $container->getDefinition($this->getDefinitionArgumentTransformerId());
+        $definition = $container->getDefinition(self::DEFINITION_ARGUMENT_TRANSFORMER_ID);
 
         foreach ($references as $reference) {
             $definition->addMethodCall('registerArgumentTransformer', array($reference));
@@ -169,9 +171,13 @@ class TransformationExtension implements Extension
      * Returns definition argument transformer service id.
      *
      * @return string
+     * 
+     * @deprecated Use DEFINITION_ARGUMENT_TRANSFORMER_ID constant instead
+     * 
+     * @todo Remove method in next major version
      */
     protected function getDefinitionArgumentTransformerId()
     {
-        return CallExtension::CALL_FILTER_TAG . '.definition_argument_transformer';
+        return self::DEFINITION_ARGUMENT_TRANSFORMER_ID;
     }
 }

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -25,7 +25,7 @@ use ReflectionMethod;
  */
 final class ColumnBasedTableTransformation extends RuntimeCallee implements SimpleArgumentTransformation
 {
-    const PATTERN_REGEX = '/^table\:(?:\*|[[:print:]]+)$/';
+    public const PATTERN_REGEX = '/^table\:(?:\*|[[:print:]]+)$/';
 
     /**
      * @var string

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -26,7 +26,7 @@ use ReflectionMethod;
  */
 final class RowBasedTableTransformation extends RuntimeCallee implements SimpleArgumentTransformation
 {
-    const PATTERN_REGEX = '/^rowtable\:[[:print:]]+$/';
+    public const PATTERN_REGEX = '/^rowtable\:[[:print:]]+$/';
 
     /**
      * @var string

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -25,7 +25,7 @@ use ReflectionMethod;
  */
 final class TableRowTransformation extends RuntimeCallee implements SimpleArgumentTransformation
 {
-    const PATTERN_REGEX = '/^row\:[[:print:]]+$/';
+    public const PATTERN_REGEX = '/^row\:[[:print:]]+$/';
 
     /**
      * @var string

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -24,7 +24,7 @@ use ReflectionMethod;
  */
 final class TokenNameTransformation extends RuntimeCallee implements SimpleArgumentTransformation
 {
-    const PATTERN_REGEX = '/^\:\w+$/';
+    public const PATTERN_REGEX = '/^\:\w+$/';
 
     /**
      * @var string

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -115,11 +115,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
     private function applySimpleTransformations(array $transformations, DefinitionCall $definitionCall, $index, $value)
     {
         usort($transformations, function (SimpleArgumentTransformation $t1, SimpleArgumentTransformation $t2) {
-            if ($t1->getPriority() == $t2->getPriority()) {
-                return 0;
-            }
-
-            return ($t1->getPriority() > $t2->getPriority()) ? -1 : 1;
+            return $t2->getPriority() <=> $t1->getPriority();
         });
 
         $newValue = $value;

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -283,7 +283,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
         $predicate
     ) {
         foreach ($candidates as $candidateIndex => $candidate) {
-            if (call_user_func_array($predicate, array($parameter->getClass(), $candidate))) {
+            if ($predicate($parameter->getClass(), $candidate)) {
                 $num = $parameter->getPosition();
 
                 $arguments[$num] = $candidate;

--- a/src/Behat/Testwork/Argument/ServiceContainer/ArgumentExtension.php
+++ b/src/Behat/Testwork/Argument/ServiceContainer/ArgumentExtension.php
@@ -27,9 +27,9 @@ final class ArgumentExtension implements Extension
     /*
      * Available services
      */
-    const MIXED_ARGUMENT_ORGANISER_ID = 'argument.mixed_organiser';
-    const PREG_MATCH_ARGUMENT_ORGANISER_ID = 'argument.preg_match_organiser';
-    const CONSTRUCTOR_ARGUMENT_ORGANISER_ID = 'argument.constructor_organiser';
+    public const MIXED_ARGUMENT_ORGANISER_ID = 'argument.mixed_organiser';
+    public const PREG_MATCH_ARGUMENT_ORGANISER_ID = 'argument.preg_match_organiser';
+    public const CONSTRUCTOR_ARGUMENT_ORGANISER_ID = 'argument.constructor_organiser';
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
+++ b/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
@@ -28,7 +28,7 @@ final class AutoloaderExtension implements Extension
     /*
      * Available services
      */
-    const CLASS_LOADER_ID = 'class_loader';
+    public const CLASS_LOADER_ID = 'class_loader';
 
     /**
      * @var array

--- a/src/Behat/Testwork/Call/CallCenter.php
+++ b/src/Behat/Testwork/Call/CallCenter.php
@@ -94,8 +94,6 @@ final class CallCenter
     {
         try {
             return $this->filterResult($this->handleCall($this->filterCall($call)));
-        } catch (Exception $exception) {
-            return new CallResult($call, null, $this->handleException($exception), null);
         } catch (Throwable $exception) {
             return new CallResult($call, null, $this->handleException($exception), null);
         }

--- a/src/Behat/Testwork/Call/Exception/CallErrorException.php
+++ b/src/Behat/Testwork/Call/Exception/CallErrorException.php
@@ -42,7 +42,7 @@ final class CallErrorException extends ErrorException
         parent::__construct(
             sprintf(
                 '%s: %s in %s line %d',
-                isset($this->levels[$level]) ? $this->levels[$level] : $level,
+                $this->levels[$level] ?? $level,
                 $message,
                 $file,
                 $line

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -22,7 +22,7 @@ use Error;
  */
 abstract class ClassNotFoundHandler implements ExceptionHandler
 {
-    const PATTERN = "/^Class '([^']+)' not found$/";
+    public const PATTERN = "/^Class '([^']+)' not found$/";
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
@@ -22,7 +22,7 @@ use Error;
  */
 abstract class MethodNotFoundHandler implements ExceptionHandler
 {
-    const PATTERN = '/^Call to undefined method ([^:]+)::([^\)]+)\(\)$/';
+    public const PATTERN = '/^Call to undefined method ([^:]+)::([^\)]+)\(\)$/';
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -106,7 +106,7 @@ final class RuntimeCallHandler implements CallHandler
 
         try {
             $this->validator->validateArguments($reflection, $arguments);
-            $return = call_user_func_array($callable, $arguments);
+            $return = $callable(...array_values($arguments));
         } catch (Exception $caught) {
             $exception = $caught;
         }

--- a/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
+++ b/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
@@ -27,15 +27,15 @@ final class CallExtension implements Extension
     /*
      * Available services
      */
-    const CALL_CENTER_ID = 'call.center';
+    public const CALL_CENTER_ID = 'call.center';
 
     /*
      * Available extension points
      */
-    const CALL_FILTER_TAG = 'call.call_filter';
-    const CALL_HANDLER_TAG = 'call.call_handler';
-    const RESULT_FILTER_TAG = 'call.result_filter';
-    const EXCEPTION_HANDLER_TAG = 'call.exception_handler';
+    public const CALL_FILTER_TAG = 'call.call_filter';
+    public const CALL_HANDLER_TAG = 'call.call_handler';
+    public const RESULT_FILTER_TAG = 'call.result_filter';
+    public const EXCEPTION_HANDLER_TAG = 'call.exception_handler';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
+++ b/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
@@ -27,14 +27,14 @@ final class CliExtension implements Extension
     /*
      * Available services
      */
-    const COMMAND_ID = 'cli.command';
-    const INPUT_ID = 'cli.input';
-    const OUTPUT_ID = 'cli.output';
+    public const COMMAND_ID = 'cli.command';
+    public const INPUT_ID = 'cli.input';
+    public const OUTPUT_ID = 'cli.output';
 
     /*
      * Available extension points
      */
-    const CONTROLLER_TAG = 'cli.controller';
+    public const CONTROLLER_TAG = 'cli.controller';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/Environment/ServiceContainer/EnvironmentExtension.php
+++ b/src/Behat/Testwork/Environment/ServiceContainer/EnvironmentExtension.php
@@ -29,13 +29,13 @@ final class EnvironmentExtension implements Extension
     /*
      * Available services
      */
-    const MANAGER_ID = 'environment.manager';
+    public const MANAGER_ID = 'environment.manager';
 
     /*
      * Available extension points
      */
-    const HANDLER_TAG = 'environment.handler';
-    const READER_TAG = 'environment.reader';
+    public const HANDLER_TAG = 'environment.handler';
+    public const READER_TAG = 'environment.reader';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/EventDispatcher/Cli/SigintController.php
+++ b/src/Behat/Testwork/EventDispatcher/Cli/SigintController.php
@@ -54,7 +54,7 @@ final class SigintController implements Controller
     public function execute(InputInterface $input, OutputInterface $output)
     {
         if (function_exists('pcntl_signal')) {
-            declare(ticks = 1);
+            pcntl_async_signals(true);
             pcntl_signal(SIGINT, array($this, 'abortExercise'));
         }
     }

--- a/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
@@ -21,10 +21,10 @@ use Behat\Testwork\Specification\SpecificationIterator;
  */
 abstract class ExerciseCompleted extends Event
 {
-    const BEFORE = 'tester.exercise_completed.before';
-    const AFTER_SETUP = 'tester.exercise_completed.after_setup';
-    const BEFORE_TEARDOWN = 'tester.exercise_completed.before_teardown';
-    const AFTER = 'tester.exercise_completed.after';
+    public const BEFORE = 'tester.exercise_completed.before';
+    public const AFTER_SETUP = 'tester.exercise_completed.after_setup';
+    public const BEFORE_TEARDOWN = 'tester.exercise_completed.before_teardown';
+    public const AFTER = 'tester.exercise_completed.after';
 
     /**
      * Returns specification iterators.

--- a/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
@@ -19,10 +19,10 @@ use Behat\Testwork\Specification\SpecificationIterator;
  */
 abstract class SuiteTested extends LifecycleEvent
 {
-    const BEFORE = 'tester.suite_tested.before';
-    const AFTER_SETUP = 'tester.suite_tested.after_setup';
-    const BEFORE_TEARDOWN = 'tester.suite_tested.before_teardown';
-    const AFTER = 'tester.suite_tested.after';
+    public const BEFORE = 'tester.suite_tested.before';
+    public const AFTER_SETUP = 'tester.suite_tested.after_setup';
+    public const BEFORE_TEARDOWN = 'tester.suite_tested.before_teardown';
+    public const AFTER = 'tester.suite_tested.after';
 
     /**
      * Returns specification iterator.

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -30,12 +30,12 @@ class EventDispatcherExtension implements Extension
     /*
      * Available services
      */
-    const DISPATCHER_ID = 'event_dispatcher';
+    public const DISPATCHER_ID = 'event_dispatcher';
 
     /*
      * Available extension points
      */
-    const SUBSCRIBER_TAG = 'event_dispatcher.subscriber';
+    public const SUBSCRIBER_TAG = 'event_dispatcher.subscriber';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
@@ -58,9 +58,9 @@ if (false) {
     {
 
         // These constant definitions are required to prevent scrutinizer failing static analysis
-        const BEFORE_ALL_EVENTS = '*~';
-        const AFTER_ALL_EVENTS = '~*';
-        const DISPATCHER_VERSION = 'undefined';
+        public const BEFORE_ALL_EVENTS = '*~';
+        public const AFTER_ALL_EVENTS = '~*';
+        public const DISPATCHER_VERSION = 'undefined';
     }
 
 }

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfony5.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfony5.php
@@ -16,9 +16,9 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  */
 final class TestworkEventDispatcherSymfony5 extends EventDispatcher
 {
-    const BEFORE_ALL_EVENTS = '*~';
-    const AFTER_ALL_EVENTS = '~*';
-    const DISPATCHER_VERSION = 2;
+    public const BEFORE_ALL_EVENTS = '*~';
+    public const AFTER_ALL_EVENTS = '~*';
+    public const DISPATCHER_VERSION = 2;
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfonyLegacy.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfonyLegacy.php
@@ -16,9 +16,9 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  */
 final class TestworkEventDispatcherSymfonyLegacy extends EventDispatcher
 {
-    const BEFORE_ALL_EVENTS = '*~';
-    const AFTER_ALL_EVENTS = '~*';
-    const DISPATCHER_VERSION = 1;
+    public const BEFORE_ALL_EVENTS = '*~';
+    public const AFTER_ALL_EVENTS = '~*';
+    public const DISPATCHER_VERSION = 1;
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
+++ b/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
@@ -30,12 +30,12 @@ final class ExceptionExtension implements Extension
     /*
      * Available services
      */
-    const PRESENTER_ID = 'exception.presenter';
+    public const PRESENTER_ID = 'exception.presenter';
 
     /*
      * Available extension points
      */
-    const STRINGER_TAG = 'exception.stringer';
+    public const STRINGER_TAG = 'exception.stringer';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/Filesystem/ServiceContainer/FilesystemExtension.php
+++ b/src/Behat/Testwork/Filesystem/ServiceContainer/FilesystemExtension.php
@@ -28,7 +28,7 @@ final class FilesystemExtension implements Extension
     /*
      * Available services
      */
-    const LOGGER_ID = 'filesystem.logger';
+    public const LOGGER_ID = 'filesystem.logger';
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Testwork/Hook/Scope/SuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/SuiteScope.php
@@ -19,8 +19,8 @@ use Behat\Testwork\Specification\SpecificationIterator;
  */
 interface SuiteScope extends HookScope
 {
-    const BEFORE = 'suite.before';
-    const AFTER = 'suite.after';
+    public const BEFORE = 'suite.before';
+    public const AFTER = 'suite.after';
 
     /**
      * Returns specification iterator.

--- a/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
+++ b/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
@@ -30,8 +30,8 @@ class HookExtension implements Extension
     /*
      * Available services
      */
-    const DISPATCHER_ID = 'hook.dispatcher';
-    const REPOSITORY_ID = 'hook.repository';
+    public const DISPATCHER_ID = 'hook.dispatcher';
+    public const REPOSITORY_ID = 'hook.repository';
 
     /**
      * {@inheritdoc}

--- a/src/Behat/Testwork/Ordering/ServiceContainer/OrderingExtension.php
+++ b/src/Behat/Testwork/Ordering/ServiceContainer/OrderingExtension.php
@@ -28,7 +28,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class OrderingExtension implements Extension
 {
-    const ORDERER_TAG = 'tester.orderer';
+    public const ORDERER_TAG = 'tester.orderer';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -121,6 +121,6 @@ final class NodeEventListeningFormatter implements Formatter
      */
     public function getParameter($name)
     {
-        return isset($this->parameters[$name]) ? $this->parameters[$name] : null;
+        return $this->parameters[$name] ?? null;
     }
 }

--- a/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
@@ -18,10 +18,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class OutputFactory
 {
-    const VERBOSITY_NORMAL       = 1;
-    const VERBOSITY_VERBOSE      = 2;
-    const VERBOSITY_VERY_VERBOSE = 3;
-    const VERBOSITY_DEBUG        = 4;
+    public const VERBOSITY_NORMAL       = 1;
+    public const VERBOSITY_VERBOSE      = 2;
+    public const VERBOSITY_VERY_VERBOSE = 3;
+    public const VERBOSITY_DEBUG        = 4;
 
     /**
      * @var null|string

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -23,8 +23,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class JUnitOutputPrinter extends StreamOutputPrinter
 {
-    const XML_VERSION  = '1.0';
-    const XML_ENCODING = 'UTF-8';
+    public const XML_VERSION  = '1.0';
+    public const XML_ENCODING = 'UTF-8';
 
     /**
      * @var \DOMDocument

--- a/src/Behat/Testwork/Output/Printer/OutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/OutputPrinter.php
@@ -20,19 +20,19 @@ interface OutputPrinter
     /**
      * @deprecated since 3.1, to be removed in 4.0
      */
-    const VERBOSITY_NORMAL       = 1;
+    public const VERBOSITY_NORMAL       = 1;
     /**
      * @deprecated since 3.1, to be removed in 4.0
      */
-    const VERBOSITY_VERBOSE      = 2;
+    public const VERBOSITY_VERBOSE      = 2;
     /**
      * @deprecated since 3.1, to be removed in 4.0
      */
-    const VERBOSITY_VERY_VERBOSE = 3;
+    public const VERBOSITY_VERY_VERBOSE = 3;
     /**
      * @deprecated since 3.1, to be removed in 4.0
      */
-    const VERBOSITY_DEBUG        = 4;
+    public const VERBOSITY_DEBUG        = 4;
 
     /**
      * Sets output path.

--- a/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
@@ -31,12 +31,12 @@ final class OutputExtension implements Extension
     /*
      * Available services
      */
-    const MANAGER_ID = 'output.manager';
+    public const MANAGER_ID = 'output.manager';
 
     /*
      * Available extension points
      */
-    const FORMATTER_TAG = 'output.formatter';
+    public const FORMATTER_TAG = 'output.formatter';
 
     /**
      * @var string

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -85,7 +85,7 @@ final class ExtensionManager
      */
     public function getExtension($key)
     {
-        return isset($this->extensions[$key]) ? $this->extensions[$key] : null;
+        return $this->extensions[$key] ?? null;
     }
 
     /**

--- a/src/Behat/Testwork/Specification/ServiceContainer/SpecificationExtension.php
+++ b/src/Behat/Testwork/Specification/ServiceContainer/SpecificationExtension.php
@@ -27,12 +27,12 @@ final class SpecificationExtension implements Extension
     /*
      * Available services
      */
-    const FINDER_ID = 'specifications.finder';
+    public const FINDER_ID = 'specifications.finder';
 
     /*
      * Available extension points
      */
-    const LOCATOR_TAG = 'specifications.locator';
+    public const LOCATOR_TAG = 'specifications.locator';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -89,9 +89,7 @@ final class SuiteExtension implements Extension
                         return is_array($suite) && count($suite);
                     })
                     ->then(function ($suite) {
-                        $suite['settings'] = isset($suite['settings'])
-                            ? $suite['settings']
-                            : array();
+                        $suite['settings'] = $suite['settings'] ?? array();
 
                         foreach ($suite as $key => $val) {
                             $suiteKeys = array('enabled', 'type', 'settings');

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -29,14 +29,14 @@ final class SuiteExtension implements Extension
     /*
      * Available services
      */
-    const REGISTRY_ID = 'suite.registry';
-    const BOOTSTRAPPER_ID = 'suite.bootstrapper';
+    public const REGISTRY_ID = 'suite.registry';
+    public const BOOTSTRAPPER_ID = 'suite.bootstrapper';
 
     /*
      * Available extension points
      */
-    const GENERATOR_TAG = 'suite.generator';
-    const SETUP_TAG = 'suite.setup';
+    public const GENERATOR_TAG = 'suite.generator';
+    public const SETUP_TAG = 'suite.setup';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/Tester/Result/TestResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestResult.php
@@ -17,10 +17,10 @@ namespace Behat\Testwork\Tester\Result;
  */
 interface TestResult
 {
-    const PASSED = 0;
-    const SKIPPED = 10;
-    const PENDING = 20;
-    const FAILED = 99;
+    public const PASSED = 0;
+    public const SKIPPED = 10;
+    public const PENDING = 20;
+    public const FAILED = 99;
 
     /**
      * Checks that test has passed.

--- a/src/Behat/Testwork/Tester/Result/TestResults.php
+++ b/src/Behat/Testwork/Tester/Result/TestResults.php
@@ -21,7 +21,7 @@ use IteratorAggregate;
  */
 final class TestResults implements TestResult, Countable, IteratorAggregate
 {
-    const NO_TESTS = -100;
+    public const NO_TESTS = -100;
 
     /**
      * @var TestResult[]

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -32,18 +32,18 @@ abstract class TesterExtension implements Extension
     /*
      * Available services
      */
-    const EXERCISE_ID = 'tester.exercise';
-    const SUITE_TESTER_ID = 'tester.suite';
-    const SPECIFICATION_TESTER_ID = 'tester.specification';
-    const RESULT_INTERPRETER_ID = 'tester.result.interpreter';
+    public const EXERCISE_ID = 'tester.exercise';
+    public const SUITE_TESTER_ID = 'tester.suite';
+    public const SPECIFICATION_TESTER_ID = 'tester.specification';
+    public const RESULT_INTERPRETER_ID = 'tester.result.interpreter';
 
     /**
      * Available extension points
      */
-    const EXERCISE_WRAPPER_TAG = 'tester.exercise.wrapper';
-    const SUITE_TESTER_WRAPPER_TAG = 'tester.suite.wrapper';
-    const SPECIFICATION_TESTER_WRAPPER_TAG = 'tester.specification.wrapper';
-    const RESULT_INTERPRETATION_TAG = 'test.result.interpretation';
+    public const EXERCISE_WRAPPER_TAG = 'tester.exercise.wrapper';
+    public const SUITE_TESTER_WRAPPER_TAG = 'tester.suite.wrapper';
+    public const SPECIFICATION_TESTER_WRAPPER_TAG = 'tester.specification.wrapper';
+    public const RESULT_INTERPRETATION_TAG = 'test.result.interpretation';
 
     /**
      * @var ServiceProcessor

--- a/src/Behat/Testwork/Translator/ServiceContainer/TranslatorExtension.php
+++ b/src/Behat/Testwork/Translator/ServiceContainer/TranslatorExtension.php
@@ -28,7 +28,7 @@ final class TranslatorExtension implements Extension
     /*
      * Available services
      */
-    const TRANSLATOR_ID = 'translator';
+    public const TRANSLATOR_ID = 'translator';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
A first batch of refactorings to use newer PHP construction where possible.

Notably absent are:

- Scalar type hints
- Use short array notation
- `::class` constants instead of strings with FQCNs

I think these deserve PRs of their own, given their impact.