### PR TITLE
Ensure zend.exception_ignore_args is disabled in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   - if [ "$SKIP_INTEROP" != "" ]; then composer remove --dev --no-update container-interop/container-interop; fi;
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-lowest; fi;
+  - echo 'zend.exception_ignore_args=Off' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - export PATH=./bin:$PATH
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,7 @@ install:
             Add-Content php.ini "`n extension=php_curl.dll"
             Add-Content php.ini "`n extension=php_mbstring.dll"
             Add-Content php.ini "`n extension=php_fileinfo.dll"
+            Add-Content php.ini "`n zend.exception_ignore_args=Off"
 
             # download Composer
             if (!(Test-Path C:\tools\composer)) {


### PR DESCRIPTION
When enabled the stack trace output for exceptions changes, which causes
the tests to fail as the changed output does not match the expected
output.