### PR TITLE
Scenario Hook should allowed negated filters (fixes #1235)

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -84,6 +84,20 @@ Feature: hooks
           }
 
           /**
+           * @BeforeScenario @filtered
+           */
+          public function beforeScenarioFiltered($event) {
+              $this->scenarioFilter = 'filtered';
+          }
+
+          /**
+           * @BeforeScenario @~filtered
+           */
+          public function beforeScenarioNotFiltered($event) {
+              $this->scenarioFilter = '~filtered';
+          }
+
+          /**
            * @BeforeStep I must have 100
            */
           public function beforeStep100($event) {
@@ -102,6 +116,13 @@ Feature: hooks
            */
           public function iMustHave($number) {
               \PHPUnit\Framework\Assert::assertEquals(intval($number), $this->number);
+          }
+
+          /**
+           * @Then I must have a scenario filter value of :value
+           */
+          public function iMustHaveScenarioFilter($filterValue) {
+              \PHPUnit\Framework\Assert::assertEquals($filterValue, $this->scenarioFilter);
           }
       }
       """
@@ -129,6 +150,17 @@ Feature: hooks
 
         Scenario: 130
           Given I must have 130
+
+        @filtered
+        Scenario:
+          Then I must have a scenario filter value of "filtered"
+
+        @~filtered
+        Scenario:
+          Then I must have a scenario filter value of "~filtered"
+
+        Scenario:
+          Then I must have a scenario filter value of "~filtered"
       """
     When I run "behat --no-colors -f pretty"
     Then it should pass with:
@@ -161,13 +193,24 @@ Feature: hooks
         Scenario: 130           # features/test.feature:19
           Given I must have 130 # FeatureContext::iMustHave()
 
+        @filtered
+        Scenario:                                                # features/test.feature:23
+          Then I must have a scenario filter value of "filtered" # FeatureContext::iMustHaveScenarioFilter()
+
+        @~filtered
+        Scenario:                                                 # features/test.feature:27
+          Then I must have a scenario filter value of "~filtered" # FeatureContext::iMustHaveScenarioFilter()
+
+        Scenario:                                                 # features/test.feature:30
+          Then I must have a scenario filter value of "~filtered" # FeatureContext::iMustHaveScenarioFilter()
+
       │
       │  = do something AFTER EVERY FEATURE
       │
       └─ @AfterFeature # FeatureContext::doSomethingAfterFeature()
 
-      5 scenarios (5 passed)
-      10 steps (10 passed)
+      8 scenarios (8 passed)
+      13 steps (13 passed)
       """
 
   Scenario: Filter features

--- a/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
@@ -76,10 +76,6 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
     {
         $filter = new TagFilter($filterString);
 
-        if ($filter->isFeatureMatch($feature)) {
-            return true;
-        }
-
         return $filter->isScenarioMatch($feature, $scenario);
     }
 


### PR DESCRIPTION
Scenario hooks support filtering by tag. The tag can be filtered on
either the Feature tags, or the Scenario tags.

When checking these tags, the tags must be combined before checking to
allow support of negated tags.

The `TagFilter::isScenarioMatch()` function in Gherkin takes both the
FeatureNode, and ScenarioNode as arguments, and then combines the tags
on both of these.

This fix addresses an issue whereby the Feature does not contain a tag,
but the Scenario does, and the hook is filtered on the absence of that
Scenario tag.

For example, Given the following Feature:
```
Feature:

  @doNotMatch
  Scenario:
    I should not be called with the @~doNotMatch filter
```

And the following Hooks:
```
/**
 * @BeforeScenario @~doNotMatch
 */
public negatedBeforeScenarioHook($event) {
  throw new \Exception('I should not have been called');
}
```

The Feature contains no hooks, but the Scenario contains the
`@doNotMatch` hook.

When processed before applying this patch the call to
`TagFilter::isFeatureMatch($feature)` will not not match (i.e. it _will_ match),
the `isMatchTagFilter` function returns early with a true value, and
therefore the hook incorrectly applies.

Following this change the, `TagFilter::isScenarioMatch($scenario)`
function is called and checks the values of all tags on _both_ the
Feature, _and_ the Scenario. The tag does _not_ match, the
`isMatchTagFilter()` function return false,a dn the tag _does not_ apply
which is the correct behaviour.