### PR TITLE
Phpunit9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 behat.yml
 vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 
     "require-dev": {
         "symfony/process": "^4.4 || ^5.0",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5|^9.0",
         "herrera-io/box": "~1.6.1",
         "container-interop/container-interop": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 
     "require-dev": {
         "symfony/process": "^4.4 || ^5.0",
-        "phpunit/phpunit": "^7.5.20",
+        "phpunit/phpunit": "^8.5",
         "herrera-io/box": "~1.6.1",
         "container-interop/container-interop": "^1.2"
     },

--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -61,7 +61,7 @@ Feature: Append snippets option
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
@@ -176,7 +176,7 @@ Feature: Append snippets option
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
@@ -281,7 +281,7 @@ Feature: Append snippets option
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
@@ -346,7 +346,7 @@ Feature: Append snippets option
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
@@ -449,7 +449,7 @@ Feature: Append snippets option
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
@@ -514,7 +514,7 @@ Feature: Append snippets option
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              \PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              \PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               \PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -337,7 +337,7 @@ EOL;
      */
     public function theOutputShouldContain(PyStringNode $text)
     {
-        Assert::assertContains($this->getExpectedOutput($text), $this->getOutput());
+        Assert::assertStringContainsString($this->getExpectedOutput($text), $this->getOutput());
     }
 
     private function getExpectedOutput(PyStringNode $expectedText)

--- a/features/context.feature
+++ b/features/context.feature
@@ -61,7 +61,7 @@ Feature: Context consistency
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }
@@ -496,7 +496,7 @@ Feature: Context consistency
 
           /** @Given foo */
           public function foo() {
-            PHPUnit\Framework\Assert::assertInternalType('array', $this->foo);
+            PHPUnit\Framework\Assert::assertIsArray($this->foo);
 
             PHPUnit\Framework\Assert::assertSame('foo', $this->foo[0]);
             PHPUnit\Framework\Assert::assertSame('bar', $this->foo[1]);

--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -125,7 +125,7 @@ Feature: Step Arguments Transformations
            */
           public function ageMustBe($age) {
               PHPUnit\Framework\Assert::assertEquals($age, $this->user->getAge());
-              PHPUnit\Framework\Assert::assertInternalType('int', $age);
+              PHPUnit\Framework\Assert::assertIsInt($age);
           }
 
           /**

--- a/features/format_options.feature
+++ b/features/format_options.feature
@@ -61,7 +61,7 @@ Feature: Format options
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -61,7 +61,7 @@ Feature: Multiple formats
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }

--- a/features/rerun.feature
+++ b/features/rerun.feature
@@ -58,7 +58,7 @@ Feature: Rerun
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -74,7 +74,7 @@ Feature: Rerun with multiple suite
            * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
            */
           public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit\Framework\Assert::assertInternalType('array', $this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
               PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
           }
       }

--- a/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
+++ b/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
@@ -66,12 +66,10 @@ class PatternTransformerTest extends TestCase
         $this->assertEquals('/hello world/', $regex3);
     }
 
-    /**
-     * @expectedException \Behat\Behat\Definition\Exception\UnknownPatternException
-     * @expectedExceptionMessage Can not find policy for a pattern `hello world`.
-     */
     public function testTransformPatternToRegexNoMatch()
     {
+        $this->expectException('\Behat\Behat\Definition\Exception\UnknownPatternException');
+        $this->expectExceptionMessage("Can not find policy for a pattern `hello world`.");
         // first pattern
         $policy1Prophecy = $this->prophesize('Behat\Behat\Definition\Pattern\Policy\PatternPolicy');
         $policy1Prophecy->supportsPattern('hello world')->willReturn(false);


### PR DESCRIPTION
Make an attempt to use phpunit9.

It might be a little difficult to have code that works cleanly with both phpunit 8 and 9 - let's see.

https://phpunit.de/supported-versions.html
PHPUnit8 is for PHP 7.2+
PHPUnit9 is for PHP 7.3+
