### PR TITLE
Add support for specification of a preferred profile

### DIFF
--- a/features/preferred_profile.feature
+++ b/features/preferred_profile.feature
@@ -1,0 +1,144 @@
+Feature: Preferred Profiles
+  In order to test my preferred profile
+  As a tester
+  I need to be able to specify a preferred profile
+
+  Background:
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          private $result;
+          private $numbers;
+
+          /**
+           * @Given /I have basic calculator/
+           */
+          public function iHaveBasicCalculator() {
+              $this->result  = 0;
+              $this->numbers = array();
+          }
+
+          /**
+           * @Given /I have entered (\d+)/
+           */
+          public function iHaveEntered($number) {
+              $this->numbers[] = intval($number);
+          }
+
+          /**
+           * @When /I add/
+           */
+          public function iAdd() {
+              $this->result  = array_sum($this->numbers);
+              $this->numbers = array();
+          }
+
+          /**
+           * @When /I sub/
+           */
+          public function iSub() {
+              $this->result  = array_shift($this->numbers);
+              $this->result -= array_sum($this->numbers);
+              $this->numbers = array();
+          }
+
+          /**
+           * @Then /The result should be (\d+)/
+           */
+          public function theResultShouldBe($result) {
+              PHPUnit\Framework\Assert::assertEquals($result, $this->result);
+          }
+      }
+      """
+    And a file named "features/math.feature" with:
+      """
+      Feature: Math
+        Background:
+          Given I have basic calculator
+
+        Scenario Outline:
+          Given I have entered <number1>
+          And I have entered <number2>
+          When I add
+          Then The result should be <result>
+
+          Examples:
+            | number1 | number2 | result |
+            | 10      | 12      | 22     |
+            | 5       | 3       | 8      |
+            | 5       | 5       | 10     |
+      """
+    And a file named "pretty.yml" with:
+      """
+      pretty_without_paths:
+        formatters:
+          progress: false
+          pretty:
+            paths: false
+
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+
+      progress:
+        formatters:
+          progress: true
+          pretty: false
+
+      preferredProfileName:
+        progress
+
+      imports:
+        - pretty.yml
+      """
+
+  Scenario:
+    Given I run "behat --no-colors features/math.feature"
+    Then it should pass with:
+      """
+      ...............
+
+      3 scenarios (3 passed)
+      15 steps (15 passed)
+      """
+
+  Scenario:
+    Given I run "behat --no-colors features/math.feature --profile progress"
+    Then it should pass with:
+      """
+      ...............
+
+      3 scenarios (3 passed)
+      15 steps (15 passed)
+      """
+
+  Scenario:
+    Given I run "behat --no-colors --profile pretty_without_paths"
+    Then it should pass with:
+      """
+      Feature: Math
+
+        Background:
+          Given I have basic calculator
+
+        Scenario Outline:
+          Given I have entered <number1>
+          And I have entered <number2>
+          When I add
+          Then The result should be <result>
+
+          Examples:
+            | number1 | number2 | result |
+            | 10      | 12      | 22     |
+            | 5       | 3       | 8      |
+            | 5       | 5       | 10     |
+
+      3 scenarios (3 passed)
+      15 steps (15 passed)
+      """

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -213,6 +213,8 @@ final class ConfigurationLoader
     {
         $configs = array();
 
+        $profile = $this->getProfileName($config, $profile);
+
         // first load default profile from current config, but only if custom profile requested
         if ('default' !== $profile && isset($config['default'])) {
             $configs[] = $config['default'];
@@ -229,7 +231,31 @@ final class ConfigurationLoader
             $this->profileFound = true;
         }
 
+        if (!$this->profileFound && isset($config['preferredProfileName'])) {
+            throw new ConfigurationLoadingException(sprintf(
+                'Can not find configuration for `%s` profile.',
+                $config['preferredProfileName']
+            ));
+        }
+
         return $configs;
+    }
+
+    /**
+     * Get the name of the requested profile, after considering any preferred profile name.
+     *
+     * @param array $config
+     * @param string $profile
+     *
+     * @return string
+     */
+    private function getProfileName(array $config, string $profile): string
+    {
+        if (isset($config['preferredProfileName']) && 'default' === $profile) {
+            return $config['preferredProfileName'];
+        }
+
+        return $profile;
     }
 
     /**


### PR DESCRIPTION
In many situations it is desirable to have a specific profile that is
used when none is specified, however because of the way in which all
profiles inherit from the `default` profile, this is not currently
possible.

For example, if you have different MinkExtension configurations for a
range of different browsers, then each browser may only be specified in
its own profile. This works well, but often you will want to specify a
default browser configuration.

To achieve this you may think that you can set the Extension
configuration for your preferred browser into the `default` profile, but
this means that all other profiles will include this configuration, and
may not work as expected.

This change introduces the concept of a preferred profile, which is the
profile which will be used unless the `--profile` CLI argument is
provided to override it.

This means that if you have profiles for chrome, headlesschrome,
firefox, headlessfirefox, edge, and headlessedge, you can choose to
specify a preferred profile of `headlesschrome`, which will be used
unless you explicitly set the `--profile` argument when running behat.