### PR TITLE
Adding "file"-attribute to "testcase"-tag in JUnit format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.9.0] - 2021-02-14
+
+### Added
+ * "file"-attribute in JUnit "testcase"-tag containing the relative filepath to the feature file
+
 ## [3.8.1] - 2020-11-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.9.0] - 2021-02-14
 
 ### Added
- * "file"-attribute in JUnit "testcase"-tag containing the relative filepath to the feature file
+ * [1335](https://github.com/Behat/Behat/pull/1335): "file"-attribute in JUnit "testcase"-tag containing the relative filepath to the feature file
 
 ## [3.8.1] - 2020-11-07
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-mbstring": "*",
-        "behat/gherkin": "^4.6.0",
+        "behat/gherkin": "^4.8.0",
         "behat/transliterator": "^1.2",
         "symfony/console": "^4.4 || ^5.0",
         "symfony/config": "^4.4 || ^5.0",

--- a/features/bootstrap/schema/junit.xsd
+++ b/features/bootstrap/schema/junit.xsd
@@ -48,6 +48,7 @@
             <xs:attribute name="time" type="xs:string" use="optional"/>
             <xs:attribute name="classname" type="xs:string" use="optional"/>
             <xs:attribute name="status" type="xs:string" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -105,24 +105,24 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="World consistency" tests="8" skipped="0" failures="3" errors="2" time="-IGNORE-VALUE-">
-          <testcase name="Undefined" classname="World consistency" status="undefined" time="-IGNORE-VALUE-">
+          <testcase name="Undefined" classname="World consistency" file="features/World.feature" status="undefined" time="-IGNORE-VALUE-">
             <error message="And Something new" type="undefined"/>
           </testcase>
-          <testcase name="Pending" classname="World consistency" status="pending" time="-IGNORE-VALUE-">
+          <testcase name="Pending" classname="World consistency" file="features/World.feature" status="pending" time="-IGNORE-VALUE-">
             <error message="And Something not done yet: TODO: write pending definition" type="pending"/>
           </testcase>
-          <testcase name="Failed" classname="World consistency" status="failed" time="-IGNORE-VALUE-">
+          <testcase name="Failed" classname="World consistency" file="features/World.feature" status="failed" time="-IGNORE-VALUE-">
             <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #1" classname="World consistency" status="failed" time="-IGNORE-VALUE-">
+          <testcase name="Passed &amp; Failed #1" classname="World consistency" file="features/World.feature" status="failed" time="-IGNORE-VALUE-">
             <failure message="Then I must have 16: Failed asserting that 15 matches expected '16'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #2" classname="World consistency" status="passed" time="-IGNORE-VALUE-"/>
-          <testcase name="Passed &amp; Failed #3" classname="World consistency" status="failed" time="-IGNORE-VALUE-">
+          <testcase name="Passed &amp; Failed #2" classname="World consistency" file="features/World.feature" status="passed" time="-IGNORE-VALUE-"/>
+          <testcase name="Passed &amp; Failed #3" classname="World consistency" file="features/World.feature" status="failed" time="-IGNORE-VALUE-">
             <failure message="Then I must have 32: Failed asserting that 33 matches expected '32'."/>
           </testcase>
-          <testcase name="Another Outline #1" classname="World consistency" status="passed" time="-IGNORE-VALUE-"/>
-          <testcase name="Another Outline #2" classname="World consistency" status="passed" time="-IGNORE-VALUE-"/>
+          <testcase name="Another Outline #1" classname="World consistency" file="features/World.feature" status="passed" time="-IGNORE-VALUE-"/>
+          <testcase name="Another Outline #2" classname="World consistency" file="features/World.feature" status="passed" time="-IGNORE-VALUE-"/>
         </testsuite>
       </testsuites>
       """
@@ -192,10 +192,10 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="Adding Feature 1" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding 4 to 10" classname="Adding Feature 1" status="passed" time="-IGNORE-VALUE-"></testcase>
+          <testcase name="Adding 4 to 10" classname="Adding Feature 1" file="features/adding_feature_1.feature" status="passed" time="-IGNORE-VALUE-"></testcase>
         </testsuite>
         <testsuite name="Adding Feature 2" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding 8 to 10" classname="Adding Feature 2" status="passed" time="-IGNORE-VALUE-"></testcase>
+          <testcase name="Adding 8 to 10" classname="Adding Feature 2" file="features/adding_feature_2.feature" status="passed" time="-IGNORE-VALUE-"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -267,8 +267,8 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="World consistency" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding some interesting value" classname="World consistency" status="passed" time="-IGNORE-VALUE-"/>
-          <testcase name="Subtracting some value" classname="World consistency" status="passed" time="-IGNORE-VALUE-"/>
+          <testcase name="Adding some interesting value" classname="World consistency" file="features/World.feature" status="passed" time="-IGNORE-VALUE-"/>
+          <testcase name="Subtracting some value" classname="World consistency" file="features/World.feature" status="passed" time="-IGNORE-VALUE-"/>
         </testsuite>
       </testsuites>
       """
@@ -387,7 +387,7 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="small_kid">
         <testsuite name="Apple Eating" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Eating one apple" classname="Apple Eating" status="passed" time="-IGNORE-VALUE-"/>
+          <testcase name="Eating one apple" classname="Apple Eating" file="features/apple_eating_smallkid.feature" status="passed" time="-IGNORE-VALUE-"/>
         </testsuite>
       </testsuites>
       """
@@ -397,7 +397,7 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="old_man">
         <testsuite name="Apple Eating" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Eating one apple" classname="Apple Eating" status="failed" time="-IGNORE-VALUE-">
+          <testcase name="Eating one apple" classname="Apple Eating" file="features/apple_eating_oldmen.feature" status="failed" time="-IGNORE-VALUE-">
             <failure message="Then I will be stronger: Failed asserting that 0 is not equal to 0."/>
           </testcase>
         </testsuite>
@@ -456,8 +456,8 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="World consistency" tests="2" skipped="2" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Skipped" classname="World consistency" status="skipped" time="-IGNORE-VALUE-"/>
-          <testcase name="Another skipped" classname="World consistency" status="skipped" time="-IGNORE-VALUE-"/>
+          <testcase name="Skipped" classname="World consistency" file="features/World.feature" status="skipped" time="-IGNORE-VALUE-"/>
+          <testcase name="Another skipped" classname="World consistency" file="features/World.feature" status="skipped" time="-IGNORE-VALUE-"/>
         </testsuite>
       </testsuites>
       """
@@ -518,7 +518,7 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="World consistency" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Failed" classname="World consistency" status="failed" time="-IGNORE-VALUE-">
+          <testcase name="Failed" classname="World consistency" file="features/World.feature" status="failed" time="-IGNORE-VALUE-">
             <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
           </testcase>
         </testsuite>
@@ -526,8 +526,8 @@
       """
     And the file "junit/default.xml" should be a valid document according to "junit.xsd"
 
-    Scenario: Aborting due to PHP error
-      Given a file named "features/bootstrap/FeatureContext.php" with:
+  Scenario: Aborting due to PHP error
+    Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
       use Behat\Behat\Context\Context,
@@ -556,7 +556,7 @@
           }
       }
       """
-      And a file named "features/World.feature" with:
+    And a file named "features/World.feature" with:
       """
       Feature: World consistency
         In order to maintain stable behaviors
@@ -568,12 +568,12 @@
           When I add 4
           Then I must have 14
       """
-      When I run "behat --no-colors -f junit -o junit"
-      Then it should fail with:
+    When I run "behat --no-colors -f junit -o junit"
+    Then it should fail with:
       """
       cannot implement Foo - it is not an interface
       """
-      And "junit/default.xml" file xml should be like:
+    And "junit/default.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default"/>
@@ -648,7 +648,7 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="World consistency" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Failed" classname="World consistency" status="failed" time="-IGNORE-VALUE-">
+          <testcase name="Failed" classname="World consistency" file="features/World.feature" status="failed" time="-IGNORE-VALUE-">
             <failure message="Given I have entered 10: failure (Exception)" type="setup"></failure>
           </testcase>
         </testsuite>
@@ -704,7 +704,7 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="World consistency" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Failed" classname="World consistency" status="failed" time="-IGNORE-VALUE-">
+          <testcase name="Failed" classname="World consistency" file="features/World.feature" status="failed" time="-IGNORE-VALUE-">
             <failure message="Given I have entered 10: failure (Exception)" type="teardown"></failure>
           </testcase>
         </testsuite>

--- a/features/syntax_help.feature
+++ b/features/syntax_help.feature
@@ -11,7 +11,7 @@ Feature: Syntax helpers
     When I run "behat --no-colors --story-syntax"
     Then the output should contain:
       """
-      [Business Need|Feature|Ability]: Internal operations
+      [Business Need|Ability|Feature]: Internal operations
         In order to stay secret
         As a secret organization
         We need to be able to erase past agents' memory
@@ -281,7 +281,7 @@ Feature: Syntax helpers
 
           /**
            * Eating apples
-           * 
+           *
            * More details on eating apples, and a list:
            * - one
            * - two

--- a/features/syntax_help.feature
+++ b/features/syntax_help.feature
@@ -318,7 +318,6 @@ Feature: Syntax helpers
 
       default | [When|*] /^I ate (\d+) apples?$/
               | Eating apples
-              |
               | More details on eating apples, and a list:
               | - one
               | - two

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
@@ -165,11 +165,17 @@ final class JUnitFeatureElementListener implements EventListener
             return;
         }
 
+        $file = $event->getFeature()->getFile();
+
+        if (substr($file, 0, strlen(getcwd())) === getcwd()) {
+            $file = ltrim(substr($file, strlen(getcwd())), DIRECTORY_SEPARATOR);
+        }
+
         $this->featurePrinter->printHeader($formatter, $this->beforeFeatureTestedEvent);
 
         foreach ($this->afterScenarioTestedEvents as $afterScenario) {
             $afterScenarioTested = $afterScenario['event'];
-            $this->scenarioPrinter->printOpenTag($formatter, $afterScenarioTested->getFeature(), $afterScenarioTested->getScenario(), $afterScenarioTested->getTestResult());
+            $this->scenarioPrinter->printOpenTag($formatter, $afterScenarioTested->getFeature(), $afterScenarioTested->getScenario(), $afterScenarioTested->getTestResult(), $file);
 
             /** @var AfterStepSetup $afterStepSetup */
             foreach ($afterScenario['step_setup_events'] as $afterStepSetup) {

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
@@ -79,9 +79,9 @@ final class JUnitScenarioPrinter
         $outputPrinter->addTestcase(array(
             'name' => $name,
             'classname' => $feature->getTitle(),
+            'file' => $file,
             'status' => $this->resultConverter->convertResultToString($result),
-            'time' => $this->durationListener ? $this->durationListener->getDuration($scenario) : '',
-            'file' => $file
+            'time' => $this->durationListener ? $this->durationListener->getDuration($scenario) : ''
         ));
     }
 

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
@@ -63,7 +63,7 @@ final class JUnitScenarioPrinter
     /**
      * {@inheritDoc}
      */
-    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result)
+    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result, string $file)
     {
         $name = implode(' ', array_map(function ($l) {
             return trim($l);
@@ -80,7 +80,8 @@ final class JUnitScenarioPrinter
             'name' => $name,
             'classname' => $feature->getTitle(),
             'status' => $this->resultConverter->convertResultToString($result),
-            'time' => $this->durationListener ? $this->durationListener->getDuration($scenario) : ''
+            'time' => $this->durationListener ? $this->durationListener->getDuration($scenario) : '',
+            'file' => $file
         ));
     }
 


### PR DESCRIPTION
This PR adds a "file" attribute to the "testcase" tags in the JUnit output format. This is e.g. necessary when trying to parallelize testruns on CircleCI that can split tests automatically by timing data.

Example of output:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="default">
    <testsuite name="World consistency" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
        <testcase name="Failed" classname="World consistency" file="features/World.feature" status="failed" time="-IGNORE-VALUE-">
            <failure message="Given I have entered 10: failure (Exception)" type="teardown"></failure>
        </testcase>
    </testsuite>
</testsuites>
```