### PR TITLE
Allow Symfony 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
                     -   php: 7.4
                         symfony-version: ^4.4
                     -   php: 8.0
+                    -   php: 8.0
+                        stability: dev
+                        symfony-version: ^6.0
                     -   php: 8.1
 
         steps:
@@ -37,6 +40,10 @@ jobs:
                     php-version: "${{ matrix.php }}"
                     ini-values: "phar.readonly=0,zend.exception_ignore_args=Off"
                     coverage: none
+
+            -   name: Configure Composer minimum stability
+                if: matrix.stability
+                run: composer config minimum-stability ${{ matrix.stability }}
 
             -   name: Update Symfony version
                 if: matrix.symfony-version != ''

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
         "ext-mbstring": "*",
         "behat/gherkin": "^4.8.0",
         "behat/transliterator": "^1.2",
-        "symfony/console": "^4.4 || ^5.0",
-        "symfony/config": "^4.4 || ^5.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0",
-        "symfony/event-dispatcher": "^4.4 || ^5.0",
-        "symfony/translation": "^4.4 || ^5.0",
-        "symfony/yaml": "^4.4 || ^5.0",
+        "symfony/console": "^4.4 || ^5.0 || ^6.0",
+        "symfony/config": "^4.4 || ^5.0 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
+        "symfony/translation": "^4.4 || ^5.0 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.0 || ^6.0",
         "psr/container": "^1.0"
     },
 
     "require-dev": {
-        "symfony/process": "^4.4 || ^5.0",
+        "symfony/process": "^4.4 || ^5.0 || ^6.0",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "herrera-io/box": "~1.6.1",
         "container-interop/container-interop": "^1.2"

--- a/composer.json
+++ b/composer.json
@@ -57,5 +57,6 @@
         }
     },
 
-    "bin": ["bin/behat"]
+    "bin": ["bin/behat"],
+    "minimum-stability": "dev"
 }

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -149,5 +149,5 @@ Feature: Error Reporting
             Exception: Exception is thrown in features/bootstrap/FeatureContext.php:56
             Stack trace:
             #0 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(110): FeatureContext->anExceptionIsThrown()
-            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(Object(Behat\Behat\Definition\Call\DefinitionCall))
+            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(
     """

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -28,7 +28,7 @@ final class ConsoleFormatter extends BaseOutputFormatter
      *
      * @return string The styled message
      */
-    public function format($message)
+    public function format($message): string
     {
         return preg_replace_callback(self::CUSTOM_PATTERN, array($this, 'replaceStyle'), $message);
     }

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -63,7 +63,7 @@ final class Application extends BaseApplication
      *
      * @return InputDefinition An InputDefinition instance
      */
-    public function getDefaultInputDefinition()
+    public function getDefaultInputDefinition(): InputDefinition
     {
         return new InputDefinition(array(
             new InputOption('--profile', '-p', InputOption::VALUE_REQUIRED, 'Specify config profile to use.'),
@@ -124,7 +124,7 @@ final class Application extends BaseApplication
         return parent::doRun($input, $output);
     }
 
-    protected function getDefaultCommands()
+    protected function getDefaultCommands(): array
     {
         $commands = parent::getDefaultCommands();
 
@@ -210,7 +210,7 @@ final class Application extends BaseApplication
      *
      * @return string The command name
      */
-    protected function getCommandName(InputInterface $input)
+    protected function getCommandName(InputInterface $input): string
     {
         if ($input->hasParameterOption(array('--config-reference'))) {
             return 'dump-reference';

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
@@ -26,10 +26,12 @@ final class TestworkEventDispatcher extends EventDispatcher
 
     /**
      * {@inheritdoc}
+     *
+     * @param string|null $eventName
      */
-    public function getListeners($eventName = null)
+    public function getListeners($eventName = null): array
     {
-        if (null == $eventName || self::BEFORE_ALL_EVENTS === $eventName) {
+        if (null === $eventName || self::BEFORE_ALL_EVENTS === $eventName) {
             return parent::getListeners($eventName);
         }
 


### PR DESCRIPTION
Symfony 6 will be released in 5 months, but I think it would be a nice thing to prepare Behat for Symfony 6.

I had to update a test, the stacktrace displayed when an exception is thrown does not contains parameters anymore. Changed `RuntimeCallHandler->executeCall(Object(Behat\Behat\Definition\Call\DefinitionCall))` to `RuntimeCallHandler->executeCall(Object(` to fix that:
![2021-06-20_21-10](https://user-images.githubusercontent.com/2103975/122685577-89e72700-d20c-11eb-814b-25faeb559b0b.png)


WDYT?

