### PR TITLE
Remove support for PHP 7.2 and 7.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,15 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    -   php: 7.2
-                        publish-phar: true
-                    -   php: 7.2
-                        skip-interop: true
-                    -   php: 7.2
-                        composer-flags: --prefer-lowest
-                    -   php: 7.3
                     -   php: 7.4
+                        publish-phar: true
+                    -   php: 7.4
+                        skip-interop: true
+                    -   php: 7.4
+                        composer-flags: --prefer-lowest
                     -   php: 7.4
                         symfony-version: ^4.4
+                    -   php: 7.4
                     -   php: 8.0
                     -   php: 8.1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ init:
 install:
     - ps: |
         if (!(Test-Path c:\tools\php)) {
-            appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version 7.2
+            appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version 7.4
             Get-ChildItem -Path c:\tools\php
             cd c:\tools\php
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
 
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-mbstring": "*",
         "behat/gherkin": "^4.8.0",
         "behat/transliterator": "^1.2",


### PR DESCRIPTION
PHP 7.2 is not maintained at all anymore and PHP 7.3's security support ends in 2 months.