### PR TITLE
Remove minimum-stability dev from composer.json & require Gherkin ^4.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-mbstring": "*",
-        "behat/gherkin": "^4.8.0",
+        "behat/gherkin": "^4.9.0",
         "behat/transliterator": "^1.2",
         "symfony/console": "^4.4 || ^5.0 || ^6.0",
         "symfony/config": "^4.4 || ^5.0 || ^6.0",

--- a/features/syntax_help.feature
+++ b/features/syntax_help.feature
@@ -64,7 +64,7 @@ Feature: Syntax helpers
           [Затем|Тогда|То|*] there should be agent J
           [Иначе|Но|*|А] there should not be agent K
 
-        Структура сценария: Erasing other agents' memory
+        [Структура сценария|Шаблон сценария]: Erasing other agents' memory
           [Допустим|Пусть|Дано|*] there is agent <agent1>
           [К тому же|Также|*|И] there is agent <agent2>
           [Когда|Если|*] I erase agent <agent2>'s memory


### PR DESCRIPTION
It was introduced in #1346, made every build require unstable dependencies.