### PR TITLE
Added failed scenario statistics to progress statistics printer

### DIFF
--- a/features/progress_format.feature
+++ b/features/progress_format.feature
@@ -1,0 +1,35 @@
+Feature: Progress format
+
+  In order to show large test results rapidly, the progress formatter uses a dot notation to use very little terminal space
+
+  Scenario: Failing scenarios are listed at the end of output
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context,
+          Behat\Behat\Tester\Exception\PendingException;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @Given a failing step
+           */
+          public function fail() {
+              throw new \Exception('oops');
+          }
+      }
+      """
+    And a file named "features/World.feature" with:
+      """
+      Feature:
+        Scenario: Undefined
+          Given a failing step
+      """
+    When I run "behat --format=progress"
+    Then it should fail with:
+      """
+      --- Failed scenarios:
+
+          features/World.feature:2
+      """

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
@@ -64,6 +64,9 @@ final class ProgressStatisticsPrinter implements StatisticsPrinter
         $stepStats = $statistics->getPendingSteps();
         $this->listPrinter->printStepList($printer, 'pending_steps_title', TestResult::PENDING, $stepStats);
 
+        $scenarioStats = $statistics->getFailedScenarios();
+        $this->listPrinter->printScenariosList($printer, 'failed_scenarios_title', TestResult::FAILED, $scenarioStats);
+
         $this->counterPrinter->printCounters($printer, 'scenarios_count', $statistics->getScenarioStatCounts());
         $this->counterPrinter->printCounters($printer, 'steps_count', $statistics->getStepStatCounts());
 


### PR DESCRIPTION
When using the --progress option with behat there was a situation where an issue failed in an @AfterStep context. The information printed to the output was not sufficient to determine in which feature file or scenario the issue occured. With the simple addition proposed a listing of the failed scenarios will be printed at the end of the run, thus greatly simplifying the task of finding the offending scenario, especially in a large suite such as ours with hundreds of feature files.

Example:
`
[2022-06-20T14:18:31.605Z] ...................................................................... 5180

[2022-06-20T14:18:36.955Z] ...................................................................... 5250

[2022-06-20T14:18:40.835Z] ..................................................----

[2022-06-20T14:18:40.835Z] 

[2022-06-20T14:18:40.835Z] --- Failed hooks:

[2022-06-20T14:18:40.835Z] 

[2022-06-20T14:18:40.835Z]     AfterStep # ****Context::verifyHtml()

[2022-06-20T14:18:40.835Z]       Behat\Mink\Exception\ExpectationException: HTML errors were found in page: http://web:8080/************ Errors: 

[2022-06-20T14:18:40.835Z]       Line: 183 Error: Element “div” not allowed as child of element “a” in this context. 

(Suppressing further errors from this subtree.)

[2022-06-20T14:18:40.835Z]       Line: 183 Error: Heading cannot be a child of another heading.

[2022-06-20T14:18:40.835Z]       Line: 183 Error: Stray end tag “h2”. in sites/default/modules/custom/eyp/eyp.behat.inc:900

[2022-06-20T14:18:40.835Z]       Stack trace:

[2022-06-20T14:18:40.835Z] 

[2022-06-20T14:18:40.835Z] 689 scenarios (688 passed, 1 failed)

[2022-06-20T14:18:40.835Z] 5304 steps (5300 passed, 4 skipped)

[2022-06-20T14:18:40.835Z] 10m33.02s (195.65Mb)

script returned exit code 1
`