### PR TITLE
Fix CI fails because symfony/flex is blocked

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,9 @@ jobs:
                 run: composer config minimum-stability ${{ matrix.stability }}
 
             -   name: Install symfony/flex
-                run: composer global require symfony/flex
+                run: |
+                    composer config --global --no-plugins allow-plugins.symfony/flex true &&
+                    composer global require symfony/flex
 
             -   name: Uninstall Psalm
                 run: composer remove --dev --no-update vimeo/psalm


### PR DESCRIPTION
## Problem:
When running the workflow, it fails at the "Install symfony/flex" step with the following error:

Error: symfony/flex contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.

## Cause:
A newer version of Composer has introduced a strict check whereby all plugins have to be explicitly allowed for security reasons.

## Fix:
Explicitly allow the global plugin before installing it.