### PR TITLE
Deprecated error PHP 8.1 compatibility.

### DIFF
--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -115,7 +115,7 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
     private function addAttributesToNode(\DOMElement $node, array $attributes)
     {
         foreach ($attributes as $name => $value){
-            $node->setAttribute($name, $value);
+            $node->setAttribute($name, $value ?? '');
         }
     }
 


### PR DESCRIPTION
Issue #1411 
The following error appears working with a Drupal when launching behat tests:

`Deprecated function: DOMElement::setAttribute(): Passing null to parameter #2 ($value) of type string is deprecated in Behat\Testwork\Output\Printer\JUnitOutputPrinter->addAttributesToNode() (line 118 of /var/www/html/vendor/behat/behat/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php)`

The problem is solved by substituting an empty string for those cases where the value is NULL, which is now deprecated.