### PR TITLE
Add prophecy back to PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "symfony/process": "^4.4 || ^5.0 || ^6.0",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "herrera-io/box": "~1.6.1",
-        "vimeo/psalm": "^4.8"
+        "vimeo/psalm": "^4.8",
+        "phpspec/prophecy": "^1.15"
     },
 
     "suggest": {


### PR DESCRIPTION
PHPUnit has dropped Prophecy as a dependency but we use it, so this adds the dependency

When PHPUnit comes out we should remove prophecy dependency probably