### PR TITLE
feature: `--allow-no-tests` option to pass even if no specifications found

### DIFF
--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -102,6 +102,12 @@ final class ExerciseController implements Controller
                 null,
                 InputOption::VALUE_NONE,
                 'Invokes formatters without executing the tests and hooks.'
+            )
+            ->addOption(
+                '--allow-no-tests',
+                null,
+                InputOption::VALUE_NONE,
+                'Will not fail if no specifications are found.'
             );
     }
 
@@ -113,7 +119,7 @@ final class ExerciseController implements Controller
         $specs = $this->findSpecifications($input);
         $result = $this->testSpecifications($input, $specs);
 
-        if ($input->getArgument('paths') && TestResults::NO_TESTS === $result->getResultCode()) {
+        if ($input->getArgument('paths') && !$input->getOption('allow-no-tests') && TestResults::NO_TESTS === $result->getResultCode()) {
             throw new WrongPathsException(
                 sprintf(
                     'No specifications found at path(s) `%s`. This might be because of incorrect paths configuration in your `suites`.',


### PR DESCRIPTION
In our CI we split out test jobs based on folder. Additionally we run each `.feature` file individually so we can create output test groups. However, due to how we've arranged our tags and our test matrices it could be that Behat is called with a path to a file that has all tests excluded using a tag.

The change in this PR provides an option to mute this error and prevent a CI from failing when no tests were executed deliberately.

Fixes #1389