### PR TITLE
bug: Fix high memory consumption when using Junit formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+* [#1103](https://github.com/Behat/Behat/issues/1103) Reduce memory consumption of Junit formatter [@simon-auch](https://github.com/simon-auch)
+
 ## [3.12.0] - 2022-11-29
 
 ### Added

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
@@ -96,9 +96,10 @@ final class JUnitFeatureElementListener implements EventListener
      */
     private function printFeatureOnBeforeEvent(Formatter $formatter, Event $event)
     {
-        if ($event instanceof BeforeFeatureTested) {
-            $this->featurePrinter->printHeader($formatter, $event->getFeature());
+        if (!$event instanceof BeforeFeatureTested) {
+            return;
         }
+        $this->featurePrinter->printHeader($formatter, $event->getFeature());
     }
 
     /**
@@ -120,32 +121,33 @@ final class JUnitFeatureElementListener implements EventListener
      * Captures scenario tested event.
      *
      * @param Formatter $formatter
-     * @param ScenarioTested $event
+     * @param Event $event
      */
     private function printScenarioEvent(Formatter $formatter, Event $event)
     {
-        if ($event instanceof AfterScenarioTested) {
-            $afterScenarioTested = $event;
-            $this->scenarioPrinter->printOpenTag(
-                $formatter,
-                $afterScenarioTested->getFeature(),
-                $afterScenarioTested->getScenario(),
-                $afterScenarioTested->getTestResult(),
-                $event->getFeature()->getFile()
-            );
-
-            /** @var AfterStepSetup $afterStepSetup */
-            foreach ($this->afterStepSetupEvents as $afterStepSetup) {
-                $this->setupPrinter->printSetup($formatter, $afterStepSetup->getSetup());
-            }
-            foreach ($this->afterStepTestedEvents as $afterStepTested) {
-                $this->stepPrinter->printStep($formatter, $afterScenarioTested->getScenario(), $afterStepTested->getStep(), $afterStepTested->getTestResult());
-                $this->setupPrinter->printTeardown($formatter, $afterStepTested->getTeardown());
-            }
-
-            $this->afterStepTestedEvents = array();
-            $this->afterStepSetupEvents = array();
+        if (!$event instanceof AfterScenarioTested) {
+            return;
         }
+        $afterScenarioTested = $event;
+        $this->scenarioPrinter->printOpenTag(
+            $formatter,
+            $afterScenarioTested->getFeature(),
+            $afterScenarioTested->getScenario(),
+            $afterScenarioTested->getTestResult(),
+            $event->getFeature()->getFile()
+        );
+
+        /** @var AfterStepSetup $afterStepSetup */
+        foreach ($this->afterStepSetupEvents as $afterStepSetup) {
+            $this->setupPrinter->printSetup($formatter, $afterStepSetup->getSetup());
+        }
+        foreach ($this->afterStepTestedEvents as $afterStepTested) {
+            $this->stepPrinter->printStep($formatter, $afterScenarioTested->getScenario(), $afterStepTested->getStep(), $afterStepTested->getTestResult());
+            $this->setupPrinter->printTeardown($formatter, $afterStepTested->getTeardown());
+        }
+
+        $this->afterStepTestedEvents = array();
+        $this->afterStepSetupEvents = array();
     }
 
     /**
@@ -156,8 +158,9 @@ final class JUnitFeatureElementListener implements EventListener
      */
     private function printFeatureOnAfterEvent(Formatter $formatter, Event $event)
     {
-        if ($event instanceof AfterFeatureTested) {
-            $this->featurePrinter->printFooter($formatter, $event->getTestResult());
+        if (!$event instanceof AfterFeatureTested) {
+            return;
         }
+        $this->featurePrinter->printFooter($formatter, $event->getTestResult());
     }
 }

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
@@ -54,7 +54,7 @@ final class JUnitFeatureElementListener implements EventListener
      */
     private $afterStepTestedEvents = array();
     /**
-     * @var AfterSetup[]
+     * @var AfterStepSetup[]
      */
     private $afterStepSetupEvents = array();
 
@@ -118,7 +118,7 @@ final class JUnitFeatureElementListener implements EventListener
     }
 
     /**
-     * Captures scenario tested event.
+     * Prints the scenario tested event.
      *
      * @param Formatter $formatter
      * @param Event $event
@@ -137,7 +137,6 @@ final class JUnitFeatureElementListener implements EventListener
             $event->getFeature()->getFile()
         );
 
-        /** @var AfterStepSetup $afterStepSetup */
         foreach ($this->afterStepSetupEvents as $afterStepSetup) {
             $this->setupPrinter->printSetup($formatter, $afterStepSetup->getSetup());
         }

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -88,7 +88,7 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
     /**
      * Extends the current <testsuite> node.
      *
-     * @param array $testsuiteAttributes
+     * @param array<string, string|int|null> $testsuiteAttributes
      */
     public function extendTestsuiteAttributes(array $testsuiteAttributes)
     {

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -90,7 +90,8 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
      *
      * @param array $testsuiteAttributes
      */
-    public function extendTestsuiteAttributes(array $testsuiteAttributes = array()){
+    public function extendTestsuiteAttributes(array $testsuiteAttributes = array())
+    {
         $this->addAttributesToNode($this->currentTestsuite, $testsuiteAttributes);
     }
 

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -90,7 +90,7 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
      *
      * @param array $testsuiteAttributes
      */
-    public function extendTestsuiteAttributes(array $testsuiteAttributes = array())
+    public function extendTestsuiteAttributes(array $testsuiteAttributes)
     {
         $this->addAttributesToNode($this->currentTestsuite, $testsuiteAttributes);
     }

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -85,6 +85,15 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
         $this->addAttributesToNode($this->currentTestsuite, $testsuiteAttributes);
     }
 
+    /**
+     * Extends the current <testsuite> node.
+     *
+     * @param array $testsuiteAttributes
+     */
+    public function extendTestsuiteAttributes(array $testsuiteAttributes = array()){
+        $this->addAttributesToNode($this->currentTestsuite, $testsuiteAttributes);
+    }
+
 
     /**
      * Adds a new <testcase> node.


### PR DESCRIPTION
The high memory consumption is caused by the formatter keeping many events for the lifetime of a feature.
Some events contain references to the BehatContext, resulting in the BehatContext not being dropped.
If a feature contains many scenarios/examples and the BehatContext is big, this can lead to OoM errors.

This commit drastically reduces the amount of events the Junit formatter keeps and limits the lifetime of those it keeps to the lifetime of an example.

This PR fixes https://github.com/Behat/Behat/issues/1103