### PR TITLE
Exception stringification followup

### DIFF
--- a/src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
@@ -35,17 +35,24 @@ final class PHPUnitExceptionStringer implements ExceptionStringer
      */
     public function stringException(Exception $exception, $verbosity)
     {
-        if (class_exists('PHPUnit\\Util\\ThrowableToStringMapper')) {
-            return trim(\PHPUnit\Util\ThrowableToStringMapper::map($exception));
-        }
-
-        if (!class_exists('PHPUnit\\Framework\\TestFailure')) {
-            return trim(\PHPUnit_Framework_TestFailure::exceptionToString($exception));
-        }
-
         // PHPUnit assertion exceptions do not include expected / observed info in their
         // messages, but expect the test listeners to format that info like the following
         // (see e.g. PHPUnit_TextUI_ResultPrinter::printDefectTrace)
-        return trim(\PHPUnit\Framework\TestFailure::exceptionToString($exception));
+
+        switch (true) {
+            case class_exists(\PHPUnit\Util\ThrowableToStringMapper::class):
+                return trim(\PHPUnit\Util\ThrowableToStringMapper::map($exception));
+
+            case class_exists(\PHPUnit\Framework\TestFailure::class):
+                return trim(\PHPUnit\Framework\TestFailure::exceptionToString($exception));
+
+            case class_exists(\PHPUnit_Framework_TestFailure::class):
+                return trim(\PHPUnit_Framework_TestFailure::exceptionToString($exception));
+
+            default:
+                throw new \RuntimeException(
+                    'Cannot stringify PHPUnit exception, a valid stringifier class could not be found'
+                );
+        }
     }
 }


### PR DESCRIPTION
This is the follow up for https://github.com/Behat/Behat/issues/1421#issuecomment-1500089547

On a side note, I'm wondering if `supportsException` should also check for the stringification classes.
Although its name relates to the exception, the usage actually relates to if it can stringify an exception or not.