### PR TITLE
Uniformize files coding style

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Enforce php-cs-fixer new rules
+59dbff8de6a45fa6cbd7fb6c37075c151562b875

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$header = <<<'OEF'
+This file is part of the Behat.
+(c) Konstantin Kudryashov <ever.zet@gmail.com>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+OEF;
+
+$rules = [
+    '@PSR2' => true,
+    '@PSR12' => true,
+    '@PhpCsFixer' => true,
+    'header_comment' => ['header' => $header],
+    'array_syntax' => ['syntax' => 'short'],
+    'class_definition' => ['multi_line_extends_each_single_line' => true],
+	'concat_space' => false,
+    'heredoc_to_nowdoc' => true,
+	'php_unit_strict' => false,
+	'php_unit_construct' => true,
+	'php_unit_internal_class' => false,
+	'php_unit_test_class_requires_covers' => false,
+	'php_unit_test_case_static_method_calls' => false,
+    'phpdoc_add_missing_param_annotation' => true,
+    'phpdoc_order' => true,
+    'phpdoc_to_comment' => false,
+    'phpdoc_separation' => false,
+    'strict_comparison' => true,
+    'strict_param' => true,
+    'no_extra_blank_lines' => [
+        'tokens' => [
+            'break',
+            'continue',
+            'extra',
+            'return',
+            'throw',
+            'use',
+            'parenthesis_brace_block',
+            'square_brace_block',
+            'curly_brace_block',
+        ],
+    ],
+    'echo_tag_syntax' => true,
+    'semicolon_after_instruction' => true,
+	'single_line_comment_style' => false,
+    'combine_consecutive_unsets' => true,
+    'ternary_to_null_coalescing' => true,
+    'no_unused_imports' => true,
+    'no_superfluous_phpdoc_tags' => [
+        'allow_mixed' => true,
+    ],
+    'phpdoc_no_empty_return' => true,
+    'single_blank_line_at_eof' => true,
+    'yoda_style' => false,
+    'nullable_type_declaration_for_default_null_value' => true,
+	'multiline_whitespace_before_semicolons' => false
+];
+
+$finder = Finder::create()
+    ->in('src')
+    ->in('tests')
+    ->notPath('bootstrap.php');
+
+return (new Config())
+    ->setFinder($finder)
+    ->setRules($rules)
+    ->setRiskyAllowed(true);

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -151,6 +151,6 @@ Feature: Error Reporting
           When an exception is thrown # features/exception_in_scenario.feature:7
             Exception: Exception is thrown in features/bootstrap/FeatureContext.php:59
             Stack trace:
-            #0 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(110): FeatureContext->anExceptionIsThrown()
-            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(
+            #0 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(108): FeatureContext->anExceptionIsThrown()
+            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(65): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(
     """

--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -14,11 +14,11 @@ use Behat\Behat\Context\ServiceContainer\ContextExtension;
 use Behat\Behat\Definition\ServiceContainer\DefinitionExtension;
 use Behat\Behat\EventDispatcher\ServiceContainer\EventDispatcherExtension;
 use Behat\Behat\Gherkin\ServiceContainer\GherkinExtension;
+use Behat\Behat\HelperContainer\ServiceContainer\HelperContainerExtension;
 use Behat\Behat\Hook\ServiceContainer\HookExtension;
 use Behat\Behat\Output\ServiceContainer\Formatter\JUnitFormatterFactory;
 use Behat\Behat\Output\ServiceContainer\Formatter\PrettyFormatterFactory;
 use Behat\Behat\Output\ServiceContainer\Formatter\ProgressFormatterFactory;
-use Behat\Behat\HelperContainer\ServiceContainer\HelperContainerExtension;
 use Behat\Behat\Snippet\ServiceContainer\SnippetExtension;
 use Behat\Behat\Tester\ServiceContainer\TesterExtension;
 use Behat\Behat\Transformation\ServiceContainer\TransformationExtension;
@@ -71,9 +71,9 @@ final class ApplicationFactory extends BaseFactory
     {
         $processor = new ServiceProcessor();
 
-        return array(
+        return [
             new ArgumentExtension(),
-            new AutoloaderExtension(array('' => '%paths.base%/features/bootstrap')),
+            new AutoloaderExtension(['' => '%paths.base%/features/bootstrap']),
             new SuiteExtension($processor),
             new OutputExtension('pretty', $this->getDefaultFormatterFactories($processor), $processor),
             new ExceptionExtension($processor),
@@ -93,8 +93,8 @@ final class ApplicationFactory extends BaseFactory
             new HookExtension(),
             new TransformationExtension($processor),
             new OrderingExtension($processor),
-            new HelperContainerExtension($processor)
-        );
+            new HelperContainerExtension($processor),
+        ];
     }
 
     /**
@@ -112,7 +112,7 @@ final class ApplicationFactory extends BaseFactory
     {
         $cwd = rtrim(getcwd(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $configDir = $cwd . 'config' . DIRECTORY_SEPARATOR;
-        $paths = array(
+        $paths = [
             $cwd . 'behat.yaml',
             $cwd . 'behat.yml',
             $cwd . 'behat.yaml.dist',
@@ -121,7 +121,7 @@ final class ApplicationFactory extends BaseFactory
             $configDir . 'behat.yml',
             $configDir . 'behat.yaml.dist',
             $configDir . 'behat.yml.dist',
-        );
+        ];
 
         foreach ($paths as $path) {
             if (is_file($path)) {
@@ -135,16 +135,14 @@ final class ApplicationFactory extends BaseFactory
     /**
      * Returns default formatter factories.
      *
-     * @param ServiceProcessor $processor
-     *
      * @return FormatterFactory[]
      */
     private function getDefaultFormatterFactories(ServiceProcessor $processor)
     {
-        return array(
+        return [
             new PrettyFormatterFactory($processor),
             new ProgressFormatterFactory($processor),
             new JUnitFormatterFactory(),
-        );
+        ];
     }
 }

--- a/src/Behat/Behat/Context/Annotation/AnnotationReader.php
+++ b/src/Behat/Behat/Context/Annotation/AnnotationReader.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\Context\Annotation;
 
 use Behat\Behat\Context\Reader\AnnotatedContextReader;
 use Behat\Testwork\Call\Callee;
-use ReflectionMethod;
 
 /**
  * Reads custom annotation of a provided context method into a Callee.
@@ -26,12 +25,11 @@ interface AnnotationReader
     /**
      * Reads all callees associated with a provided method.
      *
-     * @param string           $contextClass
-     * @param ReflectionMethod $method
-     * @param string           $docLine
-     * @param string           $description
+     * @param string $contextClass
+     * @param string $docLine
+     * @param string $description
      *
      * @return null|Callee
      */
-    public function readCallee($contextClass, ReflectionMethod $method, $docLine, $description);
+    public function readCallee($contextClass, \ReflectionMethod $method, $docLine, $description);
 }

--- a/src/Behat/Behat/Context/Annotation/DocBlockHelper.php
+++ b/src/Behat/Behat/Context/Annotation/DocBlockHelper.php
@@ -11,7 +11,7 @@
 namespace Behat\Behat\Context\Annotation;
 
 /**
- * Helper class for DocBlock parsing
+ * Helper class for DocBlock parsing.
  */
 class DocBlockHelper
 {

--- a/src/Behat/Behat/Context/Argument/ArgumentResolver.php
+++ b/src/Behat/Behat/Context/Argument/ArgumentResolver.php
@@ -11,7 +11,6 @@
 namespace Behat\Behat\Context\Argument;
 
 use Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler;
-use ReflectionClass;
 
 /**
  * Resolves arguments of context constructors.
@@ -25,10 +24,9 @@ interface ArgumentResolver
     /**
      * Resolves context constructor arguments.
      *
-     * @param ReflectionClass $classReflection
-     * @param mixed[]         $arguments
+     * @param mixed[] $arguments
      *
      * @return mixed[]
      */
-    public function resolveArguments(ReflectionClass $classReflection, array $arguments);
+    public function resolveArguments(\ReflectionClass $classReflection, array $arguments);
 }

--- a/src/Behat/Behat/Context/Argument/ArgumentResolverFactory.php
+++ b/src/Behat/Behat/Context/Argument/ArgumentResolverFactory.php
@@ -24,8 +24,6 @@ interface ArgumentResolverFactory
     /**
      * Builds argument resolvers for provided suite.
      *
-     * @param Environment $environment
-     *
      * @return ArgumentResolver[]
      */
     public function createArgumentResolvers(Environment $environment);

--- a/src/Behat/Behat/Context/Argument/CompositeArgumentResolverFactory.php
+++ b/src/Behat/Behat/Context/Argument/CompositeArgumentResolverFactory.php
@@ -24,12 +24,10 @@ final class CompositeArgumentResolverFactory implements ArgumentResolverFactory
     /**
      * @var ArgumentResolverFactory[]
      */
-    private $factories = array();
+    private $factories = [];
 
     /**
      * Registers factory.
-     *
-     * @param ArgumentResolverFactory $factory
      */
     public function registerFactory(ArgumentResolverFactory $factory)
     {
@@ -46,7 +44,7 @@ final class CompositeArgumentResolverFactory implements ArgumentResolverFactory
             function (array $resolvers, ArgumentResolverFactory $factory) use ($environment) {
                 return array_merge($resolvers, $factory->createArgumentResolvers($environment));
             },
-            array()
+            []
         );
     }
 }

--- a/src/Behat/Behat/Context/Argument/CompositeFactory.php
+++ b/src/Behat/Behat/Context/Argument/CompositeFactory.php
@@ -26,12 +26,10 @@ final class CompositeFactory implements SuiteScopedResolverFactory
     /**
      * @var SuiteScopedResolverFactory[]
      */
-    private $factories = array();
+    private $factories = [];
 
     /**
      * Registers factory.
-     *
-     * @param SuiteScopedResolverFactory $factory
      */
     public function registerFactory(SuiteScopedResolverFactory $factory)
     {
@@ -48,7 +46,7 @@ final class CompositeFactory implements SuiteScopedResolverFactory
             function (array $resolvers, SuiteScopedResolverFactory $factory) use ($suite) {
                 return array_merge($resolvers, $factory->generateArgumentResolvers($suite));
             },
-            array()
+            []
         );
     }
 }

--- a/src/Behat/Behat/Context/Argument/NullFactory.php
+++ b/src/Behat/Behat/Context/Argument/NullFactory.php
@@ -27,7 +27,7 @@ final class NullFactory implements ArgumentResolverFactory, SuiteScopedResolverF
      */
     public function generateArgumentResolvers(Suite $suite)
     {
-        return array();
+        return [];
     }
 
     /**
@@ -35,6 +35,6 @@ final class NullFactory implements ArgumentResolverFactory, SuiteScopedResolverF
      */
     public function createArgumentResolvers(Environment $environment)
     {
-        return array();
+        return [];
     }
 }

--- a/src/Behat/Behat/Context/Argument/SuiteScopedResolverFactory.php
+++ b/src/Behat/Behat/Context/Argument/SuiteScopedResolverFactory.php
@@ -26,8 +26,6 @@ interface SuiteScopedResolverFactory
     /**
      * Creates argument resolvers for provided suite.
      *
-     * @param Suite $suite
-     *
      * @return ArgumentResolver[]
      */
     public function generateArgumentResolvers(Suite $suite);

--- a/src/Behat/Behat/Context/Argument/SuiteScopedResolverFactoryAdapter.php
+++ b/src/Behat/Behat/Context/Argument/SuiteScopedResolverFactoryAdapter.php
@@ -30,8 +30,6 @@ final class SuiteScopedResolverFactoryAdapter implements ArgumentResolverFactory
 
     /**
      * Initialises adapter.
-     *
-     * @param SuiteScopedResolverFactory $factory
      */
     public function __construct(SuiteScopedResolverFactory $factory)
     {

--- a/src/Behat/Behat/Context/Attribute/AttributeReader.php
+++ b/src/Behat/Behat/Context/Attribute/AttributeReader.php
@@ -10,8 +10,6 @@
 
 namespace Behat\Behat\Context\Attribute;
 
-use ReflectionMethod;
-
 /**
  * Reads Attributes of a provided context method into a Callee.
  *
@@ -24,10 +22,7 @@ interface AttributeReader
     /**
      * Reads all callees associated with a provided method.
      *
-     * @param string           $contextClass
-     * @param ReflectionMethod $method
-     *
      * @return array
      */
-    public function readCallees(string $contextClass, ReflectionMethod $method);
+    public function readCallees(string $contextClass, \ReflectionMethod $method);
 }

--- a/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
+++ b/src/Behat/Behat/Context/Cli/ContextSnippetsController.php
@@ -10,13 +10,13 @@
 
 namespace Behat\Behat\Context\Cli;
 
+use Behat\Behat\Context\Snippet\Generator\AggregateContextIdentifier;
 use Behat\Behat\Context\Snippet\Generator\AggregatePatternIdentifier;
 use Behat\Behat\Context\Snippet\Generator\ContextInterfaceBasedContextIdentifier;
 use Behat\Behat\Context\Snippet\Generator\ContextInterfaceBasedPatternIdentifier;
 use Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator;
 use Behat\Behat\Context\Snippet\Generator\FixedContextIdentifier;
 use Behat\Behat\Context\Snippet\Generator\FixedPatternIdentifier;
-use Behat\Behat\Context\Snippet\Generator\AggregateContextIdentifier;
 use Behat\Behat\Definition\Translator\TranslatorInterface;
 use Behat\Testwork\Cli\Controller;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -35,6 +35,7 @@ final class ContextSnippetsController implements Controller
      * @var ContextSnippetGenerator
      */
     private $generator;
+
     /**
      * @var TranslatorInterface
      */
@@ -42,9 +43,6 @@ final class ContextSnippetsController implements Controller
 
     /**
      * Initialises controller.
-     *
-     * @param ContextSnippetGenerator $generator
-     * @param TranslatorInterface     $translator
      */
     public function __construct(ContextSnippetGenerator $generator, TranslatorInterface $translator)
     {
@@ -59,12 +57,16 @@ final class ContextSnippetsController implements Controller
     {
         $command
             ->addOption(
-                '--snippets-for', null, InputOption::VALUE_OPTIONAL,
-                "Specifies which context class to generate snippets for."
+                '--snippets-for',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Specifies which context class to generate snippets for.'
             )
             ->addOption(
-                '--snippets-type', null, InputOption::VALUE_REQUIRED,
-                "Specifies which type of snippets (turnip, regex) to generate."
+                '--snippets-type',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Specifies which type of snippets (turnip, regex) to generate.'
             );
     }
 
@@ -74,18 +76,18 @@ final class ContextSnippetsController implements Controller
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $this->generator->setContextIdentifier(
-            new AggregateContextIdentifier(array(
+            new AggregateContextIdentifier([
                 new ContextInterfaceBasedContextIdentifier(),
                 new FixedContextIdentifier($input->getOption('snippets-for')),
-                new InteractiveContextIdentifier($this->translator, $input, $output)
-            ))
+                new InteractiveContextIdentifier($this->translator, $input, $output),
+            ])
         );
 
         $this->generator->setPatternIdentifier(
-            new AggregatePatternIdentifier(array(
+            new AggregatePatternIdentifier([
                 new ContextInterfaceBasedPatternIdentifier(),
-                new FixedPatternIdentifier($input->getOption('snippets-type'))
-            ))
+                new FixedPatternIdentifier($input->getOption('snippets-type')),
+            ])
         );
     }
 }

--- a/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
+++ b/src/Behat/Behat/Context/Cli/InteractiveContextIdentifier.php
@@ -29,10 +29,12 @@ final class InteractiveContextIdentifier implements TargetContextIdentifier
      * @var TranslatorInterface
      */
     private $translator;
+
     /**
      * @var InputInterface
      */
     private $input;
+
     /**
      * @var OutputInterface
      */
@@ -40,10 +42,6 @@ final class InteractiveContextIdentifier implements TargetContextIdentifier
 
     /**
      * Initialises identifier.
-     *
-     * @param TranslatorInterface $translator
-     * @param InputInterface      $input
-     * @param OutputInterface     $output
      */
     public function __construct(TranslatorInterface $translator, InputInterface $input, OutputInterface $output)
     {
@@ -68,8 +66,8 @@ final class InteractiveContextIdentifier implements TargetContextIdentifier
             return null;
         }
 
-        $message = $this->translator->trans('snippet_context_choice', array('%count%' => $suiteName), 'output');
-        $choices = array_values(array_merge(array('None'), $contextClasses));
+        $message = $this->translator->trans('snippet_context_choice', ['%count%' => $suiteName], 'output');
+        $choices = array_values(array_merge(['None'], $contextClasses));
         $default = 1;
 
         $answer = $this->askQuestion('>> ' . $message, $choices, $default);

--- a/src/Behat/Behat/Context/ContextClass/ClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/ClassGenerator.php
@@ -25,7 +25,6 @@ interface ClassGenerator
     /**
      * Checks if generator supports provided context class.
      *
-     * @param Suite  $suite
      * @param string $contextClass
      *
      * @return bool
@@ -35,7 +34,6 @@ interface ClassGenerator
     /**
      * Generates context class code.
      *
-     * @param Suite  $suite
      * @param string $contextClass
      *
      * @return string The context class source code

--- a/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
@@ -22,7 +22,7 @@ final class SimpleClassGenerator implements ClassGenerator
     /**
      * @var string
      */
-    protected static $template = <<<'PHP'
+    private static $template = <<<'PHP'
 <?php
 
 {namespace}use Behat\Behat\Context\Context;
@@ -71,10 +71,10 @@ PHP;
 
         return strtr(
             static::$template,
-            array(
+            [
                 '{namespace}' => $namespace,
                 '{className}' => $contextClass,
-            )
+            ]
         );
     }
 }

--- a/src/Behat/Behat/Context/ContextFactory.php
+++ b/src/Behat/Behat/Context/ContextFactory.php
@@ -10,11 +10,10 @@
 
 namespace Behat\Behat\Context;
 
-use Behat\Testwork\Argument\Validator;
 use Behat\Behat\Context\Argument\ArgumentResolver;
 use Behat\Behat\Context\Initializer\ContextInitializer;
 use Behat\Testwork\Argument\ArgumentOrganiser;
-use ReflectionClass;
+use Behat\Testwork\Argument\Validator;
 
 /**
  * Instantiates contexts using registered argument resolvers and context initializers.
@@ -27,14 +26,17 @@ final class ContextFactory
      * @var ArgumentOrganiser
      */
     private $argumentOrganiser;
+
     /**
      * @var ArgumentResolver[]
      */
-    private $argumentResolvers = array();
+    private $argumentResolvers = [];
+
     /**
      * @var ContextInitializer[]
      */
-    private $contextInitializers = array();
+    private $contextInitializers = [];
+
     /**
      * @var Validator
      */
@@ -42,8 +44,6 @@ final class ContextFactory
 
     /**
      * Initialises factory.
-     *
-     * @param ArgumentOrganiser $argumentOrganiser
      */
     public function __construct(ArgumentOrganiser $argumentOrganiser)
     {
@@ -53,8 +53,6 @@ final class ContextFactory
 
     /**
      * Registers context argument resolver.
-     *
-     * @param ArgumentResolver $resolver
      */
     public function registerArgumentResolver(ArgumentResolver $resolver)
     {
@@ -63,8 +61,6 @@ final class ContextFactory
 
     /**
      * Registers context initializer.
-     *
-     * @param ContextInitializer $initializer
      */
     public function registerContextInitializer(ContextInitializer $initializer)
     {
@@ -75,14 +71,13 @@ final class ContextFactory
      * Creates and initializes context class.
      *
      * @param string             $class
-     * @param array              $arguments
      * @param ArgumentResolver[] $singleUseResolvers
      *
      * @return Context
      */
-    public function createContext($class, array $arguments = array(), array $singleUseResolvers = array())
+    public function createContext($class, array $arguments = [], array $singleUseResolvers = [])
     {
-        $reflection = new ReflectionClass($class);
+        $reflection = new \ReflectionClass($class);
         $resolvers = array_merge($singleUseResolvers, $this->argumentResolvers);
         $resolvedArguments = $this->resolveArguments($reflection, $arguments, $resolvers);
         $context = $this->createInstance($reflection, $resolvedArguments);
@@ -94,13 +89,11 @@ final class ContextFactory
     /**
      * Resolves arguments for a specific class using registered argument resolvers.
      *
-     * @param ReflectionClass    $reflection
-     * @param array              $arguments
      * @param ArgumentResolver[] $resolvers
      *
      * @return mixed[]
      */
-    private function resolveArguments(ReflectionClass $reflection, array $arguments, array $resolvers)
+    private function resolveArguments(\ReflectionClass $reflection, array $arguments, array $resolvers)
     {
         $newArguments = $arguments;
 
@@ -122,12 +115,9 @@ final class ContextFactory
     /**
      * Creates context instance.
      *
-     * @param ReflectionClass $reflection
-     * @param array           $arguments
-     *
      * @return mixed
      */
-    private function createInstance(ReflectionClass $reflection, array $arguments)
+    private function createInstance(\ReflectionClass $reflection, array $arguments)
     {
         if (count($arguments)) {
             return $reflection->newInstanceArgs(array_values($arguments));
@@ -138,8 +128,6 @@ final class ContextFactory
 
     /**
      * Initializes context class and returns new context instance.
-     *
-     * @param Context $context
      */
     private function initializeInstance(Context $context)
     {

--- a/src/Behat/Behat/Context/CustomSnippetAcceptingContext.php
+++ b/src/Behat/Behat/Context/CustomSnippetAcceptingContext.php
@@ -24,8 +24,8 @@ use Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator;
 interface CustomSnippetAcceptingContext extends SnippetAcceptingContext
 {
     /**
-     * Returns type of the snippets that this context accepts. 
-     * 
+     * Returns type of the snippets that this context accepts.
+     *
      * Behat implements a couple of types by default: "regex" and "turnip"
      *
      * @return string

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -10,10 +10,10 @@
 
 namespace Behat\Behat\Context\Environment\Handler;
 
-use Behat\Behat\Context\Argument\SuiteScopedResolverFactory;
-use Behat\Behat\Context\Argument\SuiteScopedResolverFactoryAdapter;
 use Behat\Behat\Context\Argument\ArgumentResolverFactory;
 use Behat\Behat\Context\Argument\NullFactory;
+use Behat\Behat\Context\Argument\SuiteScopedResolverFactory;
+use Behat\Behat\Context\Argument\SuiteScopedResolverFactoryAdapter;
 use Behat\Behat\Context\ContextClass\ClassResolver;
 use Behat\Behat\Context\ContextFactory;
 use Behat\Behat\Context\Environment\InitializedContextEnvironment;
@@ -37,19 +37,20 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
      * @var ContextFactory
      */
     private $contextFactory;
+
     /**
      * @var ArgumentResolverFactory
      */
     private $resolverFactory;
+
     /**
      * @var ClassResolver[]
      */
-    private $classResolvers = array();
+    private $classResolvers = [];
 
     /**
      * Initializes handler.
      *
-     * @param ContextFactory                                     $factory
      * @param ArgumentResolverFactory|SuiteScopedResolverFactory $resolverFactory
      */
     public function __construct(ContextFactory $factory, $resolverFactory = null)
@@ -65,8 +66,6 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
 
     /**
      * Registers context class resolver.
-     *
-     * @param ClassResolver $resolver
      */
     public function registerClassResolver(ClassResolver $resolver)
     {
@@ -128,8 +127,6 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
     /**
      * Returns normalized suite context settings.
      *
-     * @param Suite $suite
-     *
      * @return array
      */
     private function getNormalizedContextSettings(Suite $suite)
@@ -137,14 +134,14 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
         return array_map(
             function ($context) {
                 $class = $context;
-                $arguments = array();
+                $arguments = [];
 
                 if (is_array($context)) {
                     $class = current(array_keys($context));
                     $arguments = $context[$class];
                 }
 
-                return array($class, $arguments);
+                return [$class, $arguments];
             },
             $this->getSuiteContexts($suite)
         );
@@ -153,17 +150,15 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
     /**
      * Returns array of context classes configured for the provided suite.
      *
-     * @param Suite $suite
-     *
-     * @return string[]
-     *
      * @throws SuiteConfigurationException If `contexts` setting is not an array
+     * @return string[]
      */
     private function getSuiteContexts(Suite $suite)
     {
         if (!is_array($suite->getSetting('contexts'))) {
             throw new SuiteConfigurationException(
-                sprintf('`contexts` setting of the "%s" suite is expected to be an array, %s given.',
+                sprintf(
+                    '`contexts` setting of the "%s" suite is expected to be an array, %s given.',
                     $suite->getName(),
                     gettype($suite->getSetting('contexts'))
                 ),

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -31,20 +31,20 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
      * @var string
      */
     private $suite;
+
     /**
      * @var ContainerInterface
      */
     private $serviceContainer;
+
     /**
      * @var array<class-string<Context>, Context>
      * @psalm-var class-string-map<T as Context, T>
      */
-    private $contexts = array();
+    private $contexts = [];
 
     /**
      * Initializes environment.
-     *
-     * @param Suite $suite
      */
     public function __construct(Suite $suite)
     {
@@ -53,8 +53,6 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
 
     /**
      * Registers context instance in the environment.
-     *
-     * @param Context $context
      */
     public function registerContext(Context $context)
     {
@@ -64,7 +62,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
     /**
      * {@inheritdoc}
      */
-    public function setServiceContainer(ContainerInterface $container = null)
+    public function setServiceContainer(?ContainerInterface $container = null)
     {
         $this->serviceContainer = $container;
     }
@@ -118,9 +116,8 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
      *
      * @param class-string<T> $class
      *
-     * @return T
-     *
      * @throws ContextNotFoundException If context is not in the environment
+     * @return T
      */
     public function getContext($class)
     {
@@ -150,7 +147,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
         $callable = $callee->getCallable();
 
         if ($callee->isAnInstanceMethod()) {
-            return array($this->getContext($callable[0]), $callable[1]);
+            return [$this->getContext($callable[0]), $callable[1]];
         }
 
         return $callable;

--- a/src/Behat/Behat/Context/Environment/Reader/ContextEnvironmentReader.php
+++ b/src/Behat/Behat/Context/Environment/Reader/ContextEnvironmentReader.php
@@ -27,12 +27,10 @@ final class ContextEnvironmentReader implements EnvironmentReader
     /**
      * @var ContextReader[]
      */
-    private $contextReaders = array();
+    private $contextReaders = [];
 
     /**
      * Registers context loader.
-     *
-     * @param ContextReader $contextReader
      */
     public function registerContextReader(ContextReader $contextReader)
     {
@@ -59,7 +57,7 @@ final class ContextEnvironmentReader implements EnvironmentReader
             ), $environment);
         }
 
-        $callees = array();
+        $callees = [];
         foreach ($environment->getContextClasses() as $contextClass) {
             $callees = array_merge(
                 $callees,
@@ -73,14 +71,13 @@ final class ContextEnvironmentReader implements EnvironmentReader
     /**
      * Reads callees from a specific suite's context.
      *
-     * @param ContextEnvironment $environment
-     * @param string             $contextClass
+     * @param string $contextClass
      *
      * @return Callee[]
      */
     private function readContextCallees(ContextEnvironment $environment, $contextClass)
     {
-        $callees = array();
+        $callees = [];
         foreach ($this->contextReaders as $loader) {
             $callees = array_merge(
                 $callees,

--- a/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
@@ -28,18 +28,17 @@ final class UninitializedContextEnvironment extends StaticEnvironment implements
     /**
      * @var array<class-string<Context>, array>
      */
-    private $contextClasses = array();
+    private $contextClasses = [];
 
     /**
      * Registers context class.
      *
      * @param class-string<Context> $contextClass
-     * @param null|array            $arguments
      *
      * @throws ContextNotFoundException   If class does not exist
      * @throws WrongContextClassException if class does not implement Context interface
      */
-    public function registerContextClass($contextClass, array $arguments = null)
+    public function registerContextClass($contextClass, ?array $arguments = null)
     {
         if (!class_exists($contextClass)) {
             throw new ContextNotFoundException(sprintf(
@@ -57,7 +56,7 @@ final class UninitializedContextEnvironment extends StaticEnvironment implements
             ), $contextClass);
         }
 
-        $this->contextClasses[$contextClass] = $arguments ? : array();
+        $this->contextClasses[$contextClass] = $arguments ?: [];
     }
 
     /**

--- a/src/Behat/Behat/Context/Exception/ContextNotFoundException.php
+++ b/src/Behat/Behat/Context/Exception/ContextNotFoundException.php
@@ -10,14 +10,12 @@
 
 namespace Behat\Behat\Context\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception thrown when provided context class is not found.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class ContextNotFoundException extends InvalidArgumentException implements ContextException
+final class ContextNotFoundException extends \InvalidArgumentException implements ContextException
 {
     /**
      * @var string

--- a/src/Behat/Behat/Context/Exception/UnknownTranslationResourceException.php
+++ b/src/Behat/Behat/Context/Exception/UnknownTranslationResourceException.php
@@ -10,14 +10,12 @@
 
 namespace Behat\Behat\Context\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception when provided translation resource is not recognised.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class UnknownTranslationResourceException extends InvalidArgumentException implements ContextException
+final class UnknownTranslationResourceException extends \InvalidArgumentException implements ContextException
 {
     /**
      * @var string

--- a/src/Behat/Behat/Context/Exception/WrongContextClassException.php
+++ b/src/Behat/Behat/Context/Exception/WrongContextClassException.php
@@ -10,14 +10,12 @@
 
 namespace Behat\Behat\Context\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception when provided class exists, but is not an acceptable as a context.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class WrongContextClassException extends InvalidArgumentException implements ContextException
+final class WrongContextClassException extends \InvalidArgumentException implements ContextException
 {
     /**
      * @var string
@@ -27,8 +25,8 @@ final class WrongContextClassException extends InvalidArgumentException implemen
     /**
      * Initializes exception.
      *
-     * @param integer $message
-     * @param string  $class
+     * @param int    $message
+     * @param string $class
      */
     public function __construct($message, $class)
     {

--- a/src/Behat/Behat/Context/Initializer/ContextInitializer.php
+++ b/src/Behat/Behat/Context/Initializer/ContextInitializer.php
@@ -21,8 +21,6 @@ interface ContextInitializer
 {
     /**
      * Initializes provided context.
-     *
-     * @param Context $context
      */
     public function initializeContext(Context $context);
 }

--- a/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
@@ -14,9 +14,6 @@ use Behat\Behat\Context\Annotation\AnnotationReader;
 use Behat\Behat\Context\Annotation\DocBlockHelper;
 use Behat\Behat\Context\Environment\ContextEnvironment;
 use Behat\Testwork\Call\Callee;
-use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
 
 /**
  * Reads context callees by annotations using registered annotation readers.
@@ -30,18 +27,19 @@ final class AnnotatedContextReader implements ContextReader
     /**
      * @var string[]
      */
-    private static $ignoreAnnotations = array(
+    private static $ignoreAnnotations = [
         '@param',
         '@return',
         '@throws',
         '@see',
         '@uses',
-        '@todo'
-    );
+        '@todo',
+    ];
+
     /**
      * @var AnnotationReader[]
      */
-    private $readers = array();
+    private $readers = [];
 
     /**
      * @var DocBlockHelper
@@ -50,8 +48,6 @@ final class AnnotatedContextReader implements ContextReader
 
     /**
      * Initializes reader.
-     *
-     * @param DocBlockHelper $docBlockHelper
      */
     public function __construct(DocBlockHelper $docBlockHelper)
     {
@@ -60,8 +56,6 @@ final class AnnotatedContextReader implements ContextReader
 
     /**
      * Registers annotation reader.
-     *
-     * @param AnnotationReader $reader
      */
     public function registerAnnotationReader(AnnotationReader $reader)
     {
@@ -73,10 +67,10 @@ final class AnnotatedContextReader implements ContextReader
      */
     public function readContextCallees(ContextEnvironment $environment, $contextClass)
     {
-        $reflection = new ReflectionClass($contextClass);
+        $reflection = new \ReflectionClass($contextClass);
 
-        $callees = array();
-        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+        $callees = [];
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
             foreach ($this->readMethodCallees($reflection->getName(), $method) as $callee) {
                 $callees[] = $callee;
             }
@@ -88,14 +82,13 @@ final class AnnotatedContextReader implements ContextReader
     /**
      * Loads callees associated with specific method.
      *
-     * @param string           $class
-     * @param ReflectionMethod $method
+     * @param string $class
      *
      * @return Callee[]
      */
-    private function readMethodCallees($class, ReflectionMethod $method)
+    private function readMethodCallees($class, \ReflectionMethod $method)
     {
-        $callees = array();
+        $callees = [];
 
         // read parent annotations
         try {
@@ -104,7 +97,7 @@ final class AnnotatedContextReader implements ContextReader
             if ($prototype->getDeclaringClass()->getName() !== $method->getDeclaringClass()->getName()) {
                 $callees = array_merge($callees, $this->readMethodCallees($class, $prototype));
             }
-        } catch (ReflectionException $e) {
+        } catch (\ReflectionException $e) {
         }
 
         if ($docBlock = $method->getDocComment()) {
@@ -117,15 +110,14 @@ final class AnnotatedContextReader implements ContextReader
     /**
      * Reads callees from the method doc block.
      *
-     * @param string           $class
-     * @param ReflectionMethod $method
-     * @param string           $docBlock
+     * @param string $class
+     * @param string $docBlock
      *
      * @return Callee[]
      */
-    private function readDocBlockCallees($class, ReflectionMethod $method, $docBlock)
+    private function readDocBlockCallees($class, \ReflectionMethod $method, $docBlock)
     {
-        $callees = array();
+        $callees = [];
         $description = $this->docBlockHelper->extractDescription($docBlock);
         $docBlock = $this->mergeMultilines($docBlock);
 
@@ -149,7 +141,7 @@ final class AnnotatedContextReader implements ContextReader
     }
 
     /**
-     * Merges multiline strings (strings ending with "\")
+     * Merges multiline strings (strings ending with "\").
      *
      * @param string $docBlock
      *
@@ -157,7 +149,7 @@ final class AnnotatedContextReader implements ContextReader
      */
     private function mergeMultilines($docBlock)
     {
-        return preg_replace("#\\\\$\s*+\*\s*+([^\\\\$]++)#m", '$1', $docBlock);
+        return preg_replace('#\\\$\\s*+\\*\\s*+([^\\\$]++)#m', '$1', $docBlock);
     }
 
     /**
@@ -169,7 +161,7 @@ final class AnnotatedContextReader implements ContextReader
      */
     private function isEmpty($docLine)
     {
-        return '' == $docLine;
+        return '' === $docLine;
     }
 
     /**
@@ -187,14 +179,13 @@ final class AnnotatedContextReader implements ContextReader
     /**
      * Reads callee from provided doc line using registered annotation readers.
      *
-     * @param string           $class
-     * @param ReflectionMethod $method
-     * @param string           $docLine
-     * @param null|string      $description
+     * @param string      $class
+     * @param string      $docLine
+     * @param null|string $description
      *
      * @return null|Callee
      */
-    private function readDocLineCallee($class, ReflectionMethod $method, $docLine, $description = null)
+    private function readDocLineCallee($class, \ReflectionMethod $method, $docLine, $description = null)
     {
         if ($this->isIgnoredAnnotation($docLine)) {
             return null;
@@ -220,7 +211,7 @@ final class AnnotatedContextReader implements ContextReader
     {
         $lowDocLine = strtolower($docLine);
         foreach (self::$ignoreAnnotations as $ignoredAnnotation) {
-            if ($ignoredAnnotation == substr($lowDocLine, 0, strlen($ignoredAnnotation))) {
+            if ($ignoredAnnotation === substr($lowDocLine, 0, strlen($ignoredAnnotation))) {
                 return true;
             }
         }

--- a/src/Behat/Behat/Context/Reader/AttributeContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AttributeContextReader.php
@@ -12,8 +12,6 @@ namespace Behat\Behat\Context\Reader;
 
 use Behat\Behat\Context\Attribute\AttributeReader;
 use Behat\Behat\Context\Environment\ContextEnvironment;
-use ReflectionClass;
-use ReflectionMethod;
 
 /**
  * Reads context callees by Attributes using registered Attribute readers.
@@ -25,12 +23,10 @@ final class AttributeContextReader implements ContextReader
     /**
      * @var AttributeReader[]
      */
-    private $readers = array();
+    private $readers = [];
 
     /**
      * Registers attribute reader.
-     *
-     * @param AttributeReader $reader
      */
     public function registerAttributeReader(AttributeReader $reader)
     {
@@ -46,10 +42,10 @@ final class AttributeContextReader implements ContextReader
             return [];
         }
 
-        $reflection = new ReflectionClass($contextClass);
+        $reflection = new \ReflectionClass($contextClass);
 
-        $callees = array();
-        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+        $callees = [];
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
             foreach ($this->readMethodCallees($reflection->getName(), $method) as $callee) {
                 $callees[] = $callee;
             }
@@ -58,7 +54,7 @@ final class AttributeContextReader implements ContextReader
         return $callees;
     }
 
-    private function readMethodCallees(string $contextClass, ReflectionMethod $method)
+    private function readMethodCallees(string $contextClass, \ReflectionMethod $method)
     {
         $callees = [];
         foreach ($this->readers as $reader) {

--- a/src/Behat/Behat/Context/Reader/ContextReader.php
+++ b/src/Behat/Behat/Context/Reader/ContextReader.php
@@ -23,8 +23,7 @@ interface ContextReader
     /**
      * Reads callees from specific environment & context.
      *
-     * @param ContextEnvironment $environment
-     * @param string             $contextClass
+     * @param string $contextClass
      *
      * @return Callee[]
      */

--- a/src/Behat/Behat/Context/Reader/ContextReaderCachedPerContext.php
+++ b/src/Behat/Behat/Context/Reader/ContextReaderCachedPerContext.php
@@ -23,15 +23,14 @@ final class ContextReaderCachedPerContext implements ContextReader
      * @var ContextReader
      */
     private $childReader;
+
     /**
      * @var array[]
      */
-    private $cachedCallees = array();
+    private $cachedCallees = [];
 
     /**
      * Initializes reader.
-     *
-     * @param ContextReader $childReader
      */
     public function __construct(ContextReader $childReader)
     {
@@ -48,7 +47,8 @@ final class ContextReaderCachedPerContext implements ContextReader
         }
 
         return $this->cachedCallees[$contextClass] = $this->childReader->readContextCallees(
-            $environment, $contextClass
+            $environment,
+            $contextClass
         );
     }
 }

--- a/src/Behat/Behat/Context/Reader/ContextReaderCachedPerSuite.php
+++ b/src/Behat/Behat/Context/Reader/ContextReaderCachedPerSuite.php
@@ -23,15 +23,14 @@ final class ContextReaderCachedPerSuite implements ContextReader
      * @var ContextReader
      */
     private $childReader;
+
     /**
      * @var array[]
      */
-    private $cachedCallees = array();
+    private $cachedCallees = [];
 
     /**
      * Initializes reader.
-     *
-     * @param ContextReader $childReader
      */
     public function __construct(ContextReader $childReader)
     {
@@ -50,15 +49,15 @@ final class ContextReaderCachedPerSuite implements ContextReader
         }
 
         return $this->cachedCallees[$key] = $this->childReader->readContextCallees(
-            $environment, $contextClass
+            $environment,
+            $contextClass
         );
     }
 
     /**
      * Generates cache key.
      *
-     * @param ContextEnvironment $environment
-     * @param string             $contextClass
+     * @param string $contextClass
      *
      * @return string
      */

--- a/src/Behat/Behat/Context/Reader/TranslatableContextReader.php
+++ b/src/Behat/Behat/Context/Reader/TranslatableContextReader.php
@@ -29,8 +29,6 @@ final class TranslatableContextReader implements ContextReader
 
     /**
      * Initializes loader.
-     *
-     * @param Translator $translator
      */
     public function __construct(Translator $translator)
     {
@@ -47,15 +45,15 @@ final class TranslatableContextReader implements ContextReader
         $reflClass = new \ReflectionClass($contextClass);
 
         if (!$reflClass->implementsInterface('Behat\Behat\Context\TranslatableContext')) {
-            return array();
+            return [];
         }
 
         $assetsId = $environment->getSuite()->getName();
-        foreach (call_user_func(array($contextClass, 'getTranslationResources')) as $path) {
+        foreach (call_user_func([$contextClass, 'getTranslationResources']) as $path) {
             $this->addTranslationResource($path, $assetsId);
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -71,13 +69,19 @@ final class TranslatableContextReader implements ContextReader
         switch ($ext = pathinfo($path, PATHINFO_EXTENSION)) {
             case 'yml':
                 $this->addTranslatorResource('yaml', $path, basename($path, '.' . $ext), $assetsId);
+
                 break;
+
             case 'xliff':
                 $this->addTranslatorResource('xliff', $path, basename($path, '.' . $ext), $assetsId);
+
                 break;
+
             case 'php':
                 $this->addTranslatorResource('php', $path, basename($path, '.' . $ext), $assetsId);
+
                 break;
+
             default:
                 throw new UnknownTranslationResourceException(sprintf(
                     'Can not read translations from `%s`. File type is not supported.',

--- a/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
+++ b/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
@@ -37,16 +37,11 @@ use Symfony\Component\DependencyInjection\Reference;
 final class ContextExtension implements Extension
 {
     /**
-     * Available services
+     * Available services.
      */
     public const FACTORY_ID = 'context.factory';
     public const CONTEXT_SNIPPET_GENERATOR_ID = 'snippet.generator.context';
     public const AGGREGATE_RESOLVER_FACTORY_ID = 'context.argument.aggregate_resolver_factory';
-    private const ENVIRONMENT_HANDLER_ID = EnvironmentExtension::HANDLER_TAG . '.context';
-    private const ENVIRONMENT_READER_ID = EnvironmentExtension::READER_TAG . '.context';
-    private const SUITE_SETUP_ID = SuiteExtension::SETUP_TAG . '.suite_with_contexts';
-    private const ANNOTATED_CONTEXT_READER_ID = self::READER_TAG . '.annotated';
-    private const ATTRIBUTED_CONTEXT_READER_ID = self::READER_TAG . '.attributed';
 
     /*
      * Available extension points
@@ -60,6 +55,11 @@ final class ContextExtension implements Extension
     public const CLASS_GENERATOR_TAG = 'context.class_generator';
     public const SUITE_SCOPED_RESOLVER_FACTORY_TAG = 'context.argument.suite_resolver_factory';
     public const DOC_BLOCK_HELPER_ID = 'context.docblock_helper';
+    private const ENVIRONMENT_HANDLER_ID = EnvironmentExtension::HANDLER_TAG . '.context';
+    private const ENVIRONMENT_READER_ID = EnvironmentExtension::READER_TAG . '.context';
+    private const SUITE_SETUP_ID = SuiteExtension::SETUP_TAG . '.suite_with_contexts';
+    private const ANNOTATED_CONTEXT_READER_ID = self::READER_TAG . '.annotated';
+    private const ATTRIBUTED_CONTEXT_READER_ID = self::READER_TAG . '.attributed';
 
     /**
      * @var ServiceProcessor
@@ -68,12 +68,10 @@ final class ContextExtension implements Extension
 
     /**
      * Initializes compiler pass.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -133,21 +131,17 @@ final class ContextExtension implements Extension
 
     /**
      * Loads context factory.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadFactory(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\ContextFactory', array(
-            new Reference(ArgumentExtension::CONSTRUCTOR_ARGUMENT_ORGANISER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Context\ContextFactory', [
+            new Reference(ArgumentExtension::CONSTRUCTOR_ARGUMENT_ORGANISER_ID),
+        ]);
         $container->setDefinition(self::FACTORY_ID, $definition);
     }
 
     /**
      * Loads argument resolver factory used in the environment handler.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadArgumentResolverFactory(ContainerBuilder $container)
     {
@@ -157,103 +151,86 @@ final class ContextExtension implements Extension
 
     /**
      * Loads context environment handlers.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadEnvironmentHandler(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler', array(
+        $definition = new Definition('Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler', [
             new Reference(self::FACTORY_ID),
-            new Reference(self::AGGREGATE_RESOLVER_FACTORY_ID)
-        ));
-        $definition->addTag(EnvironmentExtension::HANDLER_TAG, array('priority' => 50));
+            new Reference(self::AGGREGATE_RESOLVER_FACTORY_ID),
+        ]);
+        $definition->addTag(EnvironmentExtension::HANDLER_TAG, ['priority' => 50]);
         $container->setDefinition(self::ENVIRONMENT_HANDLER_ID, $definition);
     }
 
     /**
      * Loads context environment readers.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadEnvironmentReader(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Context\Environment\Reader\ContextEnvironmentReader');
-        $definition->addTag(EnvironmentExtension::READER_TAG, array('priority' => 50));
+        $definition->addTag(EnvironmentExtension::READER_TAG, ['priority' => 50]);
         $container->setDefinition(self::ENVIRONMENT_READER_ID, $definition);
     }
 
     /**
      * Loads context environment setup.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadSuiteSetup(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\Suite\Setup\SuiteWithContextsSetup', array(
+        $definition = new Definition('Behat\Behat\Context\Suite\Setup\SuiteWithContextsSetup', [
             new Reference(AutoloaderExtension::CLASS_LOADER_ID),
-            new Reference(FilesystemExtension::LOGGER_ID)
-        ));
-        $definition->addTag(SuiteExtension::SETUP_TAG, array('priority' => 20));
+            new Reference(FilesystemExtension::LOGGER_ID),
+        ]);
+        $definition->addTag(SuiteExtension::SETUP_TAG, ['priority' => 20]);
         $container->setDefinition(self::SUITE_SETUP_ID, $definition);
     }
 
     /**
      * Loads context snippet appender.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadSnippetAppender(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\Snippet\Appender\ContextSnippetAppender', array(
-            new Reference(FilesystemExtension::LOGGER_ID)
-        ));
-        $definition->addTag(SnippetExtension::APPENDER_TAG, array('priority' => 50));
+        $definition = new Definition('Behat\Behat\Context\Snippet\Appender\ContextSnippetAppender', [
+            new Reference(FilesystemExtension::LOGGER_ID),
+        ]);
+        $definition->addTag(SnippetExtension::APPENDER_TAG, ['priority' => 50]);
         $container->setDefinition(SnippetExtension::APPENDER_TAG . '.context', $definition);
     }
 
     /**
      * Loads context snippet generators.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadSnippetGenerators(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator', array(
-            new Reference(DefinitionExtension::PATTERN_TRANSFORMER_ID)
-        ));
-        $definition->addTag(SnippetExtension::GENERATOR_TAG, array('priority' => 50));
+        $definition = new Definition('Behat\Behat\Context\Snippet\Generator\ContextSnippetGenerator', [
+            new Reference(DefinitionExtension::PATTERN_TRANSFORMER_ID),
+        ]);
+        $definition->addTag(SnippetExtension::GENERATOR_TAG, ['priority' => 50]);
         $container->setDefinition(self::CONTEXT_SNIPPET_GENERATOR_ID, $definition);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
-    protected function loadSnippetsController(ContainerBuilder $container)
+    private function loadSnippetsController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\Cli\ContextSnippetsController', array(
+        $definition = new Definition('Behat\Behat\Context\Cli\ContextSnippetsController', [
             new Reference(self::CONTEXT_SNIPPET_GENERATOR_ID),
-            new Reference(TranslatorExtension::TRANSLATOR_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 410));
+            new Reference(TranslatorExtension::TRANSLATOR_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 410]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.context_snippets', $definition);
     }
 
     /**
      * Loads default context class generators.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadDefaultClassGenerators(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Context\ContextClass\SimpleClassGenerator');
-        $definition->addTag(self::CLASS_GENERATOR_TAG, array('priority' => 50));
+        $definition->addTag(self::CLASS_GENERATOR_TAG, ['priority' => 50]);
         $container->setDefinition(self::CLASS_GENERATOR_TAG . '.simple', $definition);
     }
 
     /**
      * Loads default context readers.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadDefaultContextReaders(ContainerBuilder $container)
     {
@@ -265,65 +242,58 @@ final class ContextExtension implements Extension
     }
 
     /**
-     * Loads AnnotatedContextReader
-     *
-     * @param ContainerBuilder $container
+     * Loads AnnotatedContextReader.
      */
     private function loadAnnotatedContextReader(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\Reader\AnnotatedContextReader', array(
-            new Reference(self::DOC_BLOCK_HELPER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Context\Reader\AnnotatedContextReader', [
+            new Reference(self::DOC_BLOCK_HELPER_ID),
+        ]);
         $container->setDefinition(self::ANNOTATED_CONTEXT_READER_ID, $definition);
 
-        $definition = new Definition('Behat\Behat\Context\Reader\ContextReaderCachedPerContext', array(
-            new Reference(self::ANNOTATED_CONTEXT_READER_ID)
-        ));
-        $definition->addTag(self::READER_TAG, array('priority' => 50));
+        $definition = new Definition('Behat\Behat\Context\Reader\ContextReaderCachedPerContext', [
+            new Reference(self::ANNOTATED_CONTEXT_READER_ID),
+        ]);
+        $definition->addTag(self::READER_TAG, ['priority' => 50]);
         $container->setDefinition(self::ANNOTATED_CONTEXT_READER_ID . '.cached', $definition);
     }
 
     /**
-     * Loads AttributedContextReader
-     *
-     * @param ContainerBuilder $container
+     * Loads AttributedContextReader.
      */
     private function loadAttributedContextReader(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Context\Reader\AttributeContextReader');
         $container->setDefinition(self::ATTRIBUTED_CONTEXT_READER_ID, $definition);
 
-        $definition = new Definition('Behat\Behat\Context\Reader\ContextReaderCachedPerContext', array(
-            new Reference(self::ATTRIBUTED_CONTEXT_READER_ID)
-        ));
-        $definition->addTag(self::READER_TAG, array('priority' => 50));
+        $definition = new Definition('Behat\Behat\Context\Reader\ContextReaderCachedPerContext', [
+            new Reference(self::ATTRIBUTED_CONTEXT_READER_ID),
+        ]);
+        $definition->addTag(self::READER_TAG, ['priority' => 50]);
         $container->setDefinition(self::ATTRIBUTED_CONTEXT_READER_ID . '.cached', $definition);
+
         return $definition;
     }
 
     /**
-     * Loads TranslatableContextReader
-     *
-     * @param ContainerBuilder $container
+     * Loads TranslatableContextReader.
      */
     private function loadTranslatableContextReader(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Context\Reader\TranslatableContextReader', array(
-            new Reference(TranslatorExtension::TRANSLATOR_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Context\Reader\TranslatableContextReader', [
+            new Reference(TranslatorExtension::TRANSLATOR_ID),
+        ]);
         $container->setDefinition(self::READER_TAG . '.translatable', $definition);
 
-        $definition = new Definition('Behat\Behat\Context\Reader\ContextReaderCachedPerSuite', array(
-            new Reference(self::READER_TAG . '.translatable')
-        ));
-        $definition->addTag(self::READER_TAG, array('priority' => 50));
+        $definition = new Definition('Behat\Behat\Context\Reader\ContextReaderCachedPerSuite', [
+            new Reference(self::READER_TAG . '.translatable'),
+        ]);
+        $definition->addTag(self::READER_TAG, ['priority' => 50]);
         $container->setDefinition(self::READER_TAG . '.translatable.cached', $definition);
     }
 
     /**
-     * Loads DocBlockHelper
-     *
-     * @param ContainerBuilder $container
+     * Loads DocBlockHelper.
      */
     private function loadDocblockHelper(ContainerBuilder $container)
     {
@@ -334,8 +304,6 @@ final class ContextExtension implements Extension
 
     /**
      * Processes all class resolvers.
-     *
-     * @param ContainerBuilder $container
      */
     private function processClassResolvers(ContainerBuilder $container)
     {
@@ -343,7 +311,7 @@ final class ContextExtension implements Extension
         $definition = $container->getDefinition(self::ENVIRONMENT_HANDLER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerClassResolver', array($reference));
+            $definition->addMethodCall('registerClassResolver', [$reference]);
         }
     }
 
@@ -358,14 +326,12 @@ final class ContextExtension implements Extension
         $definition = $container->getDefinition(self::AGGREGATE_RESOLVER_FACTORY_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerFactory', array($reference));
+            $definition->addMethodCall('registerFactory', [$reference]);
         }
     }
 
     /**
      * Processes all argument resolvers.
-     *
-     * @param ContainerBuilder $container
      */
     private function processArgumentResolvers(ContainerBuilder $container)
     {
@@ -373,14 +339,12 @@ final class ContextExtension implements Extension
         $definition = $container->getDefinition(self::FACTORY_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerArgumentResolver', array($reference));
+            $definition->addMethodCall('registerArgumentResolver', [$reference]);
         }
     }
 
     /**
      * Processes all context initializers.
-     *
-     * @param ContainerBuilder $container
      */
     private function processContextInitializers(ContainerBuilder $container)
     {
@@ -388,14 +352,12 @@ final class ContextExtension implements Extension
         $definition = $container->getDefinition(self::FACTORY_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerContextInitializer', array($reference));
+            $definition->addMethodCall('registerContextInitializer', [$reference]);
         }
     }
 
     /**
      * Processes all context readers.
-     *
-     * @param ContainerBuilder $container
      */
     private function processContextReaders(ContainerBuilder $container)
     {
@@ -403,14 +365,12 @@ final class ContextExtension implements Extension
         $definition = $container->getDefinition(self::ENVIRONMENT_READER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerContextReader', array($reference));
+            $definition->addMethodCall('registerContextReader', [$reference]);
         }
     }
 
     /**
      * Processes all class generators.
-     *
-     * @param ContainerBuilder $container
      */
     private function processClassGenerators(ContainerBuilder $container)
     {
@@ -418,14 +378,12 @@ final class ContextExtension implements Extension
         $definition = $container->getDefinition(self::SUITE_SETUP_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerClassGenerator', array($reference));
+            $definition->addMethodCall('registerClassGenerator', [$reference]);
         }
     }
 
     /**
      * Processes all annotation readers.
-     *
-     * @param ContainerBuilder $container
      */
     private function processAnnotationReaders(ContainerBuilder $container)
     {
@@ -433,14 +391,12 @@ final class ContextExtension implements Extension
         $definition = $container->getDefinition(self::ANNOTATED_CONTEXT_READER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerAnnotationReader', array($reference));
+            $definition->addMethodCall('registerAnnotationReader', [$reference]);
         }
     }
 
     /**
      * Processes all attribute readers.
-     *
-     * @param ContainerBuilder $container
      */
     private function processAttributeReaders(ContainerBuilder $container)
     {
@@ -448,7 +404,7 @@ final class ContextExtension implements Extension
         $definition = $container->getDefinition(self::ATTRIBUTED_CONTEXT_READER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerAttributeReader', array($reference));
+            $definition->addMethodCall('registerAttributeReader', [$reference]);
         }
     }
 }

--- a/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
+++ b/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
@@ -13,7 +13,6 @@ namespace Behat\Behat\Context\Snippet\Appender;
 use Behat\Behat\Snippet\AggregateSnippet;
 use Behat\Behat\Snippet\Appender\SnippetAppender;
 use Behat\Testwork\Filesystem\FilesystemLogger;
-use ReflectionClass;
 
 /**
  * Appends context-related snippets to their context classes.
@@ -34,10 +33,8 @@ final class ContextSnippetAppender implements SnippetAppender
 
     /**
      * Initializes appender.
-     *
-     * @param null|FilesystemLogger $logger
      */
-    public function __construct(FilesystemLogger $logger = null)
+    public function __construct(?FilesystemLogger $logger = null)
     {
         $this->logger = $logger;
     }
@@ -56,7 +53,7 @@ final class ContextSnippetAppender implements SnippetAppender
     public function appendSnippet(AggregateSnippet $snippet)
     {
         foreach ($snippet->getTargets() as $contextClass) {
-            $reflection = new ReflectionClass($contextClass);
+            $reflection = new \ReflectionClass($contextClass);
             $content = file_get_contents($reflection->getFileName());
 
             foreach ($snippet->getUsedClasses() as $class) {
@@ -65,7 +62,7 @@ final class ContextSnippetAppender implements SnippetAppender
                 }
             }
 
-            $generated = rtrim(strtr($snippet->getSnippet(), array('\\' => '\\\\', '$' => '\\$')));
+            $generated = rtrim(strtr($snippet->getSnippet(), ['\\' => '\\\\', '$' => '\\$']));
             $content = preg_replace('/}\s*$/', "\n" . $generated . "\n}\n", $content);
             $path = $reflection->getFileName();
 
@@ -103,7 +100,7 @@ final class ContextSnippetAppender implements SnippetAppender
      */
     private function importClass($class, $contextFileContent)
     {
-        $replaceWith = "\$1" . 'use ' . $class . ";\n\$2;";
+        $replaceWith = '$1use '. $class . ";\n\$2;";
 
         return preg_replace('@^(.*)(use\s+[^;]*);@m', $replaceWith, $contextFileContent, 1);
     }
@@ -111,8 +108,7 @@ final class ContextSnippetAppender implements SnippetAppender
     /**
      * Logs snippet addition to the provided path (if logger is given).
      *
-     * @param AggregateSnippet $snippet
-     * @param string           $path
+     * @param string $path
      */
     private function logSnippetAddition(AggregateSnippet $snippet, $path)
     {
@@ -121,7 +117,7 @@ final class ContextSnippetAppender implements SnippetAppender
         }
 
         $steps = $snippet->getSteps();
-        $reason = sprintf("`<comment>%s</comment>` definition added", $steps[0]->getText());
+        $reason = sprintf('`<comment>%s</comment>` definition added', $steps[0]->getText());
 
         $this->logger->fileUpdated($path, $reason);
     }

--- a/src/Behat/Behat/Context/Snippet/ContextSnippet.php
+++ b/src/Behat/Behat/Context/Snippet/ContextSnippet.php
@@ -24,14 +24,17 @@ final class ContextSnippet implements Snippet
      * @var StepNode
      */
     private $step;
+
     /**
      * @var string
      */
     private $template;
+
     /**
      * @var string
      */
     private $contextClass;
+
     /**
      * @var string[]
      */
@@ -40,12 +43,11 @@ final class ContextSnippet implements Snippet
     /**
      * Initializes definition snippet.
      *
-     * @param StepNode $step
      * @param string   $template
      * @param string   $contextClass
      * @param string[] $usedClasses
      */
-    public function __construct(StepNode $step, $template, $contextClass, array $usedClasses = array())
+    public function __construct(StepNode $step, $template, $contextClass, array $usedClasses = [])
     {
         $this->step = $step;
         $this->template = $template;

--- a/src/Behat/Behat/Context/Snippet/Generator/CachedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/CachedContextIdentifier.php
@@ -23,15 +23,14 @@ final class CachedContextIdentifier implements TargetContextIdentifier
      * @var TargetContextIdentifier
      */
     private $decoratedIdentifier;
+
     /**
      * @var array
      */
-    private $contextClasses = array();
+    private $contextClasses = [];
 
     /**
      * Initialise the identifier.
-     *
-     * @param TargetContextIdentifier $identifier
      */
     public function __construct(TargetContextIdentifier $identifier)
     {

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextInterfaceBasedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextInterfaceBasedContextIdentifier.php
@@ -27,7 +27,7 @@ final class ContextInterfaceBasedContextIdentifier implements TargetContextIdent
     public function guessTargetContextClass(ContextEnvironment $environment)
     {
         foreach ($environment->getContextClasses() as $class) {
-            if (in_array('Behat\Behat\Context\SnippetAcceptingContext', class_implements($class))) {
+            if (in_array('Behat\Behat\Context\SnippetAcceptingContext', class_implements($class), true)) {
                 return $class;
             }
         }

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextInterfaceBasedPatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextInterfaceBasedPatternIdentifier.php
@@ -24,7 +24,7 @@ final class ContextInterfaceBasedPatternIdentifier implements PatternIdentifier
      */
     public function guessPatternType($contextClass)
     {
-        if (!in_array('Behat\Behat\Context\CustomSnippetAcceptingContext', class_implements($contextClass))) {
+        if (!in_array('Behat\Behat\Context\CustomSnippetAcceptingContext', class_implements($contextClass), true)) {
             return null;
         }
 

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -19,7 +19,6 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Environment\Environment;
-use ReflectionClass;
 
 /**
  * Generates snippets for a context class.
@@ -31,11 +30,12 @@ final class ContextSnippetGenerator implements SnippetGenerator
     /**
      * @var string[string]
      */
-    private static $proposedMethods = array();
+    private static $proposedMethods = [];
+
     /**
      * @var string
      */
-    private static $templateTemplate = <<<TPL
+    private static $templateTemplate = <<<'TPL'
     /**
      * @%%s %s
      */
@@ -44,14 +44,17 @@ final class ContextSnippetGenerator implements SnippetGenerator
         throw new PendingException();
     }
 TPL;
+
     /**
      * @var PatternTransformer
      */
     private $patternTransformer;
+
     /**
      * @var TargetContextIdentifier
      */
     private $contextIdentifier;
+
     /**
      * @var PatternIdentifier
      */
@@ -59,8 +62,6 @@ TPL;
 
     /**
      * Initializes snippet generator.
-     *
-     * @param PatternTransformer $patternTransformer
      */
     public function __construct(PatternTransformer $patternTransformer)
     {
@@ -72,8 +73,6 @@ TPL;
 
     /**
      * Sets target context identifier.
-     *
-     * @param TargetContextIdentifier $identifier
      */
     public function setContextIdentifier(TargetContextIdentifier $identifier)
     {
@@ -82,8 +81,6 @@ TPL;
 
     /**
      * Sets target pattern type identifier.
-     *
-     * @param PatternIdentifier $identifier
      */
     public function setPatternIdentifier(PatternIdentifier $identifier)
     {
@@ -144,23 +141,21 @@ TPL;
     private function getMethodName($contextClass, $canonicalText, $pattern)
     {
         $methodName = $this->deduceMethodName($canonicalText);
-        $methodName = $this->getUniqueMethodName($contextClass, $pattern, $methodName);
 
-        return $methodName;
+        return $this->getUniqueMethodName($contextClass, $pattern, $methodName);
     }
 
     /**
      * Returns an array of method argument names from step and token count.
      *
-     * @param StepNode $step
-     * @param integer  $tokenCount
+     * @param int $tokenCount
      *
      * @return string[]
      */
     private function getMethodArguments(StepNode $step, $tokenCount)
     {
-        $args = array();
-        for ($i = 0; $i < $tokenCount; $i++) {
+        $args = [];
+        for ($i = 0; $i < $tokenCount; ++$i) {
             $args[] = '$arg' . ($i + 1);
         }
 
@@ -172,15 +167,13 @@ TPL;
     }
 
     /**
-     * Returns an array of classes used by the snippet template
-     *
-     * @param StepNode $step
+     * Returns an array of classes used by the snippet template.
      *
      * @return string[]
      */
     private function getUsedClasses(StepNode $step)
     {
-        $usedClasses = array('Behat\Behat\Tester\Exception\PendingException');
+        $usedClasses = ['Behat\Behat\Tester\Exception\PendingException'];
 
         foreach ($step->getArguments() as $argument) {
             if ($argument instanceof TableNode) {
@@ -242,13 +235,12 @@ TPL;
      */
     private function getUniqueMethodName($contextClass, $stepPattern, $name)
     {
-        $reflection = new ReflectionClass($contextClass);
+        $reflection = new \ReflectionClass($contextClass);
 
         $number = $this->getMethodNumberFromTheMethodName($name);
         list($name, $number) = $this->getMethodNameNotExistentInContext($reflection, $name, $number);
-        $name = $this->getMethodNameNotProposedEarlier($contextClass, $stepPattern, $name, $number);
 
-        return $name;
+        return $this->getMethodNameNotProposedEarlier($contextClass, $stepPattern, $name, $number);
     }
 
     /**
@@ -256,7 +248,7 @@ TPL;
      *
      * @param string $methodName
      *
-     * @return integer
+     * @return int
      */
     private function getMethodNumberFromTheMethodName($methodName)
     {
@@ -271,29 +263,28 @@ TPL;
     /**
      * Tries to guess method name that is not yet defined in the context class.
      *
-     * @param ReflectionClass $reflection
-     * @param string          $methodName
-     * @param integer         $methodNumber
+     * @param string $methodName
+     * @param int    $methodNumber
      *
      * @return array
      */
-    private function getMethodNameNotExistentInContext(ReflectionClass $reflection, $methodName, $methodNumber)
+    private function getMethodNameNotExistentInContext(\ReflectionClass $reflection, $methodName, $methodNumber)
     {
         while ($reflection->hasMethod($methodName)) {
             $methodName = preg_replace('/\d+$/', '', $methodName);
             $methodName .= $methodNumber++;
         }
 
-        return array($methodName, $methodNumber);
+        return [$methodName, $methodNumber];
     }
 
     /**
      * Tries to guess method name that is not yet proposed to the context class.
      *
-     * @param string  $contextClass
-     * @param string  $stepPattern
-     * @param string  $name
-     * @param integer $number
+     * @param string $contextClass
+     * @param string $stepPattern
+     * @param string $name
+     * @param int    $number
      *
      * @return string
      */
@@ -324,7 +315,7 @@ TPL;
      */
     private function getAlreadyProposedMethods($contextClass)
     {
-        return self::$proposedMethods[$contextClass] ?? array();
+        return self::$proposedMethods[$contextClass] ?? [];
     }
 
     /**

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedContextIdentifier.php
@@ -19,9 +19,6 @@ use Behat\Behat\Context\Environment\ContextEnvironment;
  */
 final class FixedContextIdentifier implements TargetContextIdentifier
 {
-    /**
-     * @var
-     */
     private $contextClass;
 
     /**

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
@@ -10,8 +10,6 @@
 
 namespace Behat\Behat\Context\Snippet\Generator;
 
-use Behat\Behat\Context\Context;
-
 /**
  * Identifier that always returns same pattern type.
  *

--- a/src/Behat/Behat/Context/Snippet/Generator/TargetContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/TargetContextIdentifier.php
@@ -22,8 +22,6 @@ interface TargetContextIdentifier
     /**
      * Attempts to guess the target context class from the environment.
      *
-     * @param ContextEnvironment $environment
-     *
      * @return null|string
      */
     public function guessTargetContextClass(ContextEnvironment $environment);

--- a/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
+++ b/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
@@ -29,22 +29,21 @@ final class SuiteWithContextsSetup implements SuiteSetup
      * @var ClassLoader
      */
     private $autoloader;
+
     /**
      * @var null|FilesystemLogger
      */
     private $logger;
+
     /**
      * @var ClassGenerator[]
      */
-    private $classGenerators = array();
+    private $classGenerators = [];
 
     /**
      * Initializes setup.
-     *
-     * @param ClassLoader           $autoloader
-     * @param null|FilesystemLogger $logger
      */
-    public function __construct(ClassLoader $autoloader, FilesystemLogger $logger = null)
+    public function __construct(ClassLoader $autoloader, ?FilesystemLogger $logger = null)
     {
         $this->autoloader = $autoloader;
         $this->logger = $logger;
@@ -52,8 +51,6 @@ final class SuiteWithContextsSetup implements SuiteSetup
 
     /**
      * Registers class generator.
-     *
-     * @param ClassGenerator $generator
      */
     public function registerClassGenerator(ClassGenerator $generator)
     {
@@ -89,8 +86,6 @@ final class SuiteWithContextsSetup implements SuiteSetup
     /**
      * Returns normalized context classes.
      *
-     * @param Suite $suite
-     *
      * @return string[]
      */
     private function getNormalizedContextClasses(Suite $suite)
@@ -106,11 +101,8 @@ final class SuiteWithContextsSetup implements SuiteSetup
     /**
      * Returns array of context classes configured for the provided suite.
      *
-     * @param Suite $suite
-     *
-     * @return string[]
-     *
      * @throws SuiteConfigurationException If `contexts` setting is not an array
+     * @return string[]
      */
     private function getSuiteContexts(Suite $suite)
     {
@@ -118,7 +110,8 @@ final class SuiteWithContextsSetup implements SuiteSetup
 
         if (!is_array($contexts)) {
             throw new SuiteConfigurationException(
-                sprintf('`contexts` setting of the "%s" suite is expected to be an array, `%s` given.',
+                sprintf(
+                    '`contexts` setting of the "%s" suite is expected to be an array, `%s` given.',
                     $suite->getName(),
                     gettype($contexts)
                 ),
@@ -163,9 +156,8 @@ final class SuiteWithContextsSetup implements SuiteSetup
      *
      * @param string $class
      *
-     * @return string
-     *
      * @throws ContextNotFoundException If class file could not be determined
+     * @return string
      */
     private function findClassFile($class)
     {
@@ -191,7 +183,6 @@ final class SuiteWithContextsSetup implements SuiteSetup
     /**
      * Generates class using registered class generators.
      *
-     * @param Suite  $suite
      * @param string $class
      *
      * @return null|string
@@ -234,13 +225,13 @@ final class SuiteWithContextsSetup implements SuiteSetup
             $classpath = str_replace('\\', DIRECTORY_SEPARATOR, substr($class, 0, $pos)) . DIRECTORY_SEPARATOR;
             $classname = substr($class, $pos + 1);
 
-            return array($classpath, $classname);
+            return [$classpath, $classname];
         }
 
         // PEAR-like class name
         $classpath = null;
         $classname = $class;
 
-        return array($classpath, $classname);
+        return [$classpath, $classname];
     }
 }

--- a/src/Behat/Behat/Definition/Call/DefinitionCall.php
+++ b/src/Behat/Behat/Definition/Call/DefinitionCall.php
@@ -27,6 +27,7 @@ final class DefinitionCall extends EnvironmentCall
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var StepNode
      */
@@ -35,12 +36,7 @@ final class DefinitionCall extends EnvironmentCall
     /**
      * Initializes definition call.
      *
-     * @param Environment  $environment
-     * @param FeatureNode  $feature
-     * @param StepNode     $step
-     * @param Definition   $definition
-     * @param array        $arguments
-     * @param null|integer $errorReportingLevel
+     * @param null|int $errorReportingLevel
      */
     public function __construct(
         Environment $environment,

--- a/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
+++ b/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
@@ -24,6 +24,7 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Definition
      * @var string
      */
     private $type;
+
     /**
      * @var string
      */
@@ -48,6 +49,14 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Definition
     /**
      * {@inheritdoc}
      */
+    public function __toString()
+    {
+        return $this->getType() . ' ' . $this->getPattern();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getType()
     {
         return $this->type;
@@ -59,13 +68,5 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Definition
     public function getPattern()
     {
         return $this->pattern;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return $this->getType() . ' ' . $this->getPattern();
     }
 }

--- a/src/Behat/Behat/Definition/Cli/AvailableDefinitionsController.php
+++ b/src/Behat/Behat/Definition/Cli/AvailableDefinitionsController.php
@@ -32,14 +32,17 @@ final class AvailableDefinitionsController implements Controller
      * @var SuiteRepository
      */
     private $suiteRepository;
+
     /**
      * @var DefinitionWriter
      */
     private $writer;
+
     /**
      * @var ConsoleDefinitionListPrinter
      */
     private $listPrinter;
+
     /**
      * @var ConsoleDefinitionInformationPrinter
      */
@@ -47,11 +50,6 @@ final class AvailableDefinitionsController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param SuiteRepository                     $suiteRepository
-     * @param DefinitionWriter                    $writer
-     * @param ConsoleDefinitionListPrinter        $listPrinter
-     * @param ConsoleDefinitionInformationPrinter $infoPrinter
      */
     public function __construct(
         SuiteRepository $suiteRepository,
@@ -70,12 +68,15 @@ final class AvailableDefinitionsController implements Controller
      */
     public function configure(Command $command)
     {
-        $command->addOption('--definitions', '-d', InputOption::VALUE_REQUIRED,
-            "Print all available step definitions:" . PHP_EOL .
-            "- use <info>--definitions l</info> to just list definition expressions." . PHP_EOL .
-            "- use <info>--definitions i</info> to show definitions with extended info." . PHP_EOL .
+        $command->addOption(
+            '--definitions',
+            '-d',
+            InputOption::VALUE_REQUIRED,
+            'Print all available step definitions:' . PHP_EOL .
+            '- use <info>--definitions l</info> to just list definition expressions.' . PHP_EOL .
+            '- use <info>--definitions i</info> to show definitions with extended info.' . PHP_EOL .
             "- use <info>--definitions 'needle'</info> to find specific definitions." . PHP_EOL .
-            "Use <info>--lang</info> to see definitions in specific language."
+            'Use <info>--lang</info> to see definitions in specific language.'
         );
     }
 

--- a/src/Behat/Behat/Definition/Context/Annotation/DefinitionAnnotationReader.php
+++ b/src/Behat/Behat/Definition/Context/Annotation/DefinitionAnnotationReader.php
@@ -11,7 +11,6 @@
 namespace Behat\Behat\Definition\Context\Annotation;
 
 use Behat\Behat\Context\Annotation\AnnotationReader;
-use ReflectionMethod;
 
 /**
  * Reads definition annotations from the context class.
@@ -24,19 +23,20 @@ final class DefinitionAnnotationReader implements AnnotationReader
      * @var string
      */
     private static $regex = '/^\@(given|when|then)\s+(.+)$/i';
+
     /**
      * @var string[]
      */
-    private static $classes = array(
+    private static $classes = [
         'given' => 'Behat\Behat\Definition\Call\Given',
-        'when'  => 'Behat\Behat\Definition\Call\When',
-        'then'  => 'Behat\Behat\Definition\Call\Then',
-    );
+        'when' => 'Behat\Behat\Definition\Call\When',
+        'then' => 'Behat\Behat\Definition\Call\Then',
+    ];
 
     /**
      * {@inheritdoc}
      */
-    public function readCallee($contextClass, ReflectionMethod $method, $docLine, $description)
+    public function readCallee($contextClass, \ReflectionMethod $method, $docLine, $description)
     {
         if (!preg_match(self::$regex, $docLine, $match)) {
             return null;
@@ -45,7 +45,7 @@ final class DefinitionAnnotationReader implements AnnotationReader
         $type = strtolower($match[1]);
         $class = self::$classes[$type];
         $pattern = $match[2];
-        $callable = array($contextClass, $method->getName());
+        $callable = [$contextClass, $method->getName()];
 
         return new $class($pattern, $callable, $description);
     }

--- a/src/Behat/Behat/Definition/Context/Attribute/DefinitionAttributeReader.php
+++ b/src/Behat/Behat/Definition/Context/Attribute/DefinitionAttributeReader.php
@@ -16,7 +16,6 @@ use Behat\Step\Definition;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use ReflectionMethod;
 
 /**
  * Reads definition Attributes from the context class.
@@ -28,11 +27,11 @@ final class DefinitionAttributeReader implements AttributeReader
     /**
      * @var string[]
      */
-    private static $classes = array(
+    private static $classes = [
         Given::class => 'Behat\Behat\Definition\Call\Given',
-        When::class  => 'Behat\Behat\Definition\Call\When',
-        Then::class  => 'Behat\Behat\Definition\Call\Then',
-    );
+        When::class => 'Behat\Behat\Definition\Call\When',
+        Then::class => 'Behat\Behat\Definition\Call\Then',
+    ];
 
     /**
      * @var DocBlockHelper
@@ -41,8 +40,6 @@ final class DefinitionAttributeReader implements AttributeReader
 
     /**
      * Initializes reader.
-     *
-     * @param DocBlockHelper $docBlockHelper
      */
     public function __construct(DocBlockHelper $docBlockHelper)
     {
@@ -50,9 +47,9 @@ final class DefinitionAttributeReader implements AttributeReader
     }
 
     /**
-     * @{inheritdoc}
+     * {@inheritdoc}
      */
-    public function readCallees(string $contextClass, ReflectionMethod $method)
+    public function readCallees(string $contextClass, \ReflectionMethod $method)
     {
         if (\PHP_MAJOR_VERSION < 8) {
             return [];
@@ -66,7 +63,7 @@ final class DefinitionAttributeReader implements AttributeReader
         $callees = [];
         foreach ($attributes as $attribute) {
             $class = self::$classes[$attribute->getName()];
-            $callable = array($contextClass, $method->getName());
+            $callable = [$contextClass, $method->getName()];
             $description = null;
             if ($docBlock = $method->getDocComment()) {
                 $description = $this->docBlockHelper->extractDescription($docBlock);

--- a/src/Behat/Behat/Definition/Definition.php
+++ b/src/Behat/Behat/Definition/Definition.php
@@ -20,6 +20,13 @@ use Behat\Testwork\Call\Callee;
 interface Definition extends Callee
 {
     /**
+     * Represents definition as a string.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
      * Returns definition type (Given|When|Then).
      *
      * @return string
@@ -32,11 +39,4 @@ interface Definition extends Callee
      * @return string
      */
     public function getPattern();
-
-    /**
-     * Represents definition as a string.
-     *
-     * @return string
-     */
-    public function __toString();
 }

--- a/src/Behat/Behat/Definition/DefinitionFinder.php
+++ b/src/Behat/Behat/Definition/DefinitionFinder.php
@@ -25,12 +25,10 @@ final class DefinitionFinder
     /**
      * @var SearchEngine[]
      */
-    private $engines = array();
+    private $engines = [];
 
     /**
      * Registers definition search engine.
-     *
-     * @param SearchEngine $searchEngine
      */
     public function registerSearchEngine(SearchEngine $searchEngine)
     {
@@ -39,10 +37,6 @@ final class DefinitionFinder
 
     /**
      * Searches definition for a provided step in a provided environment.
-     *
-     * @param Environment $environment
-     * @param FeatureNode $feature
-     * @param StepNode    $step
      *
      * @return SearchResult
      */

--- a/src/Behat/Behat/Definition/DefinitionRepository.php
+++ b/src/Behat/Behat/Definition/DefinitionRepository.php
@@ -28,8 +28,6 @@ final class DefinitionRepository
 
     /**
      * Initializes repository.
-     *
-     * @param EnvironmentManager $environmentManager
      */
     public function __construct(EnvironmentManager $environmentManager)
     {
@@ -39,16 +37,13 @@ final class DefinitionRepository
     /**
      * Returns all available definitions for a specific environment.
      *
-     * @param Environment $environment
-     *
-     * @return Definition[]
-     *
      * @throws RedundantStepException
+     * @return Definition[]
      */
     public function getEnvironmentDefinitions(Environment $environment)
     {
-        $patterns = array();
-        $definitions = array();
+        $patterns = [];
+        $definitions = [];
 
         foreach ($this->environmentManager->readEnvironmentCallees($environment) as $callee) {
             if (!$callee instanceof Definition) {

--- a/src/Behat/Behat/Definition/DefinitionWriter.php
+++ b/src/Behat/Behat/Definition/DefinitionWriter.php
@@ -25,6 +25,7 @@ final class DefinitionWriter
      * @var EnvironmentManager
      */
     private $environmentManager;
+
     /**
      * @var DefinitionRepository
      */
@@ -32,9 +33,6 @@ final class DefinitionWriter
 
     /**
      * Initializes writer.
-     *
-     * @param EnvironmentManager   $environmentManager
-     * @param DefinitionRepository $repository
      */
     public function __construct(EnvironmentManager $environmentManager, DefinitionRepository $repository)
     {
@@ -45,8 +43,7 @@ final class DefinitionWriter
     /**
      * Prints definitions for provided suite using printer.
      *
-     * @param DefinitionPrinter $printer
-     * @param Suite             $suite
+     * @param Suite $suite
      */
     public function printSuiteDefinitions(DefinitionPrinter $printer, $suite)
     {

--- a/src/Behat/Behat/Definition/Exception/AmbiguousMatchException.php
+++ b/src/Behat/Behat/Definition/Exception/AmbiguousMatchException.php
@@ -11,7 +11,6 @@
 namespace Behat\Behat\Definition\Exception;
 
 use Behat\Behat\Definition\Definition;
-use RuntimeException;
 
 /**
  * Represents an exception caused by an ambiguous step definition match.
@@ -21,16 +20,17 @@ use RuntimeException;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class AmbiguousMatchException extends RuntimeException implements SearchException
+final class AmbiguousMatchException extends \RuntimeException implements SearchException
 {
     /**
      * @var string
      */
     private $text;
+
     /**
      * @var Definition[]
      */
-    private $matches = array();
+    private $matches = [];
 
     /**
      * Initializes ambiguous exception.
@@ -43,7 +43,7 @@ final class AmbiguousMatchException extends RuntimeException implements SearchEx
         $this->text = $text;
         $this->matches = $matches;
 
-        $message = sprintf("Ambiguous match of \"%s\":", $text);
+        $message = sprintf('Ambiguous match of "%s":', $text);
         foreach ($matches as $definition) {
             $message .= sprintf(
                 "\nto `%s` from %s",

--- a/src/Behat/Behat/Definition/Exception/InvalidPatternException.php
+++ b/src/Behat/Behat/Definition/Exception/InvalidPatternException.php
@@ -10,13 +10,11 @@
 
 namespace Behat\Behat\Definition\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception caused by an invalid definition pattern (not able to transform it to a regex).
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-final class InvalidPatternException extends InvalidArgumentException implements DefinitionException
+final class InvalidPatternException extends \InvalidArgumentException implements DefinitionException
 {
 }

--- a/src/Behat/Behat/Definition/Exception/RedundantStepException.php
+++ b/src/Behat/Behat/Definition/Exception/RedundantStepException.php
@@ -11,7 +11,6 @@
 namespace Behat\Behat\Definition\Exception;
 
 use Behat\Behat\Definition\Definition;
-use RuntimeException;
 
 /**
  * Represents an exception caused by a redundant step definition.
@@ -21,7 +20,7 @@ use RuntimeException;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class RedundantStepException extends RuntimeException implements SearchException
+final class RedundantStepException extends \RuntimeException implements SearchException
 {
     /**
      * Initializes redundant exception.
@@ -33,7 +32,10 @@ final class RedundantStepException extends RuntimeException implements SearchExc
     {
         $message = sprintf(
             "Step \"%s\" is already defined in %s\n\n%s\n%s",
-            $step2->getPattern(), $step1->getPath(), $step1->getPath(), $step2->getPath()
+            $step2->getPattern(),
+            $step1->getPath(),
+            $step1->getPath(),
+            $step2->getPath()
         );
 
         parent::__construct($message);

--- a/src/Behat/Behat/Definition/Exception/UnknownPatternException.php
+++ b/src/Behat/Behat/Definition/Exception/UnknownPatternException.php
@@ -10,14 +10,12 @@
 
 namespace Behat\Behat\Definition\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception caused by an unrecognised definition pattern.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class UnknownPatternException extends InvalidArgumentException implements DefinitionException
+final class UnknownPatternException extends \InvalidArgumentException implements DefinitionException
 {
     /**
      * @var string
@@ -27,8 +25,8 @@ final class UnknownPatternException extends InvalidArgumentException implements 
     /**
      * Initializes exception.
      *
-     * @param string  $message
-     * @param integer $pattern
+     * @param string $message
+     * @param int    $pattern
      */
     public function __construct($message, $pattern)
     {

--- a/src/Behat/Behat/Definition/Exception/UnsupportedPatternTypeException.php
+++ b/src/Behat/Behat/Definition/Exception/UnsupportedPatternTypeException.php
@@ -10,14 +10,12 @@
 
 namespace Behat\Behat\Definition\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception caused by an unsupported pattern type.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class UnsupportedPatternTypeException extends InvalidArgumentException implements DefinitionException
+final class UnsupportedPatternTypeException extends \InvalidArgumentException implements DefinitionException
 {
     /**
      * @var string

--- a/src/Behat/Behat/Definition/Pattern/Pattern.php
+++ b/src/Behat/Behat/Definition/Pattern/Pattern.php
@@ -21,21 +21,23 @@ final class Pattern
      * @var string
      */
     private $canonicalText;
+
     /**
      * @var string
      */
     private $pattern;
+
     /**
-     * @var integer
+     * @var int
      */
     private $placeholderCount;
 
     /**
      * Initializes pattern.
      *
-     * @param string  $canonicalText
-     * @param string  $pattern
-     * @param integer $placeholderCount
+     * @param string $canonicalText
+     * @param string $pattern
+     * @param int    $placeholderCount
      */
     public function __construct($canonicalText, $pattern, $placeholderCount = 0)
     {
@@ -67,7 +69,7 @@ final class Pattern
     /**
      * Returns pattern placeholder count.
      *
-     * @return integer
+     * @return int
      */
     public function getPlaceholderCount()
     {

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -24,22 +24,20 @@ final class PatternTransformer
     /**
      * @var PatternPolicy[]
      */
-    private $policies = array();
+    private $policies = [];
 
     /**
      * @var string[]
      */
-    private $patternToRegexpCache = array();
+    private $patternToRegexpCache = [];
 
     /**
      * Registers pattern policy.
-     *
-     * @param PatternPolicy $policy
      */
     public function registerPatternPolicy(PatternPolicy $policy)
     {
         $this->policies[] = $policy;
-        $this->patternToRegexpCache = array();
+        $this->patternToRegexpCache = [];
     }
 
     /**
@@ -48,9 +46,8 @@ final class PatternTransformer
      * @param string $type
      * @param string $stepText
      *
-     * @return Pattern
-     *
      * @throws UnsupportedPatternTypeException
+     * @return Pattern
      */
     public function generatePattern($type, $stepText)
     {
@@ -68,9 +65,8 @@ final class PatternTransformer
      *
      * @param string $pattern
      *
-     * @return string
-     *
      * @throws UnknownPatternException
+     * @return string
      */
     public function transformPatternToRegex($pattern)
     {
@@ -84,9 +80,8 @@ final class PatternTransformer
     /**
      * @param string $pattern
      *
-     * @return string
-     *
      * @throws UnknownPatternException
+     * @return string
      */
     private function transformPatternToRegexWithSupportedPolicy($pattern)
     {

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -24,11 +24,11 @@ final class RegexPatternPolicy implements PatternPolicy
     /**
      * @var string[string]
      */
-    private static $replacePatterns = array(
-        "/(?<=\W|^)\\\'(?:((?!\\').)*)\\\'(?=\W|$)/" => "'([^']*)'", // Single quoted strings
-        '/(?<=\W|^)\"(?:[^\"]*)\"(?=\W|$)/'          => "\"([^\"]*)\"", // Double quoted strings
-        '/(?<=\W|^)(\d+)(?=\W|$)/'                   => "(\\d+)", // Numbers
-    );
+    private static $replacePatterns = [
+        "/(?<=\\W|^)\\\\'(?:((?!\\').)*)\\\\'(?=\\W|$)/" => "'([^']*)'", // Single quoted strings
+        '/(?<=\W|^)\"(?:[^\"]*)\"(?=\W|$)/' => '"([^"]*)"', // Double quoted strings
+        '/(?<=\W|^)(\d+)(?=\W|$)/' => '(\\d+)', // Numbers
+    ];
 
     /**
      * {@inheritdoc}
@@ -101,9 +101,8 @@ final class RegexPatternPolicy implements PatternPolicy
         $canonicalText = preg_replace(array_keys(self::$replacePatterns), '', $stepText);
         $canonicalText = Transliterator::transliterate($canonicalText, ' ');
         $canonicalText = preg_replace('/[^a-zA-Z\_\ ]/', '', $canonicalText);
-        $canonicalText = str_replace(' ', '', ucwords($canonicalText));
 
-        return $canonicalText;
+        return str_replace(' ', '', ucwords($canonicalText));
     }
 
     /**
@@ -112,7 +111,7 @@ final class RegexPatternPolicy implements PatternPolicy
      * @param string $stepText
      * @param string $stepRegex
      *
-     * @return integer
+     * @return int
      */
     private function countPlaceholders($stepText, $stepRegex)
     {

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -10,8 +10,8 @@
 
 namespace Behat\Behat\Definition\Pattern\Policy;
 
-use Behat\Behat\Definition\Pattern\Pattern;
 use Behat\Behat\Definition\Exception\InvalidPatternException;
+use Behat\Behat\Definition\Pattern\Pattern;
 use Behat\Transliterator\Transliterator;
 
 /**
@@ -21,25 +21,25 @@ use Behat\Transliterator\Transliterator;
  */
 final class TurnipPatternPolicy implements PatternPolicy
 {
-    public const TOKEN_REGEX = "[\"']?(?P<%s>(?<=\")[^\"]*(?=\")|(?<=')[^']*(?=')|\-?[\w\.\,]+)['\"]?";
+    public const TOKEN_REGEX = "[\"']?(?P<%s>(?<=\")[^\"]*(?=\")|(?<=')[^']*(?=')|\\-?[\\w\\.\\,]+)['\"]?";
 
-    public const PLACEHOLDER_REGEXP = "/\\\:(\w+)/";
+    public const PLACEHOLDER_REGEXP = '/\\\\:(\\w+)/';
     public const OPTIONAL_WORD_REGEXP = '/(\s)?\\\\\(([^\\\]+)\\\\\)(\s)?/';
     public const ALTERNATIVE_WORD_REGEXP = '/(\w+)\\\\\/(\w+)/';
 
     /**
      * @var string[]
      */
-    private $regexCache = array();
+    private $regexCache = [];
 
     /**
      * @var string[]
      */
-    private static $placeholderPatterns = array(
-        "/(?<!\w)\"[^\"]+\"(?!\w)/",
-        "/(?<!\w)'[^']+'(?!\w)/",
-        "/(?<!\w|\.|\,)\-?\d+(?:[\.\,]\d+)?(?!\w|\.|\,)/"
-    );
+    private static $placeholderPatterns = [
+        '/(?<!\\w)"[^"]+"(?!\\w)/',
+        "/(?<!\\w)'[^']+'(?!\\w)/",
+        '/(?<!\\w|\\.|\\,)\\-?\\d+(?:[\\.\\,]\\d+)?(?!\\w|\\.|\\,)/',
+    ];
 
     /**
      * {@inheritdoc}
@@ -85,11 +85,12 @@ final class TurnipPatternPolicy implements PatternPolicy
         if (!isset($this->regexCache[$pattern])) {
             $this->regexCache[$pattern] = $this->createTransformedRegex($pattern);
         }
+
         return $this->regexCache[$pattern];
     }
 
     /**
-     * @param string $pattern
+     * @param  string $pattern
      * @return string
      */
     private function createTransformedRegex($pattern)
@@ -115,9 +116,8 @@ final class TurnipPatternPolicy implements PatternPolicy
         $canonicalText = preg_replace(self::$placeholderPatterns, '', $stepText);
         $canonicalText = Transliterator::transliterate($canonicalText, ' ');
         $canonicalText = preg_replace('/[^a-zA-Z\_\ ]/', '', $canonicalText);
-        $canonicalText = str_replace(' ', '', ucwords($canonicalText));
 
-        return $canonicalText;
+        return str_replace(' ', '', ucwords($canonicalText));
     }
 
     /**
@@ -133,7 +133,7 @@ final class TurnipPatternPolicy implements PatternPolicy
 
         return preg_replace_callback(
             self::PLACEHOLDER_REGEXP,
-            array($this, 'replaceTokenWithRegexCaptureGroup'),
+            [$this, 'replaceTokenWithRegexCaptureGroup'],
             $regex
         );
     }
@@ -171,9 +171,8 @@ final class TurnipPatternPolicy implements PatternPolicy
     private function replaceTurnipAlternativeWordsWithRegex($regex)
     {
         $regex = preg_replace(self::ALTERNATIVE_WORD_REGEXP, '(?:\1|\2)', $regex);
-        $regex = $this->removeEscapingOfAlternationSyntax($regex);
 
-        return $regex;
+        return $this->removeEscapingOfAlternationSyntax($regex);
     }
 
     /**

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
@@ -41,7 +41,7 @@ final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
     public function printDefinitions(Suite $suite, $definitions)
     {
         $search = $this->searchCriterion;
-        $output = array();
+        $output = [];
 
         foreach ($definitions as $definition) {
             $definition = $this->translateDefinition($suite, $definition);
@@ -66,21 +66,19 @@ final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
     /**
      * Extracts the formatted header from the definition.
      *
-     * @param Suite      $suite
-     * @param Definition $definition
-     *
      * @return string[]
      */
     private function extractHeader(Suite $suite, Definition $definition)
     {
         $pattern = $definition->getPattern();
-        $lines = array();
+        $lines = [];
         $lines[] = strtr(
-            '{suite} <def_dimmed>|</def_dimmed> <info>{type}</info> <def_regex>{regex}</def_regex>', array(
+            '{suite} <def_dimmed>|</def_dimmed> <info>{type}</info> <def_regex>{regex}</def_regex>',
+            [
                 '{suite}' => $suite->getName(),
-                '{type}'  => $this->getDefinitionType($definition),
+                '{type}' => $this->getDefinitionType($definition),
                 '{regex}' => $pattern,
-            )
+            ]
         );
 
         return $lines;
@@ -89,23 +87,21 @@ final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
     /**
      * Extracts the formatted description from the definition.
      *
-     * @param Suite      $suite
-     * @param Definition $definition
-     *
      * @return string[]
      */
     private function extractDescription(Suite $suite, Definition $definition)
     {
         $definition = $this->translateDefinition($suite, $definition);
 
-        $lines = array();
+        $lines = [];
         if ($description = $definition->getDescription()) {
             foreach (explode("\n", $description) as $descriptionLine) {
                 $lines[] = strtr(
-                    '{space}<def_dimmed>|</def_dimmed> {description}', array(
-                        '{space}'       => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
-                        '{description}' => $descriptionLine
-                    )
+                    '{space}<def_dimmed>|</def_dimmed> {description}',
+                    [
+                        '{space}' => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
+                        '{description}' => $descriptionLine,
+                    ]
                 );
             }
         }
@@ -116,29 +112,28 @@ final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
     /**
      * Extracts the formatted footer from the definition.
      *
-     * @param Suite      $suite
-     * @param Definition $definition
-     *
      * @return string[]
      */
     private function extractFooter(Suite $suite, Definition $definition)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = strtr(
-            '{space}<def_dimmed>|</def_dimmed> at `{path}`', array(
+            '{space}<def_dimmed>|</def_dimmed> at `{path}`',
+            [
                 '{space}' => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
-                '{path}'  => $definition->getPath()
-            )
+                '{path}' => $definition->getPath(),
+            ]
         );
 
         if ($this->isVerbose()) {
             $lines[] = strtr(
-                '{space}<def_dimmed>|</def_dimmed> on `{filepath}[{start}:{end}]`', array(
+                '{space}<def_dimmed>|</def_dimmed> on `{filepath}[{start}:{end}]`',
+                [
                     '{space}' => str_pad('', mb_strlen($suite->getName(), 'utf8') + 1),
                     '{filepath}' => $definition->getReflection()->getFileName(),
                     '{start}' => $definition->getReflection()->getStartLine(),
-                    '{end}' => $definition->getReflection()->getEndLine()
-                )
+                    '{end}' => $definition->getReflection()->getEndLine(),
+                ]
             );
         }
 

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionListPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionListPrinter.php
@@ -24,17 +24,18 @@ final class ConsoleDefinitionListPrinter extends ConsoleDefinitionPrinter
      */
     public function printDefinitions(Suite $suite, $definitions)
     {
-        $output = array();
+        $output = [];
 
         foreach ($definitions as $definition) {
             $definition = $this->translateDefinition($suite, $definition);
 
             $output[] = strtr(
-                '{suite} <def_dimmed>|</def_dimmed> <info>{type}</info> <def_regex>{regex}</def_regex>', array(
+                '{suite} <def_dimmed>|</def_dimmed> <info>{type}</info> <def_regex>{regex}</def_regex>',
+                [
                     '{suite}' => $suite->getName(),
-                    '{type}'  => $this->getDefinitionType($definition, true),
+                    '{type}' => $this->getDefinitionType($definition, true),
                     '{regex}' => $definition->getPattern(),
-                )
+                ]
             );
         }
 

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
@@ -29,14 +29,17 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
      * @var OutputInterface
      */
     private $output;
+
     /**
      * @var PatternTransformer
      */
     private $patternTransformer;
+
     /**
      * @var DefinitionTranslator
      */
     private $translator;
+
     /**
      * @var KeywordsInterface
      */
@@ -44,11 +47,6 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param OutputInterface     $output
-     * @param PatternTransformer  $patternTransformer
-     * @param DefinitionTranslator $translator
-     * @param KeywordsInterface   $keywords
      */
     public function __construct(
         OutputInterface $output,
@@ -64,11 +62,11 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
         $output->getFormatter()->setStyle('def_regex', new OutputFormatterStyle('yellow'));
         $output->getFormatter()->setStyle(
             'def_regex_capture',
-            new OutputFormatterStyle('yellow', null, array('bold'))
+            new OutputFormatterStyle('yellow', null, ['bold'])
         );
         $output->getFormatter()->setStyle(
             'def_dimmed',
-            new OutputFormatterStyle('black', null, array('bold'))
+            new OutputFormatterStyle('black', null, ['bold'])
         );
     }
 
@@ -89,7 +87,7 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
 
         $method = 'get'.ucfirst($definition->getType()).'Keywords';
 
-        $keywords = explode('|', $this->keywords->$method());
+        $keywords = explode('|', $this->keywords->{$method}());
 
         if ($onlyOne) {
             return current($keywords);
@@ -100,9 +98,6 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
 
     /**
      * Translates definition using translator.
-     *
-     * @param Suite      $suite
-     * @param Definition $definition
      *
      * @return Definition
      */

--- a/src/Behat/Behat/Definition/Printer/DefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/DefinitionPrinter.php
@@ -23,7 +23,6 @@ interface DefinitionPrinter
     /**
      * Prints definition.
      *
-     * @param Suite        $suite
      * @param Definition[] $definitions
      */
     public function printDefinitions(Suite $suite, $definitions);

--- a/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
@@ -35,14 +35,17 @@ final class RepositorySearchEngine implements SearchEngine
      * @var DefinitionRepository
      */
     private $repository;
+
     /**
      * @var PatternTransformer
      */
     private $patternTransformer;
+
     /**
      * @var DefinitionTranslator
      */
     private $translator;
+
     /**
      * @var ArgumentOrganiser
      */
@@ -50,11 +53,6 @@ final class RepositorySearchEngine implements SearchEngine
 
     /**
      * Initializes search engine.
-     *
-     * @param DefinitionRepository $repository
-     * @param PatternTransformer   $patternTransformer
-     * @param DefinitionTranslator $translator
-     * @param ArgumentOrganiser    $argumentOrganiser
      */
     public function __construct(
         DefinitionRepository $repository,
@@ -83,7 +81,7 @@ final class RepositorySearchEngine implements SearchEngine
         $stepText = $step->getText();
         $multi = $step->getArguments();
 
-        $definitions = array();
+        $definitions = [];
         $result = null;
 
         foreach ($this->repository->getEnvironmentDefinitions($environment) as $definition) {
@@ -107,7 +105,6 @@ final class RepositorySearchEngine implements SearchEngine
     /**
      * Attempts to match provided definition against a step text.
      *
-     * @param Definition          $definition
      * @param string              $stepText
      * @param ArgumentInterface[] $multiline
      *

--- a/src/Behat/Behat/Definition/Search/SearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/SearchEngine.php
@@ -28,10 +28,6 @@ interface SearchEngine
     /**
      * Searches for a step definition.
      *
-     * @param Environment $environment
-     * @param FeatureNode $feature
-     * @param StepNode    $step
-     *
      * @return null|SearchResult
      */
     public function searchDefinition(Environment $environment, FeatureNode $feature, StepNode $step);

--- a/src/Behat/Behat/Definition/SearchResult.php
+++ b/src/Behat/Behat/Definition/SearchResult.php
@@ -21,10 +21,12 @@ final class SearchResult
      * @var null|Definition
      */
     private $definition;
+
     /**
      * @var null|string
      */
     private $matchedText;
+
     /**
      * @var null|array
      */
@@ -33,11 +35,9 @@ final class SearchResult
     /**
      * Registers search match.
      *
-     * @param null|Definition $definition
-     * @param null|string     $matchedText
-     * @param null|array      $arguments
+     * @param null|string $matchedText
      */
-    public function __construct(Definition $definition = null, $matchedText = null, array $arguments = null)
+    public function __construct(?Definition $definition = null, $matchedText = null, ?array $arguments = null)
     {
         $this->definition = $definition;
         $this->matchedText = $matchedText;

--- a/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
+++ b/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
@@ -11,8 +11,8 @@
 namespace Behat\Behat\Definition\ServiceContainer;
 
 use Behat\Behat\Context\ServiceContainer\ContextExtension;
-use Behat\Testwork\Argument\ServiceContainer\ArgumentExtension;
 use Behat\Behat\Gherkin\ServiceContainer\GherkinExtension;
+use Behat\Testwork\Argument\ServiceContainer\ArgumentExtension;
 use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\Environment\ServiceContainer\EnvironmentExtension;
 use Behat\Testwork\ServiceContainer\Extension;
@@ -55,12 +55,10 @@ final class DefinitionExtension implements Extension
 
     /**
      * Initializes compiler pass.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -115,8 +113,6 @@ final class DefinitionExtension implements Extension
 
     /**
      * Loads definition finder.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadFinder(ContainerBuilder $container)
     {
@@ -126,35 +122,29 @@ final class DefinitionExtension implements Extension
 
     /**
      * Loads definition repository.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadRepository(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Definition\DefinitionRepository', array(
-            new Reference(EnvironmentExtension::MANAGER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Definition\DefinitionRepository', [
+            new Reference(EnvironmentExtension::MANAGER_ID),
+        ]);
         $container->setDefinition(self::REPOSITORY_ID, $definition);
     }
 
     /**
      * Loads definition writer.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadWriter(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Definition\DefinitionWriter', array(
+        $definition = new Definition('Behat\Behat\Definition\DefinitionWriter', [
             new Reference(EnvironmentExtension::MANAGER_ID),
-            new Reference(self::REPOSITORY_ID)
-        ));
+            new Reference(self::REPOSITORY_ID),
+        ]);
         $container->setDefinition(self::WRITER_ID, $definition);
     }
 
     /**
      * Loads definition pattern transformer.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadPatternTransformer(ContainerBuilder $container)
     {
@@ -164,121 +154,105 @@ final class DefinitionExtension implements Extension
 
     /**
      * Loads definition translator.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadDefinitionTranslator(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Definition\Translator\DefinitionTranslator', array(
-            new Reference(TranslatorExtension::TRANSLATOR_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Definition\Translator\DefinitionTranslator', [
+            new Reference(TranslatorExtension::TRANSLATOR_ID),
+        ]);
         $container->setDefinition(self::DEFINITION_TRANSLATOR_ID, $definition);
     }
 
     /**
      * Loads default search engines.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadDefaultSearchEngines(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Definition\Search\RepositorySearchEngine', array(
+        $definition = new Definition('Behat\Behat\Definition\Search\RepositorySearchEngine', [
             new Reference(self::REPOSITORY_ID),
             new Reference(self::PATTERN_TRANSFORMER_ID),
             new Reference(self::DEFINITION_TRANSLATOR_ID),
-            new Reference(ArgumentExtension::PREG_MATCH_ARGUMENT_ORGANISER_ID)
-        ));
-        $definition->addTag(self::SEARCH_ENGINE_TAG, array('priority' => 50));
+            new Reference(ArgumentExtension::PREG_MATCH_ARGUMENT_ORGANISER_ID),
+        ]);
+        $definition->addTag(self::SEARCH_ENGINE_TAG, ['priority' => 50]);
         $container->setDefinition(self::SEARCH_ENGINE_TAG . '.repository', $definition);
     }
 
     /**
      * Loads default pattern policies.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadDefaultPatternPolicies(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Definition\Pattern\Policy\TurnipPatternPolicy');
-        $definition->addTag(self::PATTERN_POLICY_TAG, array('priority' => 50));
+        $definition->addTag(self::PATTERN_POLICY_TAG, ['priority' => 50]);
         $container->setDefinition(self::PATTERN_POLICY_TAG . '.turnip', $definition);
 
         $definition = new Definition('Behat\Behat\Definition\Pattern\Policy\RegexPatternPolicy');
-        $definition->addTag(self::PATTERN_POLICY_TAG, array('priority' => 60));
+        $definition->addTag(self::PATTERN_POLICY_TAG, ['priority' => 60]);
         $container->setDefinition(self::PATTERN_POLICY_TAG . '.regex', $definition);
     }
 
     /**
      * Loads definition annotation reader.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadAnnotationReader(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Definition\Context\Annotation\DefinitionAnnotationReader');
-        $definition->addTag(ContextExtension::ANNOTATION_READER_TAG, array('priority' => 50));
+        $definition->addTag(ContextExtension::ANNOTATION_READER_TAG, ['priority' => 50]);
         $container->setDefinition(ContextExtension::ANNOTATION_READER_TAG . '.definition', $definition);
     }
 
     /**
      * Loads definition Attribute reader.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadAttributeReader(ContainerBuilder $container)
     {
-        $definition = new Definition('\Behat\Behat\Definition\Context\Attribute\DefinitionAttributeReader', array(
-            new Reference(self::DOC_BLOCK_HELPER_ID)
-        ));
-        $definition->addTag(ContextExtension::ATTRIBUTE_READER_TAG, array('priority' => 50));
+        $definition = new Definition('\Behat\Behat\Definition\Context\Attribute\DefinitionAttributeReader', [
+            new Reference(self::DOC_BLOCK_HELPER_ID),
+        ]);
+        $definition->addTag(ContextExtension::ATTRIBUTE_READER_TAG, ['priority' => 50]);
         $container->setDefinition(ContextExtension::ATTRIBUTE_READER_TAG . '.definition', $definition);
     }
 
     /**
      * Loads definition printers.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadDefinitionPrinters(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Definition\Printer\ConsoleDefinitionInformationPrinter', array(
+        $definition = new Definition('Behat\Behat\Definition\Printer\ConsoleDefinitionInformationPrinter', [
             new Reference(CliExtension::OUTPUT_ID),
             new Reference(self::PATTERN_TRANSFORMER_ID),
             new Reference(self::DEFINITION_TRANSLATOR_ID),
-            new Reference(GherkinExtension::KEYWORDS_ID)
-        ));
+            new Reference(GherkinExtension::KEYWORDS_ID),
+        ]);
         $container->setDefinition($this->getInformationPrinterId(), $definition);
 
-        $definition = new Definition('Behat\Behat\Definition\Printer\ConsoleDefinitionListPrinter', array(
+        $definition = new Definition('Behat\Behat\Definition\Printer\ConsoleDefinitionListPrinter', [
             new Reference(CliExtension::OUTPUT_ID),
             new Reference(self::PATTERN_TRANSFORMER_ID),
             new Reference(self::DEFINITION_TRANSLATOR_ID),
-            new Reference(GherkinExtension::KEYWORDS_ID)
-        ));
+            new Reference(GherkinExtension::KEYWORDS_ID),
+        ]);
         $container->setDefinition($this->getListPrinterId(), $definition);
     }
 
     /**
      * Loads definition controller.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Definition\Cli\AvailableDefinitionsController', array(
+        $definition = new Definition('Behat\Behat\Definition\Cli\AvailableDefinitionsController', [
             new Reference(SuiteExtension::REGISTRY_ID),
             new Reference(self::WRITER_ID),
             new Reference($this->getListPrinterId()),
-            new Reference($this->getInformationPrinterId())
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 500));
+            new Reference($this->getInformationPrinterId()),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 500]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.available_definitions', $definition);
     }
 
     /**
-     * Loads DocBlockHelper
-     *
-     * @param ContainerBuilder $container
+     * Loads DocBlockHelper.
      */
     private function loadDocblockHelper(ContainerBuilder $container)
     {
@@ -289,8 +263,6 @@ final class DefinitionExtension implements Extension
 
     /**
      * Processes all search engines in the container.
-     *
-     * @param ContainerBuilder $container
      */
     private function processSearchEngines(ContainerBuilder $container)
     {
@@ -298,14 +270,12 @@ final class DefinitionExtension implements Extension
         $definition = $container->getDefinition(self::FINDER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerSearchEngine', array($reference));
+            $definition->addMethodCall('registerSearchEngine', [$reference]);
         }
     }
 
     /**
      * Processes all pattern policies.
-     *
-     * @param ContainerBuilder $container
      */
     private function processPatternPolicies(ContainerBuilder $container)
     {
@@ -313,7 +283,7 @@ final class DefinitionExtension implements Extension
         $definition = $container->getDefinition(self::PATTERN_TRANSFORMER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerPatternPolicy', array($reference));
+            $definition->addMethodCall('registerPatternPolicy', [$reference]);
         }
     }
 

--- a/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
+++ b/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
@@ -27,8 +27,6 @@ final class DefinitionTranslator
 
     /**
      * Initialises definition translator.
-     *
-     * @param TranslatorInterface $translator
      */
     public function __construct(TranslatorInterface $translator)
     {
@@ -38,8 +36,6 @@ final class DefinitionTranslator
     /**
      * Attempts to translate definition using translator and produce translated one on success.
      *
-     * @param Suite       $suite
-     * @param Definition  $definition
      * @param null|string $language
      *
      * @return Definition|TranslatedDefinition
@@ -49,8 +45,8 @@ final class DefinitionTranslator
         $assetsId = $suite->getName();
         $pattern = $definition->getPattern();
 
-        $translatedPattern = $this->translator->trans($pattern, array(), $assetsId, $language);
-        if ($pattern != $translatedPattern) {
+        $translatedPattern = $this->translator->trans($pattern, [], $assetsId, $language);
+        if ($pattern !== $translatedPattern) {
             return new TranslatedDefinition($definition, $translatedPattern, $language);
         }
 

--- a/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
@@ -23,10 +23,12 @@ final class TranslatedDefinition implements Definition
      * @var Definition
      */
     private $definition;
+
     /**
      * @var string
      */
     private $translatedPattern;
+
     /**
      * @var string
      */
@@ -35,15 +37,22 @@ final class TranslatedDefinition implements Definition
     /**
      * Initialises translated definition.
      *
-     * @param Definition $definition
-     * @param string     $translatedPattern
-     * @param string     $language
+     * @param string $translatedPattern
+     * @param string $language
      */
     public function __construct(Definition $definition, $translatedPattern, $language)
     {
         $this->definition = $definition;
         $this->translatedPattern = $translatedPattern;
         $this->language = $language;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return $this->definition->__toString();
     }
 
     /**
@@ -128,13 +137,5 @@ final class TranslatedDefinition implements Definition
     public function getReflection()
     {
         return $this->definition->getReflection();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return $this->definition->__toString();
     }
 }

--- a/src/Behat/Behat/Definition/Translator/Translator.php
+++ b/src/Behat/Behat/Definition/Translator/Translator.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Behat\Behat\Definition\Translator;
 
 class Translator extends \Symfony\Component\Translation\Translator implements TranslatorInterface

--- a/src/Behat/Behat/Definition/Translator/TranslatorInterface.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatorInterface.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Behat\Behat\Definition\Translator;
 
 /**

--- a/src/Behat/Behat/EventDispatcher/Cli/StopOnFailureController.php
+++ b/src/Behat/Behat/EventDispatcher/Cli/StopOnFailureController.php
@@ -18,7 +18,6 @@ use Behat\Testwork\EventDispatcher\Event\AfterExerciseAborted;
 use Behat\Testwork\EventDispatcher\Event\AfterSuiteAborted;
 use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
 use Behat\Testwork\EventDispatcher\Event\SuiteTested;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Tester\Result\Interpretation\ResultInterpretation;
 use Behat\Testwork\Tester\Result\Interpretation\SoftInterpretation;
 use Behat\Testwork\Tester\Result\Interpretation\StrictInterpretation;
@@ -47,8 +46,6 @@ final class StopOnFailureController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(EventDispatcherInterface $eventDispatcher)
     {
@@ -58,12 +55,13 @@ final class StopOnFailureController implements Controller
 
     /**
      * Configures command to be executable by the controller.
-     *
-     * @param Command $command
      */
     public function configure(Command $command)
     {
-        $command->addOption('--stop-on-failure', null, InputOption::VALUE_NONE,
+        $command->addOption(
+            '--stop-on-failure',
+            null,
+            InputOption::VALUE_NONE,
             'Stop processing on first failed scenario.'
         );
     }
@@ -71,10 +69,7 @@ final class StopOnFailureController implements Controller
     /**
      * Executes controller.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return null|integer
+     * @return null|int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
@@ -86,14 +81,12 @@ final class StopOnFailureController implements Controller
             $this->resultInterpretation = new StrictInterpretation();
         }
 
-        $this->eventDispatcher->addListener(ScenarioTested::AFTER, array($this, 'exitOnFailure'), -100);
-        $this->eventDispatcher->addListener(ExampleTested::AFTER, array($this, 'exitOnFailure'), -100);
+        $this->eventDispatcher->addListener(ScenarioTested::AFTER, [$this, 'exitOnFailure'], -100);
+        $this->eventDispatcher->addListener(ExampleTested::AFTER, [$this, 'exitOnFailure'], -100);
     }
 
     /**
      * Exits if scenario is a failure and if stopper is enabled.
-     *
-     * @param AfterScenarioTested $event
      */
     public function exitOnFailure(AfterScenarioTested $event)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
@@ -28,10 +28,12 @@ final class AfterBackgroundSetup extends BackgroundTested implements AfterSetup
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var BackgroundNode
      */
     private $background;
+
     /**
      * @var Setup
      */
@@ -39,11 +41,6 @@ final class AfterBackgroundSetup extends BackgroundTested implements AfterSetup
 
     /**
      * Initializes event.
-     *
-     * @param Environment    $env
-     * @param FeatureNode    $feature
-     * @param BackgroundNode $background
-     * @param Setup          $setup
      */
     public function __construct(Environment $env, FeatureNode $feature, BackgroundNode $background, Setup $setup)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
@@ -29,14 +29,17 @@ final class AfterBackgroundTested extends BackgroundTested implements AfterTeste
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var BackgroundNode
      */
     private $background;
+
     /**
      * @var TestResult
      */
     private $result;
+
     /**
      * @var Teardown
      */
@@ -44,12 +47,6 @@ final class AfterBackgroundTested extends BackgroundTested implements AfterTeste
 
     /**
      * Initializes event.
-     *
-     * @param Environment    $env
-     * @param FeatureNode    $feature
-     * @param BackgroundNode $background
-     * @param TestResult     $result
-     * @param Teardown       $teardown
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Behat/EventDispatcher/Event/AfterFeatureSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterFeatureSetup.php
@@ -26,6 +26,7 @@ final class AfterFeatureSetup extends FeatureTested implements AfterSetup
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var Setup
      */
@@ -33,10 +34,6 @@ final class AfterFeatureSetup extends FeatureTested implements AfterSetup
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Setup       $setup
      */
     public function __construct(Environment $env, FeatureNode $feature, Setup $setup)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterFeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterFeatureTested.php
@@ -27,10 +27,12 @@ final class AfterFeatureTested extends FeatureTested implements AfterTested
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var TestResult
      */
     private $result;
+
     /**
      * @var Teardown
      */
@@ -38,11 +40,6 @@ final class AfterFeatureTested extends FeatureTested implements AfterTested
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param TestResult  $result
-     * @param Teardown    $teardown
      */
     public function __construct(Environment $env, FeatureNode $feature, TestResult $result, Teardown $teardown)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterOutlineSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterOutlineSetup.php
@@ -27,10 +27,12 @@ final class AfterOutlineSetup extends OutlineTested implements AfterSetup
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var OutlineNode
      */
     private $outline;
+
     /**
      * @var Setup
      */
@@ -38,11 +40,6 @@ final class AfterOutlineSetup extends OutlineTested implements AfterSetup
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param OutlineNode $outline
-     * @param Setup       $setup
      */
     public function __construct(Environment $env, FeatureNode $feature, OutlineNode $outline, Setup $setup)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterOutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterOutlineTested.php
@@ -28,14 +28,17 @@ final class AfterOutlineTested extends OutlineTested implements AfterTested
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var OutlineNode
      */
     private $outline;
+
     /**
      * @var TestResult
      */
     private $result;
+
     /**
      * @var Teardown
      */
@@ -43,12 +46,6 @@ final class AfterOutlineTested extends OutlineTested implements AfterTested
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param OutlineNode $outline
-     * @param TestResult  $result
-     * @param Teardown    $teardown
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Behat/EventDispatcher/Event/AfterScenarioSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterScenarioSetup.php
@@ -28,22 +28,19 @@ final class AfterScenarioSetup extends ScenarioTested implements AfterSetup
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var Scenario
      */
     private $scenario;
+
     /**
      * @var Setup
      */
     private $setup;
 
     /**
-     * Initializes event
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
-     * @param Setup       $setup
+     * Initializes event.
      */
     public function __construct(Environment $env, FeatureNode $feature, Scenario $scenario, Setup $setup)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterScenarioTested.php
@@ -29,27 +29,24 @@ final class AfterScenarioTested extends ScenarioTested implements AfterTested
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var Scenario
      */
     private $scenario;
+
     /**
      * @var TestResult
      */
     private $result;
+
     /**
      * @var Teardown
      */
     private $teardown;
 
     /**
-     * Initializes event
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
-     * @param TestResult  $result
-     * @param Teardown    $teardown
+     * Initializes event.
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
@@ -27,10 +27,12 @@ final class AfterStepSetup extends StepTested implements AfterSetup
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var StepNode
      */
     private $step;
+
     /**
      * @var Setup
      */
@@ -38,11 +40,6 @@ final class AfterStepSetup extends StepTested implements AfterSetup
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
-     * @param Setup       $setup
      */
     public function __construct(Environment $env, FeatureNode $feature, StepNode $step, Setup $setup)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
@@ -31,14 +31,17 @@ final class AfterStepTested extends StepTested implements AfterTested
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var StepNode
      */
     private $step;
+
     /**
      * @var StepResult
      */
     private $result;
+
     /**
      * @var Teardown
      */
@@ -46,12 +49,6 @@ final class AfterStepTested extends StepTested implements AfterTested
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
-     * @param StepResult  $result
-     * @param Teardown    $teardown
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
@@ -28,10 +28,12 @@ final class BeforeBackgroundTeardown extends BackgroundTested implements BeforeT
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var BackgroundNode
      */
     private $background;
+
     /**
      * @var TestResult
      */
@@ -39,11 +41,6 @@ final class BeforeBackgroundTeardown extends BackgroundTested implements BeforeT
 
     /**
      * Initializes event.
-     *
-     * @param Environment    $env
-     * @param FeatureNode    $feature
-     * @param BackgroundNode $background
-     * @param TestResult     $result
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
@@ -27,6 +27,7 @@ final class BeforeBackgroundTested extends BackgroundTested implements BeforeTes
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var BackgroundNode
      */
@@ -34,10 +35,6 @@ final class BeforeBackgroundTested extends BackgroundTested implements BeforeTes
 
     /**
      * Initializes event.
-     *
-     * @param Environment    $env
-     * @param FeatureNode    $feature
-     * @param BackgroundNode $background
      */
     public function __construct(Environment $env, FeatureNode $feature, BackgroundNode $background)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTeardown.php
@@ -26,6 +26,7 @@ final class BeforeFeatureTeardown extends FeatureTested implements BeforeTeardow
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var TestResult
      */
@@ -33,10 +34,6 @@ final class BeforeFeatureTeardown extends FeatureTested implements BeforeTeardow
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param TestResult  $result
      */
     public function __construct(Environment $env, FeatureNode $feature, TestResult $result)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTested.php
@@ -28,9 +28,6 @@ final class BeforeFeatureTested extends FeatureTested implements BeforeTested
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
      */
     public function __construct(Environment $env, FeatureNode $feature)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTeardown.php
@@ -27,10 +27,12 @@ final class BeforeOutlineTeardown extends OutlineTested implements BeforeTeardow
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var OutlineNode
      */
     private $outline;
+
     /**
      * @var TestResult
      */
@@ -38,11 +40,6 @@ final class BeforeOutlineTeardown extends OutlineTested implements BeforeTeardow
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param OutlineNode $outline
-     * @param TestResult  $result
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTested.php
@@ -26,6 +26,7 @@ final class BeforeOutlineTested extends OutlineTested implements BeforeTested
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var OutlineNode
      */
@@ -33,10 +34,6 @@ final class BeforeOutlineTested extends OutlineTested implements BeforeTested
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param OutlineNode $outline
      */
     public function __construct(Environment $env, FeatureNode $feature, OutlineNode $outline)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTeardown.php
@@ -28,22 +28,19 @@ final class BeforeScenarioTeardown extends ScenarioTested implements BeforeTeard
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var Scenario
      */
     private $scenario;
+
     /**
      * @var TestResult
      */
     private $result;
 
     /**
-     * Initializes event
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
-     * @param TestResult  $result
+     * Initializes event.
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTested.php
@@ -27,17 +27,14 @@ final class BeforeScenarioTested extends ScenarioTested implements BeforeTested
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var Scenario
      */
     private $scenario;
 
     /**
-     * Initializes event
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
+     * Initializes event.
      */
     public function __construct(Environment $env, FeatureNode $feature, Scenario $scenario)
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
@@ -30,10 +30,12 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var StepNode
      */
     private $step;
+
     /**
      * @var StepResult
      */
@@ -41,11 +43,6 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
-     * @param StepResult  $result
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTested.php
@@ -26,6 +26,7 @@ final class BeforeStepTested extends StepTested implements BeforeTested
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var StepNode
      */
@@ -33,10 +34,6 @@ final class BeforeStepTested extends StepTested implements BeforeTested
 
     /**
      * Initializes event.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
      */
     public function __construct(Environment $env, FeatureNode $feature, StepNode $step)
     {

--- a/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -45,113 +45,99 @@ class EventDispatcherExtension extends BaseExtension
 
     /**
      * Loads stop on failure controller.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadStopOnFailureController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\EventDispatcher\Cli\StopOnFailureController', array(
-            new Reference(EventDispatcherExtension::DISPATCHER_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 100));
+        $definition = new Definition('Behat\Behat\EventDispatcher\Cli\StopOnFailureController', [
+            new Reference(EventDispatcherExtension::DISPATCHER_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 100]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.stop_on_failure', $definition);
     }
 
     /**
      * Loads event-dispatching background tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatchingBackgroundTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingBackgroundTester', array(
+        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingBackgroundTester', [
             new Reference(TesterExtension::BACKGROUND_TESTER_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
-        $definition->addTag(TesterExtension::BACKGROUND_TESTER_WRAPPER_TAG, array('priority' => -9999));
+            new Reference(self::DISPATCHER_ID),
+        ]);
+        $definition->addTag(TesterExtension::BACKGROUND_TESTER_WRAPPER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::BACKGROUND_TESTER_WRAPPER_TAG . '.event_dispatching', $definition);
     }
 
     /**
      * Loads event-dispatching feature tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatchingFeatureTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingFeatureTester', array(
+        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingFeatureTester', [
             new Reference(TesterExtension::SPECIFICATION_TESTER_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
-        $definition->addTag(TesterExtension::SPECIFICATION_TESTER_WRAPPER_TAG, array('priority' => -9999));
+            new Reference(self::DISPATCHER_ID),
+        ]);
+        $definition->addTag(TesterExtension::SPECIFICATION_TESTER_WRAPPER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::SPECIFICATION_TESTER_WRAPPER_TAG . '.event_dispatching', $definition);
     }
 
     /**
      * Loads event-dispatching outline tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatchingOutlineTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingOutlineTester', array(
+        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingOutlineTester', [
             new Reference(TesterExtension::OUTLINE_TESTER_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
-        $definition->addTag(TesterExtension::OUTLINE_TESTER_WRAPPER_TAG, array('priority' => -9999));
+            new Reference(self::DISPATCHER_ID),
+        ]);
+        $definition->addTag(TesterExtension::OUTLINE_TESTER_WRAPPER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::OUTLINE_TESTER_WRAPPER_TAG . '.event_dispatching', $definition);
     }
 
     /**
      * Loads event-dispatching scenario tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatchingScenarioTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingScenarioTester', array(
+        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingScenarioTester', [
             new Reference(TesterExtension::SCENARIO_TESTER_ID),
             new Reference(self::DISPATCHER_ID),
             ScenarioTested::BEFORE,
             ScenarioTested::AFTER_SETUP,
             ScenarioTested::BEFORE_TEARDOWN,
-            ScenarioTested::AFTER
-        ));
-        $definition->addTag(TesterExtension::SCENARIO_TESTER_WRAPPER_TAG, array('priority' => -9999));
+            ScenarioTested::AFTER,
+        ]);
+        $definition->addTag(TesterExtension::SCENARIO_TESTER_WRAPPER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::SCENARIO_TESTER_WRAPPER_TAG . '.event_dispatching', $definition);
     }
 
     /**
      * Loads event-dispatching example tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatchingExampleTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingScenarioTester', array(
+        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingScenarioTester', [
             new Reference(TesterExtension::EXAMPLE_TESTER_ID),
             new Reference(self::DISPATCHER_ID),
             ExampleTested::BEFORE,
             ExampleTested::AFTER_SETUP,
             ExampleTested::BEFORE_TEARDOWN,
-            ExampleTested::AFTER
-        ));
-        $definition->addTag(TesterExtension::EXAMPLE_TESTER_WRAPPER_TAG, array('priority' => -9999));
+            ExampleTested::AFTER,
+        ]);
+        $definition->addTag(TesterExtension::EXAMPLE_TESTER_WRAPPER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::EXAMPLE_TESTER_WRAPPER_TAG . '.event_dispatching', $definition);
     }
 
     /**
      * Loads event-dispatching step tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatchingStepTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingStepTester', array(
+        $definition = new Definition('Behat\Behat\EventDispatcher\Tester\EventDispatchingStepTester', [
             new Reference(TesterExtension::STEP_TESTER_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
-        $definition->addTag(TesterExtension::STEP_TESTER_WRAPPER_TAG, array('priority' => -9999));
+            new Reference(self::DISPATCHER_ID),
+        ]);
+        $definition->addTag(TesterExtension::STEP_TESTER_WRAPPER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::STEP_TESTER_WRAPPER_TAG . '.event_dispatching', $definition);
     }
 
@@ -164,8 +150,6 @@ class EventDispatcherExtension extends BaseExtension
      * @todo Remove this method in next major
      *
      * @deprecated
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadTickingStepTester(ContainerBuilder $container)
     {

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingBackgroundTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingBackgroundTester.php
@@ -18,7 +18,6 @@ use Behat\Behat\EventDispatcher\Event\BeforeBackgroundTested;
 use Behat\Behat\Tester\BackgroundTester;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Environment\Environment;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Tester\Result\TestResult;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -33,6 +32,7 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
      * @var BackgroundTester
      */
     private $baseTester;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -40,9 +40,6 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
 
     /**
      * Initializes tester.
-     *
-     * @param BackgroundTester         $baseTester
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(BackgroundTester $baseTester, EventDispatcherInterface $eventDispatcher)
     {
@@ -71,14 +68,6 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, FeatureNode $feature, $skip)
-    {
-        return $this->baseTester->test($env, $feature, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result)
     {
         $event = new BeforeBackgroundTeardown($env, $feature, $feature->getBackground(), $result);
@@ -92,5 +81,13 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
         $this->eventDispatcher->dispatch($event, BackgroundTested::AFTER);
 
         return $teardown;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, FeatureNode $feature, $skip)
+    {
+        return $this->baseTester->test($env, $feature, $skip);
     }
 }

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
@@ -15,7 +15,6 @@ use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
 use Behat\Behat\EventDispatcher\Event\BeforeFeatureTeardown;
 use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
 use Behat\Testwork\Environment\Environment;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Tester\Result\TestResult;
 use Behat\Testwork\Tester\SpecificationTester;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -31,6 +30,7 @@ final class EventDispatchingFeatureTester implements SpecificationTester
      * @var SpecificationTester
      */
     private $baseTester;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -38,9 +38,6 @@ final class EventDispatchingFeatureTester implements SpecificationTester
 
     /**
      * Initializes tester.
-     *
-     * @param SpecificationTester      $baseTester
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(SpecificationTester $baseTester, EventDispatcherInterface $eventDispatcher)
     {
@@ -69,14 +66,6 @@ final class EventDispatchingFeatureTester implements SpecificationTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, $spec, $skip)
-    {
-        return $this->baseTester->test($env, $spec, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, $spec, $skip, TestResult $result)
     {
         $event = new BeforeFeatureTeardown($env, $spec, $result);
@@ -90,5 +79,13 @@ final class EventDispatchingFeatureTester implements SpecificationTester
         $this->eventDispatcher->dispatch($event, $event::AFTER);
 
         return $teardown;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, $spec, $skip)
+    {
+        return $this->baseTester->test($env, $spec, $skip);
     }
 }

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php
@@ -18,7 +18,6 @@ use Behat\Behat\Tester\OutlineTester;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Testwork\Environment\Environment;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Tester\Result\TestResult;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -33,6 +32,7 @@ final class EventDispatchingOutlineTester implements OutlineTester
      * @var OutlineTester
      */
     private $baseTester;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -40,9 +40,6 @@ final class EventDispatchingOutlineTester implements OutlineTester
 
     /**
      * Initializes tester.
-     *
-     * @param OutlineTester            $baseTester
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(OutlineTester $baseTester, EventDispatcherInterface $eventDispatcher)
     {
@@ -71,19 +68,11 @@ final class EventDispatchingOutlineTester implements OutlineTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip)
-    {
-        return $this->baseTester->test($env, $feature, $outline, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result)
     {
         $event = new BeforeOutlineTeardown($env, $feature, $outline, $result);
 
-        $this->eventDispatcher->dispatch( $event,$event::BEFORE_TEARDOWN);
+        $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
 
         $teardown = $this->baseTester->tearDown($env, $feature, $outline, $skip, $result);
 
@@ -92,5 +81,13 @@ final class EventDispatchingOutlineTester implements OutlineTester
         $this->eventDispatcher->dispatch($event, $event::AFTER);
 
         return $teardown;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip)
+    {
+        return $this->baseTester->test($env, $feature, $outline, $skip);
     }
 }

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
@@ -18,7 +18,6 @@ use Behat\Behat\Tester\ScenarioTester;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioInterface as Scenario;
 use Behat\Testwork\Environment\Environment;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Tester\Result\TestResult;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -33,22 +32,27 @@ final class EventDispatchingScenarioTester implements ScenarioTester
      * @var ScenarioTester
      */
     private $baseTester;
+
     /**
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
+
     /**
      * @var string
      */
     private $beforeEventName;
+
     /**
      * @var string
      */
     private $afterSetupEventName;
+
     /**
      * @var string
      */
     private $beforeTeardownEventName;
+
     /**
      * @var string
      */
@@ -57,12 +61,10 @@ final class EventDispatchingScenarioTester implements ScenarioTester
     /**
      * Initializes tester.
      *
-     * @param ScenarioTester           $baseTester
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param string                   $beforeEventName
-     * @param string                   $afterSetupEventName
-     * @param string                   $beforeTeardownEventName
-     * @param string                   $afterEventName
+     * @param string $beforeEventName
+     * @param string $afterSetupEventName
+     * @param string $beforeTeardownEventName
+     * @param string $afterEventName
      */
     public function __construct(
         ScenarioTester $baseTester,
@@ -101,14 +103,6 @@ final class EventDispatchingScenarioTester implements ScenarioTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
-    {
-        return $this->baseTester->test($env, $feature, $scenario, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
     {
         $event = new BeforeScenarioTeardown($env, $feature, $scenario, $result);
@@ -122,5 +116,13 @@ final class EventDispatchingScenarioTester implements ScenarioTester
         $this->eventDispatcher->dispatch($event, $this->afterEventName);
 
         return $teardown;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
+    {
+        return $this->baseTester->test($env, $feature, $scenario, $skip);
     }
 }

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingStepTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingStepTester.php
@@ -19,7 +19,6 @@ use Behat\Behat\Tester\StepTester;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\Environment\Environment;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -33,6 +32,7 @@ final class EventDispatchingStepTester implements StepTester
      * @var StepTester
      */
     private $baseTester;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -40,9 +40,6 @@ final class EventDispatchingStepTester implements StepTester
 
     /**
      * Initializes tester.
-     *
-     * @param StepTester               $baseTester
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(StepTester $baseTester, EventDispatcherInterface $eventDispatcher)
     {
@@ -71,14 +68,6 @@ final class EventDispatchingStepTester implements StepTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
-    {
-        return $this->baseTester->test($env, $feature, $step, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
     {
         $event = new BeforeStepTeardown($env, $feature, $step, $result);
@@ -92,5 +81,13 @@ final class EventDispatchingStepTester implements StepTester
         $this->eventDispatcher->dispatch($event, $event::AFTER);
 
         return $teardown;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    {
+        return $this->baseTester->test($env, $feature, $step, $skip);
     }
 }

--- a/src/Behat/Behat/EventDispatcher/Tester/TickingStepTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/TickingStepTester.php
@@ -18,13 +18,13 @@ use Behat\Testwork\Environment\Environment;
 
 /**
  * Enable ticks during step testing to allow SigintController in Testwork
- * to handle an interupt (on PHP7)
+ * to handle an interupt (on PHP7).
  *
  * @see Behat\Testwork\EventDispatcher\Cli\SigintController
- * 
- * @deprecated Since the way signals are handled changed to use pcntl_signal_dispatch
- *   this class is no longer needed.
- * 
+ *
+ * @deprecated since the way signals are handled changed to use pcntl_signal_dispatch
+ *   this class is no longer needed
+ *
  * @todo Remove this class in the next major version
  *
  * @author Peter Mitchell <peterjmit@gmail.com>
@@ -38,8 +38,6 @@ final class TickingStepTester implements StepTester
 
     /**
      * Initializes tester.
-     *
-     * @param StepTester  $baseTester
      */
     public function __construct(StepTester $baseTester)
     {
@@ -57,18 +55,18 @@ final class TickingStepTester implements StepTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
     {
-        declare(ticks = 1);
-
-        return $this->baseTester->test($env, $feature, $step, $skip);
+        return $this->baseTester->tearDown($env, $feature, $step, $skip, $result);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
     {
-        return $this->baseTester->tearDown($env, $feature, $step, $skip, $result);
+        declare(ticks=1);
+
+        return $this->baseTester->test($env, $feature, $step, $skip);
     }
 }

--- a/src/Behat/Behat/Gherkin/Cli/FilterController.php
+++ b/src/Behat/Behat/Gherkin/Cli/FilterController.php
@@ -34,8 +34,6 @@ final class FilterController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param Gherkin $gherkin
      */
     public function __construct(Gherkin $gherkin)
     {
@@ -44,40 +42,41 @@ final class FilterController implements Controller
 
     /**
      * Configures command to be executable by the controller.
-     *
-     * @param Command $command
      */
     public function configure(Command $command)
     {
         $command
             ->addOption(
-                '--name', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-                "Only executeCall the feature elements which match part" . PHP_EOL .
-                "of the given name or regex."
+                '--name',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Only executeCall the feature elements which match part' . PHP_EOL .
+                'of the given name or regex.'
             )
             ->addOption(
-                '--tags', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-                "Only executeCall the features or scenarios with tags" . PHP_EOL .
-                "matching tag filter expression."
+                '--tags',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Only executeCall the features or scenarios with tags' . PHP_EOL .
+                'matching tag filter expression.'
             )
             ->addOption(
-                '--role', null, InputOption::VALUE_REQUIRED,
-                "Only executeCall the features with actor role matching" . PHP_EOL .
-                "a wildcard."
+                '--role',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Only executeCall the features with actor role matching' . PHP_EOL .
+                'a wildcard.'
             );
     }
 
     /**
      * Executes controller.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return null|integer
+     * @return null|int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $filters = array();
+        $filters = [];
 
         foreach ($input->getOption('name') as $name) {
             $filters[] = new NameFilter($name);

--- a/src/Behat/Behat/Gherkin/Cli/SyntaxController.php
+++ b/src/Behat/Behat/Gherkin/Cli/SyntaxController.php
@@ -30,6 +30,7 @@ final class SyntaxController implements Controller
      * @var KeywordsDumper
      */
     private $keywordsDumper;
+
     /**
      * @var TranslatorInterface
      */
@@ -37,39 +38,33 @@ final class SyntaxController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param KeywordsDumper      $dumper
-     * @param TranslatorInterface $translator
      */
     public function __construct(KeywordsDumper $dumper, TranslatorInterface $translator)
     {
-        $dumper->setKeywordsDumperFunction(array($this, 'dumpKeywords'));
+        $dumper->setKeywordsDumperFunction([$this, 'dumpKeywords']);
         $this->keywordsDumper = $dumper;
         $this->translator = $translator;
     }
 
     /**
      * Configures command to be executable by the controller.
-     *
-     * @param Command $command
      */
     public function configure(Command $command)
     {
         $command
             ->addOption(
-                '--story-syntax', null, InputOption::VALUE_NONE,
-                "Print <comment>*.feature</comment> example." . PHP_EOL .
-                "Use <info>--lang</info> to see specific language."
+                '--story-syntax',
+                null,
+                InputOption::VALUE_NONE,
+                'Print <comment>*.feature</comment> example.' . PHP_EOL .
+                'Use <info>--lang</info> to see specific language.'
             );
     }
 
     /**
      * Executes controller.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return null|integer
+     * @return null|int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
@@ -77,7 +72,7 @@ final class SyntaxController implements Controller
             return null;
         }
 
-        $output->getFormatter()->setStyle('gherkin_keyword', new OutputFormatterStyle('green', null, array('bold')));
+        $output->getFormatter()->setStyle('gherkin_keyword', new OutputFormatterStyle('green', null, ['bold']));
         $output->getFormatter()->setStyle('gherkin_comment', new OutputFormatterStyle('yellow'));
 
         $story = $this->keywordsDumper->dump($this->translator->getLocale());

--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -32,26 +32,32 @@ final class LazyFeatureIterator implements SpecificationIterator
      * @var Suite
      */
     private $suite;
+
     /**
      * @var Gherkin
      */
     private $gherkin;
+
     /**
      * @var string[]
      */
-    private $paths = array();
+    private $paths = [];
+
     /**
      * @var FilterInterface[]
      */
-    private $filters = array();
+    private $filters = [];
+
     /**
-     * @var integer
+     * @var int
      */
     private $position = 0;
+
     /**
      * @var FeatureNode[]
      */
-    private $features = array();
+    private $features = [];
+
     /**
      * @var FeatureNode
      */
@@ -60,12 +66,10 @@ final class LazyFeatureIterator implements SpecificationIterator
     /**
      * Initializes specifications.
      *
-     * @param Suite             $suite
-     * @param Gherkin           $gherkin
      * @param string[]          $paths
      * @param FilterInterface[] $filters
      */
-    public function __construct(Suite $suite, Gherkin $gherkin, array $paths, array $filters = array())
+    public function __construct(Suite $suite, Gherkin $gherkin, array $paths, array $filters = [])
     {
         $this->suite = $suite;
         $this->gherkin = $gherkin;
@@ -125,17 +129,15 @@ final class LazyFeatureIterator implements SpecificationIterator
     /**
      * Returns list of filters from suite settings.
      *
-     * @param Suite $suite
-     *
      * @return FilterInterface[]
      */
     private function getSuiteFilters(Suite $suite)
     {
         if (!$suite->hasSetting('filters') || !is_array($suite->getSetting('filters'))) {
-            return array();
+            return [];
         }
 
-        $filters = array();
+        $filters = [];
         foreach ($suite->getSetting('filters') as $type => $filterString) {
             $filters[] = $this->createFilter($type, $filterString, $suite);
         }
@@ -148,11 +150,9 @@ final class LazyFeatureIterator implements SpecificationIterator
      *
      * @param string $type
      * @param string $filterString
-     * @param Suite  $suite
-     *
-     * @return FilterInterface
      *
      * @throws SuiteConfigurationException If filter type is not recognised
+     * @return FilterInterface
      */
     private function createFilter($type, $filterString, Suite $suite)
     {
@@ -176,7 +176,7 @@ final class LazyFeatureIterator implements SpecificationIterator
             '`%s` filter is not supported by the `%s` suite. Supported types are `%s`.',
             $type,
             $suite->getName(),
-            implode('`, `', array('role', 'name', 'tags'))
+            implode('`, `', ['role', 'name', 'tags'])
         ), $suite->getName());
     }
 
@@ -187,7 +187,7 @@ final class LazyFeatureIterator implements SpecificationIterator
     {
         while (!count($this->features) && $this->position < count($this->paths)) {
             $this->features = $this->parseFeature($this->paths[$this->position]);
-            $this->position++;
+            ++$this->position;
         }
 
         $this->currentFeature = array_shift($this->features);

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -17,9 +17,6 @@ use Behat\Testwork\Specification\Locator\SpecificationLocator;
 use Behat\Testwork\Specification\NoSpecificationsIterator;
 use Behat\Testwork\Suite\Exception\SuiteConfigurationException;
 use Behat\Testwork\Suite\Suite;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use RegexIterator;
 
 /**
  * Loads gherkin features from the filesystem using gherkin parser.
@@ -32,6 +29,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
      * @var Gherkin
      */
     private $gherkin;
+
     /**
      * @var string
      */
@@ -40,8 +38,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
     /**
      * Initializes loader.
      *
-     * @param Gherkin $gherkin
-     * @param string  $basePath
+     * @param string $basePath
      */
     public function __construct(Gherkin $gherkin, $basePath)
     {
@@ -54,13 +51,13 @@ final class FilesystemFeatureLocator implements SpecificationLocator
      */
     public function getLocatorExamples()
     {
-        return array(
-            "a dir <comment>(features/)</comment>",
-            "a feature <comment>(*.feature)</comment>",
-            "a scenario at specific line <comment>(*.feature:10)</comment>.",
-            "all scenarios at or after a specific line <comment>(*.feature:10-*)</comment>.",
-            "all scenarios at a line within a specific range <comment>(*.feature:10-20)</comment>."
-        );
+        return [
+            'a dir <comment>(features/)</comment>',
+            'a feature <comment>(*.feature)</comment>',
+            'a scenario at specific line <comment>(*.feature:10)</comment>.',
+            'all scenarios at or after a specific line <comment>(*.feature:10-*)</comment>.',
+            'all scenarios at a line within a specific range <comment>(*.feature:10-20)</comment>.',
+        ];
     }
 
     /**
@@ -75,12 +72,12 @@ final class FilesystemFeatureLocator implements SpecificationLocator
         $suiteLocators = $this->getSuitePaths($suite);
 
         if ($locator) {
-            $filters = array(new PathsFilter($suiteLocators));
+            $filters = [new PathsFilter($suiteLocators)];
 
             return new LazyFeatureIterator($suite, $this->gherkin, $this->findFeatureFiles($locator), $filters);
         }
 
-        $featurePaths = array();
+        $featurePaths = [];
         foreach ($suiteLocators as $suiteLocator) {
             $featurePaths = array_merge($featurePaths, $this->findFeatureFiles($suiteLocator));
         }
@@ -91,17 +88,15 @@ final class FilesystemFeatureLocator implements SpecificationLocator
     /**
      * Returns array of feature paths configured for the provided suite.
      *
-     * @param Suite $suite
-     *
-     * @return string[]
-     *
      * @throws SuiteConfigurationException If `paths` setting is not an array
+     * @return string[]
      */
     private function getSuitePaths(Suite $suite)
     {
         if (!is_array($suite->getSetting('paths'))) {
             throw new SuiteConfigurationException(
-                sprintf('`paths` setting of the "%s" suite is expected to be an array, %s given.',
+                sprintf(
+                    '`paths` setting of the "%s" suite is expected to be an array, %s given.',
                     $suite->getName(),
                     gettype($suite->getSetting('paths'))
                 ),
@@ -124,22 +119,22 @@ final class FilesystemFeatureLocator implements SpecificationLocator
         $absolutePath = $this->findAbsolutePath($path);
 
         if (!$absolutePath) {
-            return array($path);
+            return [$path];
         }
 
         if (is_file($absolutePath)) {
-            return array($absolutePath);
+            return [$absolutePath];
         }
 
-        $iterator = new RegexIterator(
-            new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator(
+        $iterator = new \RegexIterator(
+            new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(
                     $absolutePath,
-                    RecursiveDirectoryIterator::FOLLOW_SYMLINKS | RecursiveDirectoryIterator::SKIP_DOTS
+                    \RecursiveDirectoryIterator::FOLLOW_SYMLINKS | \RecursiveDirectoryIterator::SKIP_DOTS
                 )
             ),
             '/^.+\.feature$/i',
-            RegexIterator::MATCH
+            \RegexIterator::MATCH
         );
 
         $paths = array_map('strval', iterator_to_array($iterator));

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemRerunScenariosListLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemRerunScenariosListLocator.php
@@ -30,8 +30,6 @@ final class FilesystemRerunScenariosListLocator implements SpecificationLocator
 
     /**
      * Initializes locator.
-     *
-     * @param Gherkin $gherkin
      */
     public function __construct(Gherkin $gherkin)
     {
@@ -43,7 +41,7 @@ final class FilesystemRerunScenariosListLocator implements SpecificationLocator
      */
     public function getLocatorExamples()
     {
-        return array();
+        return [];
     }
 
     /**

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemScenariosListLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemScenariosListLocator.php
@@ -30,8 +30,6 @@ final class FilesystemScenariosListLocator implements SpecificationLocator
 
     /**
      * Initializes locator.
-     *
-     * @param Gherkin $gherkin
      */
     public function __construct(Gherkin $gherkin)
     {
@@ -43,7 +41,7 @@ final class FilesystemScenariosListLocator implements SpecificationLocator
      */
     public function getLocatorExamples()
     {
-        return array("a scenarios list file <comment>(*.scenarios)</comment>.");
+        return ['a scenarios list file <comment>(*.scenarios)</comment>.'];
     }
 
     /**

--- a/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
+++ b/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
@@ -25,6 +25,7 @@ final class SuiteWithPathsSetup implements SuiteSetup
      * @var string
      */
     private $basePath;
+
     /**
      * @var null|FilesystemLogger
      */
@@ -33,10 +34,9 @@ final class SuiteWithPathsSetup implements SuiteSetup
     /**
      * Initializes setup.
      *
-     * @param string                $basePath
-     * @param null|FilesystemLogger $logger
+     * @param string $basePath
      */
-    public function __construct($basePath, FilesystemLogger $logger = null)
+    public function __construct($basePath, ?FilesystemLogger $logger = null)
     {
         $this->basePath = $basePath;
         $this->logger = $logger;
@@ -101,10 +101,11 @@ final class SuiteWithPathsSetup implements SuiteSetup
      */
     private function isAbsolutePath($file)
     {
-        if ($file[0] == '/' || $file[0] == '\\'
-            || (strlen($file) > 3 && ctype_alpha($file[0])
-                && $file[1] == ':'
-                && ($file[2] == '\\' || $file[2] == '/')
+        if ($file[0] === '/' || $file[0] === '\\'
+            || (
+                strlen($file) > 3 && ctype_alpha($file[0])
+                && $file[1] === ':'
+                && ($file[2] === '\\' || $file[2] === '/')
             )
             || null !== parse_url($file, PHP_URL_SCHEME)
         ) {

--- a/src/Behat/Behat/HelperContainer/Argument/AutowiringResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/AutowiringResolver.php
@@ -13,7 +13,6 @@ namespace Behat\Behat\HelperContainer\Argument;
 use Behat\Behat\Context\Argument\ArgumentResolver;
 use Behat\Behat\HelperContainer\ArgumentAutowirer;
 use Psr\Container\ContainerInterface;
-use ReflectionClass;
 
 /**
  * Resolves arguments that weren't resolved before by autowiring.
@@ -31,8 +30,6 @@ final class AutowiringResolver implements ArgumentResolver
 
     /**
      * Initialises resolver.
-     *
-     * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {
@@ -42,7 +39,7 @@ final class AutowiringResolver implements ArgumentResolver
     /**
      * {@inheritdoc}
      */
-    public function resolveArguments(ReflectionClass $classReflection, array $arguments)
+    public function resolveArguments(\ReflectionClass $classReflection, array $arguments)
     {
         if ($constructor = $classReflection->getConstructor()) {
             return $this->autowirer->autowireArguments($constructor, $arguments);

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
@@ -13,7 +13,6 @@ namespace Behat\Behat\HelperContainer\Argument;
 use Behat\Behat\Context\Argument\ArgumentResolver;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
-use ReflectionClass;
 
 /**
  * Resolves arguments using provided service container.
@@ -31,8 +30,6 @@ final class ServicesResolver implements ArgumentResolver
 
     /**
      * Initialises resolver.
-     *
-     * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {
@@ -44,9 +41,9 @@ final class ServicesResolver implements ArgumentResolver
      *
      * @throws ContainerExceptionInterface
      */
-    public function resolveArguments(ReflectionClass $classReflection, array $arguments)
+    public function resolveArguments(\ReflectionClass $classReflection, array $arguments)
     {
-        return array_map(array($this, 'resolveArgument'), $arguments);
+        return array_map([$this, 'resolveArgument'], $arguments);
     }
 
     /**
@@ -57,9 +54,8 @@ final class ServicesResolver implements ArgumentResolver
      *
      * @param mixed $value
      *
-     * @return mixed
-     *
      * @throws ContainerExceptionInterface
+     * @return mixed
      */
     private function resolveArgument($value)
     {

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
@@ -11,10 +11,10 @@
 namespace Behat\Behat\HelperContainer\Argument;
 
 use Behat\Behat\Context\Argument\ArgumentResolver;
-use Behat\Behat\HelperContainer\Environment\ServiceContainerEnvironment;
 use Behat\Behat\Context\Argument\ArgumentResolverFactory;
 use Behat\Behat\Context\Argument\SuiteScopedResolverFactory;
 use Behat\Behat\HelperContainer\BuiltInServiceContainer;
+use Behat\Behat\HelperContainer\Environment\ServiceContainerEnvironment;
 use Behat\Behat\HelperContainer\Exception\WrongContainerClassException;
 use Behat\Behat\HelperContainer\Exception\WrongServicesConfigurationException;
 use Behat\Behat\HelperContainer\ServiceContainer\HelperContainerExtension;
@@ -39,8 +39,6 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
 
     /**
      * Initialises factory.
-     *
-     * @param TaggedContainerInterface $container
      */
     public function __construct(TaggedContainerInterface $container)
     {
@@ -63,7 +61,7 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
         );
 
         if (!$suite->hasSetting('services')) {
-            return array();
+            return [];
         }
 
         $container = $this->createContainer($suite->getSetting('services'));
@@ -82,7 +80,7 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
         $suite = $environment->getSuite();
 
         if (!$suite->hasSetting('services')) {
-            return array();
+            return [];
         }
 
         $container = $this->createContainer($suite->getSetting('services'));
@@ -100,9 +98,8 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
      *
      * @param string $settings
      *
-     * @return mixed
-     *
      * @throws WrongServicesConfigurationException
+     * @return mixed
      */
     private function createContainer($settings)
     {
@@ -124,9 +121,8 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
      *
      * @param string $settings
      *
-     * @return mixed
-     *
      * @throws WrongServicesConfigurationException
+     * @return mixed
      */
     private function createContainerFromString($settings)
     {
@@ -140,8 +136,6 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
     /**
      * Creates built-in service container with provided settings.
      *
-     * @param array $settings
-     *
      * @return BuiltInServiceContainer
      */
     private function createContainerFromArray(array $settings)
@@ -154,9 +148,8 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
      *
      * @param string $name
      *
-     * @return mixed
-     *
      * @throws WrongServicesConfigurationException
+     * @return mixed
      */
     private function loadContainerFromContainer($name)
     {
@@ -186,7 +179,7 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
             return call_user_func($constructor);
         }
 
-        return new $constructor[0];
+        return new $constructor[0]();
     }
 
     /**
@@ -195,9 +188,8 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
      * @param mixed $container
      * @param bool  $autowire
      *
-     * @return ArgumentResolver[]
-     *
      * @throws WrongContainerClassException
+     * @return ArgumentResolver[]
      */
     private function createResolvers($container, $autowire)
     {
@@ -212,9 +204,9 @@ final class ServicesResolverFactory implements SuiteScopedResolverFactory, Argum
         }
 
         if ($autowire) {
-            return array(new ServicesResolver($container), new AutowiringResolver($container));
+            return [new ServicesResolver($container), new AutowiringResolver($container)];
         }
 
-        return array(new ServicesResolver($container));
+        return [new ServicesResolver($container)];
     }
 }

--- a/src/Behat/Behat/HelperContainer/ArgumentAutowirer.php
+++ b/src/Behat/Behat/HelperContainer/ArgumentAutowirer.php
@@ -12,11 +12,6 @@ namespace Behat\Behat\HelperContainer;
 
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
-use ReflectionClass;
-use ReflectionFunctionAbstract;
-use ReflectionNamedType;
-use ReflectionParameter;
-use ReflectionException;
 
 /**
  * Automatically wires arguments of a given function from inside the container by using type-hints.
@@ -32,8 +27,6 @@ final class ArgumentAutowirer
 
     /**
      * Initialises wirer.
-     *
-     * @param PsrContainerInterface $container
      */
     public function __construct(PsrContainerInterface $container)
     {
@@ -43,14 +36,10 @@ final class ArgumentAutowirer
     /**
      * Autowires given arguments using provided container.
      *
-     * @param ReflectionFunctionAbstract $reflection
-     * @param array $arguments
-     *
-     * @return array
-     *
      * @throws ContainerExceptionInterface if unset argument typehint can not be resolved from container
+     * @return array
      */
-    public function autowireArguments(ReflectionFunctionAbstract $reflection, array $arguments)
+    public function autowireArguments(\ReflectionFunctionAbstract $reflection, array $arguments)
     {
         $newArguments = $arguments;
         foreach ($reflection->getParameters() as $index => $parameter) {
@@ -67,13 +56,11 @@ final class ArgumentAutowirer
      *
      * Argument is wireable if it was not previously set and it has a class type-hint.
      *
-     * @param array               $arguments
-     * @param integer             $index
-     * @param ReflectionParameter $parameter
+     * @param int $index
      *
      * @return bool
      */
-    private function isArgumentWireable(array $arguments, $index, ReflectionParameter $parameter)
+    private function isArgumentWireable(array $arguments, $index, \ReflectionParameter $parameter)
     {
         if (isset($arguments[$index]) || array_key_exists($index, $arguments)) {
             return false;
@@ -86,28 +73,27 @@ final class ArgumentAutowirer
         return (bool) $this->getClassFromParameter($parameter);
     }
 
-    private function getClassFromParameter(ReflectionParameter $parameter) : ?string
+    private function getClassFromParameter(\ReflectionParameter $parameter): ?string
     {
-        if (!($type = $parameter->getType()) || !($type instanceof ReflectionNamedType)) {
+        if (!($type = $parameter->getType()) || !($type instanceof \ReflectionNamedType)) {
             return null;
         }
 
         try {
             $typeString = $type->getName();
 
-            if ($typeString == 'self') {
+            if ($typeString === 'self') {
                 return $parameter->getDeclaringClass()->getName();
             }
-            elseif ($typeString == 'parent') {
+            if ($typeString === 'parent') {
                 return $parameter->getDeclaringClass()->getParentClass()->getName();
             }
 
             // will throw if not valid class
-            new ReflectionClass($typeString);
+            new \ReflectionClass($typeString);
 
             return $typeString;
-
-        } catch (ReflectionException $e) {
+        } catch (\ReflectionException $e) {
             return null;
         }
     }

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -13,8 +13,6 @@ namespace Behat\Behat\HelperContainer;
 use Behat\Behat\HelperContainer\Exception\ServiceNotFoundException;
 use Behat\Behat\HelperContainer\Exception\WrongServicesConfigurationException;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
-use ReflectionClass;
-use ReflectionMethod;
 
 /**
  * Built-in service container.
@@ -27,6 +25,7 @@ final class BuiltInServiceContainer implements PsrContainerInterface
      * @var array
      */
     private $schema;
+
     /**
      * @var array
      */
@@ -34,8 +33,6 @@ final class BuiltInServiceContainer implements PsrContainerInterface
 
     /**
      * Initialises container using provided service configuration.
-     *
-     * @param array $schema
      */
     public function __construct(array $schema)
     {
@@ -76,7 +73,7 @@ final class BuiltInServiceContainer implements PsrContainerInterface
     {
         $schema = $this->getAndValidateServiceSchema($id);
 
-        $reflection = new ReflectionClass($schema['class']);
+        $reflection = new \ReflectionClass($schema['class']);
         $arguments = $schema['arguments'];
 
         if ($factoryMethod = $this->getAndValidateFactoryMethod($reflection, $schema)) {
@@ -100,11 +97,11 @@ final class BuiltInServiceContainer implements PsrContainerInterface
         $schema = $this->schema[$id];
 
         if (null === $schema) {
-            $schema = array('class' => $id);
+            $schema = ['class' => $id];
         }
 
         if (is_string($schema)) {
-            $schema = array('class' => $schema);
+            $schema = ['class' => $schema];
         }
 
         $schema['class'] = $this->getAndValidateClass($id, $schema);
@@ -117,7 +114,7 @@ final class BuiltInServiceContainer implements PsrContainerInterface
      * Gets and validates a class from schema.
      *
      * @param string       $id
-     * @param string|array $schema
+     * @param array|string $schema
      *
      * @return string
      */
@@ -133,24 +130,19 @@ final class BuiltInServiceContainer implements PsrContainerInterface
     /**
      * Gets and validates arguments from schema.
      *
-     * @param array $schema
-     *
      * @return array
      */
     private function getAndValidateArguments(array $schema)
     {
-        return isset($schema['arguments']) ? (array)$schema['arguments'] : array();
+        return isset($schema['arguments']) ? (array) $schema['arguments'] : [];
     }
 
     /**
      * Gets and validates a factory method.
      *
-     * @param ReflectionClass $reflection
-     * @param array           $schema
-     *
-     * @return null|ReflectionMethod
+     * @return null|\ReflectionMethod
      */
-    private function getAndValidateFactoryMethod(ReflectionClass $reflection, array $schema)
+    private function getAndValidateFactoryMethod(\ReflectionClass $reflection, array $schema)
     {
         if (!isset($schema['factory_method'])) {
             return null;
@@ -167,12 +159,11 @@ final class BuiltInServiceContainer implements PsrContainerInterface
     /**
      * Checks if factory method exists.
      *
-     * @param ReflectionClass $class
-     * @param string          $methodName
+     * @param string $methodName
      *
      * @throws WrongServicesConfigurationException
      */
-    private function assertFactoryMethodExists(ReflectionClass $class, $methodName)
+    private function assertFactoryMethodExists(\ReflectionClass $class, $methodName)
     {
         if (!$class->hasMethod($methodName)) {
             throw new WrongServicesConfigurationException(sprintf(
@@ -186,11 +177,9 @@ final class BuiltInServiceContainer implements PsrContainerInterface
     /**
      * Checks if factory method is static.
      *
-     * @param ReflectionMethod $method
-     *
      * @throws WrongServicesConfigurationException
      */
-    private function assertFactoryMethodIsStatic(ReflectionMethod $method)
+    private function assertFactoryMethodIsStatic(\ReflectionMethod $method)
     {
         if (!$method->isStatic()) {
             throw new WrongServicesConfigurationException(sprintf(

--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -10,10 +10,10 @@
 
 namespace Behat\Behat\HelperContainer\Call\Filter;
 
-use Behat\Behat\Definition\Definition;
-use Behat\Behat\HelperContainer\Environment\ServiceContainerEnvironment;
 use Behat\Behat\Definition\Call\DefinitionCall;
+use Behat\Behat\Definition\Definition;
 use Behat\Behat\HelperContainer\ArgumentAutowirer;
+use Behat\Behat\HelperContainer\Environment\ServiceContainerEnvironment;
 use Behat\Behat\HelperContainer\Exception\UnsupportedCallException;
 use Behat\Behat\Transformation\Call\TransformationCall;
 use Behat\Behat\Transformation\Transformation;
@@ -42,12 +42,9 @@ final class ServicesResolver implements CallFilter
     /**
      * Filters a call and returns a new one.
      *
-     * @param Call $call
-     *
-     * @return Call
-     *
      * @throws UnsupportedCallException
      * @throws ContainerExceptionInterface
+     * @return Call
      */
     public function filterCall(Call $call)
     {
@@ -64,11 +61,8 @@ final class ServicesResolver implements CallFilter
     /**
      * Gets container from the call.
      *
-     * @param Call $call
-     *
-     * @return null|ContainerInterface
-     *
      * @throws UnsupportedCallException if given call is not EnvironmentCall or environment is not ServiceContainerEnvironment
+     * @return null|ContainerInterface
      */
     private function getContainer(Call $call)
     {
@@ -94,12 +88,8 @@ final class ServicesResolver implements CallFilter
     /**
      * Repackages old calls with new arguments, but only if two differ.
      *
-     * @param Call $call
-     * @param array $arguments
-     *
-     * @return Call
-     *
      * @throws UnsupportedCallException if given call is not DefinitionCall or TransformationCall
+     * @return Call
      */
     private function repackageCallIfNewArguments(Call $call, array $arguments)
     {
@@ -113,12 +103,8 @@ final class ServicesResolver implements CallFilter
     /**
      * Repackages old calls with new arguments.
      *
-     * @param Call  $call
-     * @param array $newArguments
-     *
-     * @return DefinitionCall|TransformationCall
-     *
      * @throws UnsupportedCallException
+     * @return DefinitionCall|TransformationCall
      */
     private function repackageCallWithNewArguments(Call $call, array $newArguments)
     {
@@ -134,19 +120,16 @@ final class ServicesResolver implements CallFilter
             sprintf(
                 'ServicesResolver can not filter `%s` call.',
                 get_class($call)
-            ), $call
+            ),
+            $call
         );
     }
 
     /**
      * Repackages definition call with new arguments.
      *
-     * @param DefinitionCall $call
-     * @param array $newArguments
-     *
-     * @return DefinitionCall
-     *
      * @throws UnsupportedCallException
+     * @return DefinitionCall
      */
     private function repackageDefinitionCall(DefinitionCall $call, array $newArguments)
     {
@@ -157,7 +140,8 @@ final class ServicesResolver implements CallFilter
                 sprintf(
                     'Something is wrong in callee associated with `%s` call.',
                     get_class($call)
-                ), $call
+                ),
+                $call
             );
         }
 
@@ -174,12 +158,8 @@ final class ServicesResolver implements CallFilter
     /**
      * Repackages transformation call with new arguments.
      *
-     * @param TransformationCall $call
-     * @param array $newArguments
-     *
-     * @return TransformationCall
-     *
      * @throws UnsupportedCallException
+     * @return TransformationCall
      */
     private function repackageTransformationCall(TransformationCall $call, array $newArguments)
     {
@@ -190,7 +170,8 @@ final class ServicesResolver implements CallFilter
                 sprintf(
                     'Something is wrong in callee associated with `%s` call.',
                     get_class($call)
-                ), $call
+                ),
+                $call
             );
         }
 

--- a/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
+++ b/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
@@ -24,10 +24,8 @@ interface ServiceContainerEnvironment extends Environment
 {
     /**
      * Sets/unsets service container for the environment.
-     *
-     * @param ContainerInterface|null $container
      */
-    public function setServiceContainer(ContainerInterface $container = null);
+    public function setServiceContainer(?ContainerInterface $container = null);
 
     /**
      * Returns environment service container if set.

--- a/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
@@ -10,14 +10,12 @@
 
 namespace Behat\Behat\HelperContainer\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception thrown when service ID is not found inside the container.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class ServiceNotFoundException extends InvalidArgumentException implements HelperContainerException, NotFoundException
+final class ServiceNotFoundException extends \InvalidArgumentException implements HelperContainerException, NotFoundException
 {
     /**
      * @var string

--- a/src/Behat/Behat/HelperContainer/Exception/UnsupportedCallException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/UnsupportedCallException.php
@@ -11,14 +11,13 @@
 namespace Behat\Behat\HelperContainer\Exception;
 
 use Behat\Testwork\Call\Call;
-use InvalidArgumentException;
 
 /**
  * Represents an exception caused by an attempt to filter an unsupported call.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class UnsupportedCallException extends InvalidArgumentException implements HelperContainerException
+final class UnsupportedCallException extends \InvalidArgumentException implements HelperContainerException
 {
     /**
      * @var Call
@@ -29,7 +28,6 @@ final class UnsupportedCallException extends InvalidArgumentException implements
      * Initializes exception.
      *
      * @param string $message
-     * @param Call   $call
      */
     public function __construct($message, Call $call)
     {

--- a/src/Behat/Behat/HelperContainer/Exception/WrongContainerClassException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/WrongContainerClassException.php
@@ -10,14 +10,12 @@
 
 namespace Behat\Behat\HelperContainer\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception when provided class exists, but is not an acceptable as a container.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class WrongContainerClassException extends InvalidArgumentException implements HelperContainerException
+final class WrongContainerClassException extends \InvalidArgumentException implements HelperContainerException
 {
     /**
      * @var string
@@ -27,8 +25,8 @@ final class WrongContainerClassException extends InvalidArgumentException implem
     /**
      * Initializes exception.
      *
-     * @param integer $message
-     * @param string  $class
+     * @param int    $message
+     * @param string $class
      */
     public function __construct($message, $class)
     {

--- a/src/Behat/Behat/HelperContainer/Exception/WrongServicesConfigurationException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/WrongServicesConfigurationException.php
@@ -10,13 +10,11 @@
 
 namespace Behat\Behat\HelperContainer\Exception;
 
-use RuntimeException;
-
 /**
  * Represents an exception when wrong value passed into `services` setting.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class WrongServicesConfigurationException extends RuntimeException implements HelperContainerException
+final class WrongServicesConfigurationException extends \RuntimeException implements HelperContainerException
 {
 }

--- a/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
+++ b/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
@@ -42,12 +42,10 @@ final class HelperContainerExtension implements Extension
 
     /**
      * Initializes compiler pass.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -77,14 +75,14 @@ final class HelperContainerExtension implements Extension
      */
     public function load(ContainerBuilder $container, array $config)
     {
-        $definition = new Definition('Behat\Behat\HelperContainer\Argument\ServicesResolverFactory', array(
-            new Reference('service_container')
-        ));
-        $definition->addTag(ContextExtension::SUITE_SCOPED_RESOLVER_FACTORY_TAG, array('priority' => 0));
+        $definition = new Definition('Behat\Behat\HelperContainer\Argument\ServicesResolverFactory', [
+            new Reference('service_container'),
+        ]);
+        $definition->addTag(ContextExtension::SUITE_SCOPED_RESOLVER_FACTORY_TAG, ['priority' => 0]);
         $container->setDefinition(ContextExtension::SUITE_SCOPED_RESOLVER_FACTORY_TAG . '.helper_container', $definition);
 
         $definition = new Definition('Behat\Behat\HelperContainer\Call\Filter\ServicesResolver');
-        $definition->addTag(CallExtension::CALL_FILTER_TAG, array('priority' => 0));
+        $definition->addTag(CallExtension::CALL_FILTER_TAG, ['priority' => 0]);
         $container->setDefinition(CallExtension::CALL_FILTER_TAG . '.helper_container', $definition);
     }
 
@@ -98,7 +96,8 @@ final class HelperContainerExtension implements Extension
         foreach ($references as $reference) {
             if ($container->getDefinition((string) $reference)->isShared()) {
                 throw new WrongServicesConfigurationException(sprintf(
-                    'Container services must not be configured as shared, but `@%s` is.', $reference
+                    'Container services must not be configured as shared, but `@%s` is.',
+                    $reference
                 ));
             }
         }

--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -65,8 +65,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
     }
 
     /**
-     * @param FeatureNode $feature
-     * @param string      $filterString
+     * @param string $filterString
      *
      * @return bool
      */
@@ -86,8 +85,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
     /**
      * Checks if feature matches tag filter.
      *
-     * @param FeatureNode $feature
-     * @param string      $filterString
+     * @param string $filterString
      *
      * @return bool
      */
@@ -101,8 +99,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
     /**
      * Checks if feature matches name filter.
      *
-     * @param FeatureNode $feature
-     * @param string      $filterString
+     * @param string $filterString
      *
      * @return bool
      */

--- a/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
@@ -44,9 +44,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
     /**
      * Checks if nodes match filter.
      *
-     * @param FeatureNode       $feature
-     * @param ScenarioInterface $scenario
-     * @param string            $filterString
+     * @param string $filterString
      *
      * @return bool
      */
@@ -66,9 +64,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
     /**
      * Checks if node match tag filter.
      *
-     * @param FeatureNode       $feature
-     * @param ScenarioInterface $scenario
-     * @param string            $filterString
+     * @param string $filterString
      *
      * @return bool
      */
@@ -82,8 +78,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
     /**
      * Checks if scenario matches name filter.
      *
-     * @param ScenarioInterface $scenario
-     * @param string            $filterString
+     * @param string $filterString
      *
      * @return bool
      */

--- a/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
@@ -52,8 +52,7 @@ abstract class RuntimeStepHook extends RuntimeFilterableHook
     /**
      * Checks if Feature matches specified filter.
      *
-     * @param StepNode $step
-     * @param string   $filterString
+     * @param string $filterString
      *
      * @return bool
      */

--- a/src/Behat/Behat/Hook/Context/Annotation/HookAnnotationReader.php
+++ b/src/Behat/Behat/Hook/Context/Annotation/HookAnnotationReader.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\Hook\Context\Annotation;
 
 use Behat\Behat\Context\Annotation\AnnotationReader;
 use Behat\Testwork\Hook\Call\RuntimeHook;
-use ReflectionMethod;
 
 /**
  * Reads hook callees from context method annotations.
@@ -25,31 +24,31 @@ final class HookAnnotationReader implements AnnotationReader
      * @var string
      */
     private static $regex = '/^\@(beforesuite|aftersuite|beforefeature|afterfeature|beforescenario|afterscenario|beforestep|afterstep)(?:\s+(.+))?$/i';
+
     /**
      * @var string[]
      */
-    private static $classes = array(
-        'beforesuite'    => 'Behat\Testwork\Hook\Call\BeforeSuite',
-        'aftersuite'     => 'Behat\Testwork\Hook\Call\AfterSuite',
-        'beforefeature'  => 'Behat\Behat\Hook\Call\BeforeFeature',
-        'afterfeature'   => 'Behat\Behat\Hook\Call\AfterFeature',
+    private static $classes = [
+        'beforesuite' => 'Behat\Testwork\Hook\Call\BeforeSuite',
+        'aftersuite' => 'Behat\Testwork\Hook\Call\AfterSuite',
+        'beforefeature' => 'Behat\Behat\Hook\Call\BeforeFeature',
+        'afterfeature' => 'Behat\Behat\Hook\Call\AfterFeature',
         'beforescenario' => 'Behat\Behat\Hook\Call\BeforeScenario',
-        'afterscenario'  => 'Behat\Behat\Hook\Call\AfterScenario',
-        'beforestep'     => 'Behat\Behat\Hook\Call\BeforeStep',
-        'afterstep'      => 'Behat\Behat\Hook\Call\AfterStep'
-    );
+        'afterscenario' => 'Behat\Behat\Hook\Call\AfterScenario',
+        'beforestep' => 'Behat\Behat\Hook\Call\BeforeStep',
+        'afterstep' => 'Behat\Behat\Hook\Call\AfterStep',
+    ];
 
     /**
      * Loads step callees (if exist) associated with specific method.
      *
-     * @param string           $contextClass
-     * @param ReflectionMethod $method
-     * @param string           $docLine
-     * @param string           $description
+     * @param string $contextClass
+     * @param string $docLine
+     * @param string $description
      *
      * @return null|RuntimeHook
      */
-    public function readCallee($contextClass, ReflectionMethod $method, $docLine, $description)
+    public function readCallee($contextClass, \ReflectionMethod $method, $docLine, $description)
     {
         if (!preg_match(self::$regex, $docLine, $match)) {
             return null;
@@ -58,7 +57,7 @@ final class HookAnnotationReader implements AnnotationReader
         $type = strtolower($match[1]);
         $class = self::$classes[$type];
         $pattern = $match[2] ?? null;
-        $callable = array($contextClass, $method->getName());
+        $callable = [$contextClass, $method->getName()];
 
         return new $class($pattern, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Context/Attribute/HookAttributeReader.php
+++ b/src/Behat/Behat/Hook/Context/Attribute/HookAttributeReader.php
@@ -19,21 +19,20 @@ use Behat\Hook\BeforeFeature;
 use Behat\Hook\BeforeScenario;
 use Behat\Hook\BeforeStep;
 use Behat\Hook\Hook;
-use ReflectionMethod;
 
 final class HookAttributeReader implements AttributeReader
 {
     /**
      * @var string[]
      */
-    private const KNOWN_ATTRIBUTES = array(
+    private const KNOWN_ATTRIBUTES = [
         AfterFeature::class => 'Behat\Behat\Hook\Call\AfterFeature',
         AfterScenario::class => 'Behat\Behat\Hook\Call\AfterScenario',
         AfterStep::class => 'Behat\Behat\Hook\Call\AfterStep',
         BeforeFeature::class => 'Behat\Behat\Hook\Call\BeforeFeature',
         BeforeScenario::class => 'Behat\Behat\Hook\Call\BeforeScenario',
         BeforeStep::class => 'Behat\Behat\Hook\Call\BeforeStep',
-    );
+    ];
 
     /**
      * @var DocBlockHelper
@@ -42,8 +41,6 @@ final class HookAttributeReader implements AttributeReader
 
     /**
      * Initializes reader.
-     *
-     * @param DocBlockHelper $docBlockHelper
      */
     public function __construct(DocBlockHelper $docBlockHelper)
     {
@@ -51,9 +48,9 @@ final class HookAttributeReader implements AttributeReader
     }
 
     /**
-     * @{inheritdoc}
+     * {@inheritdoc}
      */
-    public function readCallees(string $contextClass, ReflectionMethod $method)
+    public function readCallees(string $contextClass, \ReflectionMethod $method)
     {
         if (\PHP_MAJOR_VERSION < 8) {
             return [];
@@ -67,7 +64,7 @@ final class HookAttributeReader implements AttributeReader
         $callees = [];
         foreach ($attributes as $attribute) {
             $class = self::KNOWN_ATTRIBUTES[$attribute->getName()];
-            $callable = array($contextClass, $method->getName());
+            $callable = [$contextClass, $method->getName()];
             $description = null;
             if ($docBlock = $method->getDocComment()) {
                 $description = $this->docBlockHelper->extractDescription($docBlock);

--- a/src/Behat/Behat/Hook/Scope/AfterFeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterFeatureScope.php
@@ -27,10 +27,12 @@ final class AfterFeatureScope implements FeatureScope, AfterTestScope
      * @var Environment
      */
     private $environment;
+
     /**
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var TestResult
      */
@@ -38,10 +40,6 @@ final class AfterFeatureScope implements FeatureScope, AfterTestScope
 
     /**
      * Initializes scope.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param TestResult  $result
      */
     public function __construct(Environment $env, FeatureNode $feature, TestResult $result)
     {

--- a/src/Behat/Behat/Hook/Scope/AfterScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterScenarioScope.php
@@ -28,14 +28,17 @@ final class AfterScenarioScope implements ScenarioScope, AfterTestScope
      * @var Environment
      */
     private $environment;
+
     /**
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var Scenario
      */
     private $scenario;
+
     /**
      * @var TestResult
      */
@@ -43,11 +46,6 @@ final class AfterScenarioScope implements ScenarioScope, AfterTestScope
 
     /**
      * Initializes scope.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
-     * @param TestResult  $result
      */
     public function __construct(Environment $env, FeatureNode $feature, Scenario $scenario, TestResult $result)
     {

--- a/src/Behat/Behat/Hook/Scope/AfterStepScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterStepScope.php
@@ -29,14 +29,17 @@ final class AfterStepScope implements StepScope, AfterTestScope
      * @var Environment
      */
     private $environment;
+
     /**
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var StepNode
      */
     private $step;
+
     /**
      * @var StepResult
      */
@@ -44,11 +47,6 @@ final class AfterStepScope implements StepScope, AfterTestScope
 
     /**
      * Initializes scope.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
-     * @param StepResult  $result
      */
     public function __construct(Environment $env, FeatureNode $feature, StepNode $step, StepResult $result)
     {

--- a/src/Behat/Behat/Hook/Scope/BeforeFeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeFeatureScope.php
@@ -25,6 +25,7 @@ final class BeforeFeatureScope implements FeatureScope
      * @var Environment
      */
     private $environment;
+
     /**
      * @var FeatureNode
      */
@@ -32,9 +33,6 @@ final class BeforeFeatureScope implements FeatureScope
 
     /**
      * Initializes scope.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
      */
     public function __construct(Environment $env, FeatureNode $feature)
     {

--- a/src/Behat/Behat/Hook/Scope/BeforeScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeScenarioScope.php
@@ -26,10 +26,12 @@ final class BeforeScenarioScope implements ScenarioScope
      * @var Environment
      */
     private $environment;
+
     /**
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var Scenario
      */
@@ -37,10 +39,6 @@ final class BeforeScenarioScope implements ScenarioScope
 
     /**
      * Initializes scope.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
      */
     public function __construct(Environment $env, FeatureNode $feature, Scenario $scenario)
     {

--- a/src/Behat/Behat/Hook/Scope/BeforeStepScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeStepScope.php
@@ -26,10 +26,12 @@ final class BeforeStepScope implements StepScope
      * @var Environment
      */
     private $environment;
+
     /**
      * @var FeatureNode
      */
     private $feature;
+
     /**
      * @var StepNode
      */
@@ -37,10 +39,6 @@ final class BeforeStepScope implements StepScope
 
     /**
      * Initializes scope.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
      */
     public function __construct(Environment $env, FeatureNode $feature, StepNode $step)
     {

--- a/src/Behat/Behat/Hook/ServiceContainer/HookExtension.php
+++ b/src/Behat/Behat/Hook/ServiceContainer/HookExtension.php
@@ -38,67 +38,65 @@ final class HookExtension extends BaseExtension
 
     /**
      * Loads hookable testers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadHookableTesters(ContainerBuilder $container)
     {
         parent::loadHookableTesters($container);
 
-        $definition = new Definition('Behat\Behat\Hook\Tester\HookableFeatureTester', array(
+        $definition = new Definition('Behat\Behat\Hook\Tester\HookableFeatureTester', [
             new Reference(TesterExtension::SPECIFICATION_TESTER_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
-        $definition->addTag(TesterExtension::SPECIFICATION_TESTER_WRAPPER_TAG, array('priority' => 9999));
+            new Reference(self::DISPATCHER_ID),
+        ]);
+        $definition->addTag(TesterExtension::SPECIFICATION_TESTER_WRAPPER_TAG, ['priority' => 9999]);
         $container->setDefinition(TesterExtension::SPECIFICATION_TESTER_WRAPPER_TAG . '.hookable', $definition);
 
-        $definition = new Definition('Behat\Behat\Hook\Tester\HookableScenarioTester', array(
+        $definition = new Definition(
+            'Behat\Behat\Hook\Tester\HookableScenarioTester',
+            [
                 new Reference(TesterExtension::SCENARIO_TESTER_ID),
-                new Reference(self::DISPATCHER_ID)
-            )
+                new Reference(self::DISPATCHER_ID),
+            ]
         );
-        $definition->addTag(TesterExtension::SCENARIO_TESTER_WRAPPER_TAG, array('priority' => 9999));
+        $definition->addTag(TesterExtension::SCENARIO_TESTER_WRAPPER_TAG, ['priority' => 9999]);
         $container->setDefinition(TesterExtension::SCENARIO_TESTER_WRAPPER_TAG . '.hookable', $definition);
 
-        $definition = new Definition('Behat\Behat\Hook\Tester\HookableScenarioTester', array(
+        $definition = new Definition(
+            'Behat\Behat\Hook\Tester\HookableScenarioTester',
+            [
                 new Reference(TesterExtension::EXAMPLE_TESTER_ID),
-                new Reference(self::DISPATCHER_ID)
-            )
+                new Reference(self::DISPATCHER_ID),
+            ]
         );
-        $definition->addTag(TesterExtension::EXAMPLE_TESTER_WRAPPER_TAG, array('priority' => 9999));
+        $definition->addTag(TesterExtension::EXAMPLE_TESTER_WRAPPER_TAG, ['priority' => 9999]);
         $container->setDefinition(TesterExtension::EXAMPLE_TESTER_WRAPPER_TAG . '.hookable', $definition);
 
-        $definition = new Definition('Behat\Behat\Hook\Tester\HookableStepTester', array(
+        $definition = new Definition('Behat\Behat\Hook\Tester\HookableStepTester', [
             new Reference(TesterExtension::STEP_TESTER_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
-        $definition->addTag(TesterExtension::STEP_TESTER_WRAPPER_TAG, array('priority' => 9999));
+            new Reference(self::DISPATCHER_ID),
+        ]);
+        $definition->addTag(TesterExtension::STEP_TESTER_WRAPPER_TAG, ['priority' => 9999]);
         $container->setDefinition(TesterExtension::STEP_TESTER_WRAPPER_TAG . '.hookable', $definition);
     }
 
     /**
      * Loads hook annotation reader.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadAnnotationReader(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Hook\Context\Annotation\HookAnnotationReader');
-        $definition->addTag(ContextExtension::ANNOTATION_READER_TAG, array('priority' => 50));
+        $definition->addTag(ContextExtension::ANNOTATION_READER_TAG, ['priority' => 50]);
         $container->setDefinition(ContextExtension::ANNOTATION_READER_TAG . '.hook', $definition);
     }
 
     /**
      * Loads hook attribute reader.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadAttributeReader(ContainerBuilder $container)
     {
-        $definition = new Definition('\Behat\Behat\Hook\Context\Attribute\HookAttributeReader', array(
-            new Reference(DefinitionExtension::DOC_BLOCK_HELPER_ID)
-        ));
-        $definition->addTag(ContextExtension::ATTRIBUTE_READER_TAG, array('priority' => 50));
+        $definition = new Definition('\Behat\Behat\Hook\Context\Attribute\HookAttributeReader', [
+            new Reference(DefinitionExtension::DOC_BLOCK_HELPER_ID),
+        ]);
+        $definition->addTag(ContextExtension::ATTRIBUTE_READER_TAG, ['priority' => 50]);
         $container->setDefinition(ContextExtension::ATTRIBUTE_READER_TAG . '.hook', $definition);
     }
 }

--- a/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
@@ -30,6 +30,7 @@ final class HookableFeatureTester implements SpecificationTester
      * @var SpecificationTester
      */
     private $baseTester;
+
     /**
      * @var HookDispatcher
      */
@@ -37,9 +38,6 @@ final class HookableFeatureTester implements SpecificationTester
 
     /**
      * Initializes tester.
-     *
-     * @param SpecificationTester $baseTester
-     * @param HookDispatcher      $hookDispatcher
      */
     public function __construct(SpecificationTester $baseTester, HookDispatcher $hookDispatcher)
     {
@@ -67,14 +65,6 @@ final class HookableFeatureTester implements SpecificationTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, $spec, $skip)
-    {
-        return $this->baseTester->test($env, $spec, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, $spec, $skip, TestResult $result)
     {
         $teardown = $this->baseTester->tearDown($env, $spec, $skip, $result);
@@ -87,5 +77,13 @@ final class HookableFeatureTester implements SpecificationTester
         $hookCallResults = $this->hookDispatcher->dispatchScopeHooks($scope);
 
         return new HookedTeardown($teardown, $hookCallResults);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, $spec, $skip)
+    {
+        return $this->baseTester->test($env, $spec, $skip);
     }
 }

--- a/src/Behat/Behat/Hook/Tester/HookableScenarioTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableScenarioTester.php
@@ -32,6 +32,7 @@ final class HookableScenarioTester implements ScenarioTester
      * @var ScenarioTester
      */
     private $baseTester;
+
     /**
      * @var HookDispatcher
      */
@@ -39,9 +40,6 @@ final class HookableScenarioTester implements ScenarioTester
 
     /**
      * Initializes tester.
-     *
-     * @param ScenarioTester $baseTester
-     * @param HookDispatcher $hookDispatcher
      */
     public function __construct(ScenarioTester $baseTester, HookDispatcher $hookDispatcher)
     {
@@ -69,14 +67,6 @@ final class HookableScenarioTester implements ScenarioTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
-    {
-        return $this->baseTester->test($env, $feature, $scenario, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
     {
         $teardown = $this->baseTester->tearDown($env, $feature, $scenario, $skip, $result);
@@ -89,5 +79,13 @@ final class HookableScenarioTester implements ScenarioTester
         $hookCallResults = $this->hookDispatcher->dispatchScopeHooks($scope);
 
         return new HookedTeardown($teardown, $hookCallResults);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
+    {
+        return $this->baseTester->test($env, $feature, $scenario, $skip);
     }
 }

--- a/src/Behat/Behat/Hook/Tester/HookableStepTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableStepTester.php
@@ -32,6 +32,7 @@ final class HookableStepTester implements StepTester
      * @var StepTester
      */
     private $baseTester;
+
     /**
      * @var HookDispatcher
      */
@@ -39,9 +40,6 @@ final class HookableStepTester implements StepTester
 
     /**
      * Initializes tester.
-     *
-     * @param StepTester     $baseTester
-     * @param HookDispatcher $hookDispatcher
      */
     public function __construct(StepTester $baseTester, HookDispatcher $hookDispatcher)
     {
@@ -69,14 +67,6 @@ final class HookableStepTester implements StepTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
-    {
-        return $this->baseTester->test($env, $feature, $step, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
     {
         $teardown = $this->baseTester->tearDown($env, $feature, $step, $skip, $result);
@@ -89,5 +79,13 @@ final class HookableStepTester implements StepTester
         $hookCallResults = $this->hookDispatcher->dispatchScopeHooks($scope);
 
         return new HookedTeardown($teardown, $hookCallResults);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    {
+        return $this->baseTester->test($env, $feature, $step, $skip);
     }
 }

--- a/src/Behat/Behat/Output/Exception/NodeVisitorNotFoundException.php
+++ b/src/Behat/Behat/Output/Exception/NodeVisitorNotFoundException.php
@@ -11,13 +11,12 @@
 namespace Behat\Behat\Output\Exception;
 
 use Behat\Testwork\Output\Exception\OutputException;
-use InvalidArgumentException;
 
 /**
  * Represents an exception caused by a request for non-existent node visitor.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class NodeVisitorNotFoundException extends InvalidArgumentException implements OutputException
+class NodeVisitorNotFoundException extends \InvalidArgumentException implements OutputException
 {
 }

--- a/src/Behat/Behat/Output/Node/EventListener/AST/FeatureListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/FeatureListener.php
@@ -30,6 +30,7 @@ final class FeatureListener implements EventListener
      * @var FeaturePrinter
      */
     private $featurePrinter;
+
     /**
      * @var SetupPrinter
      */
@@ -37,9 +38,6 @@ final class FeatureListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param FeaturePrinter $featurePrinter
-     * @param SetupPrinter   $setupPrinter
      */
     public function __construct(FeaturePrinter $featurePrinter, SetupPrinter $setupPrinter)
     {
@@ -62,9 +60,6 @@ final class FeatureListener implements EventListener
 
     /**
      * Prints feature header on BEFORE event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printHeaderOnBeforeEvent(Formatter $formatter, Event $event)
     {
@@ -78,9 +73,6 @@ final class FeatureListener implements EventListener
 
     /**
      * Prints feature footer on AFTER event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printFooterOnAfterEvent(Formatter $formatter, Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/AST/OutlineListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/OutlineListener.php
@@ -37,22 +37,27 @@ final class OutlineListener implements EventListener
      * @var OutlinePrinter
      */
     private $outlinePrinter;
+
     /**
      * @var ExamplePrinter
      */
     private $examplePrinter;
+
     /**
      * @var StepPrinter
      */
     private $stepPrinter;
+
     /**
      * @var SetupPrinter
      */
     private $stepSetupPrinter;
+
     /**
      * @var SetupPrinter
      */
     private $exampleSetupPrinter;
+
     /**
      * @var ExampleNode
      */
@@ -60,12 +65,6 @@ final class OutlineListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param OutlinePrinter $outlinePrinter
-     * @param ExamplePrinter $examplePrinter
-     * @param StepPrinter    $stepPrinter
-     * @param SetupPrinter   $exampleSetupPrinter
-     * @param SetupPrinter   $stepSetupPrinter
      */
     public function __construct(
         OutlinePrinter $outlinePrinter,
@@ -96,9 +95,6 @@ final class OutlineListener implements EventListener
 
     /**
      * Prints outline header and captures outline into ivar on BEFORE event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printAndCaptureOutlineHeaderOnBeforeEvent(Formatter $formatter, Event $event)
     {
@@ -111,9 +107,6 @@ final class OutlineListener implements EventListener
 
     /**
      * Prints outline footer and removes outline from ivar on AFTER event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printAndForgetOutlineFooterOnAfterEvent(Formatter $formatter, Event $event)
     {
@@ -126,9 +119,6 @@ final class OutlineListener implements EventListener
 
     /**
      * Prints example header on example BEFORE event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printExampleHeaderOnBeforeExampleEvent(Formatter $formatter, Event $event)
     {
@@ -145,9 +135,7 @@ final class OutlineListener implements EventListener
     /**
      * Prints example footer on example AFTER event.
      *
-     * @param Formatter $formatter
-     * @param Event     $event
-     * @param string    $eventName
+     * @param string $eventName
      */
     private function printExampleFooterOnAfterExampleEvent(Formatter $formatter, Event $event, $eventName)
     {
@@ -163,9 +151,6 @@ final class OutlineListener implements EventListener
 
     /**
      * Prints step setup on step BEFORE event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printStepSetupOnBeforeStepEvent(Formatter $formatter, Event $event)
     {
@@ -178,9 +163,6 @@ final class OutlineListener implements EventListener
 
     /**
      * Prints example step on step AFTER event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printStepOnAfterStepEvent(Formatter $formatter, Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
@@ -40,46 +40,49 @@ final class OutlineTableListener implements EventListener
      * @var OutlineTablePrinter
      */
     private $tablePrinter;
+
     /**
      * @var ExampleRowPrinter
      */
     private $exampleRowPrinter;
+
     /**
      * @var SetupPrinter
      */
     private $stepSetupPrinter;
+
     /**
      * @var SetupPrinter
      */
     private $exampleSetupPrinter;
+
     /**
      * @var OutlineNode
      */
     private $outline;
+
     /**
      * @var Setup
      */
     private $exampleSetup;
+
     /**
      * @var bool
      */
     private $headerPrinted = false;
+
     /**
      * @var AfterStepSetup[]
      */
-    private $stepBeforeTestedEvents = array();
+    private $stepBeforeTestedEvents = [];
+
     /**
      * @var AfterStepTested[]
      */
-    private $stepAfterTestedEvents = array();
+    private $stepAfterTestedEvents = [];
 
     /**
      * Initializes listener.
-     *
-     * @param OutlineTablePrinter $tablePrinter
-     * @param ExampleRowPrinter   $exampleRowPrinter
-     * @param SetupPrinter        $exampleSetupPrinter
-     * @param SetupPrinter        $stepSetupPrinter
      */
     public function __construct(
         OutlineTablePrinter $tablePrinter,
@@ -115,8 +118,6 @@ final class OutlineTableListener implements EventListener
 
     /**
      * Captures step tested event.
-     *
-     * @param StepTested $event
      */
     private function captureStepEvent(StepTested $event)
     {
@@ -129,8 +130,6 @@ final class OutlineTableListener implements EventListener
 
     /**
      * Captures outline into the ivar on outline BEFORE event.
-     *
-     * @param Event $event
      */
     private function captureOutlineOnBeforeOutlineEvent(Event $event)
     {
@@ -144,8 +143,6 @@ final class OutlineTableListener implements EventListener
 
     /**
      * Captures example setup on example BEFORE event.
-     *
-     * @param Event $event
      */
     private function captureExampleSetupOnBeforeEvent(Event $event)
     {
@@ -173,9 +170,7 @@ final class OutlineTableListener implements EventListener
     /**
      * Prints outline header (if has not been printed yet) on example AFTER event.
      *
-     * @param Formatter $formatter
-     * @param Event     $event
-     * @param string    $eventName
+     * @param string $eventName
      */
     private function printHeaderOnAfterExampleEvent(Formatter $formatter, Event $event, $eventName)
     {
@@ -197,9 +192,7 @@ final class OutlineTableListener implements EventListener
     /**
      * Prints example row on example AFTER event.
      *
-     * @param Formatter $formatter
-     * @param Event     $event
-     * @param string    $eventName
+     * @param string $eventName
      */
     private function printExampleRowOnAfterExampleEvent(Formatter $formatter, Event $event, $eventName)
     {
@@ -224,15 +217,12 @@ final class OutlineTableListener implements EventListener
         $this->exampleSetupPrinter->printTeardown($formatter, $event->getTeardown());
 
         $this->exampleSetup = null;
-        $this->stepBeforeTestedEvents = array();
-        $this->stepAfterTestedEvents = array();
+        $this->stepBeforeTestedEvents = [];
+        $this->stepAfterTestedEvents = [];
     }
 
     /**
      * Prints outline footer on outline AFTER event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printFooterOnAfterEvent(Formatter $formatter, Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/AST/ScenarioNodeListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/ScenarioNodeListener.php
@@ -30,14 +30,17 @@ final class ScenarioNodeListener implements EventListener
      * @var string
      */
     private $beforeEventName;
+
     /**
      * @var string
      */
     private $afterEventName;
+
     /**
      * @var ScenarioPrinter
      */
     private $scenarioPrinter;
+
     /**
      * @var SetupPrinter
      */
@@ -46,16 +49,14 @@ final class ScenarioNodeListener implements EventListener
     /**
      * Initializes listener.
      *
-     * @param string            $beforeEventName
-     * @param string            $afterEventName
-     * @param ScenarioPrinter   $scenarioPrinter
-     * @param null|SetupPrinter $setupPrinter
+     * @param string $beforeEventName
+     * @param string $afterEventName
      */
     public function __construct(
         $beforeEventName,
         $afterEventName,
         ScenarioPrinter $scenarioPrinter,
-        SetupPrinter $setupPrinter = null
+        ?SetupPrinter $setupPrinter = null
     ) {
         $this->beforeEventName = $beforeEventName;
         $this->afterEventName = $afterEventName;
@@ -79,8 +80,7 @@ final class ScenarioNodeListener implements EventListener
     /**
      * Prints scenario/background header on BEFORE event.
      *
-     * @param Formatter                     $formatter
-     * @param ScenarioLikeTested|AfterSetup $event
+     * @param AfterSetup|ScenarioLikeTested $event
      * @param string                        $eventName
      */
     private function printHeaderOnBeforeEvent(Formatter $formatter, ScenarioLikeTested $event, $eventName)
@@ -99,8 +99,7 @@ final class ScenarioNodeListener implements EventListener
     /**
      * Prints scenario/background footer on AFTER event.
      *
-     * @param Formatter                      $formatter
-     * @param ScenarioLikeTested|AfterTested $event
+     * @param AfterTested|ScenarioLikeTested $event
      * @param string                         $eventName
      */
     private function printFooterOnAfterEvent(Formatter $formatter, ScenarioLikeTested $event, $eventName)

--- a/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
@@ -33,10 +33,12 @@ final class StepListener implements EventListener
      * @var StepPrinter
      */
     private $stepPrinter;
+
     /**
      * @var ScenarioLikeInterface
      */
     private $scenario;
+
     /**
      * @var null|SetupPrinter
      */
@@ -44,11 +46,8 @@ final class StepListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param StepPrinter       $stepPrinter
-     * @param null|SetupPrinter $setupPrinter
      */
-    public function __construct(StepPrinter $stepPrinter, SetupPrinter $setupPrinter = null)
+    public function __construct(StepPrinter $stepPrinter, ?SetupPrinter $setupPrinter = null)
     {
         $this->stepPrinter = $stepPrinter;
         $this->setupPrinter = $setupPrinter;
@@ -67,8 +66,6 @@ final class StepListener implements EventListener
 
     /**
      * Captures scenario into the ivar on scenario/background/example BEFORE event.
-     *
-     * @param Event $event
      */
     private function captureScenarioOnScenarioEvent(Event $event)
     {
@@ -86,7 +83,7 @@ final class StepListener implements EventListener
      */
     private function forgetScenarioOnAfterEvent($eventName)
     {
-        if (!in_array($eventName, array(ScenarioTested::AFTER, ExampleTested::AFTER))) {
+        if (!in_array($eventName, [ScenarioTested::AFTER, ExampleTested::AFTER], true)) {
             return;
         }
 
@@ -106,9 +103,6 @@ final class StepListener implements EventListener
 
     /**
      * Prints step on AFTER event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     private function printStepOnAfterEvent(Formatter $formatter, Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/AST/SuiteListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/SuiteListener.php
@@ -31,8 +31,6 @@ final class SuiteListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param SetupPrinter $setupPrinter
      */
     public function __construct(SetupPrinter $setupPrinter)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
@@ -28,14 +28,17 @@ class FireOnlySiblingsListener implements EventListener
      * @var string
      */
     private $beforeEventName;
+
     /**
      * @var string
      */
     private $afterEventName;
+
     /**
      * @var EventListener
      */
     private $descendant;
+
     /**
      * @var bool
      */
@@ -44,9 +47,8 @@ class FireOnlySiblingsListener implements EventListener
     /**
      * Initializes listener.
      *
-     * @param string        $beforeEventName
-     * @param string        $afterEventName
-     * @param EventListener $descendant
+     * @param string $beforeEventName
+     * @param string $afterEventName
      */
     public function __construct($beforeEventName, $afterEventName, EventListener $descendant)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
@@ -33,19 +33,19 @@ class FirstBackgroundFiresFirstListener implements EventListener
      * @var \Behat\Testwork\Output\Node\EventListener\EventListener
      */
     private $descendant;
+
     /**
      * @var bool
      */
     private $firstBackgroundEnded = false;
+
     /**
      * @var Event[]
      */
-    private $delayedUntilBackgroundEnd = array();
+    private $delayedUntilBackgroundEnd = [];
 
     /**
      * Initializes listener.
-     *
-     * @param EventListener $descendant
      */
     public function __construct(EventListener $descendant)
     {
@@ -61,7 +61,7 @@ class FirstBackgroundFiresFirstListener implements EventListener
         $this->markFirstBackgroundPrintedAfterBackground($eventName);
 
         if ($this->isEventDelayedUntilFirstBackgroundPrinted($event)) {
-            $this->delayedUntilBackgroundEnd[] = array($event, $eventName);
+            $this->delayedUntilBackgroundEnd[] = [$event, $eventName];
 
             return;
         }
@@ -101,8 +101,6 @@ class FirstBackgroundFiresFirstListener implements EventListener
     /**
      * Checks if provided event should be postponed until background is printed.
      *
-     * @param Event $event
-     *
      * @return bool
      */
     private function isEventDelayedUntilFirstBackgroundPrinted(Event $event)
@@ -117,8 +115,7 @@ class FirstBackgroundFiresFirstListener implements EventListener
     /**
      * Fires delayed events on AFTER background event.
      *
-     * @param Formatter $formatter
-     * @param string    $eventName
+     * @param string $eventName
      */
     private function fireDelayedEventsOnAfterBackground(Formatter $formatter, $eventName)
     {
@@ -132,6 +129,6 @@ class FirstBackgroundFiresFirstListener implements EventListener
             $this->descendant->listenEvent($formatter, $event, $eventName);
         }
 
-        $this->delayedUntilBackgroundEnd = array();
+        $this->delayedUntilBackgroundEnd = [];
     }
 }

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
@@ -35,14 +35,17 @@ class OnlyFirstBackgroundFiresListener implements EventListener
      * @var EventListener
      */
     private $descendant;
+
     /**
      * @var bool
      */
     private $firstBackgroundEnded = false;
+
     /**
      * @var bool
      */
     private $inBackground = false;
+
     /**
      * @var bool
      */
@@ -50,8 +53,6 @@ class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param EventListener $descendant
      */
     public function __construct(EventListener $descendant)
     {
@@ -123,8 +124,6 @@ class OnlyFirstBackgroundFiresListener implements EventListener
     /**
      * Checks if provided event is skippable.
      *
-     * @param Event $event
-     *
      * @return bool
      */
     private function isSkippableEvent(Event $event)
@@ -138,8 +137,6 @@ class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Checks if provided event is a non-failing step in consequent background.
-     *
-     * @param Event $event
      *
      * @return bool
      */
@@ -155,8 +152,6 @@ class OnlyFirstBackgroundFiresListener implements EventListener
     /**
      * Checks if provided event is a step event which setup or teardown produced any output.
      *
-     * @param Event $event
-     *
      * @return bool
      */
     private function isStepEventWithOutput(Event $event)
@@ -166,8 +161,6 @@ class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Checks if provided event is a BEFORE step with setup that produced output.
-     *
-     * @param Event $event
      *
      * @return bool
      */
@@ -184,8 +177,6 @@ class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Checks if provided event is an AFTER step with teardown that produced output.
-     *
-     * @param Event $event
      *
      * @return bool
      */

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitDurationListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitDurationListener.php
@@ -1,4 +1,13 @@
 <?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Behat\Behat\Output\Node\EventListener\JUnit;
 
 use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
@@ -15,12 +24,12 @@ use Behat\Testwork\Output\Node\EventListener\EventListener;
 
 final class JUnitDurationListener implements EventListener
 {
-    private $scenarioTimerStore = array();
-    private $featureTimerStore = array();
-    private $resultStore = array();
-    private $featureResultStore = array();
+    private $scenarioTimerStore = [];
+    private $featureTimerStore = [];
+    private $resultStore = [];
+    private $featureResultStore = [];
 
-    /** @inheritdoc */
+    /** {@inheritdoc} */
     public function listenEvent(Formatter $formatter, Event $event, $eventName)
     {
         $this->captureBeforeScenarioEvent($event);
@@ -32,12 +41,14 @@ final class JUnitDurationListener implements EventListener
     public function getDuration(ScenarioLikeInterface $scenario)
     {
         $key = $this->getHash($scenario);
+
         return array_key_exists($key, $this->resultStore) ? $this->resultStore[$key] : '';
     }
 
     public function getFeatureDuration(FeatureNode $feature)
     {
         $key = $this->getHash($feature);
+
         return array_key_exists($key, $this->featureResultStore) ? $this->featureResultStore[$key] : '';
     }
 

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
@@ -38,48 +38,51 @@ final class JUnitFeatureElementListener implements EventListener
      * @var FeaturePrinter
      */
     private $featurePrinter;
+
     /**
      * @var JUnitScenarioPrinter
      */
     private $scenarioPrinter;
+
     /**
      * @var StepPrinter
      */
     private $stepPrinter;
+
     /**
      * @var SetupPrinter
      */
     private $setupPrinter;
+
     /**
      * @var FeatureNode
      */
     private $beforeFeatureTestedEvent;
+
     /**
      * @var AfterScenarioTested[]
      */
-    private $afterScenarioTestedEvents = array();
+    private $afterScenarioTestedEvents = [];
+
     /**
      * @var AfterStepTested[]
      */
-    private $afterStepTestedEvents = array();
+    private $afterStepTestedEvents = [];
+
     /**
      * @var AfterSetup[]
      */
-    private $afterStepSetupEvents = array();
+    private $afterStepSetupEvents = [];
 
     /**
      * Initializes listener.
-     *
-     * @param FeaturePrinter $featurePrinter
-     * @param JUnitScenarioPrinter $scenarioPrinter
-     * @param StepPrinter $stepPrinter
-     * @param SetupPrinter $setupPrinter
      */
-    public function __construct(FeaturePrinter $featurePrinter,
-                                JUnitScenarioPrinter $scenarioPrinter,
-                                StepPrinter $stepPrinter,
-                                SetupPrinter $setupPrinter)
-    {
+    public function __construct(
+        FeaturePrinter $featurePrinter,
+        JUnitScenarioPrinter $scenarioPrinter,
+        StepPrinter $stepPrinter,
+        SetupPrinter $setupPrinter
+    ) {
         $this->featurePrinter = $featurePrinter;
         $this->scenarioPrinter = $scenarioPrinter;
         $this->stepPrinter = $stepPrinter;
@@ -106,58 +109,7 @@ final class JUnitFeatureElementListener implements EventListener
     }
 
     /**
-     * Captures scenario tested event.
-     *
-     * @param ScenarioTested $event
-     */
-    private function captureScenarioEvent(ScenarioTested $event)
-    {
-        if ($event instanceof AfterScenarioTested) {
-            $this->afterScenarioTestedEvents[$event->getScenario()->getLine()] = array(
-                'event'             => $event,
-                'step_events'       => $this->afterStepTestedEvents,
-                'step_setup_events' => $this->afterStepSetupEvents,
-            );
-
-            $this->afterStepTestedEvents = array();
-            $this->afterStepSetupEvents = array();
-        }
-    }
-
-    /**
-     * Captures feature on BEFORE event.
-     *
-     * @param Event $event
-     */
-    private function captureFeatureOnBeforeEvent(Event $event)
-    {
-        if (!$event instanceof BeforeFeatureTested) {
-            return;
-        }
-
-        $this->beforeFeatureTestedEvent = $event->getFeature();
-    }
-
-    /**
-     * Captures step tested event.
-     *
-     * @param Event $event
-     */
-    private function captureStepEvent(Event $event)
-    {
-        if ($event instanceof AfterStepTested) {
-            $this->afterStepTestedEvents[$event->getStep()->getLine()] = $event;
-        }
-        if ($event instanceof AfterStepSetup) {
-            $this->afterStepSetupEvents[$event->getStep()->getLine()] = $event;
-        }
-    }
-
-    /**
      * Prints the feature on AFTER event.
-     *
-     * @param Formatter $formatter
-     * @param Event     $event
      */
     public function printFeatureOnAfterEvent(Formatter $formatter, Event $event)
     {
@@ -188,6 +140,48 @@ final class JUnitFeatureElementListener implements EventListener
         }
 
         $this->featurePrinter->printFooter($formatter, $event->getTestResult());
-        $this->afterScenarioTestedEvents = array();
+        $this->afterScenarioTestedEvents = [];
+    }
+
+    /**
+     * Captures scenario tested event.
+     */
+    private function captureScenarioEvent(ScenarioTested $event)
+    {
+        if ($event instanceof AfterScenarioTested) {
+            $this->afterScenarioTestedEvents[$event->getScenario()->getLine()] = [
+                'event' => $event,
+                'step_events' => $this->afterStepTestedEvents,
+                'step_setup_events' => $this->afterStepSetupEvents,
+            ];
+
+            $this->afterStepTestedEvents = [];
+            $this->afterStepSetupEvents = [];
+        }
+    }
+
+    /**
+     * Captures feature on BEFORE event.
+     */
+    private function captureFeatureOnBeforeEvent(Event $event)
+    {
+        if (!$event instanceof BeforeFeatureTested) {
+            return;
+        }
+
+        $this->beforeFeatureTestedEvent = $event->getFeature();
+    }
+
+    /**
+     * Captures step tested event.
+     */
+    private function captureStepEvent(Event $event)
+    {
+        if ($event instanceof AfterStepTested) {
+            $this->afterStepTestedEvents[$event->getStep()->getLine()] = $event;
+        }
+        if ($event instanceof AfterStepSetup) {
+            $this->afterStepSetupEvents[$event->getStep()->getLine()] = $event;
+        }
     }
 }

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
@@ -21,13 +21,12 @@ use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Node\EventListener\EventListener;
 
 /**
- * Listens for Outline events store the current one
+ * Listens for Outline events store the current one.
  *
  * @author James Watson <james@sitepulse.org>
  */
 final class JUnitOutlineStoreListener implements EventListener
 {
-
     /**
      * @var SuitePrinter
      */
@@ -36,12 +35,10 @@ final class JUnitOutlineStoreListener implements EventListener
     /**
      * @var array
      */
-    private $lineScenarioMap = array();
+    private $lineScenarioMap = [];
 
     /**
      * Initializes listener.
-     *
-     * @param SuitePrinter $suitePrinter
      */
     public function __construct(SuitePrinter $suitePrinter)
     {
@@ -60,9 +57,15 @@ final class JUnitOutlineStoreListener implements EventListener
     }
 
     /**
+     * @return OutlineNode
+     */
+    public function getCurrentOutline(ExampleNode $scenario)
+    {
+        return $this->lineScenarioMap[$scenario->getLine()];
+    }
+
+    /**
      * Captures outline into the ivar on outline BEFORE event.
-     *
-     * @param Event $event
      */
     private function captureOutlineOnBeforeOutlineEvent(Event $event)
     {
@@ -76,10 +79,6 @@ final class JUnitOutlineStoreListener implements EventListener
         }
     }
 
-    /**
-     * @param Formatter $formatter
-     * @param Event     $event
-     */
     private function printHeaderOnBeforeSuiteTestedEvent(Formatter $formatter, Event $event)
     {
         if (!$event instanceof BeforeSuiteTested) {
@@ -88,24 +87,11 @@ final class JUnitOutlineStoreListener implements EventListener
         $this->suitePrinter->printHeader($formatter, $event->getSuite());
     }
 
-    /**
-     * @param Formatter $formatter
-     * @param Event     $event
-     */
     private function printFooterOnAfterSuiteTestedEvent(Formatter $formatter, Event $event)
     {
         if (!$event instanceof AfterSuiteTested) {
             return;
         }
         $this->suitePrinter->printFooter($formatter, $event->getSuite());
-    }
-
-    /**
-     * @param ExampleNode $scenario
-     * @return OutlineNode
-     */
-    public function getCurrentOutline(ExampleNode $scenario)
-    {
-        return $this->lineScenarioMap[$scenario->getLine()];
     }
 }

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
@@ -33,6 +33,7 @@ final class HookStatsListener implements EventListener
      * @var Statistics
      */
     private $statistics;
+
     /**
      * @var ExceptionPresenter
      */
@@ -40,9 +41,6 @@ final class HookStatsListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param Statistics         $statistics
-     * @param ExceptionPresenter $exceptionPresenter
      */
     public function __construct(Statistics $statistics, ExceptionPresenter $exceptionPresenter)
     {
@@ -60,8 +58,6 @@ final class HookStatsListener implements EventListener
 
     /**
      * Captures hook stats on hooked event.
-     *
-     * @param Event $event
      */
     private function captureHookStatsOnEvent(Event $event)
     {
@@ -76,8 +72,6 @@ final class HookStatsListener implements EventListener
 
     /**
      * Captures before hook stats.
-     *
-     * @param HookedSetup $setup
      */
     private function captureBeforeHookStats(HookedSetup $setup)
     {
@@ -90,8 +84,6 @@ final class HookStatsListener implements EventListener
 
     /**
      * Captures before hook stats.
-     *
-     * @param HookedTeardown $teardown
      */
     private function captureAfterHookStats(HookedTeardown $teardown)
     {
@@ -104,8 +96,6 @@ final class HookStatsListener implements EventListener
 
     /**
      * Captures hook call result.
-     *
-     * @param CallResult $hookCallResult
      */
     private function captureHookStat(CallResult $hookCallResult)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/ScenarioStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/ScenarioStatsListener.php
@@ -30,6 +30,7 @@ final class ScenarioStatsListener implements EventListener
      * @var Statistics
      */
     private $statistics;
+
     /**
      * @var string
      */
@@ -37,8 +38,6 @@ final class ScenarioStatsListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param Statistics $statistics
      */
     public function __construct(Statistics $statistics)
     {
@@ -57,8 +56,6 @@ final class ScenarioStatsListener implements EventListener
 
     /**
      * Captures current feature file path to the ivar on feature BEFORE event.
-     *
-     * @param Event $event
      */
     private function captureCurrentFeaturePathOnBeforeFeatureEvent(Event $event)
     {
@@ -85,8 +82,6 @@ final class ScenarioStatsListener implements EventListener
 
     /**
      * Captures scenario or example stats on their AFTER event.
-     *
-     * @param Event $event
      */
     private function captureScenarioOrExampleStatsOnAfterEvent(Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StatisticsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StatisticsListener.php
@@ -28,6 +28,7 @@ final class StatisticsListener implements EventListener
      * @var Statistics
      */
     private $statistics;
+
     /**
      * @var StatisticsPrinter
      */
@@ -35,9 +36,6 @@ final class StatisticsListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param Statistics        $statistics
-     * @param StatisticsPrinter $statisticsPrinter
      */
     public function __construct(Statistics $statistics, StatisticsPrinter $statisticsPrinter)
     {
@@ -71,8 +69,7 @@ final class StatisticsListener implements EventListener
     /**
      * Prints statistics on after exercise event.
      *
-     * @param Formatter $formatter
-     * @param string    $eventName
+     * @param string $eventName
      */
     private function printStatisticsOnAfterExerciseEvent(Formatter $formatter, $eventName)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
@@ -15,8 +15,8 @@ use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
 use Behat\Behat\EventDispatcher\Event\BeforeScenarioTested;
 use Behat\Behat\EventDispatcher\Event\FeatureTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
-use Behat\Behat\Output\Statistics\StepStatV2;
 use Behat\Behat\Output\Statistics\Statistics;
+use Behat\Behat\Output\Statistics\StepStatV2;
 use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Behat\Tester\Result\StepResult;
@@ -38,18 +38,22 @@ final class StepStatsListener implements EventListener
      * @var Statistics
      */
     private $statistics;
+
     /**
      * @var string
      */
     private $currentFeaturePath;
+
     /**
      * @var ExceptionPresenter
      */
     private $exceptionPresenter;
+
     /**
      * @var string
      */
     private $scenarioTitle;
+
     /**
      * @var string
      */
@@ -57,9 +61,6 @@ final class StepStatsListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param Statistics         $statistics
-     * @param ExceptionPresenter $exceptionPresenter
      */
     public function __construct(Statistics $statistics, ExceptionPresenter $exceptionPresenter)
     {
@@ -81,8 +82,6 @@ final class StepStatsListener implements EventListener
 
     /**
      * Captures current feature file path to the ivar on feature BEFORE event.
-     *
-     * @param Event $event
      */
     private function captureCurrentFeaturePathOnBeforeFeatureEvent(Event $event)
     {
@@ -109,8 +108,6 @@ final class StepStatsListener implements EventListener
 
     /**
      * Captures current scenario title and path on scenario BEFORE event.
-     *
-     * @param Event $event
      */
     private function captureScenarioOnBeforeFeatureEvent(Event $event)
     {
@@ -133,8 +130,6 @@ final class StepStatsListener implements EventListener
 
     /**
      * Captures step stats on step AFTER event.
-     *
-     * @param Event $event
      */
     private function captureStepStatsOnAfterEvent(Event $event)
     {
@@ -160,9 +155,7 @@ final class StepStatsListener implements EventListener
     /**
      * Gets exception from the step test results.
      *
-     * @param StepResult $result
-     *
-     * @return null|Exception
+     * @return null|\Exception
      */
     private function getStepException(StepResult $result)
     {
@@ -176,12 +169,9 @@ final class StepStatsListener implements EventListener
     /**
      * Gets step path from the AFTER test event and exception.
      *
-     * @param AfterStepTested $event
-     * @param null|Exception  $exception
-     *
      * @return string
      */
-    private function getStepPath(AfterStepTested $event, Exception $exception = null)
+    private function getStepPath(AfterStepTested $event, ?\Exception $exception = null)
     {
         $path = sprintf('%s:%d', $this->currentFeaturePath, $event->getStep()->getLine());
 

--- a/src/Behat/Behat/Output/Node/Printer/CounterPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/CounterPrinter.php
@@ -25,6 +25,7 @@ final class CounterPrinter
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
      * @var TranslatorInterface
      */
@@ -32,9 +33,6 @@ final class CounterPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param ResultToStringConverter $resultConverter
-     * @param TranslatorInterface     $translator
      */
     public function __construct(ResultToStringConverter $resultConverter, TranslatorInterface $translator)
     {
@@ -45,9 +43,7 @@ final class CounterPrinter
     /**
      * Prints scenario and step counters.
      *
-     * @param OutputPrinter $printer
-     * @param string        $intro
-     * @param array         $stats
+     * @param string $intro
      */
     public function printCounters(OutputPrinter $printer, $intro, array $stats)
     {
@@ -59,17 +55,17 @@ final class CounterPrinter
             $totalCount = array_sum($stats);
         }
 
-        $detailedStats = array();
+        $detailedStats = [];
         foreach ($stats as $resultCode => $count) {
             $style = $this->resultConverter->convertResultCodeToString($resultCode);
 
             $transId = $style . '_count';
-            $message = $this->translator->trans($transId, array('%count%' => $count), 'output');
+            $message = $this->translator->trans($transId, ['%count%' => $count], 'output');
 
             $detailedStats[] = sprintf('{+%s}%s{-%s}', $style, $message, $style);
         }
 
-        $message = $this->translator->trans($intro, array('%count%' => $totalCount), 'output');
+        $message = $this->translator->trans($intro, ['%count%' => $totalCount], 'output');
         $printer->write($message);
 
         if (count($detailedStats)) {

--- a/src/Behat/Behat/Output/Node/Printer/ExamplePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ExamplePrinter.php
@@ -24,18 +24,11 @@ interface ExamplePrinter
 {
     /**
      * Prints example header using provided printer.
-     *
-     * @param Formatter   $formatter
-     * @param FeatureNode $feature
-     * @param ExampleNode $example
      */
     public function printHeader(Formatter $formatter, FeatureNode $feature, ExampleNode $example);
 
     /**
      * Prints example footer using provided printer.
-     *
-     * @param Formatter  $formatter
-     * @param TestResult $result
      */
     public function printFooter(Formatter $formatter, TestResult $result);
 }

--- a/src/Behat/Behat/Output/Node/Printer/ExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ExampleRowPrinter.php
@@ -25,9 +25,6 @@ interface ExampleRowPrinter
     /**
      * Prints example row result using provided printer.
      *
-     * @param Formatter         $formatter
-     * @param OutlineNode       $outline
-     * @param ExampleNode       $example
      * @param AfterStepTested[] $events
      */
     public function printExampleRow(Formatter $formatter, OutlineNode $outline, ExampleNode $example, array $events);

--- a/src/Behat/Behat/Output/Node/Printer/FeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/FeaturePrinter.php
@@ -23,17 +23,11 @@ interface FeaturePrinter
 {
     /**
      * Prints feature header using provided formatter.
-     *
-     * @param Formatter   $formatter
-     * @param FeatureNode $feature
      */
     public function printHeader(Formatter $formatter, FeatureNode $feature);
 
     /**
      * Prints feature footer using provided printer.
-     *
-     * @param Formatter  $formatter
-     * @param TestResult $result
      */
     public function printFooter(Formatter $formatter, TestResult $result);
 }

--- a/src/Behat/Behat/Output/Node/Printer/Helper/ResultToStringConverter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/ResultToStringConverter.php
@@ -23,8 +23,6 @@ final class ResultToStringConverter
     /**
      * Converts provided test result to a string.
      *
-     * @param TestResult $result
-     *
      * @return string
      */
     public function convertResultToString(TestResult $result)
@@ -35,7 +33,7 @@ final class ResultToStringConverter
     /**
      * Converts provided result code to a string.
      *
-     * @param integer $resultCode
+     * @param int $resultCode
      *
      * @return string
      */
@@ -44,10 +42,13 @@ final class ResultToStringConverter
         switch ($resultCode) {
             case TestResult::SKIPPED:
                 return 'skipped';
+
             case TestResult::PENDING:
                 return 'pending';
+
             case TestResult::FAILED:
                 return 'failed';
+
             case StepResult::UNDEFINED:
                 return 'undefined';
         }

--- a/src/Behat/Behat/Output/Node/Printer/Helper/StepTextPainter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/StepTextPainter.php
@@ -25,6 +25,7 @@ final class StepTextPainter
      * @var PatternTransformer
      */
     private $patternTransformer;
+
     /**
      * @var ResultToStringConverter
      */
@@ -32,9 +33,6 @@ final class StepTextPainter
 
     /**
      * Initializes painter.
-     *
-     * @param PatternTransformer      $patternTransformer
-     * @param ResultToStringConverter $resultConverter
      */
     public function __construct(PatternTransformer $patternTransformer, ResultToStringConverter $resultConverter)
     {
@@ -45,9 +43,7 @@ final class StepTextPainter
     /**
      * Colorizes step text arguments according to definition.
      *
-     * @param string     $text
-     * @param Definition $definition
-     * @param TestResult $result
+     * @param string $text
      *
      * @return string
      */
@@ -63,7 +59,7 @@ final class StepTextPainter
         }
 
         // Find arguments with offsets
-        $matches = array();
+        $matches = [];
         preg_match($regex, $text, $matches, PREG_OFFSET_CAPTURE);
         array_shift($matches);
 
@@ -86,7 +82,7 @@ final class StepTextPainter
 
             $begin = substr($text, 0, $offset);
             $end = substr($text, $lastReplacementPosition);
-            $format = "{-$style}{+$paramStyle}%s{-$paramStyle}{+$style}";
+            $format = "{-{$style}}{+{$paramStyle}}%s{-{$paramStyle}}{+{$style}}";
             $text = sprintf("%s{$format}%s", $begin, $value, $end);
 
             // Keep track of how many extra characters are added
@@ -95,12 +91,10 @@ final class StepTextPainter
         }
 
         // Replace "<", ">" with colorized ones
-        $text = preg_replace(
+        return preg_replace(
             '/(<[^>]+>)/',
-            "{-$style}{+$paramStyle}\$1{-$paramStyle}{+$style}",
+            "{-{$style}}{+{$paramStyle}}\$1{-{$paramStyle}}{+{$style}}",
             $text
         );
-
-        return $text;
     }
 }

--- a/src/Behat/Behat/Output/Node/Printer/Helper/WidthCalculator.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/WidthCalculator.php
@@ -24,11 +24,10 @@ final class WidthCalculator
     /**
      * Calculates scenario width.
      *
-     * @param Scenario $scenario
-     * @param integer  $indentation
-     * @param integer  $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      *
-     * @return integer
+     * @return int
      */
     public function calculateScenarioWidth(Scenario $scenario, $indentation, $subIndentation)
     {
@@ -45,11 +44,10 @@ final class WidthCalculator
     /**
      * Calculates outline examples width.
      *
-     * @param ExampleNode $example
-     * @param integer     $indentation
-     * @param integer     $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      *
-     * @return integer
+     * @return int
      */
     public function calculateExampleWidth(ExampleNode $example, $indentation, $subIndentation)
     {
@@ -66,10 +64,9 @@ final class WidthCalculator
     /**
      * Calculates scenario header width.
      *
-     * @param Scenario $scenario
-     * @param integer  $indentation
+     * @param int $indentation
      *
-     * @return integer
+     * @return int
      */
     public function calculateScenarioHeaderWidth(Scenario $scenario, $indentation)
     {
@@ -89,10 +86,9 @@ final class WidthCalculator
     /**
      * Calculates step width.
      *
-     * @param StepNode $step
-     * @param integer  $indentation
+     * @param int $indentation
      *
-     * @return integer
+     * @return int
      */
     public function calculateStepWidth(StepNode $step, $indentation)
     {

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitFeaturePrinter.php
@@ -32,11 +32,11 @@ final class JUnitFeaturePrinter implements FeaturePrinter
     private $statistics;
 
     /**
-     * @var JUnitDurationListener|null
+     * @var null|JUnitDurationListener
      */
     private $durationListener;
 
-    public function __construct(PhaseStatistics $statistics, JUnitDurationListener $durationListener = null)
+    public function __construct(PhaseStatistics $statistics, ?JUnitDurationListener $durationListener = null)
     {
         $this->statistics = $statistics;
         $this->durationListener = $durationListener;
@@ -58,14 +58,14 @@ final class JUnitFeaturePrinter implements FeaturePrinter
         /** @var JUnitOutputPrinter $outputPrinter */
         $outputPrinter = $formatter->getOutputPrinter();
 
-        $outputPrinter->addTestsuite(array(
+        $outputPrinter->addTestsuite([
             'name' => $feature->getTitle(),
             'tests' => $totalCount,
             'skipped' => $stats[TestResult::SKIPPED],
             'failures' => $stats[TestResult::FAILED],
             'errors' => $stats[TestResult::PENDING] + $stats[StepResult::UNDEFINED],
             'time' => $this->durationListener ? $this->durationListener->getFeatureDuration($feature) : '',
-        ));
+        ]);
         $this->statistics->reset();
     }
 

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
@@ -10,8 +10,8 @@
 
 namespace Behat\Behat\Output\Node\Printer\JUnit;
 
-use Behat\Behat\Output\Node\EventListener\JUnit\JUnitOutlineStoreListener;
 use Behat\Behat\Output\Node\EventListener\JUnit\JUnitDurationListener;
+use Behat\Behat\Output\Node\EventListener\JUnit\JUnitOutlineStoreListener;
 use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
 use Behat\Gherkin\Node\ExampleNode;
 use Behat\Gherkin\Node\FeatureNode;
@@ -49,21 +49,18 @@ final class JUnitScenarioPrinter
     private $outlineStepCount;
 
     /**
-     * @var JUnitDurationListener|null
+     * @var null|JUnitDurationListener
      */
     private $durationListener;
 
-    public function __construct(ResultToStringConverter $resultConverter, JUnitOutlineStoreListener $outlineListener, JUnitDurationListener $durationListener = null)
+    public function __construct(ResultToStringConverter $resultConverter, JUnitOutlineStoreListener $outlineListener, ?JUnitDurationListener $durationListener = null)
     {
         $this->resultConverter = $resultConverter;
         $this->outlineStoreListener = $outlineListener;
         $this->durationListener = $durationListener;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result, string $file = null)
+    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result, ?string $file = null)
     {
         $name = implode(' ', array_map(function ($l) {
             return trim($l);
@@ -76,12 +73,12 @@ final class JUnitScenarioPrinter
         /** @var JUnitOutputPrinter $outputPrinter */
         $outputPrinter = $formatter->getOutputPrinter();
 
-        $testCaseAttributes = array(
-            'name'      => $name,
+        $testCaseAttributes = [
+            'name' => $name,
             'classname' => $feature->getTitle(),
-            'status'    => $this->resultConverter->convertResultToString($result),
-            'time'      => $this->durationListener ? $this->durationListener->getDuration($scenario) : ''
-        );
+            'status' => $this->resultConverter->convertResultToString($result),
+            'time' => $this->durationListener ? $this->durationListener->getDuration($scenario) : '',
+        ];
 
         if ($file) {
             $cwd = realpath(getcwd());
@@ -94,20 +91,18 @@ final class JUnitScenarioPrinter
     }
 
     /**
-     * @param ExampleNode $scenario
      * @return string
      */
     private function buildExampleName(ExampleNode $scenario)
     {
         $currentOutline = $this->outlineStoreListener->getCurrentOutline($scenario);
         if ($currentOutline === $this->lastOutline) {
-            $this->outlineStepCount++;
+            ++$this->outlineStepCount;
         } else {
             $this->lastOutline = $currentOutline;
             $this->outlineStepCount = 1;
         }
 
-        $name = $currentOutline->getTitle() . ' #' . $this->outlineStepCount;
-        return $name;
+        return $currentOutline->getTitle() . ' #' . $this->outlineStepCount;
     }
 }

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
@@ -1,4 +1,13 @@
 <?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Behat\Behat\Output\Node\Printer\JUnit;
 
 use Behat\Behat\Hook\Scope\StepScope;
@@ -19,7 +28,6 @@ use Behat\Testwork\Tester\Setup\Teardown;
  */
 class JUnitSetupPrinter implements SetupPrinter
 {
-
     /** @var ExceptionPresenter */
     private $exceptionPresenter;
 
@@ -53,8 +61,6 @@ class JUnitSetupPrinter implements SetupPrinter
     }
 
     /**
-     * @param Formatter $formatter
-     * @param CallResults $results
      * @param string $messageType
      */
     private function handleHookCalls(Formatter $formatter, CallResults $results, $messageType)
@@ -65,6 +71,7 @@ class JUnitSetupPrinter implements SetupPrinter
                 /** @var HookCall $call */
                 $call = $hookCallResult->getCall();
                 $scope = $call->getScope();
+
                 /** @var JUnitOutputPrinter $outputPrinter */
                 $outputPrinter = $formatter->getOutputPrinter();
 
@@ -74,13 +81,12 @@ class JUnitSetupPrinter implements SetupPrinter
                 }
                 $message .= $this->exceptionPresenter->presentException($hookCallResult->getException());
 
-                $attributes = array(
+                $attributes = [
                     'message' => $message,
-                    'type'    => $messageType,
-                );
+                    'type' => $messageType,
+                ];
 
                 $outputPrinter->addTestcaseChild('failure', $attributes);
-
             }
         }
     }

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
@@ -10,15 +10,15 @@
 
 namespace Behat\Behat\Output\Node\Printer\JUnit;
 
-use Behat\Behat\Tester\Result\StepResult;
 use Behat\Behat\Output\Node\Printer\StepPrinter;
+use Behat\Behat\Tester\Result\StepResult;
 use Behat\Gherkin\Node\ScenarioLikeInterface as Scenario;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\Exception\ExceptionPresenter;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\JUnitOutputPrinter;
-use Behat\Testwork\Tester\Result\TestResult;
 use Behat\Testwork\Tester\Result\ExceptionResult;
+use Behat\Testwork\Tester\Result\TestResult;
 
 /**
  * Prints step with optional results.
@@ -40,11 +40,6 @@ class JUnitStepPrinter implements StepPrinter
 
     /**
      * Prints step using provided printer.
-     *
-     * @param Formatter  $formatter
-     * @param Scenario   $scenario
-     * @param StepNode   $step
-     * @param StepResult $result
      */
     public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result)
     {
@@ -57,21 +52,24 @@ class JUnitStepPrinter implements StepPrinter
             $message .= ': ' . $this->exceptionPresenter->presentException($result->getException());
         }
 
-        $attributes = array('message' => $message);
+        $attributes = ['message' => $message];
 
         switch ($result->getResultCode()) {
             case TestResult::FAILED:
                 $outputPrinter->addTestcaseChild('failure', $attributes);
+
                 break;
 
             case TestResult::PENDING:
                 $attributes['type'] = 'pending';
                 $outputPrinter->addTestcaseChild('error', $attributes);
+
                 break;
 
             case StepResult::UNDEFINED:
                 $attributes['type'] = 'undefined';
                 $outputPrinter->addTestcaseChild('error', $attributes);
+
                 break;
         }
     }

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSuitePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSuitePrinter.php
@@ -28,7 +28,7 @@ final class JUnitSuitePrinter implements SuitePrinter
      */
     private $statistics;
 
-    public function __construct(PhaseStatistics $statistics = null)
+    public function __construct(?PhaseStatistics $statistics = null)
     {
         $this->statistics = $statistics;
     }

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -14,8 +14,8 @@ use Behat\Behat\Definition\Translator\TranslatorInterface;
 use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
 use Behat\Behat\Output\Statistics\HookStat;
 use Behat\Behat\Output\Statistics\ScenarioStat;
-use Behat\Behat\Output\Statistics\StepStatV2;
 use Behat\Behat\Output\Statistics\StepStat;
+use Behat\Behat\Output\Statistics\StepStatV2;
 use Behat\Testwork\Exception\ExceptionPresenter;
 use Behat\Testwork\Output\Printer\OutputPrinter;
 use Behat\Testwork\Tester\Result\TestResult;
@@ -31,14 +31,17 @@ final class ListPrinter
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
      * @var ExceptionPresenter
      */
     private $exceptionPresenter;
+
     /**
      * @var TranslatorInterface
      */
     private $translator;
+
     /**
      * @var string
      */
@@ -47,10 +50,7 @@ final class ListPrinter
     /**
      * Initializes printer.
      *
-     * @param ResultToStringConverter $resultConverter
-     * @param ExceptionPresenter      $exceptionPresenter
-     * @param TranslatorInterface     $translator
-     * @param string                  $basePath
+     * @param string $basePath
      */
     public function __construct(
         ResultToStringConverter $resultConverter,
@@ -67,9 +67,8 @@ final class ListPrinter
     /**
      * Prints scenarios list.
      *
-     * @param OutputPrinter  $printer
      * @param string         $intro
-     * @param integer        $resultCode
+     * @param int            $resultCode
      * @param ScenarioStat[] $scenarioStats
      */
     public function printScenariosList(OutputPrinter $printer, $intro, $resultCode, array $scenarioStats)
@@ -79,7 +78,7 @@ final class ListPrinter
         }
 
         $style = $this->resultConverter->convertResultCodeToString($resultCode);
-        $intro = $this->translator->trans($intro, array(), 'output');
+        $intro = $this->translator->trans($intro, [], 'output');
 
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
         foreach ($scenarioStats as $stat) {
@@ -93,10 +92,9 @@ final class ListPrinter
     /**
      * Prints step list.
      *
-     * @param OutputPrinter $printer
-     * @param string        $intro
-     * @param integer       $resultCode
-     * @param StepStat[]    $stepStats
+     * @param string     $intro
+     * @param int        $resultCode
+     * @param StepStat[] $stepStats
      */
     public function printStepList(OutputPrinter $printer, $intro, $resultCode, array $stepStats)
     {
@@ -105,7 +103,7 @@ final class ListPrinter
         }
 
         $style = $this->resultConverter->convertResultCodeToString($resultCode);
-        $intro = $this->translator->trans($intro, array(), 'output');
+        $intro = $this->translator->trans($intro, [], 'output');
 
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
 
@@ -121,9 +119,8 @@ final class ListPrinter
     /**
      * Prints failed hooks list.
      *
-     * @param OutputPrinter $printer
-     * @param string        $intro
-     * @param HookStat[]    $failedHookStats
+     * @param string     $intro
+     * @param HookStat[] $failedHookStats
      */
     public function printFailedHooksList(OutputPrinter $printer, $intro, array $failedHookStats)
     {
@@ -132,7 +129,7 @@ final class ListPrinter
         }
 
         $style = $this->resultConverter->convertResultCodeToString(TestResult::FAILED);
-        $intro = $this->translator->trans($intro, array(), 'output');
+        $intro = $this->translator->trans($intro, [], 'output');
 
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
         foreach ($failedHookStats as $hookStat) {
@@ -143,12 +140,11 @@ final class ListPrinter
     /**
      * Prints hook stat.
      *
-     * @param OutputPrinter $printer
-     * @param string        $name
-     * @param string        $path
-     * @param string        $style
-     * @param null|string   $stdOut
-     * @param null|string   $error
+     * @param string      $name
+     * @param string      $path
+     * @param string      $style
+     * @param null|string $stdOut
+     * @param null|string $error
      *
      * @deprecated Remove in 4.0
      */
@@ -176,15 +172,17 @@ final class ListPrinter
     /**
      * Prints hook stat.
      *
-     * @param OutputPrinter $printer
-     * @param HookStat      $hookStat
-     * @param string        $style
+     * @param string $style
      */
     private function printHookStat(OutputPrinter $printer, HookStat $hookStat, $style)
     {
         $printer->writeln(
-            sprintf('    {+%s}%s{-%s} {+comment}# %s{-comment}',
-                $style, $hookStat->getName(), $style, $this->relativizePaths($hookStat->getPath())
+            sprintf(
+                '    {+%s}%s{-%s} {+comment}# %s{-comment}',
+                $style,
+                $hookStat->getName(),
+                $style,
+                $this->relativizePaths($hookStat->getPath())
             )
         );
 
@@ -207,17 +205,16 @@ final class ListPrinter
     /**
      * Prints hook stat.
      *
-     * @param OutputPrinter $printer
-     * @param integer       $number
-     * @param StepStatV2    $stat
-     * @param string        $style
+     * @param int    $number
+     * @param string $style
      */
     private function printStepStat(OutputPrinter $printer, $number, StepStatV2 $stat, $style)
     {
         $maxLength = max(mb_strlen($stat->getScenarioText(), 'utf8'), mb_strlen($stat->getStepText(), 'utf8') + 2) + 1;
 
         $printer->writeln(
-            sprintf('%03d {+%s}%s{-%s}%s{+comment}# %s{-comment}',
+            sprintf(
+                '%03d {+%s}%s{-%s}%s{+comment}# %s{-comment}',
                 $number,
                 $style,
                 $stat->getScenarioText(),
@@ -228,7 +225,8 @@ final class ListPrinter
         );
 
         $printer->writeln(
-            sprintf('      {+%s}%s{-%s}%s{+comment}# %s{-comment}',
+            sprintf(
+                '      {+%s}%s{-%s}%s{+comment}# %s{-comment}',
                 $style,
                 $stat->getStepText(),
                 $style,

--- a/src/Behat/Behat/Output/Node/Printer/OutlinePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/OutlinePrinter.php
@@ -24,18 +24,11 @@ interface OutlinePrinter
 {
     /**
      * Prints outline header using provided printer.
-     *
-     * @param Formatter   $formatter
-     * @param FeatureNode $feature
-     * @param OutlineNode $outline
      */
     public function printHeader(Formatter $formatter, FeatureNode $feature, OutlineNode $outline);
 
     /**
      * Prints outline footer using provided printer.
-     *
-     * @param Formatter  $formatter
-     * @param TestResult $result
      */
     public function printFooter(Formatter $formatter, TestResult $result);
 }

--- a/src/Behat/Behat/Output/Node/Printer/OutlineTablePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/OutlineTablePrinter.php
@@ -26,18 +26,12 @@ interface OutlineTablePrinter
     /**
      * Prints outline header using provided printer and first row example step results.
      *
-     * @param Formatter    $formatter
-     * @param FeatureNode  $feature
-     * @param OutlineNode  $outline
      * @param StepResult[] $results
      */
     public function printHeader(Formatter $formatter, FeatureNode $feature, OutlineNode $outline, array $results);
 
     /**
      * Prints outline footer using provided printer.
-     *
-     * @param Formatter  $formatter
-     * @param TestResult $result
      */
     public function printFooter(Formatter $formatter, TestResult $result);
 }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExamplePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExamplePrinter.php
@@ -28,6 +28,7 @@ final class PrettyExamplePrinter implements ExamplePrinter
      * @var PrettyPathPrinter
      */
     private $pathPrinter;
+
     /**
      * @var string
      */
@@ -36,8 +37,7 @@ final class PrettyExamplePrinter implements ExamplePrinter
     /**
      * Initializes printer.
      *
-     * @param PrettyPathPrinter $pathPrinter
-     * @param integer           $indentation
+     * @param int $indentation
      */
     public function __construct(PrettyPathPrinter $pathPrinter, $indentation = 6)
     {
@@ -63,9 +63,6 @@ final class PrettyExamplePrinter implements ExamplePrinter
 
     /**
      * Prints example title.
-     *
-     * @param OutputPrinter $printer
-     * @param ExampleNode   $example
      */
     private function printTitle(OutputPrinter $printer, ExampleNode $example)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
@@ -36,18 +36,22 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
      * @var ExceptionPresenter
      */
     private $exceptionPresenter;
+
     /**
      * @var string
      */
     private $indentText;
+
     /**
      * @var string
      */
     private $subIndentText;
+
     /**
      * @var TranslatorInterface
      */
@@ -56,10 +60,8 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
     /**
      * Initializes printer.
      *
-     * @param ResultToStringConverter $resultConverter
-     * @param ExceptionPresenter      $exceptionPresenter
-     * @param integer                 $indentation
-     * @param integer                 $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      */
     public function __construct(
         ResultToStringConverter $resultConverter,
@@ -80,7 +82,7 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
      */
     public function printExampleRow(Formatter $formatter, OutlineNode $outline, ExampleNode $example, array $events)
     {
-        $rowNum = array_search($example, $outline->getExamples()) + 1;
+        $rowNum = array_search($example, $outline->getExamples(), true) + 1;
         $wrapper = $this->getWrapperClosure($outline, $example, $events);
         $row = $outline->getExampleTable()->getRowAsStringWithWrappedValues($rowNum, $wrapper);
 
@@ -91,8 +93,6 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
     /**
      * Creates wrapper-closure for the example table.
      *
-     * @param OutlineNode   $outline
-     * @param ExampleNode   $example
      * @param AfterStepTested[] $stepEvents
      *
      * @return callable
@@ -102,9 +102,9 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
         $resultConverter = $this->resultConverter;
 
         return function ($value, $column) use ($outline, $example, $stepEvents, $resultConverter) {
-            $results = array();
+            $results = [];
             foreach ($stepEvents as $event) {
-                $index = array_search($event->getStep(), $example->getSteps());
+                $index = array_search($event->getStep(), $example->getSteps(), true);
                 $header = $outline->getExampleTable()->getRow(0);
                 $steps = $outline->getSteps();
                 $outlineStepText = $steps[$index]->getText();
@@ -124,7 +124,6 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
     /**
      * Prints step events exceptions (if has some).
      *
-     * @param OutputPrinter $printer
      * @param AfterTested[] $events
      */
     private function printStepExceptionsAndStdOut(OutputPrinter $printer, array $events)
@@ -137,9 +136,6 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
 
     /**
      * Prints step exception (if has one).
-     *
-     * @param OutputPrinter $printer
-     * @param AfterTested   $event
      */
     private function printStepException(OutputPrinter $printer, AfterTested $event)
     {
@@ -158,15 +154,12 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
         }
 
         $text = $this->exceptionPresenter->presentException($result->getException());
-        $indentedText = implode("\n", array_map(array($this, 'subIndent'), explode("\n", $text)));
+        $indentedText = implode("\n", array_map([$this, 'subIndent'], explode("\n", $text)));
         $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $indentedText, $style));
     }
 
     /**
      * Prints step output (if has one).
-     *
-     * @param OutputPrinter $printer
-     * @param StepResult    $result
      */
     private function printStepStdOut(OutputPrinter $printer, StepResult $result)
     {
@@ -179,7 +172,9 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
 
         $pad = function ($line) use ($indentedText) {
             return sprintf(
-                '%s│ {+stdout}%s{-stdout}', $indentedText, $line
+                '%s│ {+stdout}%s{-stdout}',
+                $indentedText,
+                $line
             );
         };
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
@@ -28,6 +28,7 @@ final class PrettyFeaturePrinter implements FeaturePrinter
      * @var string
      */
     private $indentText;
+
     /**
      * @var string
      */
@@ -36,8 +37,8 @@ final class PrettyFeaturePrinter implements FeaturePrinter
     /**
      * Initializes printer.
      *
-     * @param integer $indentation
-     * @param integer $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      */
     public function __construct($indentation = 0, $subIndentation = 2)
     {
@@ -68,8 +69,7 @@ final class PrettyFeaturePrinter implements FeaturePrinter
     /**
      * Prints feature tags.
      *
-     * @param OutputPrinter $printer
-     * @param string[]      $tags
+     * @param string[] $tags
      */
     private function printTags(OutputPrinter $printer, array $tags)
     {
@@ -77,15 +77,12 @@ final class PrettyFeaturePrinter implements FeaturePrinter
             return;
         }
 
-        $tags = array_map(array($this, 'prependTagWithTagSign'), $tags);
+        $tags = array_map([$this, 'prependTagWithTagSign'], $tags);
         $printer->writeln(sprintf('%s{+tag}%s{-tag}', $this->indentText, implode(' ', $tags)));
     }
 
     /**
      * Prints feature title using provided printer.
-     *
-     * @param OutputPrinter $printer
-     * @param FeatureNode   $feature
      */
     private function printTitle(OutputPrinter $printer, FeatureNode $feature)
     {
@@ -100,9 +97,6 @@ final class PrettyFeaturePrinter implements FeaturePrinter
 
     /**
      * Prints feature description using provided printer.
-     *
-     * @param OutputPrinter $printer
-     * @param FeatureNode   $feature
      */
     private function printDescription(OutputPrinter $printer, FeatureNode $feature)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlinePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlinePrinter.php
@@ -34,29 +34,30 @@ final class PrettyOutlinePrinter implements OutlinePrinter
      * @var ScenarioPrinter
      */
     private $scenarioPrinter;
+
     /**
      * @var StepPrinter
      */
     private $stepPrinter;
+
     /**
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
      * @var string
      */
     private $indentText;
+
     /**
      * @var string
      */
     private $subIndentText;
 
     /**
-     * @param ScenarioPrinter         $scenarioPrinter
-     * @param StepPrinter             $stepPrinter
-     * @param ResultToStringConverter $resultConverter
-     * @param integer                 $indentation
-     * @param integer                 $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      */
     public function __construct(
         ScenarioPrinter $scenarioPrinter,
@@ -94,9 +95,7 @@ final class PrettyOutlinePrinter implements OutlinePrinter
     /**
      * Prints outline steps.
      *
-     * @param Formatter   $formatter
-     * @param OutlineNode $outline
-     * @param StepNode[]  $steps
+     * @param StepNode[] $steps
      */
     private function printExamplesSteps(Formatter $formatter, OutlineNode $outline, array $steps)
     {
@@ -109,9 +108,6 @@ final class PrettyOutlinePrinter implements OutlinePrinter
 
     /**
      * Prints examples table header.
-     *
-     * @param OutputPrinter    $printer
-     * @param ExampleTableNode $table
      */
     private function printExamplesTableHeader(OutputPrinter $printer, ExampleTableNode $table)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlineTablePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlineTablePrinter.php
@@ -34,18 +34,22 @@ final class PrettyOutlineTablePrinter implements OutlineTablePrinter
      * @var ScenarioPrinter
      */
     private $scenarioPrinter;
+
     /**
      * @var StepPrinter
      */
     private $stepPrinter;
+
     /**
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
      * @var string
      */
     private $indentText;
+
     /**
      * @var string
      */
@@ -54,11 +58,8 @@ final class PrettyOutlineTablePrinter implements OutlineTablePrinter
     /**
      * Initializes printer.
      *
-     * @param ScenarioPrinter         $scenarioPrinter
-     * @param StepPrinter             $stepPrinter
-     * @param ResultToStringConverter $resultConverter
-     * @param integer                 $indentation
-     * @param integer                 $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      */
     public function __construct(
         ScenarioPrinter $scenarioPrinter,
@@ -96,8 +97,6 @@ final class PrettyOutlineTablePrinter implements OutlineTablePrinter
     /**
      * Prints example steps with definition paths (if has some), but without exceptions or state (skipped).
      *
-     * @param Formatter    $formatter
-     * @param OutlineNode  $outline
      * @param StepNode[]   $steps
      * @param StepResult[] $results
      */
@@ -114,9 +113,6 @@ final class PrettyOutlineTablePrinter implements OutlineTablePrinter
 
     /**
      * Prints examples table header.
-     *
-     * @param OutputPrinter    $printer
-     * @param ExampleTableNode $table
      */
     private function printExamplesTableHeader(OutputPrinter $printer, ExampleTableNode $table)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
@@ -30,6 +30,7 @@ final class PrettyPathPrinter
      * @var WidthCalculator
      */
     private $widthCalculator;
+
     /**
      * @var string
      */
@@ -38,8 +39,7 @@ final class PrettyPathPrinter
     /**
      * Initializes printer.
      *
-     * @param WidthCalculator $widthCalculator
-     * @param string          $basePath
+     * @param string $basePath
      */
     public function __construct(WidthCalculator $widthCalculator, $basePath)
     {
@@ -50,10 +50,7 @@ final class PrettyPathPrinter
     /**
      * Prints scenario path comment.
      *
-     * @param Formatter   $formatter
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
-     * @param integer     $indentation
+     * @param int $indentation
      */
     public function printScenarioPath(Formatter $formatter, FeatureNode $feature, Scenario $scenario, $indentation)
     {
@@ -76,11 +73,7 @@ final class PrettyPathPrinter
     /**
      * Prints step path comment.
      *
-     * @param Formatter  $formatter
-     * @param Scenario   $scenario
-     * @param StepNode   $step
-     * @param StepResult $result
-     * @param integer    $indentation
+     * @param int $indentation
      */
     public function printStepPath(
         Formatter $formatter,
@@ -106,10 +99,8 @@ final class PrettyPathPrinter
     /**
      * Prints defined step path.
      *
-     * @param OutputPrinter     $printer
-     * @param DefinedStepResult $result
-     * @param integer           $scenarioWidth
-     * @param integer           $stepWidth
+     * @param int $scenarioWidth
+     * @param int $stepWidth
      */
     private function printDefinedStepPath(OutputPrinter $printer, DefinedStepResult $result, $scenarioWidth, $stepWidth)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -29,10 +29,12 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
      * @var PrettyPathPrinter
      */
     private $pathPrinter;
+
     /**
      * @var string
      */
     private $indentText;
+
     /**
      * @var string
      */
@@ -41,9 +43,8 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
     /**
      * Initializes printer.
      *
-     * @param PrettyPathPrinter $pathPrinter
-     * @param integer           $indentation
-     * @param integer           $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      */
     public function __construct(PrettyPathPrinter $pathPrinter, $indentation = 2, $subIndentation = 2)
     {
@@ -78,8 +79,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
     /**
      * Prints scenario tags.
      *
-     * @param OutputPrinter $printer
-     * @param string[]      $tags
+     * @param string[] $tags
      */
     private function printTags(OutputPrinter $printer, array $tags)
     {
@@ -87,15 +87,14 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
             return;
         }
 
-        $tags = array_map(array($this, 'prependTagWithTagSign'), $tags);
+        $tags = array_map([$this, 'prependTagWithTagSign'], $tags);
         $printer->writeln(sprintf('%s{+tag}%s{-tag}', $this->indentText, implode(' ', $tags)));
     }
 
     /**
      * Prints scenario keyword.
      *
-     * @param OutputPrinter $printer
-     * @param string        $keyword
+     * @param string $keyword
      */
     private function printKeyword(OutputPrinter $printer, $keyword)
     {
@@ -105,8 +104,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
     /**
      * Prints scenario title (first line of long title).
      *
-     * @param OutputPrinter $printer
-     * @param string        $longTitle
+     * @param string $longTitle
      */
     private function printTitle(OutputPrinter $printer, $longTitle)
     {
@@ -121,8 +119,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
     /**
      * Prints scenario description (other lines of long title).
      *
-     * @param OutputPrinter $printer
-     * @param string        $longTitle
+     * @param string $longTitle
      */
     private function printDescription(OutputPrinter $printer, $longTitle)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
@@ -33,18 +33,22 @@ final class PrettySetupPrinter implements SetupPrinter
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
      * @var ExceptionPresenter
      */
     private $exceptionPresenter;
+
     /**
      * @var string
      */
     private $indentText;
+
     /**
      * @var bool
      */
     private $newlineBefore;
+
     /**
      * @var bool
      */
@@ -53,11 +57,9 @@ final class PrettySetupPrinter implements SetupPrinter
     /**
      * Initializes printer.
      *
-     * @param ResultToStringConverter $resultConverter
-     * @param ExceptionPresenter      $exceptionPresenter
-     * @param integer                 $indentation
-     * @param bool                 $newlineBefore
-     * @param bool                 $newlineAfter
+     * @param int  $indentation
+     * @param bool $newlineBefore
+     * @param bool $newlineAfter
      */
     public function __construct(
         ResultToStringConverter $resultConverter,
@@ -103,9 +105,6 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Prints setup hook call result.
-     *
-     * @param OutputPrinter $printer
-     * @param CallResult    $callResult
      */
     private function printSetupHookCallResult(OutputPrinter $printer, CallResult $callResult)
     {
@@ -134,9 +133,6 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Prints teardown hook call result.
-     *
-     * @param OutputPrinter $printer
-     * @param CallResult    $callResult
      */
     private function printTeardownHookCallResult(OutputPrinter $printer, CallResult $callResult)
     {
@@ -166,9 +162,7 @@ final class PrettySetupPrinter implements SetupPrinter
     /**
      * Prints hook call output (if has some).
      *
-     * @param OutputPrinter $printer
-     * @param CallResult    $callResult
-     * @param string        $indentText
+     * @param string $indentText
      */
     private function printHookCallStdOut(OutputPrinter $printer, CallResult $callResult, $indentText)
     {
@@ -178,7 +172,9 @@ final class PrettySetupPrinter implements SetupPrinter
 
         $pad = function ($line) use ($indentText) {
             return sprintf(
-                '%s│  {+stdout}%s{-stdout}', $indentText, $line
+                '%s│  {+stdout}%s{-stdout}',
+                $indentText,
+                $line
             );
         };
 
@@ -189,9 +185,7 @@ final class PrettySetupPrinter implements SetupPrinter
     /**
      * Prints hook call exception (if has some).
      *
-     * @param OutputPrinter $printer
-     * @param CallResult    $callResult
-     * @param string        $indentText
+     * @param string $indentText
      */
     private function printHookCallException(OutputPrinter $printer, CallResult $callResult, $indentText)
     {
@@ -201,7 +195,9 @@ final class PrettySetupPrinter implements SetupPrinter
 
         $pad = function ($l) use ($indentText) {
             return sprintf(
-                '%s╳  {+exception}%s{-exception}', $indentText, $l
+                '%s╳  {+exception}%s{-exception}',
+                $indentText,
+                $l
             );
         };
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -35,18 +35,22 @@ final class PrettySkippedStepPrinter implements StepPrinter
      * @var StepTextPainter
      */
     private $textPainter;
+
     /**
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
      * @var PrettyPathPrinter
      */
     private $pathPrinter;
+
     /**
      * @var string
      */
     private $indentText;
+
     /**
      * @var string
      */
@@ -55,11 +59,8 @@ final class PrettySkippedStepPrinter implements StepPrinter
     /**
      * Initializes printer.
      *
-     * @param StepTextPainter         $textPainter
-     * @param ResultToStringConverter $resultConverter
-     * @param PrettyPathPrinter       $pathPrinter
-     * @param integer                 $indentation
-     * @param integer                 $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      */
     public function __construct(
         StepTextPainter $textPainter,
@@ -88,10 +89,8 @@ final class PrettySkippedStepPrinter implements StepPrinter
     /**
      * Prints step text.
      *
-     * @param OutputPrinter $printer
-     * @param string        $stepType
-     * @param string        $stepText
-     * @param StepResult    $result
+     * @param string $stepType
+     * @param string $stepText
      */
     private function printText(OutputPrinter $printer, $stepType, $stepText, StepResult $result)
     {
@@ -100,7 +99,9 @@ final class PrettySkippedStepPrinter implements StepPrinter
         if ($result instanceof DefinedStepResult && $result->getStepDefinition()) {
             $definition = $result->getStepDefinition();
             $stepText = $this->textPainter->paintText(
-                $stepText, $definition, new IntegerTestResult(TestResult::SKIPPED)
+                $stepText,
+                $definition,
+                new IntegerTestResult(TestResult::SKIPPED)
             );
         }
 
@@ -110,7 +111,6 @@ final class PrettySkippedStepPrinter implements StepPrinter
     /**
      * Prints step multiline arguments.
      *
-     * @param Formatter           $formatter
      * @param ArgumentInterface[] $arguments
      */
     private function printArguments(Formatter $formatter, array $arguments)
@@ -120,7 +120,7 @@ final class PrettySkippedStepPrinter implements StepPrinter
         foreach ($arguments as $argument) {
             $text = $this->getArgumentString($argument, !$formatter->getParameter('multiline'));
 
-            $indentedText = implode("\n", array_map(array($this, 'subIndent'), explode("\n", $text)));
+            $indentedText = implode("\n", array_map([$this, 'subIndent'], explode("\n", $text)));
             $formatter->getOutputPrinter()->writeln(sprintf('{+%s}%s{-%s}', $style, $indentedText, $style));
         }
     }
@@ -128,8 +128,7 @@ final class PrettySkippedStepPrinter implements StepPrinter
     /**
      * Returns argument string for provided argument.
      *
-     * @param ArgumentInterface $argument
-     * @param bool           $collapse
+     * @param bool $collapse
      *
      * @return string
      */
@@ -140,9 +139,7 @@ final class PrettySkippedStepPrinter implements StepPrinter
         }
 
         if ($argument instanceof PyStringNode) {
-            $text = '"""' . "\n" . $argument . "\n" . '"""';
-
-            return $text;
+            return '"""' . "\n" . $argument . "\n" . '"""';
         }
 
         return (string) $argument;

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStatisticsPrinter.php
@@ -28,6 +28,7 @@ final class PrettyStatisticsPrinter implements StatisticsPrinter
      * @var CounterPrinter
      */
     private $counterPrinter;
+
     /**
      * @var ListPrinter
      */
@@ -35,9 +36,6 @@ final class PrettyStatisticsPrinter implements StatisticsPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param CounterPrinter $counterPrinter
-     * @param ListPrinter    $listPrinter
      */
     public function __construct(CounterPrinter $counterPrinter, ListPrinter $listPrinter)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -36,22 +36,27 @@ final class PrettyStepPrinter implements StepPrinter
      * @var StepTextPainter
      */
     private $textPainter;
+
     /**
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
      * @var PrettyPathPrinter
      */
     private $pathPrinter;
+
     /**
      * @var ExceptionPresenter
      */
     private $exceptionPresenter;
+
     /**
      * @var string
      */
     private $indentText;
+
     /**
      * @var string
      */
@@ -60,12 +65,8 @@ final class PrettyStepPrinter implements StepPrinter
     /**
      * Initializes printer.
      *
-     * @param StepTextPainter         $textPainter
-     * @param ResultToStringConverter $resultConverter
-     * @param PrettyPathPrinter       $pathPrinter
-     * @param ExceptionPresenter      $exceptionPresenter
-     * @param integer                 $indentation
-     * @param integer                 $subIndentation
+     * @param int $indentation
+     * @param int $subIndentation
      */
     public function __construct(
         StepTextPainter $textPainter,
@@ -98,10 +99,8 @@ final class PrettyStepPrinter implements StepPrinter
     /**
      * Prints step text.
      *
-     * @param OutputPrinter $printer
-     * @param string        $stepType
-     * @param string        $stepText
-     * @param StepResult    $result
+     * @param string $stepType
+     * @param string $stepText
      */
     private function printText(OutputPrinter $printer, $stepType, $stepText, StepResult $result)
     {
@@ -117,9 +116,7 @@ final class PrettyStepPrinter implements StepPrinter
     /**
      * Prints step multiline arguments.
      *
-     * @param Formatter           $formatter
      * @param ArgumentInterface[] $arguments
-     * @param StepResult          $result
      */
     private function printArguments(Formatter $formatter, array $arguments, StepResult $result)
     {
@@ -128,16 +125,13 @@ final class PrettyStepPrinter implements StepPrinter
         foreach ($arguments as $argument) {
             $text = $this->getArgumentString($argument, !$formatter->getParameter('multiline'));
 
-            $indentedText = implode("\n", array_map(array($this, 'subIndent'), explode("\n", $text)));
+            $indentedText = implode("\n", array_map([$this, 'subIndent'], explode("\n", $text)));
             $formatter->getOutputPrinter()->writeln(sprintf('{+%s}%s{-%s}', $style, $indentedText, $style));
         }
     }
 
     /**
      * Prints step output (if has one).
-     *
-     * @param OutputPrinter $printer
-     * @param StepResult    $result
      */
     private function printStdOut(OutputPrinter $printer, StepResult $result)
     {
@@ -150,7 +144,9 @@ final class PrettyStepPrinter implements StepPrinter
 
         $pad = function ($line) use ($indentedText) {
             return sprintf(
-                '%s│ {+stdout}%s{-stdout}', $indentedText, $line
+                '%s│ {+stdout}%s{-stdout}',
+                $indentedText,
+                $line
             );
         };
 
@@ -159,9 +155,6 @@ final class PrettyStepPrinter implements StepPrinter
 
     /**
      * Prints step exception (if has one).
-     *
-     * @param OutputPrinter $printer
-     * @param StepResult    $result
      */
     private function printException(OutputPrinter $printer, StepResult $result)
     {
@@ -172,15 +165,14 @@ final class PrettyStepPrinter implements StepPrinter
         }
 
         $text = $this->exceptionPresenter->presentException($result->getException());
-        $indentedText = implode("\n", array_map(array($this, 'subIndent'), explode("\n", $text)));
+        $indentedText = implode("\n", array_map([$this, 'subIndent'], explode("\n", $text)));
         $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $indentedText, $style));
     }
 
     /**
      * Returns argument string for provided argument.
      *
-     * @param ArgumentInterface $argument
-     * @param bool           $collapse
+     * @param bool $collapse
      *
      * @return string
      */
@@ -191,9 +183,7 @@ final class PrettyStepPrinter implements StepPrinter
         }
 
         if ($argument instanceof PyStringNode) {
-            $text = '"""' . "\n" . $argument . "\n" . '"""';
-
-            return $text;
+            return '"""' . "\n" . $argument . "\n" . '"""';
         }
 
         return (string) $argument;

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
@@ -28,6 +28,7 @@ final class ProgressStatisticsPrinter implements StatisticsPrinter
      * @var CounterPrinter
      */
     private $counterPrinter;
+
     /**
      * @var ListPrinter
      */
@@ -35,9 +36,6 @@ final class ProgressStatisticsPrinter implements StatisticsPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param CounterPrinter $counterPrinter
-     * @param ListPrinter    $listPrinter
      */
     public function __construct(CounterPrinter $counterPrinter, ListPrinter $listPrinter)
     {

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
@@ -29,15 +29,14 @@ final class ProgressStepPrinter implements StepPrinter
      * @var ResultToStringConverter
      */
     private $resultConverter;
+
     /**
-     * @var integer
+     * @var int
      */
     private $stepsPrinted = 0;
 
     /**
      * Initializes printer.
-     *
-     * @param ResultToStringConverter $resultConverter
      */
     public function __construct(ResultToStringConverter $resultConverter)
     {
@@ -54,23 +53,32 @@ final class ProgressStepPrinter implements StepPrinter
 
         switch ($result->getResultCode()) {
             case TestResult::PASSED:
-                $printer->write("{+$style}.{-$style}");
+                $printer->write("{+{$style}}.{-{$style}}");
+
                 break;
+
             case TestResult::SKIPPED:
-                $printer->write("{+$style}-{-$style}");
+                $printer->write("{+{$style}}-{-{$style}}");
+
                 break;
+
             case TestResult::PENDING:
-                $printer->write("{+$style}P{-$style}");
+                $printer->write("{+{$style}}P{-{$style}}");
+
                 break;
+
             case StepResult::UNDEFINED:
-                $printer->write("{+$style}U{-$style}");
+                $printer->write("{+{$style}}U{-{$style}}");
+
                 break;
+
             case TestResult::FAILED:
-                $printer->write("{+$style}F{-$style}");
+                $printer->write("{+{$style}}F{-{$style}}");
+
                 break;
         }
 
-        if (++$this->stepsPrinted % 70 == 0) {
+        if (++$this->stepsPrinted % 70 === 0) {
             $printer->writeln(' ' . $this->stepsPrinted);
         }
     }

--- a/src/Behat/Behat/Output/Node/Printer/ScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ScenarioPrinter.php
@@ -24,18 +24,11 @@ interface ScenarioPrinter
 {
     /**
      * Prints scenario header using provided printer.
-     *
-     * @param Formatter   $formatter
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
      */
     public function printHeader(Formatter $formatter, FeatureNode $feature, Scenario $scenario);
 
     /**
      * Prints scenario footer using provided printer.
-     *
-     * @param Formatter  $formatter
-     * @param TestResult $result
      */
     public function printFooter(Formatter $formatter, TestResult $result);
 }

--- a/src/Behat/Behat/Output/Node/Printer/SetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/SetupPrinter.php
@@ -23,17 +23,11 @@ interface SetupPrinter
 {
     /**
      * Prints setup state.
-     *
-     * @param Formatter $formatter
-     * @param Setup     $setup
      */
     public function printSetup(Formatter $formatter, Setup $setup);
 
     /**
      * Prints teardown state.
-     *
-     * @param Formatter $formatter
-     * @param Teardown  $teardown
      */
     public function printTeardown(Formatter $formatter, Teardown $teardown);
 }

--- a/src/Behat/Behat/Output/Node/Printer/StatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/StatisticsPrinter.php
@@ -22,9 +22,6 @@ interface StatisticsPrinter
 {
     /**
      * Prints test suite statistics after run.
-     *
-     * @param Formatter  $formatter
-     * @param Statistics $statistics
      */
     public function printStatistics(Formatter $formatter, Statistics $statistics);
 }

--- a/src/Behat/Behat/Output/Node/Printer/StepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/StepPrinter.php
@@ -24,11 +24,6 @@ interface StepPrinter
 {
     /**
      * Prints step using provided printer.
-     *
-     * @param Formatter  $formatter
-     * @param Scenario   $scenario
-     * @param StepNode   $step
-     * @param StepResult $result
      */
     public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result);
 }

--- a/src/Behat/Behat/Output/Node/Printer/SuitePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/SuitePrinter.php
@@ -22,17 +22,11 @@ interface SuitePrinter
 {
     /**
      * Prints suite header using provided formatter.
-     *
-     * @param Formatter $formatter
-     * @param Suite     $suite
      */
     public function printHeader(Formatter $formatter, Suite $suite);
 
     /**
      * Prints suite footer using provided printer.
-     *
-     * @param Formatter $formatter
-     * @param Suite     $suite
      */
     public function printFooter(Formatter $formatter, Suite $suite);
 }

--- a/src/Behat/Behat/Output/Printer/ConsoleOutputFactory.php
+++ b/src/Behat/Behat/Output/Printer/ConsoleOutputFactory.php
@@ -42,21 +42,21 @@ final class ConsoleOutputFactory extends BaseFactory
      */
     private function getDefaultStyles()
     {
-        return array(
-            'keyword'       => new OutputFormatterStyle(null, null, array('bold')),
-            'stdout'        => new OutputFormatterStyle(null, null, array()),
-            'exception'     => new OutputFormatterStyle('red'),
-            'undefined'     => new OutputFormatterStyle('yellow'),
-            'pending'       => new OutputFormatterStyle('yellow'),
-            'pending_param' => new OutputFormatterStyle('yellow', null, array('bold')),
-            'failed'        => new OutputFormatterStyle('red'),
-            'failed_param'  => new OutputFormatterStyle('red', null, array('bold')),
-            'passed'        => new OutputFormatterStyle('green'),
-            'passed_param'  => new OutputFormatterStyle('green', null, array('bold')),
-            'skipped'       => new OutputFormatterStyle('cyan'),
-            'skipped_param' => new OutputFormatterStyle('cyan', null, array('bold')),
-            'comment'       => new OutputFormatterStyle('black'),
-            'tag'           => new OutputFormatterStyle('cyan')
-        );
+        return [
+            'keyword' => new OutputFormatterStyle(null, null, ['bold']),
+            'stdout' => new OutputFormatterStyle(null, null, []),
+            'exception' => new OutputFormatterStyle('red'),
+            'undefined' => new OutputFormatterStyle('yellow'),
+            'pending' => new OutputFormatterStyle('yellow'),
+            'pending_param' => new OutputFormatterStyle('yellow', null, ['bold']),
+            'failed' => new OutputFormatterStyle('red'),
+            'failed_param' => new OutputFormatterStyle('red', null, ['bold']),
+            'passed' => new OutputFormatterStyle('green'),
+            'passed_param' => new OutputFormatterStyle('green', null, ['bold']),
+            'skipped' => new OutputFormatterStyle('cyan'),
+            'skipped_param' => new OutputFormatterStyle('cyan', null, ['bold']),
+            'comment' => new OutputFormatterStyle('black'),
+            'tag' => new OutputFormatterStyle('cyan'),
+        ];
     }
 }

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -30,7 +30,7 @@ final class ConsoleFormatter extends BaseOutputFormatter
      */
     public function format($message): string
     {
-        return preg_replace_callback(self::CUSTOM_PATTERN, array($this, 'replaceStyle'), $message);
+        return preg_replace_callback(self::CUSTOM_PATTERN, [$this, 'replaceStyle'], $message);
     }
 
     /**

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
@@ -50,8 +50,6 @@ final class JUnitFormatterFactory implements FormatterFactory
 
     /**
      * Loads printer helpers.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadPrinterHelpers(ContainerBuilder $container)
     {
@@ -61,53 +59,51 @@ final class JUnitFormatterFactory implements FormatterFactory
 
     /**
      * Loads the printers used to print the basic JUnit report.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadCorePrinters(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitSuitePrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitSuitePrinter', [
             new Reference('output.junit.statistics'),
-        ));
+        ]);
         $container->setDefinition('output.node.printer.junit.suite', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitFeaturePrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitFeaturePrinter', [
             new Reference('output.junit.statistics'),
-            new Reference('output.node.listener.junit.duration')
-        ));
+            new Reference('output.node.listener.junit.duration'),
+        ]);
         $container->setDefinition('output.node.printer.junit.feature', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitScenarioPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitScenarioPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference('output.node.listener.junit.outline'),
-            new Reference('output.node.listener.junit.duration')
-        ));
+            new Reference('output.node.listener.junit.duration'),
+        ]);
         $container->setDefinition('output.node.printer.junit.scenario', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitStepPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitStepPrinter', [
             new Reference(ExceptionExtension::PRESENTER_ID),
-        ));
+        ]);
         $container->setDefinition('output.node.printer.junit.step', $definition);
 
         $definition = new Definition(
-            'Behat\Behat\Output\Node\Printer\JUnit\JUnitSetupPrinter', array(
-            new Reference(ExceptionExtension::PRESENTER_ID),
-        )
+            'Behat\Behat\Output\Node\Printer\JUnit\JUnitSetupPrinter',
+            [
+                new Reference(ExceptionExtension::PRESENTER_ID),
+            ]
         );
         $container->setDefinition('output.node.printer.junit.setup', $definition);
     }
 
     /**
      * Loads the node listeners required for JUnit printers to work.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadRootNodeListener(ContainerBuilder $container)
     {
-
-        $definition = new Definition('Behat\Behat\Output\Node\EventListener\JUnit\JUnitOutlineStoreListener', array(
-                new Reference('output.node.printer.junit.suite')
-            )
+        $definition = new Definition(
+            'Behat\Behat\Output\Node\EventListener\JUnit\JUnitOutlineStoreListener',
+            [
+                new Reference('output.node.printer.junit.suite'),
+            ]
         );
         $container->setDefinition('output.node.listener.junit.outline', $definition);
 
@@ -117,56 +113,54 @@ final class JUnitFormatterFactory implements FormatterFactory
 
         $container->setDefinition('output.node.listener.junit.duration', $definition);
 
-        $definition = new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', array(
-            array(
+        $definition = new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', [
+            [
                 new Reference('output.node.listener.junit.duration'),
                 new Reference('output.node.listener.junit.outline'),
-                new Definition('Behat\Behat\Output\Node\EventListener\JUnit\JUnitFeatureElementListener', array(
+                new Definition('Behat\Behat\Output\Node\EventListener\JUnit\JUnitFeatureElementListener', [
                     new Reference('output.node.printer.junit.feature'),
                     new Reference('output.node.printer.junit.scenario'),
                     new Reference('output.node.printer.junit.step'),
                     new Reference('output.node.printer.junit.setup'),
-                )),
-            ),
-        ));
+                ]),
+            ],
+        ]);
         $container->setDefinition(self::ROOT_LISTENER_ID, $definition);
     }
 
     /**
      * Loads formatter itself.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadFormatter(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Output\Statistics\PhaseStatistics');
         $container->setDefinition('output.junit.statistics', $definition);
 
-        $definition = new Definition('Behat\Testwork\Output\NodeEventListeningFormatter', array(
+        $definition = new Definition('Behat\Testwork\Output\NodeEventListeningFormatter', [
             'junit',
             'Outputs the failures in JUnit compatible files.',
-            array(
+            [
                 'timer' => true,
-            ),
+            ],
             $this->createOutputPrinterDefinition(),
-            new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', array(
-                array(
+            new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', [
+                [
                     new Reference(self::ROOT_LISTENER_ID),
-                    new Definition('Behat\Behat\Output\Node\EventListener\Statistics\ScenarioStatsListener', array(
-                        new Reference('output.junit.statistics')
-                    )),
-                    new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StepStatsListener', array(
+                    new Definition('Behat\Behat\Output\Node\EventListener\Statistics\ScenarioStatsListener', [
                         new Reference('output.junit.statistics'),
-                        new Reference(ExceptionExtension::PRESENTER_ID)
-                    )),
-                    new Definition('Behat\Behat\Output\Node\EventListener\Statistics\HookStatsListener', array(
+                    ]),
+                    new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StepStatsListener', [
                         new Reference('output.junit.statistics'),
-                        new Reference(ExceptionExtension::PRESENTER_ID)
-                    )),
-                ),
-            )),
-        ));
-        $definition->addTag(OutputExtension::FORMATTER_TAG, array('priority' => 100));
+                        new Reference(ExceptionExtension::PRESENTER_ID),
+                    ]),
+                    new Definition('Behat\Behat\Output\Node\EventListener\Statistics\HookStatsListener', [
+                        new Reference('output.junit.statistics'),
+                        new Reference(ExceptionExtension::PRESENTER_ID),
+                    ]),
+                ],
+            ]),
+        ]);
+        $definition->addTag(OutputExtension::FORMATTER_TAG, ['priority' => 100]);
         $container->setDefinition(OutputExtension::FORMATTER_TAG . '.junit', $definition);
     }
 
@@ -177,8 +171,8 @@ final class JUnitFormatterFactory implements FormatterFactory
      */
     private function createOutputPrinterDefinition()
     {
-        return new Definition('Behat\Testwork\Output\Printer\JUnitOutputPrinter', array(
+        return new Definition('Behat\Testwork\Output\Printer\JUnitOutputPrinter', [
             new Definition('Behat\Testwork\Output\Printer\Factory\FilesystemOutputFactory'),
-        ));
+        ]);
     }
 }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -30,11 +30,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class PrettyFormatterFactory implements FormatterFactory
 {
-    /**
-     * @var ServiceProcessor
-     */
-    private $processor;
-
     /*
      * Available services
      */
@@ -47,13 +42,16 @@ class PrettyFormatterFactory implements FormatterFactory
     public const ROOT_LISTENER_WRAPPER_TAG = 'output.node.listener.pretty.wrapper';
 
     /**
-     * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
+     * @var ServiceProcessor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    private $processor;
+
+    /**
+     * Initializes extension.
+     */
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -83,311 +81,297 @@ class PrettyFormatterFactory implements FormatterFactory
 
     /**
      * Loads pretty formatter node event listener.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadRootNodeListener(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', array(
-            array(
-                new Definition('Behat\Behat\Output\Node\EventListener\AST\SuiteListener', array(
-                    new Reference('output.node.printer.pretty.suite_setup')
-                )),
-                new Definition('Behat\Behat\Output\Node\EventListener\AST\FeatureListener', array(
+        $definition = new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', [
+            [
+                new Definition('Behat\Behat\Output\Node\EventListener\AST\SuiteListener', [
+                    new Reference('output.node.printer.pretty.suite_setup'),
+                ]),
+                new Definition('Behat\Behat\Output\Node\EventListener\AST\FeatureListener', [
                     new Reference('output.node.printer.pretty.feature'),
-                    new Reference('output.node.printer.pretty.feature_setup')
-                )),
+                    new Reference('output.node.printer.pretty.feature_setup'),
+                ]),
                 $this->proxySiblingEvents(
                     BackgroundTested::BEFORE,
                     BackgroundTested::AFTER,
-                    array(
-                        new Definition('Behat\Behat\Output\Node\EventListener\AST\ScenarioNodeListener', array(
+                    [
+                        new Definition('Behat\Behat\Output\Node\EventListener\AST\ScenarioNodeListener', [
                             BackgroundTested::AFTER_SETUP,
                             BackgroundTested::AFTER,
-                            new Reference('output.node.printer.pretty.scenario')
-                        )),
-                        new Definition('Behat\Behat\Output\Node\EventListener\AST\StepListener', array(
+                            new Reference('output.node.printer.pretty.scenario'),
+                        ]),
+                        new Definition('Behat\Behat\Output\Node\EventListener\AST\StepListener', [
                             new Reference('output.node.printer.pretty.step'),
-                            new Reference('output.node.printer.pretty.step_setup')
-                        )),
-                    )
+                            new Reference('output.node.printer.pretty.step_setup'),
+                        ]),
+                    ]
                 ),
                 $this->proxySiblingEvents(
                     ScenarioTested::BEFORE,
                     ScenarioTested::AFTER,
-                    array(
-                        new Definition('Behat\Behat\Output\Node\EventListener\AST\ScenarioNodeListener', array(
+                    [
+                        new Definition('Behat\Behat\Output\Node\EventListener\AST\ScenarioNodeListener', [
                             ScenarioTested::AFTER_SETUP,
                             ScenarioTested::AFTER,
                             new Reference('output.node.printer.pretty.scenario'),
-                            new Reference('output.node.printer.pretty.scenario_setup')
-                        )),
-                        new Definition('Behat\Behat\Output\Node\EventListener\AST\StepListener', array(
+                            new Reference('output.node.printer.pretty.scenario_setup'),
+                        ]),
+                        new Definition('Behat\Behat\Output\Node\EventListener\AST\StepListener', [
                             new Reference('output.node.printer.pretty.step'),
-                            new Reference('output.node.printer.pretty.step_setup')
-                        )),
-                    )
+                            new Reference('output.node.printer.pretty.step_setup'),
+                        ]),
+                    ]
                 ),
                 $this->proxySiblingEvents(
                     OutlineTested::BEFORE,
                     OutlineTested::AFTER,
-                    array(
+                    [
                         $this->proxyEventsIfParameterIsSet(
                             'expand',
                             false,
-                            new Definition('Behat\Behat\Output\Node\EventListener\AST\OutlineTableListener', array(
+                            new Definition('Behat\Behat\Output\Node\EventListener\AST\OutlineTableListener', [
                                 new Reference('output.node.printer.pretty.outline_table'),
                                 new Reference('output.node.printer.pretty.example_row'),
                                 new Reference('output.node.printer.pretty.example_setup'),
-                                new Reference('output.node.printer.pretty.example_step_setup')
-                            ))
+                                new Reference('output.node.printer.pretty.example_step_setup'),
+                            ])
                         ),
                         $this->proxyEventsIfParameterIsSet(
                             'expand',
                             true,
-                            new Definition('Behat\Behat\Output\Node\EventListener\AST\OutlineListener', array(
+                            new Definition('Behat\Behat\Output\Node\EventListener\AST\OutlineListener', [
                                 new Reference('output.node.printer.pretty.outline'),
                                 new Reference('output.node.printer.pretty.example'),
                                 new Reference('output.node.printer.pretty.example_step'),
                                 new Reference('output.node.printer.pretty.example_setup'),
-                                new Reference('output.node.printer.pretty.example_step_setup')
-                            ))
-                        )
-                    )
+                                new Reference('output.node.printer.pretty.example_step_setup'),
+                            ])
+                        ),
+                    ]
                 ),
-            )
-        ));
+            ],
+        ]);
         $container->setDefinition(self::ROOT_LISTENER_ID, $definition);
     }
 
     /**
      * Loads formatter itself.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadFormatter(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Output\Statistics\TotalStatistics');
         $container->setDefinition('output.pretty.statistics', $definition);
 
-        $definition = new Definition('Behat\Testwork\Output\NodeEventListeningFormatter', array(
+        $definition = new Definition('Behat\Testwork\Output\NodeEventListeningFormatter', [
             'pretty',
             'Prints the feature as is.',
-            array(
-                'timer'     => true,
-                'expand'    => false,
-                'paths'     => true,
+            [
+                'timer' => true,
+                'expand' => false,
+                'paths' => true,
                 'multiline' => true,
-            ),
+            ],
             $this->createOutputPrinterDefinition(),
-            new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', array(
-                    array(
+            new Definition(
+                'Behat\Testwork\Output\Node\EventListener\ChainEventListener',
+                [
+                    [
                         $this->rearrangeBackgroundEvents(
                             new Reference(self::ROOT_LISTENER_ID)
                         ),
-                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StatisticsListener', array(
+                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StatisticsListener', [
                             new Reference('output.pretty.statistics'),
-                            new Reference('output.node.printer.pretty.statistics')
-                        )),
-                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\ScenarioStatsListener', array(
-                            new Reference('output.pretty.statistics')
-                        )),
-                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StepStatsListener', array(
+                            new Reference('output.node.printer.pretty.statistics'),
+                        ]),
+                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\ScenarioStatsListener', [
                             new Reference('output.pretty.statistics'),
-                            new Reference(ExceptionExtension::PRESENTER_ID)
-                        )),
-                    )
-                )
-            )
-        ));
-        $definition->addTag(OutputExtension::FORMATTER_TAG, array('priority' => 100));
+                        ]),
+                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StepStatsListener', [
+                            new Reference('output.pretty.statistics'),
+                            new Reference(ExceptionExtension::PRESENTER_ID),
+                        ]),
+                    ],
+                ]
+            ),
+        ]);
+        $definition->addTag(OutputExtension::FORMATTER_TAG, ['priority' => 100]);
         $container->setDefinition(OutputExtension::FORMATTER_TAG . '.pretty', $definition);
     }
 
     /**
      * Loads feature, scenario and step printers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadCorePrinters(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyFeaturePrinter');
         $container->setDefinition('output.node.printer.pretty.feature', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyPathPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyPathPrinter', [
             new Reference('output.node.printer.pretty.width_calculator'),
-            '%paths.base%'
-        ));
+            '%paths.base%',
+        ]);
         $container->setDefinition('output.node.printer.pretty.path', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyScenarioPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyScenarioPrinter', [
             new Reference('output.node.printer.pretty.path'),
-        ));
+        ]);
         $container->setDefinition('output.node.printer.pretty.scenario', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyStepPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyStepPrinter', [
             new Reference('output.node.printer.pretty.step_text_painter'),
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference('output.node.printer.pretty.path'),
-            new Reference(ExceptionExtension::PRESENTER_ID)
-        ));
+            new Reference(ExceptionExtension::PRESENTER_ID),
+        ]);
         $container->setDefinition('output.node.printer.pretty.step', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySkippedStepPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySkippedStepPrinter', [
             new Reference('output.node.printer.pretty.step_text_painter'),
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference('output.node.printer.pretty.path'),
-        ));
+        ]);
         $container->setDefinition('output.node.printer.pretty.skipped_step', $definition);
     }
 
     /**
      * Loads table outline printer.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadTableOutlinePrinter(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyOutlineTablePrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyOutlineTablePrinter', [
             new Reference('output.node.printer.pretty.scenario'),
             new Reference('output.node.printer.pretty.skipped_step'),
-            new Reference(self::RESULT_TO_STRING_CONVERTER_ID)
-        ));
+            new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
+        ]);
         $container->setDefinition('output.node.printer.pretty.outline_table', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyExampleRowPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyExampleRowPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
-            new Reference(TranslatorExtension::TRANSLATOR_ID)
-        ));
+            new Reference(TranslatorExtension::TRANSLATOR_ID),
+        ]);
         $container->setDefinition('output.node.printer.pretty.example_row', $definition);
     }
 
     /**
      * Loads expanded outline printer.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadExpandedOutlinePrinter(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyOutlinePrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyOutlinePrinter', [
             new Reference('output.node.printer.pretty.scenario'),
             new Reference('output.node.printer.pretty.skipped_step'),
-            new Reference(self::RESULT_TO_STRING_CONVERTER_ID)
-        ));
+            new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
+        ]);
         $container->setDefinition('output.node.printer.pretty.outline', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyExamplePrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyExamplePrinter', [
             new Reference('output.node.printer.pretty.path'),
-        ));
+        ]);
         $container->setDefinition('output.node.printer.pretty.example', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyStepPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyStepPrinter', [
             new Reference('output.node.printer.pretty.step_text_painter'),
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference('output.node.printer.pretty.path'),
             new Reference(ExceptionExtension::PRESENTER_ID),
-            8
-        ));
+            8,
+        ]);
         $container->setDefinition('output.node.printer.pretty.example_step', $definition);
     }
 
     /**
      * Loads hook printers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadHookPrinters(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
             0,
             true,
-            true
-        ));
+            true,
+        ]);
         $container->setDefinition('output.node.printer.pretty.suite_setup', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
             0,
             false,
-            true
-        ));
+            true,
+        ]);
         $container->setDefinition('output.node.printer.pretty.feature_setup', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
-            2
-        ));
+            2,
+        ]);
         $container->setDefinition('output.node.printer.pretty.scenario_setup', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
-            4
-        ));
+            4,
+        ]);
         $container->setDefinition('output.node.printer.pretty.step_setup', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
-            8
-        ));
+            8,
+        ]);
         $container->setDefinition('output.node.printer.pretty.example_step_setup', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettySetupPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
-            6
-        ));
+            6,
+        ]);
         $container->setDefinition('output.node.printer.pretty.example_setup', $definition);
     }
 
     /**
      * Loads statistics printer.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadStatisticsPrinter(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\CounterPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\CounterPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(TranslatorExtension::TRANSLATOR_ID),
-        ));
+        ]);
         $container->setDefinition('output.node.printer.counter', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\ListPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\ListPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
             new Reference(TranslatorExtension::TRANSLATOR_ID),
-            '%paths.base%'
-        ));
+            '%paths.base%',
+        ]);
         $container->setDefinition('output.node.printer.list', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyStatisticsPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyStatisticsPrinter', [
             new Reference('output.node.printer.counter'),
-            new Reference('output.node.printer.list')
-        ));
+            new Reference('output.node.printer.list'),
+        ]);
         $container->setDefinition('output.node.printer.pretty.statistics', $definition);
     }
 
     /**
      * Loads printer helpers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadPrinterHelpers(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Helper\WidthCalculator');
         $container->setDefinition('output.node.printer.pretty.width_calculator', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Helper\StepTextPainter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Helper\StepTextPainter', [
             new Reference(DefinitionExtension::PATTERN_TRANSFORMER_ID),
-            new Reference(self::RESULT_TO_STRING_CONVERTER_ID)
-        ));
+            new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
+        ]);
         $container->setDefinition('output.node.printer.pretty.step_text_painter', $definition);
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter');
@@ -401,9 +385,9 @@ class PrettyFormatterFactory implements FormatterFactory
      */
     protected function createOutputPrinterDefinition()
     {
-        return new Definition('Behat\Testwork\Output\Printer\StreamOutputPrinter', array(
+        return new Definition('Behat\Testwork\Output\Printer\StreamOutputPrinter', [
             new Definition('Behat\Behat\Output\Printer\ConsoleOutputFactory'),
-        ));
+        ]);
     }
 
     /**
@@ -415,11 +399,11 @@ class PrettyFormatterFactory implements FormatterFactory
      */
     protected function rearrangeBackgroundEvents($listener)
     {
-        return new Definition('Behat\Behat\Output\Node\EventListener\Flow\FirstBackgroundFiresFirstListener', array(
-            new Definition('Behat\Behat\Output\Node\EventListener\Flow\OnlyFirstBackgroundFiresListener', array(
-                $listener
-            ))
-        ));
+        return new Definition('Behat\Behat\Output\Node\EventListener\Flow\FirstBackgroundFiresFirstListener', [
+            new Definition('Behat\Behat\Output\Node\EventListener\Flow\OnlyFirstBackgroundFiresListener', [
+                $listener,
+            ]),
+        ]);
     }
 
     /**
@@ -433,12 +417,13 @@ class PrettyFormatterFactory implements FormatterFactory
      */
     protected function proxySiblingEvents($beforeEventName, $afterEventName, array $listeners)
     {
-        return new Definition('Behat\Behat\Output\Node\EventListener\Flow\FireOnlySiblingsListener',
-            array(
+        return new Definition(
+            'Behat\Behat\Output\Node\EventListener\Flow\FireOnlySiblingsListener',
+            [
                 $beforeEventName,
                 $afterEventName,
-                new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', array($listeners))
-            )
+                new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', [$listeners]),
+            ]
         );
     }
 
@@ -453,15 +438,14 @@ class PrettyFormatterFactory implements FormatterFactory
      */
     protected function proxyEventsIfParameterIsSet($name, $value, Definition $listener)
     {
-        return new Definition('Behat\Testwork\Output\Node\EventListener\Flow\FireOnlyIfFormatterParameterListener',
-            array($name, $value, $listener)
+        return new Definition(
+            'Behat\Testwork\Output\Node\EventListener\Flow\FireOnlyIfFormatterParameterListener',
+            [$name, $value, $listener]
         );
     }
 
     /**
      * Processes all registered pretty formatter node listener wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processListenerWrappers(ContainerBuilder $container)
     {

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -26,11 +26,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ProgressFormatterFactory implements FormatterFactory
 {
-    /**
-     * @var ServiceProcessor
-     */
-    private $processor;
-
     /*
      * Available services
      */
@@ -43,13 +38,16 @@ class ProgressFormatterFactory implements FormatterFactory
     public const ROOT_LISTENER_WRAPPER_TAG = 'output.node.listener.progress.wrapper';
 
     /**
-     * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
+     * @var ServiceProcessor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    private $processor;
+
+    /**
+     * Initializes extension.
+     */
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -73,54 +71,48 @@ class ProgressFormatterFactory implements FormatterFactory
 
     /**
      * Loads progress formatter node event listener.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadRootNodeListener(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Output\Node\EventListener\AST\StepListener', array(
-            new Reference('output.node.printer.progress.step')
-        ));
+        $definition = new Definition('Behat\Behat\Output\Node\EventListener\AST\StepListener', [
+            new Reference('output.node.printer.progress.step'),
+        ]);
         $container->setDefinition(self::ROOT_LISTENER_ID, $definition);
     }
 
     /**
      * Loads feature, scenario and step printers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadCorePrinters(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\CounterPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\CounterPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(TranslatorExtension::TRANSLATOR_ID),
-        ));
+        ]);
         $container->setDefinition('output.node.printer.counter', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\ListPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\ListPrinter', [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference(ExceptionExtension::PRESENTER_ID),
             new Reference(TranslatorExtension::TRANSLATOR_ID),
-            '%paths.base%'
-        ));
+            '%paths.base%',
+        ]);
         $container->setDefinition('output.node.printer.list', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Progress\ProgressStepPrinter', array(
-            new Reference(self::RESULT_TO_STRING_CONVERTER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Progress\ProgressStepPrinter', [
+            new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
+        ]);
         $container->setDefinition('output.node.printer.progress.step', $definition);
 
-        $definition = new Definition('Behat\Behat\Output\Node\Printer\Progress\ProgressStatisticsPrinter', array(
+        $definition = new Definition('Behat\Behat\Output\Node\Printer\Progress\ProgressStatisticsPrinter', [
             new Reference('output.node.printer.counter'),
-            new Reference('output.node.printer.list')
-        ));
+            new Reference('output.node.printer.list'),
+        ]);
         $container->setDefinition('output.node.printer.progress.statistics', $definition);
     }
 
     /**
      * Loads printer helpers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadPrinterHelpers(ContainerBuilder $container)
     {
@@ -130,44 +122,44 @@ class ProgressFormatterFactory implements FormatterFactory
 
     /**
      * Loads formatter itself.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadFormatter(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Output\Statistics\TotalStatistics');
         $container->setDefinition('output.progress.statistics', $definition);
 
-        $definition = new Definition('Behat\Testwork\Output\NodeEventListeningFormatter', array(
+        $definition = new Definition('Behat\Testwork\Output\NodeEventListeningFormatter', [
             'progress',
             'Prints one character per step.',
-            array(
-                'timer' => true
-            ),
+            [
+                'timer' => true,
+            ],
             $this->createOutputPrinterDefinition(),
-            new Definition('Behat\Testwork\Output\Node\EventListener\ChainEventListener', array(
-                    array(
+            new Definition(
+                'Behat\Testwork\Output\Node\EventListener\ChainEventListener',
+                [
+                    [
                         new Reference(self::ROOT_LISTENER_ID),
-                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StatisticsListener', array(
+                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StatisticsListener', [
                             new Reference('output.progress.statistics'),
-                            new Reference('output.node.printer.progress.statistics')
-                        )),
-                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\ScenarioStatsListener', array(
-                            new Reference('output.progress.statistics')
-                        )),
-                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StepStatsListener', array(
+                            new Reference('output.node.printer.progress.statistics'),
+                        ]),
+                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\ScenarioStatsListener', [
                             new Reference('output.progress.statistics'),
-                            new Reference(ExceptionExtension::PRESENTER_ID)
-                        )),
-                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\HookStatsListener', array(
+                        ]),
+                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\StepStatsListener', [
                             new Reference('output.progress.statistics'),
-                            new Reference(ExceptionExtension::PRESENTER_ID)
-                        )),
-                    )
-                )
-            )
-        ));
-        $definition->addTag(OutputExtension::FORMATTER_TAG, array('priority' => 100));
+                            new Reference(ExceptionExtension::PRESENTER_ID),
+                        ]),
+                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\HookStatsListener', [
+                            new Reference('output.progress.statistics'),
+                            new Reference(ExceptionExtension::PRESENTER_ID),
+                        ]),
+                    ],
+                ]
+            ),
+        ]);
+        $definition->addTag(OutputExtension::FORMATTER_TAG, ['priority' => 100]);
         $container->setDefinition(OutputExtension::FORMATTER_TAG . '.progress', $definition);
     }
 
@@ -178,15 +170,13 @@ class ProgressFormatterFactory implements FormatterFactory
      */
     protected function createOutputPrinterDefinition()
     {
-        return new Definition('Behat\Testwork\Output\Printer\StreamOutputPrinter', array(
+        return new Definition('Behat\Testwork\Output\Printer\StreamOutputPrinter', [
             new Definition('Behat\Behat\Output\Printer\ConsoleOutputFactory'),
-        ));
+        ]);
     }
 
     /**
      * Processes all registered pretty formatter node listener wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processListenerWrappers(ContainerBuilder $container)
     {

--- a/src/Behat/Behat/Output/Statistics/HookStat.php
+++ b/src/Behat/Behat/Output/Statistics/HookStat.php
@@ -21,16 +21,19 @@ final class HookStat
      * @var string
      */
     private $name;
+
     /**
      * @var string
      */
     private $path;
+
     /**
-     * @var string|null
+     * @var null|string
      */
     private $error;
+
     /**
-     * @var string|null
+     * @var null|string
      */
     private $stdOut;
 
@@ -50,17 +53,11 @@ final class HookStat
         $this->stdOut = $stdOut;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return $this->name;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isSuccessful()
     {
         return null === $this->error;

--- a/src/Behat/Behat/Output/Statistics/PhaseStatistics.php
+++ b/src/Behat/Behat/Output/Statistics/PhaseStatistics.php
@@ -10,8 +10,8 @@
 
 namespace Behat\Behat\Output\Statistics;
 
-use Behat\Testwork\Counter\Timer;
 use Behat\Testwork\Counter\Memory;
+use Behat\Testwork\Counter\Timer;
 
 /**
  * A TotalStatistics decorator to get statistics per phase.
@@ -79,8 +79,6 @@ final class PhaseStatistics implements Statistics
 
     /**
      * Registers scenario stat.
-     *
-     * @param ScenarioStat $stat
      */
     public function registerScenarioStat(ScenarioStat $stat)
     {
@@ -89,8 +87,6 @@ final class PhaseStatistics implements Statistics
 
     /**
      * Registers step stat.
-     *
-     * @param StepStat $stat
      */
     public function registerStepStat(StepStat $stat)
     {
@@ -99,8 +95,6 @@ final class PhaseStatistics implements Statistics
 
     /**
      * Registers hook stat.
-     *
-     * @param HookStat $stat
      */
     public function registerHookStat(HookStat $stat)
     {

--- a/src/Behat/Behat/Output/Statistics/ScenarioStat.php
+++ b/src/Behat/Behat/Output/Statistics/ScenarioStat.php
@@ -21,27 +21,39 @@ final class ScenarioStat
      * @var string
      */
     private $title;
+
     /**
      * @var string
      */
     private $path;
+
     /**
-     * @var integer
+     * @var int
      */
     private $resultCode;
 
     /**
      * Initializes scenario stat.
      *
-     * @param string  $title
-     * @param string  $path
-     * @param integer $resultCode
+     * @param string $title
+     * @param string $path
+     * @param int    $resultCode
      */
     public function __construct($title, $path, $resultCode)
     {
         $this->title = $title;
         $this->path = $path;
         $this->resultCode = $resultCode;
+    }
+
+    /**
+     * Returns string representation for a stat.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getPath();
     }
 
     /**
@@ -67,20 +79,10 @@ final class ScenarioStat
     /**
      * Returns scenario result code.
      *
-     * @return integer
+     * @return int
      */
     public function getResultCode()
     {
         return $this->resultCode;
-    }
-
-    /**
-     * Returns string representation for a stat.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->getPath();
     }
 }

--- a/src/Behat/Behat/Output/Statistics/Statistics.php
+++ b/src/Behat/Behat/Output/Statistics/Statistics.php
@@ -13,7 +13,6 @@ namespace Behat\Behat\Output\Statistics;
 use Behat\Testwork\Counter\Memory;
 use Behat\Testwork\Counter\Timer;
 
-
 /**
  * Collects and provided exercise statistics.
  *
@@ -47,22 +46,16 @@ interface Statistics
 
     /**
      * Registers scenario stat.
-     *
-     * @param ScenarioStat $stat
      */
     public function registerScenarioStat(ScenarioStat $stat);
 
     /**
      * Registers step stat.
-     *
-     * @param StepStat $stat
      */
     public function registerStepStat(StepStat $stat);
 
     /**
      * Registers hook stat.
-     *
-     * @param HookStat $stat
      */
     public function registerHookStat(HookStat $stat);
 

--- a/src/Behat/Behat/Output/Statistics/StepStat.php
+++ b/src/Behat/Behat/Output/Statistics/StepStat.php
@@ -23,18 +23,22 @@ class StepStat
      * @var string
      */
     private $text;
+
     /**
      * @var string
      */
     private $path;
+
     /**
-     * @var integer
+     * @var int
      */
     private $resultCode;
+
     /**
      * @var null|string
      */
     private $error;
+
     /**
      * @var null|string
      */
@@ -45,7 +49,7 @@ class StepStat
      *
      * @param string      $text
      * @param string      $path
-     * @param integer     $resultCode
+     * @param int         $resultCode
      * @param null|string $error
      * @param null|string $stdOut
      */
@@ -56,6 +60,16 @@ class StepStat
         $this->resultCode = $resultCode;
         $this->error = $error;
         $this->stdOut = $stdOut;
+    }
+
+    /**
+     * Returns string representation for a stat.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getPath();
     }
 
     /**
@@ -81,7 +95,7 @@ class StepStat
     /**
      * Returns step result code.
      *
-     * @return integer
+     * @return int
      */
     public function getResultCode()
     {
@@ -106,15 +120,5 @@ class StepStat
     public function getStdOut()
     {
         return $this->stdOut;
-    }
-
-    /**
-     * Returns string representation for a stat.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->getPath();
     }
 }

--- a/src/Behat/Behat/Output/Statistics/StepStatV2.php
+++ b/src/Behat/Behat/Output/Statistics/StepStatV2.php
@@ -21,26 +21,32 @@ final class StepStatV2 extends StepStat
      * @var string
      */
     private $scenarioTitle;
+
     /**
      * @var string
      */
     private $scenarioPath;
+
     /**
      * @var string
      */
     private $stepText;
+
     /**
      * @var string
      */
     private $stepPath;
+
     /**
-     * @var integer
+     * @var int
      */
     private $resultCode;
+
     /**
      * @var null|string
      */
     private $error;
+
     /**
      * @var null|string
      */
@@ -53,7 +59,7 @@ final class StepStatV2 extends StepStat
      * @param string      $scenarioPath
      * @param string      $stepText
      * @param string      $stepPath
-     * @param integer     $resultCode
+     * @param int         $resultCode
      * @param null|string $error
      * @param null|string $stdOut
      */
@@ -68,6 +74,16 @@ final class StepStatV2 extends StepStat
         $this->resultCode = $resultCode;
         $this->error = $error;
         $this->stdOut = $stdOut;
+    }
+
+    /**
+     * Returns string representation for a stat.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getPath();
     }
 
     /**
@@ -113,7 +129,7 @@ final class StepStatV2 extends StepStat
     /**
      * Returns step result code.
      *
-     * @return integer
+     * @return int
      */
     public function getResultCode()
     {
@@ -138,15 +154,5 @@ final class StepStatV2 extends StepStat
     public function getStdOut()
     {
         return $this->stdOut;
-    }
-
-    /**
-     * Returns string representation for a stat.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->getPath();
     }
 }

--- a/src/Behat/Behat/Output/Statistics/TotalStatistics.php
+++ b/src/Behat/Behat/Output/Statistics/TotalStatistics.php
@@ -27,38 +27,46 @@ final class TotalStatistics implements Statistics
      * @var Timer
      */
     private $timer;
+
     /**
      * @var Memory
      */
     private $memory;
+
     /**
      * @var array
      */
-    private $scenarioCounters = array();
+    private $scenarioCounters = [];
+
     /**
      * @var array
      */
-    private $stepCounters = array();
+    private $stepCounters = [];
+
     /**
      * @var ScenarioStat[]
      */
-    private $failedScenarioStats = array();
+    private $failedScenarioStats = [];
+
     /**
      * @var ScenarioStat[]
      */
-    private $skippedScenarioStats = array();
+    private $skippedScenarioStats = [];
+
     /**
      * @var StepStat[]
      */
-    private $failedStepStats = array();
+    private $failedStepStats = [];
+
     /**
      * @var StepStat[]
      */
-    private $pendingStepStats = array();
+    private $pendingStepStats = [];
+
     /**
      * @var HookStat[]
      */
-    private $failedHookStats = array();
+    private $failedHookStats = [];
 
     /**
      * Initializes statistics.
@@ -73,13 +81,13 @@ final class TotalStatistics implements Statistics
 
     public function resetAllCounters()
     {
-        $this->scenarioCounters = $this->stepCounters = array(
-            TestResult::PASSED    => 0,
-            TestResult::FAILED    => 0,
+        $this->scenarioCounters = $this->stepCounters = [
+            TestResult::PASSED => 0,
+            TestResult::FAILED => 0,
             StepResult::UNDEFINED => 0,
-            TestResult::PENDING   => 0,
-            TestResult::SKIPPED   => 0
-        );
+            TestResult::PENDING => 0,
+            TestResult::SKIPPED => 0,
+        ];
     }
 
     /**
@@ -120,8 +128,6 @@ final class TotalStatistics implements Statistics
 
     /**
      * Registers scenario stat.
-     *
-     * @param ScenarioStat $stat
      */
     public function registerScenarioStat(ScenarioStat $stat)
     {
@@ -129,7 +135,7 @@ final class TotalStatistics implements Statistics
             return;
         }
 
-        $this->scenarioCounters[$stat->getResultCode()]++;
+        ++$this->scenarioCounters[$stat->getResultCode()];
 
         if (TestResult::FAILED === $stat->getResultCode()) {
             $this->failedScenarioStats[] = $stat;
@@ -142,12 +148,10 @@ final class TotalStatistics implements Statistics
 
     /**
      * Registers step stat.
-     *
-     * @param StepStat $stat
      */
     public function registerStepStat(StepStat $stat)
     {
-        $this->stepCounters[$stat->getResultCode()]++;
+        ++$this->stepCounters[$stat->getResultCode()];
 
         if (TestResult::FAILED === $stat->getResultCode()) {
             $this->failedStepStats[] = $stat;
@@ -160,8 +164,6 @@ final class TotalStatistics implements Statistics
 
     /**
      * Registers hook stat.
-     *
-     * @param HookStat $stat
      */
     public function registerHookStat(HookStat $stat)
     {

--- a/src/Behat/Behat/Snippet/AggregateSnippet.php
+++ b/src/Behat/Behat/Snippet/AggregateSnippet.php
@@ -108,7 +108,7 @@ final class AggregateSnippet
     public function getUsedClasses()
     {
         if (empty($this->snippets)) {
-            return array();
+            return [];
         }
 
         return array_unique(
@@ -116,7 +116,7 @@ final class AggregateSnippet
                 ...array_map(
                     function (Snippet $snippet) {
                         if (!$snippet instanceof ContextSnippet) {
-                            return array();
+                            return [];
                         }
 
                         return $snippet->getUsedClasses();

--- a/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
+++ b/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
@@ -25,16 +25,12 @@ interface SnippetAppender
     /**
      * Checks if appender supports snippet.
      *
-     * @param AggregateSnippet $snippet
-     *
      * @return bool
      */
     public function supportsSnippet(AggregateSnippet $snippet);
 
     /**
      * Appends snippet to the source.
-     *
-     * @param AggregateSnippet $snippet
      */
     public function appendSnippet(AggregateSnippet $snippet);
 }

--- a/src/Behat/Behat/Snippet/Cli/SnippetsController.php
+++ b/src/Behat/Behat/Snippet/Cli/SnippetsController.php
@@ -35,18 +35,22 @@ final class SnippetsController implements Controller
      * @var SnippetRegistry
      */
     private $registry;
+
     /**
      * @var SnippetWriter
      */
     private $writer;
+
     /**
      * @var ConsoleSnippetPrinter
      */
     private $printer;
+
     /**
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
+
     /**
      * @var OutputInterface
      */
@@ -54,11 +58,6 @@ final class SnippetsController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param SnippetRegistry          $registry
-     * @param SnippetWriter            $writer
-     * @param ConsoleSnippetPrinter    $printer
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(
         SnippetRegistry $registry,
@@ -74,52 +73,49 @@ final class SnippetsController implements Controller
 
     /**
      * Configures command to be executable by the controller.
-     *
-     * @param Command $command
      */
     public function configure(Command $command)
     {
         $command
             ->addOption(
-                '--append-snippets', null, InputOption::VALUE_NONE,
-                "Appends snippets for undefined steps into main context."
+                '--append-snippets',
+                null,
+                InputOption::VALUE_NONE,
+                'Appends snippets for undefined steps into main context.'
             )
             ->addOption(
-                '--no-snippets', null, InputOption::VALUE_NONE,
-                "Do not print snippets for undefined steps after stats."
+                '--no-snippets',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not print snippets for undefined steps after stats.'
             );
     }
 
     /**
      * Executes controller.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return null|integer
+     * @return null|int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->eventDispatcher->addListener(StepTested::AFTER, array($this, 'registerUndefinedStep'), -999);
+        $this->eventDispatcher->addListener(StepTested::AFTER, [$this, 'registerUndefinedStep'], -999);
         $this->output = $output;
 
         if ($input->getOption('append-snippets')) {
-            $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'appendAllSnippets'), -999);
+            $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, [$this, 'appendAllSnippets'], -999);
         }
 
         if (!$input->getOption('no-snippets') && !$input->getOption('append-snippets')) {
-            $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'printAllSnippets'), -999);
+            $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, [$this, 'printAllSnippets'], -999);
         }
 
         if (!$input->getOption('no-snippets')) {
-            $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'printUndefinedSteps'), -995);
+            $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, [$this, 'printUndefinedSteps'], -995);
         }
     }
 
     /**
      * Registers undefined step.
-     *
-     * @param AfterStepTested $event
      */
     public function registerUndefinedStep(AfterStepTested $event)
     {

--- a/src/Behat/Behat/Snippet/Exception/EnvironmentSnippetGenerationException.php
+++ b/src/Behat/Behat/Snippet/Exception/EnvironmentSnippetGenerationException.php
@@ -11,14 +11,13 @@
 namespace Behat\Behat\Snippet\Exception;
 
 use Behat\Testwork\Environment\Environment;
-use RuntimeException;
 
 /**
  * Represents exception caused by an attempt to generate snippet for unsupported environment.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class EnvironmentSnippetGenerationException extends RuntimeException implements SnippetException
+final class EnvironmentSnippetGenerationException extends \RuntimeException implements SnippetException
 {
     /**
      * @var Environment
@@ -28,8 +27,7 @@ final class EnvironmentSnippetGenerationException extends RuntimeException imple
     /**
      * Initializes exception.
      *
-     * @param string      $message
-     * @param Environment $environment
+     * @param string $message
      */
     public function __construct($message, Environment $environment)
     {

--- a/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
+++ b/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
@@ -27,18 +27,12 @@ interface SnippetGenerator
     /**
      * Checks if generator supports search query.
      *
-     * @param Environment $environment
-     * @param StepNode    $step
-     *
      * @return bool
      */
     public function supportsEnvironmentAndStep(Environment $environment, StepNode $step);
 
     /**
      * Generates snippet from search.
-     *
-     * @param Environment $environment
-     * @param StepNode    $step
      *
      * @return Snippet
      */

--- a/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
@@ -29,6 +29,7 @@ class ConsoleSnippetPrinter implements SnippetPrinter
      * @var OutputInterface
      */
     private $output;
+
     /**
      * @var TranslatorInterface
      */
@@ -36,16 +37,13 @@ class ConsoleSnippetPrinter implements SnippetPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param OutputInterface     $output
-     * @param TranslatorInterface $translator
      */
     public function __construct(OutputInterface $output, TranslatorInterface $translator)
     {
         $this->output = $output;
         $this->translator = $translator;
 
-        $output->getFormatter()->setStyle('snippet_keyword', new OutputFormatterStyle(null, null, array('bold')));
+        $output->getFormatter()->setStyle('snippet_keyword', new OutputFormatterStyle(null, null, ['bold']));
         $output->getFormatter()->setStyle('snippet_undefined', new OutputFormatterStyle('yellow'));
     }
 
@@ -57,7 +55,7 @@ class ConsoleSnippetPrinter implements SnippetPrinter
      */
     public function printSnippets($targetName, array $snippets)
     {
-        $message = $this->translator->trans('snippet_proposal_title', array('%count%' => $targetName), 'output');
+        $message = $this->translator->trans('snippet_proposal_title', ['%count%' => $targetName], 'output');
 
         $this->output->writeln('--- ' . $message . PHP_EOL);
 
@@ -74,7 +72,7 @@ class ConsoleSnippetPrinter implements SnippetPrinter
      */
     public function printUndefinedSteps($suiteName, array $steps)
     {
-        $message = $this->translator->trans('snippet_missing_title', array('%count%' => $suiteName), 'output');
+        $message = $this->translator->trans('snippet_missing_title', ['%count%' => $suiteName], 'output');
 
         $this->output->writeln('--- ' . $message . PHP_EOL);
 

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -47,12 +47,10 @@ class SnippetExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -96,68 +94,53 @@ class SnippetExtension implements Extension
         $this->processAppenders($container);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     protected function loadController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Snippet\Printer\ConsoleSnippetPrinter', array(
+        $definition = new Definition('Behat\Behat\Snippet\Printer\ConsoleSnippetPrinter', [
             new Reference(CliExtension::OUTPUT_ID),
-            new Reference(TranslatorExtension::TRANSLATOR_ID)
-        ));
+            new Reference(TranslatorExtension::TRANSLATOR_ID),
+        ]);
         $container->setDefinition('snippet.printer', $definition);
 
-        $definition = new Definition('Behat\Behat\Snippet\Cli\SnippetsController', array(
+        $definition = new Definition('Behat\Behat\Snippet\Cli\SnippetsController', [
             new Reference(self::REGISTRY_ID),
             new Reference(self::WRITER_ID),
             new Reference('snippet.printer'),
-            new Reference(EventDispatcherExtension::DISPATCHER_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 400));
+            new Reference(EventDispatcherExtension::DISPATCHER_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 400]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.snippet', $definition);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     protected function loadRegistry(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Snippet\SnippetRegistry');
         $container->setDefinition(self::REGISTRY_ID, $definition);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     protected function loadWriter(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Snippet\SnippetWriter');
         $container->setDefinition(self::WRITER_ID, $definition);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     protected function processGenerators(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::GENERATOR_TAG);
         $definition = $container->getDefinition(self::REGISTRY_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerSnippetGenerator', array($reference));
+            $definition->addMethodCall('registerSnippetGenerator', [$reference]);
         }
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     protected function processAppenders(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::APPENDER_TAG);
         $definition = $container->getDefinition(self::WRITER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerSnippetAppender', array($reference));
+            $definition->addMethodCall('registerSnippetAppender', [$reference]);
         }
     }
 }

--- a/src/Behat/Behat/Snippet/SnippetRegistry.php
+++ b/src/Behat/Behat/Snippet/SnippetRegistry.php
@@ -24,15 +24,18 @@ final class SnippetRegistry implements SnippetRepository
     /**
      * @var SnippetGenerator[]
      */
-    private $generators = array();
+    private $generators = [];
+
     /**
      * @var UndefinedStep[]
      */
-    private $undefinedSteps = array();
+    private $undefinedSteps = [];
+
     /**
      * @var AggregateSnippet[]
      */
-    private $snippets = array();
+    private $snippets = [];
+
     /**
      * @var bool
      */
@@ -40,8 +43,6 @@ final class SnippetRegistry implements SnippetRepository
 
     /**
      * Registers snippet generator.
-     *
-     * @param SnippetGenerator $generator
      */
     public function registerSnippetGenerator(SnippetGenerator $generator)
     {
@@ -51,9 +52,6 @@ final class SnippetRegistry implements SnippetRepository
 
     /**
      * Generates and registers snippet.
-     *
-     * @param Environment $environment
-     * @param StepNode    $step
      *
      * @return null|Snippet
      */
@@ -96,7 +94,7 @@ final class SnippetRegistry implements SnippetRepository
             return null;
         }
 
-        $snippetsSet = array();
+        $snippetsSet = [];
         foreach ($this->undefinedSteps as $i => $undefinedStep) {
             $snippet = $this->generateSnippet($undefinedStep->getEnvironment(), $undefinedStep->getStep());
 
@@ -105,7 +103,7 @@ final class SnippetRegistry implements SnippetRepository
             }
 
             if (!isset($snippetsSet[$snippet->getHash()])) {
-                $snippetsSet[$snippet->getHash()] = array();
+                $snippetsSet[$snippet->getHash()] = [];
             }
 
             $snippetsSet[$snippet->getHash()][] = $snippet;
@@ -125,9 +123,6 @@ final class SnippetRegistry implements SnippetRepository
     }
 
     /**
-     * @param Environment $environment
-     * @param StepNode    $step
-     *
      * @return null|Snippet
      */
     private function generateSnippet(Environment $environment, StepNode $step)

--- a/src/Behat/Behat/Snippet/SnippetWriter.php
+++ b/src/Behat/Behat/Snippet/SnippetWriter.php
@@ -23,12 +23,10 @@ final class SnippetWriter
     /**
      * @var SnippetAppender[]
      */
-    private $appenders = array();
+    private $appenders = [];
 
     /**
      * Registers snippet appender.
-     *
-     * @param SnippetAppender $appender
      */
     public function registerSnippetAppender(SnippetAppender $appender)
     {
@@ -50,15 +48,14 @@ final class SnippetWriter
     /**
      * Prints snippets using provided printer.
      *
-     * @param SnippetPrinter     $printer
      * @param AggregateSnippet[] $snippets
      */
     public function printSnippets(SnippetPrinter $printer, array $snippets)
     {
-        $printableSnippets = array();
+        $printableSnippets = [];
         foreach ($snippets as $snippet) {
             foreach ($snippet->getTargets() as $target) {
-                $targetSnippets = array();
+                $targetSnippets = [];
 
                 if (isset($printableSnippets[$target])) {
                     $targetSnippets = $printableSnippets[$target];
@@ -77,18 +74,17 @@ final class SnippetWriter
     /**
      * Prints undefined steps using provided printer.
      *
-     * @param SnippetPrinter  $printer
      * @param UndefinedStep[] $undefinedSteps
      */
     public function printUndefinedSteps(SnippetPrinter $printer, array $undefinedSteps)
     {
-        $printableSteps = array();
+        $printableSteps = [];
         foreach ($undefinedSteps as $undefinedStep) {
             $suiteName = $undefinedStep->getEnvironment()->getSuite()->getName();
             $step = $undefinedStep->getStep();
 
             if (!isset($printableSteps[$suiteName])) {
-                $printableSteps[$suiteName] = array();
+                $printableSteps[$suiteName] = [];
             }
 
             $printableSteps[$suiteName][$step->getText()] = $step;
@@ -101,8 +97,6 @@ final class SnippetWriter
 
     /**
      * Appends snippet to appropriate targets.
-     *
-     * @param AggregateSnippet $snippet
      */
     private function appendSnippet(AggregateSnippet $snippet)
     {

--- a/src/Behat/Behat/Snippet/UndefinedStep.php
+++ b/src/Behat/Behat/Snippet/UndefinedStep.php
@@ -24,6 +24,7 @@ final class UndefinedStep
      * @var Environment
      */
     private $environment;
+
     /**
      * @var StepNode
      */
@@ -31,9 +32,6 @@ final class UndefinedStep
 
     /**
      * Initializes undefined step.
-     *
-     * @param Environment $environment
-     * @param StepNode    $step
      */
     public function __construct(Environment $environment, StepNode $step)
     {

--- a/src/Behat/Behat/Tester/BackgroundTester.php
+++ b/src/Behat/Behat/Tester/BackgroundTester.php
@@ -26,34 +26,27 @@ interface BackgroundTester
     /**
      * Sets up background for a test.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param bool     $skip
+     * @param bool $skip
      *
      * @return Setup
      */
     public function setUp(Environment $env, FeatureNode $feature, $skip);
 
     /**
-     * Tests background.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param bool     $skip
-     *
-     * @return TestResult
-     */
-    public function test(Environment $env, FeatureNode $feature, $skip);
-
-    /**
      * Tears down background after a test.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param bool     $skip
-     * @param TestResult  $result
+     * @param bool $skip
      *
      * @return Teardown
      */
     public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result);
+
+    /**
+     * Tests background.
+     *
+     * @param bool $skip
+     *
+     * @return TestResult
+     */
+    public function test(Environment $env, FeatureNode $feature, $skip);
 }

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -33,18 +33,22 @@ final class RerunController implements Controller
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
+
     /**
      * @var null|string
      */
     private $cachePath;
+
     /**
      * @var string
      */
     private $key;
+
     /**
      * @var string[]
      */
-    private $lines = array();
+    private $lines = [];
+
     /**
      * @var string
      */
@@ -53,9 +57,8 @@ final class RerunController implements Controller
     /**
      * Initializes controller.
      *
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param null|string              $cachePath
-     * @param string                   $basepath
+     * @param null|string $cachePath
+     * @param string      $basepath
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, $cachePath, $basepath)
     {
@@ -66,12 +69,13 @@ final class RerunController implements Controller
 
     /**
      * Configures command to be executable by the controller.
-     *
-     * @param Command $command
      */
     public function configure(Command $command)
     {
-        $command->addOption('--rerun', null, InputOption::VALUE_NONE,
+        $command->addOption(
+            '--rerun',
+            null,
+            InputOption::VALUE_NONE,
             'Re-run scenarios that failed during last execution.'
         );
     }
@@ -79,16 +83,13 @@ final class RerunController implements Controller
     /**
      * Executes controller.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return null|integer
+     * @return null|int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->eventDispatcher->addListener(ScenarioTested::AFTER, array($this, 'collectFailedScenario'), -50);
-        $this->eventDispatcher->addListener(ExampleTested::AFTER, array($this, 'collectFailedScenario'), -50);
-        $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'writeCache'), -50);
+        $this->eventDispatcher->addListener(ScenarioTested::AFTER, [$this, 'collectFailedScenario'], -50);
+        $this->eventDispatcher->addListener(ExampleTested::AFTER, [$this, 'collectFailedScenario'], -50);
+        $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, [$this, 'writeCache'], -50);
 
         $this->key = $this->generateKey($input);
 
@@ -105,8 +106,6 @@ final class RerunController implements Controller
 
     /**
      * Records scenario if it is failed.
-     *
-     * @param AfterScenarioTested $event
      */
     public function collectFailedScenario(AfterScenarioTested $event)
     {
@@ -148,14 +147,12 @@ final class RerunController implements Controller
     /**
      * Generates cache key.
      *
-     * @param InputInterface $input
-     *
      * @return string
      */
     private function generateKey(InputInterface $input)
     {
         return md5(
-            $input->getParameterOption(array('--profile', '-p')) .
+            $input->getParameterOption(['--profile', '-p']) .
             $input->getOption('suite') .
             implode(' ', $input->getOption('name')) .
             implode(' ', $input->getOption('tags')) .

--- a/src/Behat/Behat/Tester/Exception/FeatureHasNoBackgroundException.php
+++ b/src/Behat/Behat/Tester/Exception/FeatureHasNoBackgroundException.php
@@ -12,14 +12,13 @@ namespace Behat\Behat\Tester\Exception;
 
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Exception\TestworkException;
-use RuntimeException;
 
 /**
  * Represents exception throw during attempt to test non-existent feature background.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class FeatureHasNoBackgroundException extends RuntimeException implements TestworkException
+final class FeatureHasNoBackgroundException extends \RuntimeException implements TestworkException
 {
     /**
      * @var FeatureNode
@@ -29,8 +28,7 @@ final class FeatureHasNoBackgroundException extends RuntimeException implements 
     /**
      * Initializes exception.
      *
-     * @param string      $message
-     * @param FeatureNode $feature
+     * @param string $message
      */
     public function __construct($message, FeatureNode $feature)
     {

--- a/src/Behat/Behat/Tester/Exception/PendingException.php
+++ b/src/Behat/Behat/Tester/Exception/PendingException.php
@@ -11,14 +11,13 @@
 namespace Behat\Behat\Tester\Exception;
 
 use Behat\Testwork\Tester\Exception\TesterException;
-use RuntimeException;
 
 /**
  * Represents a pending exception.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class PendingException extends RuntimeException implements TesterException
+final class PendingException extends \RuntimeException implements TesterException
 {
     /**
      * Initializes pending exception.

--- a/src/Behat/Behat/Tester/Exception/Stringer/PendingExceptionStringer.php
+++ b/src/Behat/Behat/Tester/Exception/Stringer/PendingExceptionStringer.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\Tester\Exception\Stringer;
 
 use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Testwork\Exception\Stringer\ExceptionStringer;
-use Exception;
 
 /**
  * Strings pending exceptions.
@@ -24,7 +23,7 @@ class PendingExceptionStringer implements ExceptionStringer
     /**
      * {@inheritdoc}
      */
-    public function supportsException(Exception $exception)
+    public function supportsException(\Exception $exception)
     {
         return $exception instanceof PendingException;
     }
@@ -32,7 +31,7 @@ class PendingExceptionStringer implements ExceptionStringer
     /**
      * {@inheritdoc}
      */
-    public function stringException(Exception $exception, $verbosity)
+    public function stringException(\Exception $exception, $verbosity)
     {
         return trim($exception->getMessage());
     }

--- a/src/Behat/Behat/Tester/OutlineTester.php
+++ b/src/Behat/Behat/Tester/OutlineTester.php
@@ -27,37 +27,27 @@ interface OutlineTester
     /**
      * Sets up background for a test.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param OutlineNode $outline
-     * @param bool     $skip
+     * @param bool $skip
      *
      * @return Setup
      */
     public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip);
 
     /**
-     * Tests outline.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param OutlineNode $outline
-     * @param bool     $skip
-     *
-     * @return TestResult
-     */
-    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip);
-
-    /**
      * Sets up background for a test.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param OutlineNode $outline
-     * @param bool     $skip
-     * @param TestResult  $result
+     * @param bool $skip
      *
      * @return Teardown
      */
     public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result);
+
+    /**
+     * Tests outline.
+     *
+     * @param bool $skip
+     *
+     * @return TestResult
+     */
+    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip);
 }

--- a/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
@@ -26,6 +26,7 @@ final class ExecutedStepResult implements StepResult, DefinedStepResult, Excepti
      * @var SearchResult
      */
     private $searchResult;
+
     /**
      * @var null|CallResult
      */
@@ -33,9 +34,6 @@ final class ExecutedStepResult implements StepResult, DefinedStepResult, Excepti
 
     /**
      * Initialize test result.
-     *
-     * @param SearchResult $searchResult
-     * @param CallResult   $callResult
      */
     public function __construct(SearchResult $searchResult, CallResult $callResult)
     {
@@ -108,6 +106,6 @@ final class ExecutedStepResult implements StepResult, DefinedStepResult, Excepti
      */
     public function isPassed()
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED === $this->getResultCode();
     }
 }

--- a/src/Behat/Behat/Tester/Result/FailedStepSearchResult.php
+++ b/src/Behat/Behat/Tester/Result/FailedStepSearchResult.php
@@ -27,8 +27,6 @@ final class FailedStepSearchResult implements StepResult, ExceptionResult
 
     /**
      * Initializes result.
-     *
-     * @param SearchException $searchException
      */
     public function __construct(SearchException $searchException)
     {

--- a/src/Behat/Behat/Tester/Result/SkippedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/SkippedStepResult.php
@@ -26,14 +26,12 @@ final class SkippedStepResult implements StepResult, DefinedStepResult
 
     /**
      * Initializes step result.
-     *
-     * @param SearchResult $searchResult
      */
     public function __construct(SearchResult $searchResult)
     {
         $this->searchResult = $searchResult;
     }
-    
+
     /**
      * Returns definition search result.
      *

--- a/src/Behat/Behat/Tester/Runtime/IsolatingScenarioTester.php
+++ b/src/Behat/Behat/Tester/Runtime/IsolatingScenarioTester.php
@@ -32,6 +32,7 @@ final class IsolatingScenarioTester implements ScenarioTester
      * @var ScenarioTester
      */
     private $decoratedTester;
+
     /**
      * @var EnvironmentManager
      */
@@ -39,9 +40,6 @@ final class IsolatingScenarioTester implements ScenarioTester
 
     /**
      * Initialises tester.
-     *
-     * @param ScenarioTester     $decoratedTester
-     * @param EnvironmentManager $envManager
      */
     public function __construct(ScenarioTester $decoratedTester, EnvironmentManager $envManager)
     {
@@ -60,6 +58,14 @@ final class IsolatingScenarioTester implements ScenarioTester
     /**
      * {@inheritdoc}
      */
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
+    {
+        return new SuccessfulTeardown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
     {
         $isolatedEnvironment = $this->envManager->isolateEnvironment($env, $scenario);
@@ -72,13 +78,5 @@ final class IsolatingScenarioTester implements ScenarioTester
         $integerResult = new IntegerTestResult($testResult->getResultCode());
 
         return new TestWithSetupResult($setup, $integerResult, $teardown);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
-    {
-        return new SuccessfulTeardown();
     }
 }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeBackgroundTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeBackgroundTester.php
@@ -35,8 +35,6 @@ final class RuntimeBackgroundTester implements BackgroundTester
 
     /**
      * Initializes tester.
-     *
-     * @param StepContainerTester $containerTester
      */
     public function __construct(StepContainerTester $containerTester)
     {
@@ -49,6 +47,14 @@ final class RuntimeBackgroundTester implements BackgroundTester
     public function setUp(Environment $env, FeatureNode $feature, $skip)
     {
         return new SuccessfulSetup();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result)
+    {
+        return new SuccessfulTeardown();
     }
 
     /**
@@ -72,13 +78,5 @@ final class RuntimeBackgroundTester implements BackgroundTester
         $results = $this->containerTester->test($env, $feature, $background, $skip);
 
         return new TestResults($results);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result)
-    {
-        return new SuccessfulTeardown();
     }
 }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
@@ -34,10 +34,12 @@ final class RuntimeFeatureTester implements SpecificationTester
      * @var ScenarioTester
      */
     private $scenarioTester;
+
     /**
      * @var OutlineTester
      */
     private $outlineTester;
+
     /**
      * @var EnvironmentManager
      */
@@ -46,8 +48,6 @@ final class RuntimeFeatureTester implements SpecificationTester
     /**
      * Initializes tester.
      *
-     * @param ScenarioTester     $scenarioTester
-     * @param OutlineTester      $outlineTester
      * @param EnvironmentManager $envManager
      *
      * TODO: Remove EnvironmentManager parameter in next major
@@ -73,9 +73,17 @@ final class RuntimeFeatureTester implements SpecificationTester
     /**
      * {@inheritdoc}
      */
+    public function tearDown(Environment $env, $spec, $skip, TestResult $result)
+    {
+        return new SuccessfulTeardown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function test(Environment $env, $spec, $skip = false)
     {
-        $results = array();
+        $results = [];
         foreach ($spec->getScenarios() as $scenario) {
             $tester = $scenario instanceof OutlineNode ? $this->outlineTester : $this->scenarioTester;
 
@@ -89,13 +97,5 @@ final class RuntimeFeatureTester implements SpecificationTester
         }
 
         return new TestResults($results);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function tearDown(Environment $env, $spec, $skip, TestResult $result)
-    {
-        return new SuccessfulTeardown();
     }
 }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeOutlineTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeOutlineTester.php
@@ -36,8 +36,6 @@ final class RuntimeOutlineTester implements OutlineTester
 
     /**
      * Initializes tester.
-     *
-     * @param ScenarioTester $scenarioTester
      */
     public function __construct(ScenarioTester $scenarioTester)
     {
@@ -55,9 +53,17 @@ final class RuntimeOutlineTester implements OutlineTester
     /**
      * {@inheritdoc}
      */
+    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result)
+    {
+        return new SuccessfulTeardown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip = false)
     {
-        $results = array();
+        $results = [];
         foreach ($outline->getExamples() as $example) {
             $setup = $this->scenarioTester->setUp($env, $feature, $example, $skip);
             $localSkip = !$setup->isSuccessful() || $skip;
@@ -69,13 +75,5 @@ final class RuntimeOutlineTester implements OutlineTester
         }
 
         return new TestResults($results);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result)
-    {
-        return new SuccessfulTeardown();
     }
 }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
@@ -11,8 +11,8 @@
 namespace Behat\Behat\Tester\Runtime;
 
 use Behat\Behat\Tester\BackgroundTester;
-use Behat\Behat\Tester\StepContainerTester;
 use Behat\Behat\Tester\ScenarioTester;
+use Behat\Behat\Tester\StepContainerTester;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioInterface as Scenario;
 use Behat\Testwork\Environment\Environment;
@@ -34,6 +34,7 @@ final class RuntimeScenarioTester implements ScenarioTester
      * @var StepContainerTester
      */
     private $containerTester;
+
     /**
      * @var BackgroundTester
      */
@@ -41,9 +42,6 @@ final class RuntimeScenarioTester implements ScenarioTester
 
     /**
      * Initializes tester.
-     *
-     * @param StepContainerTester $containerTester
-     * @param BackgroundTester    $backgroundTester
      */
     public function __construct(StepContainerTester $containerTester, BackgroundTester $backgroundTester)
     {
@@ -62,9 +60,17 @@ final class RuntimeScenarioTester implements ScenarioTester
     /**
      * {@inheritdoc}
      */
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
+    {
+        return new SuccessfulTeardown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip = false)
     {
-        $results = array();
+        $results = [];
 
         if ($feature->hasBackground()) {
             $backgroundResult = $this->testBackground($env, $feature, $skip);
@@ -79,19 +85,9 @@ final class RuntimeScenarioTester implements ScenarioTester
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
-    {
-        return new SuccessfulTeardown();
-    }
-
-    /**
      * Tests background of the provided feature against provided environment.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param bool     $skip
+     * @param bool $skip
      *
      * @return TestResult
      */

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -38,6 +38,7 @@ final class RuntimeStepTester implements StepTester
      * @var DefinitionFinder
      */
     private $definitionFinder;
+
     /**
      * @var CallCenter
      */
@@ -45,9 +46,6 @@ final class RuntimeStepTester implements StepTester
 
     /**
      * Initialize tester.
-     *
-     * @param DefinitionFinder $definitionFinder
-     * @param CallCenter       $callCenter
      */
     public function __construct(DefinitionFinder $definitionFinder, CallCenter $callCenter)
     {
@@ -66,6 +64,14 @@ final class RuntimeStepTester implements StepTester
     /**
      * {@inheritdoc}
      */
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
+    {
+        return new SuccessfulTeardown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip = false)
     {
         try {
@@ -79,19 +85,7 @@ final class RuntimeStepTester implements StepTester
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
-    {
-        return new SuccessfulTeardown();
-    }
-
-    /**
      * Searches for a definition.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
      *
      * @return SearchResult
      */
@@ -103,11 +97,7 @@ final class RuntimeStepTester implements StepTester
     /**
      * Tests found definition.
      *
-     * @param Environment  $env
-     * @param FeatureNode  $feature
-     * @param StepNode     $step
-     * @param SearchResult $search
-     * @param bool      $skip
+     * @param bool $skip
      *
      * @return StepResult
      */
@@ -129,11 +119,6 @@ final class RuntimeStepTester implements StepTester
 
     /**
      * Creates definition call.
-     *
-     * @param Environment  $env
-     * @param FeatureNode  $feature
-     * @param SearchResult $search
-     * @param StepNode     $step
      *
      * @return DefinitionCall
      */

--- a/src/Behat/Behat/Tester/ScenarioTester.php
+++ b/src/Behat/Behat/Tester/ScenarioTester.php
@@ -27,37 +27,27 @@ interface ScenarioTester
     /**
      * Sets up example for a test.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
-     * @param bool     $skip
+     * @param bool $skip
      *
      * @return Setup
      */
     public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip);
 
     /**
-     * Tests example.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
-     * @param bool     $skip
-     *
-     * @return TestResult
-     */
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip);
-
-    /**
      * Tears down example after a test.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param Scenario    $scenario
-     * @param bool     $skip
-     * @param TestResult  $result
+     * @param bool $skip
      *
      * @return Teardown
      */
     public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result);
+
+    /**
+     * Tests example.
+     *
+     * @param bool $skip
+     *
+     * @return TestResult
+     */
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip);
 }

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -40,7 +40,7 @@ class TesterExtension extends BaseExtension
     public const STEP_TESTER_ID = 'tester.step';
 
     /**
-     * Available extension points
+     * Available extension points.
      */
     public const SCENARIO_TESTER_WRAPPER_TAG = 'tester.scenario.wrapper';
     public const OUTLINE_TESTER_WRAPPER_TAG = 'tester.outline.wrapper';
@@ -55,12 +55,10 @@ class TesterExtension extends BaseExtension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
 
         parent::__construct($this->processor);
     }
@@ -74,14 +72,14 @@ class TesterExtension extends BaseExtension
 
         $builder
             ->children()
-                ->scalarNode('rerun_cache')
-                    ->info('Sets the rerun cache path')
-                    ->defaultValue(
-                        is_writable(sys_get_temp_dir())
-                            ? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat_rerun_cache'
-                            : null
-                    )
-                ->end()
+            ->scalarNode('rerun_cache')
+            ->info('Sets the rerun cache path')
+            ->defaultValue(
+                is_writable(sys_get_temp_dir())
+                    ? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat_rerun_cache'
+                    : null
+            )
+            ->end()
             ->end()
         ;
     }
@@ -113,16 +111,14 @@ class TesterExtension extends BaseExtension
 
     /**
      * Loads specification tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadSpecificationTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeFeatureTester', array(
+        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeFeatureTester', [
             new Reference(self::SCENARIO_TESTER_ID),
             new Reference(self::OUTLINE_TESTER_ID),
-            new Reference(EnvironmentExtension::MANAGER_ID)
-        ));
+            new Reference(EnvironmentExtension::MANAGER_ID),
+        ]);
         $container->setDefinition(self::SPECIFICATION_TESTER_ID, $definition);
 
         $this->loadScenarioTester($container);
@@ -133,42 +129,40 @@ class TesterExtension extends BaseExtension
 
     /**
      * Loads scenario tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadScenarioTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Tester\StepContainerTester', array(
-            new Reference(self::STEP_TESTER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Tester\StepContainerTester', [
+            new Reference(self::STEP_TESTER_ID),
+        ]);
         $container->setDefinition('tester.step_container', $definition);
 
-        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeScenarioTester', array(
+        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeScenarioTester', [
             new Reference('tester.step_container'),
-            new Reference(self::BACKGROUND_TESTER_ID)
-        ));
+            new Reference(self::BACKGROUND_TESTER_ID),
+        ]);
         $container->setDefinition(self::SCENARIO_TESTER_ID, $definition);
 
         // Proper isolation for scenarios
-        $definition = new Definition('Behat\Behat\Tester\Runtime\IsolatingScenarioTester', array(
+        $definition = new Definition(
+            'Behat\Behat\Tester\Runtime\IsolatingScenarioTester',
+            [
                 new Reference(self::SCENARIO_TESTER_ID),
-                new Reference(EnvironmentExtension::MANAGER_ID)
-            )
+                new Reference(EnvironmentExtension::MANAGER_ID),
+            ]
         );
-        $definition->addTag(self::SCENARIO_TESTER_WRAPPER_TAG, array('priority' => -999999));
+        $definition->addTag(self::SCENARIO_TESTER_WRAPPER_TAG, ['priority' => -999999]);
         $container->setDefinition(self::SCENARIO_TESTER_WRAPPER_TAG . '.isolating', $definition);
     }
 
     /**
      * Loads outline tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadOutlineTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeOutlineTester', array(
-            new Reference(self::EXAMPLE_TESTER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeOutlineTester', [
+            new Reference(self::EXAMPLE_TESTER_ID),
+        ]);
         $container->setDefinition(self::OUTLINE_TESTER_ID, $definition);
 
         $this->loadExampleTester($container);
@@ -176,85 +170,78 @@ class TesterExtension extends BaseExtension
 
     /**
      * Loads example tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadExampleTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Tester\StepContainerTester', array(
-            new Reference(self::STEP_TESTER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Tester\StepContainerTester', [
+            new Reference(self::STEP_TESTER_ID),
+        ]);
         $container->setDefinition('tester.step_container', $definition);
 
-        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeScenarioTester', array(
+        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeScenarioTester', [
             new Reference('tester.step_container'),
-            new Reference(self::BACKGROUND_TESTER_ID)
-        ));
+            new Reference(self::BACKGROUND_TESTER_ID),
+        ]);
         $container->setDefinition(self::EXAMPLE_TESTER_ID, $definition);
 
         // Proper isolation for examples
-        $definition = new Definition('Behat\Behat\Tester\Runtime\IsolatingScenarioTester', array(
+        $definition = new Definition(
+            'Behat\Behat\Tester\Runtime\IsolatingScenarioTester',
+            [
                 new Reference(self::EXAMPLE_TESTER_ID),
-                new Reference(EnvironmentExtension::MANAGER_ID)
-            )
+                new Reference(EnvironmentExtension::MANAGER_ID),
+            ]
         );
-        $definition->addTag(self::EXAMPLE_TESTER_WRAPPER_TAG, array('priority' => -999999));
+        $definition->addTag(self::EXAMPLE_TESTER_WRAPPER_TAG, ['priority' => -999999]);
         $container->setDefinition(self::EXAMPLE_TESTER_WRAPPER_TAG . '.isolating', $definition);
     }
 
     /**
      * Loads background tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadBackgroundTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Tester\StepContainerTester', array(
-            new Reference(self::STEP_TESTER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Tester\StepContainerTester', [
+            new Reference(self::STEP_TESTER_ID),
+        ]);
         $container->setDefinition('tester.step_container', $definition);
 
-        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeBackgroundTester', array(
-            new Reference('tester.step_container')
-        ));
+        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeBackgroundTester', [
+            new Reference('tester.step_container'),
+        ]);
         $container->setDefinition(self::BACKGROUND_TESTER_ID, $definition);
     }
 
     /**
      * Loads step tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadStepTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeStepTester', array(
+        $definition = new Definition('Behat\Behat\Tester\Runtime\RuntimeStepTester', [
             new Reference(DefinitionExtension::FINDER_ID),
-            new Reference(CallExtension::CALL_CENTER_ID)
-        ));
+            new Reference(CallExtension::CALL_CENTER_ID),
+        ]);
         $container->setDefinition(self::STEP_TESTER_ID, $definition);
     }
 
     /**
      * Loads rerun controller.
      *
-     * @param ContainerBuilder $container
-     * @param null|string      $cachePath
+     * @param null|string $cachePath
      */
     protected function loadRerunController(ContainerBuilder $container, $cachePath)
     {
-        $definition = new Definition('Behat\Behat\Tester\Cli\RerunController', array(
+        $definition = new Definition('Behat\Behat\Tester\Cli\RerunController', [
             new Reference(EventDispatcherExtension::DISPATCHER_ID),
             $cachePath,
-            $container->getParameter('paths.base')
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 200));
+            $container->getParameter('paths.base'),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 200]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.rerun', $definition);
     }
 
     /**
      * Loads pending exception stringer.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadPendingExceptionStringer(ContainerBuilder $container)
     {
@@ -265,8 +252,6 @@ class TesterExtension extends BaseExtension
 
     /**
      * Processes all registered scenario tester wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processScenarioTesterWrappers(ContainerBuilder $container)
     {
@@ -275,8 +260,6 @@ class TesterExtension extends BaseExtension
 
     /**
      * Processes all registered outline tester wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processOutlineTesterWrappers(ContainerBuilder $container)
     {
@@ -285,8 +268,6 @@ class TesterExtension extends BaseExtension
 
     /**
      * Processes all registered example tester wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processExampleTesterWrappers(ContainerBuilder $container)
     {
@@ -295,8 +276,6 @@ class TesterExtension extends BaseExtension
 
     /**
      * Processes all registered background tester wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processBackgroundTesterWrappers(ContainerBuilder $container)
     {
@@ -305,8 +284,6 @@ class TesterExtension extends BaseExtension
 
     /**
      * Processes all registered step tester wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processStepTesterWrappers(ContainerBuilder $container)
     {

--- a/src/Behat/Behat/Tester/StepContainerTester.php
+++ b/src/Behat/Behat/Tester/StepContainerTester.php
@@ -31,8 +31,6 @@ final class StepContainerTester
 
     /**
      * Initializes tester.
-     *
-     * @param StepTester $stepTester
      */
     public function __construct(StepTester $stepTester)
     {
@@ -42,16 +40,13 @@ final class StepContainerTester
     /**
      * Tests container.
      *
-     * @param Environment            $env
-     * @param FeatureNode            $feature
-     * @param StepContainerInterface $container
-     * @param bool                $skip
+     * @param bool $skip
      *
      * @return TestResult[]
      */
     public function test(Environment $env, FeatureNode $feature, StepContainerInterface $container, $skip)
     {
-        $results = array();
+        $results = [];
         foreach ($container->getSteps() as $step) {
             $setup = $this->stepTester->setUp($env, $feature, $step, $skip);
             $skipSetup = !$setup->isSuccessful() || $skip;

--- a/src/Behat/Behat/Tester/StepTester.php
+++ b/src/Behat/Behat/Tester/StepTester.php
@@ -27,37 +27,27 @@ interface StepTester
     /**
      * Sets up step for a test.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
-     * @param bool     $skip
+     * @param bool $skip
      *
      * @return Setup
      */
     public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip);
 
     /**
-     * Tests step.
-     *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
-     * @param bool     $skip
-     *
-     * @return StepResult
-     */
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip);
-
-    /**
      * Tears down step after a test.
      *
-     * @param Environment $env
-     * @param FeatureNode $feature
-     * @param StepNode    $step
-     * @param bool     $skip
-     * @param StepResult  $result
+     * @param bool $skip
      *
      * @return Teardown
      */
     public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result);
+
+    /**
+     * Tests step.
+     *
+     * @param bool $skip
+     *
+     * @return StepResult
+     */
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip);
 }

--- a/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
+++ b/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
@@ -26,12 +26,10 @@ final class DefinitionArgumentsTransformer implements CallFilter
     /**
      * @var ArgumentTransformer[]
      */
-    private $argumentTransformers = array();
+    private $argumentTransformers = [];
 
     /**
      * Registers new argument transformer.
-     *
-     * @param ArgumentTransformer $transformer
      */
     public function registerArgumentTransformer(ArgumentTransformer $transformer)
     {
@@ -58,7 +56,7 @@ final class DefinitionArgumentsTransformer implements CallFilter
             ), $call);
         }
 
-        $newArguments = array();
+        $newArguments = [];
         $transformed = false;
         foreach ($call->getArguments() as $index => $value) {
             $newValue = $this->transformArgument($call, $index, $value);
@@ -87,9 +85,8 @@ final class DefinitionArgumentsTransformer implements CallFilter
     /**
      * Transforms call argument using registered transformers.
      *
-     * @param DefinitionCall $definitionCall
-     * @param integer|string $index
-     * @param mixed          $value
+     * @param int|string $index
+     * @param mixed      $value
      *
      * @return mixed
      */

--- a/src/Behat/Behat/Transformation/Call/RuntimeTransformation.php
+++ b/src/Behat/Behat/Transformation/Call/RuntimeTransformation.php
@@ -44,16 +44,16 @@ final class RuntimeTransformation extends RuntimeCallee implements Transformatio
     /**
      * {@inheritdoc}
      */
-    public function getPattern()
+    public function __toString()
     {
-        return $this->pattern;
+        return 'Transform ' . $this->getPattern();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function getPattern()
     {
-        return 'Transform ' . $this->getPattern();
+        return $this->pattern;
     }
 }

--- a/src/Behat/Behat/Transformation/Call/TransformationCall.php
+++ b/src/Behat/Behat/Transformation/Call/TransformationCall.php
@@ -29,11 +29,6 @@ final class TransformationCall extends EnvironmentCall
 
     /**
      * Initializes call.
-     *
-     * @param Environment    $environment
-     * @param Definition     $definition
-     * @param Transformation $transformation
-     * @param array          $arguments
      */
     public function __construct(
         Environment $environment,

--- a/src/Behat/Behat/Transformation/Context/Annotation/TransformationAnnotationReader.php
+++ b/src/Behat/Behat/Transformation/Context/Annotation/TransformationAnnotationReader.php
@@ -11,9 +11,8 @@
 namespace Behat\Behat\Transformation\Context\Annotation;
 
 use Behat\Behat\Context\Annotation\AnnotationReader;
-use Behat\Behat\Transformation\Transformation\PatternTransformation;
 use Behat\Behat\Transformation\Transformation;
-use ReflectionMethod;
+use Behat\Behat\Transformation\Transformation\PatternTransformation;
 
 /**
  * Step transformation annotation reader.
@@ -32,21 +31,20 @@ class TransformationAnnotationReader implements AnnotationReader
     /**
      * Loads step callees (if exist) associated with specific method.
      *
-     * @param string           $contextClass
-     * @param ReflectionMethod $method
-     * @param string           $docLine
-     * @param string           $description
+     * @param string $contextClass
+     * @param string $docLine
+     * @param string $description
      *
      * @return null|Transformation
      */
-    public function readCallee($contextClass, ReflectionMethod $method, $docLine, $description)
+    public function readCallee($contextClass, \ReflectionMethod $method, $docLine, $description)
     {
         if (!preg_match(self::$regex, $docLine, $match)) {
             return null;
         }
 
         $pattern = $match[1];
-        $callable = array($contextClass, $method->getName());
+        $callable = [$contextClass, $method->getName()];
 
         foreach ($this->simpleTransformations() as $transformation) {
             if ($transformation::supportsPatternAndMethod($pattern, $method)) {
@@ -64,13 +62,13 @@ class TransformationAnnotationReader implements AnnotationReader
      */
     private function simpleTransformations()
     {
-        return array(
+        return [
             'Behat\Behat\Transformation\Transformation\RowBasedTableTransformation',
             'Behat\Behat\Transformation\Transformation\ColumnBasedTableTransformation',
             'Behat\Behat\Transformation\Transformation\TableRowTransformation',
             'Behat\Behat\Transformation\Transformation\TokenNameAndReturnTypeTransformation',
             'Behat\Behat\Transformation\Transformation\ReturnTypeTransformation',
-            'Behat\Behat\Transformation\Transformation\TokenNameTransformation'
-        );
+            'Behat\Behat\Transformation\Transformation\TokenNameTransformation',
+        ];
     }
 }

--- a/src/Behat/Behat/Transformation/Exception/UnsupportedCallException.php
+++ b/src/Behat/Behat/Transformation/Exception/UnsupportedCallException.php
@@ -11,14 +11,13 @@
 namespace Behat\Behat\Transformation\Exception;
 
 use Behat\Testwork\Call\Call;
-use InvalidArgumentException;
 
 /**
  * Represents an exception caused by an attempt to filter an unsupported call.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class UnsupportedCallException extends InvalidArgumentException implements TransformationException
+final class UnsupportedCallException extends \InvalidArgumentException implements TransformationException
 {
     /**
      * @var Call
@@ -29,7 +28,6 @@ final class UnsupportedCallException extends InvalidArgumentException implements
      * Initializes exception.
      *
      * @param string $message
-     * @param Call   $call
      */
     public function __construct($message, Call $call)
     {

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -49,10 +49,8 @@ class TransformationExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ?: new ServiceProcessor();
     }
@@ -100,62 +98,52 @@ class TransformationExtension implements Extension
 
     /**
      * Loads definition arguments transformer.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadDefinitionArgumentsTransformer(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Transformation\Call\Filter\DefinitionArgumentsTransformer');
-        $definition->addTag(CallExtension::CALL_FILTER_TAG, array('priority' => 200));
+        $definition->addTag(CallExtension::CALL_FILTER_TAG, ['priority' => 200]);
         $container->setDefinition(self::DEFINITION_ARGUMENT_TRANSFORMER_ID, $definition);
     }
 
     /**
      * Loads default transformers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadDefaultTransformers(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Transformation\Transformer\RepositoryArgumentTransformer', array(
+        $definition = new Definition('Behat\Behat\Transformation\Transformer\RepositoryArgumentTransformer', [
             new Reference(self::REPOSITORY_ID),
             new Reference(CallExtension::CALL_CENTER_ID),
             new Reference(DefinitionExtension::PATTERN_TRANSFORMER_ID),
-            new Reference(TranslatorExtension::TRANSLATOR_ID)
-        ));
-        $definition->addTag(self::ARGUMENT_TRANSFORMER_TAG, array('priority' => 50));
+            new Reference(TranslatorExtension::TRANSLATOR_ID),
+        ]);
+        $definition->addTag(self::ARGUMENT_TRANSFORMER_TAG, ['priority' => 50]);
         $container->setDefinition(self::ARGUMENT_TRANSFORMER_TAG . '.repository', $definition);
     }
 
     /**
      * Loads transformation context annotation reader.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadAnnotationReader(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Transformation\Context\Annotation\TransformationAnnotationReader');
-        $definition->addTag(ContextExtension::ANNOTATION_READER_TAG, array('priority' => 50));
+        $definition->addTag(ContextExtension::ANNOTATION_READER_TAG, ['priority' => 50]);
         $container->setDefinition(ContextExtension::ANNOTATION_READER_TAG . '.transformation', $definition);
     }
 
     /**
      * Loads transformations repository.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadRepository(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Transformation\TransformationRepository', array(
-            new Reference(EnvironmentExtension::MANAGER_ID)
-        ));
+        $definition = new Definition('Behat\Behat\Transformation\TransformationRepository', [
+            new Reference(EnvironmentExtension::MANAGER_ID),
+        ]);
         $container->setDefinition(self::REPOSITORY_ID, $definition);
     }
 
     /**
      * Processes all available argument transformers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processArgumentsTransformers(ContainerBuilder $container)
     {
@@ -163,7 +151,7 @@ class TransformationExtension implements Extension
         $definition = $container->getDefinition(self::DEFINITION_ARGUMENT_TRANSFORMER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerArgumentTransformer', array($reference));
+            $definition->addMethodCall('registerArgumentTransformer', [$reference]);
         }
     }
 
@@ -171,9 +159,9 @@ class TransformationExtension implements Extension
      * Returns definition argument transformer service id.
      *
      * @return string
-     * 
+     *
      * @deprecated Use DEFINITION_ARGUMENT_TRANSFORMER_ID constant instead
-     * 
+     *
      * @todo Remove method in next major version
      */
     protected function getDefinitionArgumentTransformerId()

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\Transformation;
 
 use Behat\Behat\Definition\Call\DefinitionCall;
 use Behat\Testwork\Call\CallCenter;
-use ReflectionMethod;
 
 /**
  * Represents a simple self-contained transformation capable of changing a single argument.
@@ -24,26 +23,24 @@ interface SimpleArgumentTransformation extends Transformation
     /**
      * Checks if transformation supports given pattern.
      *
-     * @param string           $pattern
-     * @param ReflectionMethod $method
+     * @param string $pattern
      *
      * @return bool
      */
-    static public function supportsPatternAndMethod($pattern, ReflectionMethod $method);
+    public static function supportsPatternAndMethod($pattern, \ReflectionMethod $method);
 
     /**
      * Returns transformation priority.
      *
-     * @return integer
+     * @return int
      */
     public function getPriority();
 
     /**
      * Checks if transformation supports argument.
      *
-     * @param DefinitionCall $definitionCall
-     * @param integer|string $argumentIndex
-     * @param mixed          $argumentArgumentValue
+     * @param int|string $argumentIndex
+     * @param mixed      $argumentArgumentValue
      *
      * @return bool
      */
@@ -52,10 +49,8 @@ interface SimpleArgumentTransformation extends Transformation
     /**
      * Transforms argument value using transformation and returns a new one.
      *
-     * @param CallCenter     $callCenter
-     * @param DefinitionCall $definitionCall
-     * @param integer|string $argumentIndex
-     * @param mixed          $argumentValue
+     * @param int|string $argumentIndex
+     * @param mixed      $argumentValue
      *
      * @return mixed
      */

--- a/src/Behat/Behat/Transformation/Transformation.php
+++ b/src/Behat/Behat/Transformation/Transformation.php
@@ -20,6 +20,13 @@ use Behat\Testwork\Call\Callee;
 interface Transformation extends Callee
 {
     /**
+     * Represents transformation as a string.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
      * Returns transformation pattern exactly as it was defined.
      *
      * @deprecated Will be removed in 4.0.
@@ -27,11 +34,4 @@ interface Transformation extends Callee
      * @return string
      */
     public function getPattern();
-
-    /**
-     * Represents transformation as a string.
-     *
-     * @return string
-     */
-    public function __toString();
 }

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -16,7 +16,6 @@ use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
-use ReflectionMethod;
 
 /**
  * Column-based table transformation.
@@ -31,14 +30,6 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Simp
      * @var string
      */
     private $pattern;
-
-    /**
-     * {@inheritdoc}
-     */
-    static public function supportsPatternAndMethod($pattern, ReflectionMethod $method)
-    {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
-    }
 
     /**
      * Initializes transformation.
@@ -57,11 +48,27 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Simp
     /**
      * {@inheritdoc}
      */
+    public function __toString()
+    {
+        return 'ColumnTableTransform ' . $this->pattern;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function supportsPatternAndMethod($pattern, \ReflectionMethod $method)
+    {
+        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue)
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
-        };
+        }
 
         return $this->pattern === 'table:' . implode(',', $argumentArgumentValue->getRow(0))
             || $this->pattern === 'table:*';
@@ -76,7 +83,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Simp
             $definitionCall->getEnvironment(),
             $definitionCall->getCallee(),
             $this,
-            array($argumentValue)
+            [$argumentValue]
         );
 
         $result = $callCenter->makeCall($call);
@@ -102,13 +109,5 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Simp
     public function getPattern()
     {
         return $this->pattern;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return 'ColumnTableTransform ' . $this->pattern;
     }
 }

--- a/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
@@ -45,11 +45,17 @@ final class PatternTransformation extends RuntimeCallee implements Transformatio
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return 'PatternTransform ' . $this->pattern;
+    }
+
+    /**
      * Checks if transformer supports argument.
      *
-     * @param RegexGenerator $regexGenerator
-     * @param DefinitionCall $definitionCall
-     * @param mixed          $argumentValue
+     * @param mixed $argumentValue
      *
      * @return bool
      */
@@ -70,14 +76,10 @@ final class PatternTransformation extends RuntimeCallee implements Transformatio
     /**
      * Transforms argument value using transformation and returns a new one.
      *
-     * @param RegexGenerator $regexGenerator
-     * @param CallCenter     $callCenter
-     * @param DefinitionCall $definitionCall
-     * @param mixed          $argumentValue
+     * @param mixed $argumentValue
      *
+     * @throws \Exception If transformation throws exception
      * @return mixed
-     *
-     * @throws Exception If transformation throws exception
      */
     public function transformArgument(
         RegexGenerator $regexGenerator,
@@ -118,18 +120,6 @@ final class PatternTransformation extends RuntimeCallee implements Transformatio
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return 'PatternTransform ' . $this->pattern;
-    }
-
-    /**
-     * @param $regexPattern
-     * @param $argumentValue
-     * @param $match
-     *
      * @return bool
      */
     private function match($regexPattern, $argumentValue, &$match)

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -16,12 +16,6 @@ use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use Closure;
-use ReflectionClass;
-use ReflectionException;
-use ReflectionFunctionAbstract;
-use ReflectionMethod;
-use ReflectionParameter;
-use ReflectionNamedType;
 
 /**
  * By-type object transformation.
@@ -30,21 +24,6 @@ use ReflectionNamedType;
  */
 final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgumentTransformation
 {
-
-    /**
-     * {@inheritdoc}
-     */
-    static public function supportsPatternAndMethod($pattern, ReflectionMethod $method)
-    {
-        $returnClass = self::getReturnClass($method);
-
-        if (null === $returnClass) {
-            return false;
-        }
-
-        return '' === $pattern;
-    }
-
     /**
      * Initializes transformation.
      *
@@ -55,6 +34,28 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
     public function __construct($pattern, $callable, $description = null)
     {
         parent::__construct($callable, $description);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return 'ReturnTypeTransform';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function supportsPatternAndMethod($pattern, \ReflectionMethod $method)
+    {
+        $returnClass = self::getReturnClass($method);
+
+        if (null === $returnClass) {
+            return false;
+        }
+
+        return '' === $pattern;
     }
 
     /**
@@ -82,7 +83,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
             $definitionCall->getEnvironment(),
             $definitionCall->getCallee(),
             $this,
-            array($argumentValue)
+            [$argumentValue]
         );
 
         $result = $callCenter->makeCall($call);
@@ -111,21 +112,11 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return 'ReturnTypeTransform';
-    }
-
-    /**
      * Extracts parameters from provided definition call.
-     *
-     * @param ReflectionFunctionAbstract $reflection
      *
      * @return null|string
      */
-    static private function getReturnClass(ReflectionFunctionAbstract $reflection)
+    private static function getReturnClass(\ReflectionFunctionAbstract $reflection)
     {
         $type = $reflection->getReturnType();
 
@@ -134,7 +125,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
             return null;
         }
 
-        if ($type instanceof ReflectionNamedType) {
+        if ($type instanceof \ReflectionNamedType) {
             return $type->getName();
         }
 
@@ -144,21 +135,21 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
     /**
      * Attempts to get definition parameter using its index (parameter position or name).
      *
-     * @param DefinitionCall $definitionCall
-     * @param string|integer $argumentIndex
+     * @param int|string $argumentIndex
      *
      * @return null|string
      */
     private function getParameterClassNameByIndex(DefinitionCall $definitionCall, $argumentIndex)
     {
         $parameters = array_filter(
-            array_filter($this->getCallParameters($definitionCall),
+            array_filter(
+                $this->getCallParameters($definitionCall),
                 $this->hasIndex($argumentIndex)
             ),
             $this->getClassReflection()
         );
 
-        if (count($parameters) == 0) {
+        if (count($parameters) === 0) {
             return null;
         }
 
@@ -168,9 +159,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
     /**
      * Extracts parameters from provided definition call.
      *
-     * @param DefinitionCall $definitionCall
-     *
-     * @return ReflectionParameter[]
+     * @return \ReflectionParameter[]
      */
     private function getCallParameters(DefinitionCall $definitionCall)
     {
@@ -180,9 +169,9 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
     /**
      * Returns appropriate closure for filtering parameter by index.
      *
-     * @param string|integer $index
+     * @param int|string $index
      *
-     * @return Closure
+     * @return \Closure
      */
     private function hasIndex($index)
     {
@@ -194,11 +183,11 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
      *
      * @param string $index
      *
-     * @return Closure
+     * @return \Closure
      */
     private function hasName($index)
     {
-        return function (ReflectionParameter $parameter) use ($index) {
+        return function (\ReflectionParameter $parameter) use ($index) {
             return $index === $parameter->getName();
         };
     }
@@ -206,33 +195,29 @@ final class ReturnTypeTransformation extends RuntimeCallee implements SimpleArgu
     /**
      * Returns closure to filter parameter by position.
      *
-     * @param integer $index
+     * @param int $index
      *
-     * @return Closure
+     * @return \Closure
      */
     private function hasPosition($index)
     {
-        return function (ReflectionParameter $parameter) use ($index) {
+        return function (\ReflectionParameter $parameter) use ($index) {
             return $index === $parameter->getPosition();
         };
     }
 
     /**
      * Returns closure to filter parameter by typehinted class.
-     *
-     * @return Closure
      */
-    private function getClassReflection() : closure
+    private function getClassReflection(): \closure
     {
-        return function (ReflectionParameter $parameter) : ?ReflectionClass
-        {
+        return function (\ReflectionParameter $parameter): ?\ReflectionClass {
             $t = $parameter->getType();
 
-            if ($t instanceof ReflectionNamedType) {
+            if ($t instanceof \ReflectionNamedType) {
                 try {
-                    return new ReflectionClass($t->getName());
-                }
-                catch (ReflectionException $t) {
+                    return new \ReflectionClass($t->getName());
+                } catch (\ReflectionException $t) {
                     return null;
                 }
             }

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -17,7 +17,6 @@ use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
-use ReflectionMethod;
 
 /**
  * Row-based table transformation.
@@ -32,14 +31,6 @@ final class RowBasedTableTransformation extends RuntimeCallee implements SimpleA
      * @var string
      */
     private $pattern;
-
-    /**
-     * {@inheritdoc}
-     */
-    static public function supportsPatternAndMethod($pattern, ReflectionMethod $method)
-    {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
-    }
 
     /**
      * Initializes transformation.
@@ -58,11 +49,27 @@ final class RowBasedTableTransformation extends RuntimeCallee implements SimpleA
     /**
      * {@inheritdoc}
      */
+    public function __toString()
+    {
+        return 'RowTableTransform ' . $this->pattern;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function supportsPatternAndMethod($pattern, \ReflectionMethod $method)
+    {
+        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue)
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
-        };
+        }
 
         // What we're doing here is checking that we have a 2 column table.
         // This bit checks we have two columns
@@ -92,7 +99,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements SimpleA
             $definitionCall->getEnvironment(),
             $definitionCall->getCallee(),
             $this,
-            array($argumentValue)
+            [$argumentValue]
         );
 
         $result = $callCenter->makeCall($call);
@@ -118,13 +125,5 @@ final class RowBasedTableTransformation extends RuntimeCallee implements SimpleA
     public function getPattern()
     {
         return $this->pattern;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return 'RowTableTransform ' . $this->pattern;
     }
 }

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -16,7 +16,6 @@ use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
-use ReflectionMethod;
 
 /**
  * Table row transformation.
@@ -31,14 +30,6 @@ final class TableRowTransformation extends RuntimeCallee implements SimpleArgume
      * @var string
      */
     private $pattern;
-
-    /**
-     * {@inheritdoc}
-     */
-    static public function supportsPatternAndMethod($pattern, ReflectionMethod $method)
-    {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
-    }
 
     /**
      * Initializes transformation.
@@ -57,11 +48,27 @@ final class TableRowTransformation extends RuntimeCallee implements SimpleArgume
     /**
      * {@inheritdoc}
      */
+    public function __toString()
+    {
+        return 'TableRowTransform ' . $this->pattern;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function supportsPatternAndMethod($pattern, \ReflectionMethod $method)
+    {
+        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue)
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
-        };
+        }
 
         return $this->pattern === 'row:' . implode(',', $argumentArgumentValue->getRow(0));
     }
@@ -71,13 +78,13 @@ final class TableRowTransformation extends RuntimeCallee implements SimpleArgume
      */
     public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
     {
-        $rows = array();
+        $rows = [];
         foreach ($argumentValue as $row) {
             $call = new TransformationCall(
                 $definitionCall->getEnvironment(),
                 $definitionCall->getCallee(),
                 $this,
-                array($row)
+                [$row]
             );
 
             $result = $callCenter->makeCall($call);
@@ -106,13 +113,5 @@ final class TableRowTransformation extends RuntimeCallee implements SimpleArgume
     public function getPattern()
     {
         return $this->pattern;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return 'TableRowTransform ' . $this->pattern;
     }
 }

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
@@ -15,7 +15,6 @@ use Behat\Behat\Transformation\Call\TransformationCall;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
-use ReflectionMethod;
 
 /**
  * Name and return type object transformation.
@@ -28,19 +27,11 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
      * @var TokenNameTransformation
      */
     private $tokenTransformation;
+
     /**
      * @var ReturnTypeTransformation
      */
     private $returnTransformation;
-
-    /**
-     * {@inheritdoc}
-     */
-    static public function supportsPatternAndMethod($pattern, ReflectionMethod $method)
-    {
-        return TokenNameTransformation::supportsPatternAndMethod($pattern, $method)
-            && ReturnTypeTransformation::supportsPatternAndMethod('', $method);
-    }
 
     /**
      * Initializes transformation.
@@ -55,6 +46,23 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
         $this->returnTransformation = new ReturnTypeTransformation('', $callable, $description);
 
         parent::__construct($callable, $description);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return 'NamedReturnTypeTransform ' . $this->getPattern();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function supportsPatternAndMethod($pattern, \ReflectionMethod $method)
+    {
+        return TokenNameTransformation::supportsPatternAndMethod($pattern, $method)
+            && ReturnTypeTransformation::supportsPatternAndMethod('', $method);
     }
 
     /**
@@ -75,7 +83,7 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
             $definitionCall->getEnvironment(),
             $definitionCall->getCallee(),
             $this,
-            array($argumentValue)
+            [$argumentValue]
         );
 
         $result = $callCenter->makeCall($call);
@@ -101,13 +109,5 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
     public function getPattern()
     {
         return $this->tokenTransformation->getPattern();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return 'NamedReturnTypeTransform ' . $this->getPattern();
     }
 }

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -15,7 +15,6 @@ use Behat\Behat\Transformation\Call\TransformationCall;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
-use ReflectionMethod;
 
 /**
  * Token name based transformation.
@@ -31,15 +30,6 @@ final class TokenNameTransformation extends RuntimeCallee implements SimpleArgum
      */
     private $pattern;
 
-
-    /**
-     * {@inheritdoc}
-     */
-    static public function supportsPatternAndMethod($pattern, ReflectionMethod $method)
-    {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
-    }
-
     /**
      * Initializes transformation.
      *
@@ -52,6 +42,22 @@ final class TokenNameTransformation extends RuntimeCallee implements SimpleArgum
         $this->pattern = $pattern;
 
         parent::__construct($callable, $description);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return 'TokenNameTransform ' . $this->pattern;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function supportsPatternAndMethod($pattern, \ReflectionMethod $method)
+    {
+        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
     }
 
     /**
@@ -71,7 +77,7 @@ final class TokenNameTransformation extends RuntimeCallee implements SimpleArgum
             $definitionCall->getEnvironment(),
             $definitionCall->getCallee(),
             $this,
-            array($argumentValue)
+            [$argumentValue]
         );
 
         $result = $callCenter->makeCall($call);
@@ -97,13 +103,5 @@ final class TokenNameTransformation extends RuntimeCallee implements SimpleArgum
     public function getPattern()
     {
         return $this->pattern;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return 'TokenNameTransform ' . $this->pattern;
     }
 }

--- a/src/Behat/Behat/Transformation/TransformationRepository.php
+++ b/src/Behat/Behat/Transformation/TransformationRepository.php
@@ -28,8 +28,6 @@ final class TransformationRepository
 
     /**
      * Initializes repository.
-     *
-     * @param EnvironmentManager $environmentManager
      */
     public function __construct(EnvironmentManager $environmentManager)
     {
@@ -38,8 +36,6 @@ final class TransformationRepository
 
     /**
      * Returns all available definitions for a specific environment.
-     *
-     * @param Environment $environment
      *
      * @return Transformation[]
      */

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -22,9 +22,8 @@ interface ArgumentTransformer
     /**
      * Checks if transformer supports argument.
      *
-     * @param DefinitionCall $definitionCall
-     * @param integer|string $argumentIndex
-     * @param mixed          $argumentValue
+     * @param int|string $argumentIndex
+     * @param mixed      $argumentValue
      *
      * @return bool
      */
@@ -33,9 +32,8 @@ interface ArgumentTransformer
     /**
      * Transforms argument value using transformation and returns a new one.
      *
-     * @param DefinitionCall $definitionCall
-     * @param integer|string $argumentIndex
-     * @param mixed          $argumentValue
+     * @param int|string $argumentIndex
+     * @param mixed      $argumentValue
      *
      * @return mixed
      */

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -13,10 +13,10 @@ namespace Behat\Behat\Transformation\Transformer;
 use Behat\Behat\Definition\Call\DefinitionCall;
 use Behat\Behat\Definition\Pattern\PatternTransformer;
 use Behat\Behat\Definition\Translator\TranslatorInterface;
-use Behat\Behat\Transformation\SimpleArgumentTransformation;
-use Behat\Behat\Transformation\Transformation\PatternTransformation;
 use Behat\Behat\Transformation\RegexGenerator;
+use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Behat\Transformation\Transformation;
+use Behat\Behat\Transformation\Transformation\PatternTransformation;
 use Behat\Behat\Transformation\TransformationRepository;
 use Behat\Gherkin\Node\ArgumentInterface;
 use Behat\Testwork\Call\CallCenter;
@@ -32,14 +32,17 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      * @var TransformationRepository
      */
     private $repository;
+
     /**
      * @var CallCenter
      */
     private $callCenter;
+
     /**
      * @var PatternTransformer
      */
     private $patternTransformer;
+
     /**
      * @var TranslatorInterface
      */
@@ -47,11 +50,6 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
 
     /**
      * Initializes transformer.
-     *
-     * @param TransformationRepository $repository
-     * @param CallCenter               $callCenter
-     * @param PatternTransformer       $patternTransformer
-     * @param TranslatorInterface      $translator
      */
     public function __construct(
         TransformationRepository $repository,
@@ -84,9 +82,8 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
         );
 
         $newValue = $this->applySimpleTransformations($simpleTransformations, $definitionCall, $argumentIndex, $argumentValue);
-        $newValue = $this->applyNormalTransformations($normalTransformations, $definitionCall, $argumentIndex, $newValue);
 
-        return $newValue;
+        return $this->applyNormalTransformations($normalTransformations, $definitionCall, $argumentIndex, $newValue);
     }
 
     /**
@@ -94,8 +91,8 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      */
     public function generateRegex($suiteName, $pattern, $language)
     {
-        $translatedPattern = $this->translator->trans($pattern, array(), $suiteName, $language);
-        if ($pattern == $translatedPattern) {
+        $translatedPattern = $this->translator->trans($pattern, [], $suiteName, $language);
+        if ($pattern === $translatedPattern) {
             return $this->patternTransformer->transformPatternToRegex($pattern);
         }
 
@@ -106,8 +103,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      * Apply simple argument transformations in priority order.
      *
      * @param SimpleArgumentTransformation[] $transformations
-     * @param DefinitionCall                 $definitionCall
-     * @param integer|string                 $index
+     * @param int|string                     $index
      * @param mixed                          $value
      *
      * @return mixed
@@ -130,8 +126,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      * Apply normal (non-simple) argument transformations.
      *
      * @param Transformation[] $transformations
-     * @param DefinitionCall   $definitionCall
-     * @param integer|string   $index
+     * @param int|string       $index
      * @param mixed            $value
      *
      * @return mixed
@@ -149,10 +144,8 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
     /**
      * Transforms argument value using registered transformers.
      *
-     * @param Transformation $transformation
-     * @param DefinitionCall $definitionCall
-     * @param integer|string $index
-     * @param mixed          $value
+     * @param int|string $index
+     * @param mixed      $value
      *
      * @return mixed
      */
@@ -162,13 +155,13 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
             return $value;
         }
 
-        if ($transformation instanceof SimpleArgumentTransformation &&
-            $transformation->supportsDefinitionAndArgument($definitionCall, $index, $value)) {
+        if ($transformation instanceof SimpleArgumentTransformation
+            && $transformation->supportsDefinitionAndArgument($definitionCall, $index, $value)) {
             return $transformation->transformArgument($this->callCenter, $definitionCall, $index, $value);
         }
 
-        if ($transformation instanceof PatternTransformation &&
-            $transformation->supportsDefinitionAndArgument($this, $definitionCall, $value)) {
+        if ($transformation instanceof PatternTransformation
+            && $transformation->supportsDefinitionAndArgument($this, $definitionCall, $value)) {
             return $transformation->transformArgument($this, $this->callCenter, $definitionCall, $value);
         }
 
@@ -185,10 +178,10 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
     private function splitSimpleAndNormalTransformations(array $transformations)
     {
         return array_reduce($transformations, function ($acc, $t) {
-            return array(
-                $t instanceof SimpleArgumentTransformation ? array_merge($acc[0], array($t)) : $acc[0],
-                !$t instanceof SimpleArgumentTransformation ? array_merge($acc[1], array($t)) : $acc[1],
-            );
-        }, array(array(), array()));
+            return [
+                $t instanceof SimpleArgumentTransformation ? array_merge($acc[0], [$t]) : $acc[0],
+                !$t instanceof SimpleArgumentTransformation ? array_merge($acc[1], [$t]) : $acc[1],
+            ];
+        }, [[], []]);
     }
 }

--- a/src/Behat/Behat/Translator/Cli/GherkinTranslationsController.php
+++ b/src/Behat/Behat/Translator/Cli/GherkinTranslationsController.php
@@ -30,8 +30,6 @@ final class GherkinTranslationsController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param Translator $translator
      */
     public function __construct(Translator $translator)
     {

--- a/src/Behat/Behat/Translator/ServiceContainer/GherkinTranslationsExtension.php
+++ b/src/Behat/Behat/Translator/ServiceContainer/GherkinTranslationsExtension.php
@@ -65,15 +65,13 @@ final class GherkinTranslationsExtension implements Extension
 
     /**
      * Loads translator controller.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Behat\Translator\Cli\GherkinTranslationsController', array(
-            new Reference(TranslatorExtension::TRANSLATOR_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 9999));
+        $definition = new Definition('Behat\Behat\Translator\Cli\GherkinTranslationsController', [
+            new Reference(TranslatorExtension::TRANSLATOR_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 9999]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.gherkin_translations', $definition);
     }
 }

--- a/src/Behat/Hook/AfterFeature.php
+++ b/src/Behat/Hook/AfterFeature.php
@@ -11,7 +11,7 @@
 namespace Behat\Hook;
 
 /**
- * Represents an Attribute for AfterFeature hook
+ * Represents an Attribute for AfterFeature hook.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class AfterFeature implements Hook

--- a/src/Behat/Hook/AfterScenario.php
+++ b/src/Behat/Hook/AfterScenario.php
@@ -11,7 +11,7 @@
 namespace Behat\Hook;
 
 /**
- * Represents an Attribute for AfterScenario hook
+ * Represents an Attribute for AfterScenario hook.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class AfterScenario implements Hook

--- a/src/Behat/Hook/AfterStep.php
+++ b/src/Behat/Hook/AfterStep.php
@@ -11,7 +11,7 @@
 namespace Behat\Hook;
 
 /**
- * Represents an Attribute for AfterStep hook
+ * Represents an Attribute for AfterStep hook.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class AfterStep implements Hook

--- a/src/Behat/Hook/BeforeFeature.php
+++ b/src/Behat/Hook/BeforeFeature.php
@@ -11,7 +11,7 @@
 namespace Behat\Hook;
 
 /**
- * Represents an Attribute for BeforeFeature hook
+ * Represents an Attribute for BeforeFeature hook.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class BeforeFeature implements Hook

--- a/src/Behat/Hook/BeforeScenario.php
+++ b/src/Behat/Hook/BeforeScenario.php
@@ -11,7 +11,7 @@
 namespace Behat\Hook;
 
 /**
- * Represents an Attribute for BeforeScenario hook
+ * Represents an Attribute for BeforeScenario hook.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class BeforeScenario implements Hook

--- a/src/Behat/Hook/BeforeStep.php
+++ b/src/Behat/Hook/BeforeStep.php
@@ -11,7 +11,7 @@
 namespace Behat\Hook;
 
 /**
- * Represents an Attribute for BeforeStep hook
+ * Represents an Attribute for BeforeStep hook.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class BeforeStep implements Hook

--- a/src/Behat/Hook/Hook.php
+++ b/src/Behat/Hook/Hook.php
@@ -12,7 +12,7 @@ namespace Behat\Hook;
 
 /**
  * Marker interface for all Attributes regarding
- * Hooks
+ * Hooks.
  *
  * @internal Only meant as marker, not as an extension point
  */

--- a/src/Behat/Step/Definition.php
+++ b/src/Behat/Step/Definition.php
@@ -12,7 +12,7 @@ namespace Behat\Step;
 
 /**
  * Marker interface for all Attributes regarding
- * Call definitions
+ * Call definitions.
  *
  * @internal Only meant as marker, not as an extension point
  */

--- a/src/Behat/Step/Given.php
+++ b/src/Behat/Step/Given.php
@@ -11,7 +11,7 @@
 namespace Behat\Step;
 
 /**
- * Represents an Attribute for Given steps
+ * Represents an Attribute for Given steps.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class Given implements Definition

--- a/src/Behat/Step/Then.php
+++ b/src/Behat/Step/Then.php
@@ -11,7 +11,7 @@
 namespace Behat\Step;
 
 /**
- * Represents an Attribute for Then steps
+ * Represents an Attribute for Then steps.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class Then implements Definition

--- a/src/Behat/Step/When.php
+++ b/src/Behat/Step/When.php
@@ -11,7 +11,7 @@
 namespace Behat\Step;
 
 /**
- * Represents an Attribute for When steps
+ * Represents an Attribute for When steps.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class When implements Definition

--- a/src/Behat/Testwork/ApplicationFactory.php
+++ b/src/Behat/Testwork/ApplicationFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -24,6 +24,19 @@ use Behat\Testwork\ServiceContainer\ExtensionManager;
  */
 abstract class ApplicationFactory
 {
+    /**
+     * Creates application instance.
+     *
+     * @return Application
+     */
+    public function createApplication()
+    {
+        $configurationLoader = $this->createConfigurationLoader();
+        $extensionManager = $this->createExtensionManager();
+
+        return new Application($this->getName(), $this->getVersion(), $configurationLoader, $extensionManager);
+    }
+
     /**
      * Returns application name.
      *
@@ -58,19 +71,6 @@ abstract class ApplicationFactory
      * @return null|string
      */
     abstract protected function getConfigPath();
-
-    /**
-     * Creates application instance.
-     *
-     * @return Application
-     */
-    public function createApplication()
-    {
-        $configurationLoader = $this->createConfigurationLoader();
-        $extensionManager = $this->createExtensionManager();
-
-        return new Application($this->getName(), $this->getVersion(), $configurationLoader, $extensionManager);
-    }
 
     /**
      * Creates configuration loader.

--- a/src/Behat/Testwork/Argument/ArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/ArgumentOrganiser.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -9,8 +9,6 @@
  */
 
 namespace Behat\Testwork\Argument;
-
-use ReflectionFunctionAbstract;
 
 /**
  * Organises function arguments using its reflection.
@@ -22,10 +20,9 @@ interface ArgumentOrganiser
     /**
      * Organises arguments using function reflection.
      *
-     * @param ReflectionFunctionAbstract $function
-     * @param mixed[]                    $arguments
+     * @param mixed[] $arguments
      *
      * @return mixed[]
      */
-    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments);
+    public function organiseArguments(\ReflectionFunctionAbstract $function, array $arguments);
 }

--- a/src/Behat/Testwork/Argument/ConstructorArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/ConstructorArgumentOrganiser.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -12,8 +12,6 @@ namespace Behat\Testwork\Argument;
 
 use Behat\Testwork\Argument\Exception\UnknownParameterValueException;
 use Behat\Testwork\Argument\Exception\UnsupportedFunctionException;
-use ReflectionFunctionAbstract;
-use ReflectionMethod;
 
 /**
  * Organises constructor arguments.
@@ -29,8 +27,6 @@ final class ConstructorArgumentOrganiser implements ArgumentOrganiser
 
     /**
      * Initializes organiser.
-     *
-     * @param ArgumentOrganiser $organiser
      */
     public function __construct(ArgumentOrganiser $organiser)
     {
@@ -40,9 +36,9 @@ final class ConstructorArgumentOrganiser implements ArgumentOrganiser
     /**
      * {@inheritdoc}
      */
-    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments)
+    public function organiseArguments(\ReflectionFunctionAbstract $function, array $arguments)
     {
-        if (!$function instanceof ReflectionMethod) {
+        if (!$function instanceof \ReflectionMethod) {
             throw new UnsupportedFunctionException(sprintf(
                 'ConstructorArgumentOrganiser can only work with ReflectionMethod, but `%s` given.',
                 get_class($function)
@@ -62,14 +58,13 @@ final class ConstructorArgumentOrganiser implements ArgumentOrganiser
     /**
      * Checks that all provided constructor arguments are present in the constructor.
      *
-     * @param ReflectionMethod $constructor
-     * @param mixed[]          $passedArguments
-     * @param mixed[]          $organisedArguments
+     * @param mixed[] $passedArguments
+     * @param mixed[] $organisedArguments
      *
      * @throws UnknownParameterValueException
      */
     private function validateArguments(
-        ReflectionMethod $constructor,
+        \ReflectionMethod $constructor,
         array $passedArguments,
         array $organisedArguments
     ) {

--- a/src/Behat/Testwork/Argument/Exception/ArgumentException.php
+++ b/src/Behat/Testwork/Argument/Exception/ArgumentException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Argument/Exception/UnknownParameterValueException.php
+++ b/src/Behat/Testwork/Argument/Exception/UnknownParameterValueException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,8 +10,6 @@
 
 namespace Behat\Testwork\Argument\Exception;
 
-use BadMethodCallException;
-
 /**
  * Represents an exception caused by an unknown function parameter value.
  *
@@ -19,6 +17,6 @@ use BadMethodCallException;
  *
  * @author Wouter J <wouter@wouterj.nl>
  */
-final class UnknownParameterValueException extends BadMethodCallException implements ArgumentException
+final class UnknownParameterValueException extends \BadMethodCallException implements ArgumentException
 {
 }

--- a/src/Behat/Testwork/Argument/Exception/UnsupportedFunctionException.php
+++ b/src/Behat/Testwork/Argument/Exception/UnsupportedFunctionException.php
@@ -10,13 +10,11 @@
 
 namespace Behat\Testwork\Argument\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an attempt to organise unsupported function arguments.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class UnsupportedFunctionException extends InvalidArgumentException implements ArgumentException
+final class UnsupportedFunctionException extends \InvalidArgumentException implements ArgumentException
 {
 }

--- a/src/Behat/Testwork/Argument/PregMatchArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/PregMatchArgumentOrganiser.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -9,8 +9,6 @@
  */
 
 namespace Behat\Testwork\Argument;
-
-use ReflectionFunctionAbstract;
 
 /**
  * Organises arguments coming from preg_match results.
@@ -26,8 +24,6 @@ final class PregMatchArgumentOrganiser implements ArgumentOrganiser
 
     /**
      * Initialises organiser.
-     *
-     * @param ArgumentOrganiser $organiser
      */
     public function __construct(ArgumentOrganiser $organiser)
     {
@@ -37,7 +33,7 @@ final class PregMatchArgumentOrganiser implements ArgumentOrganiser
     /**
      * {@inheritdoc}
      */
-    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments)
+    public function organiseArguments(\ReflectionFunctionAbstract $function, array $arguments)
     {
         $cleanedArguments = $this->cleanupMatchDuplicates($arguments);
 
@@ -52,23 +48,21 @@ final class PregMatchArgumentOrganiser implements ArgumentOrganiser
      * duplication and also drops the first full match element from the
      * array.
      *
-     * @param array $match
-     *
      * @return mixed[]
      */
     private function cleanupMatchDuplicates(array $match)
     {
         $cleanMatch = array_slice($match, 1);
-        $arguments = array();
+        $arguments = [];
 
         $keys = array_keys($cleanMatch);
-        for ($keyIndex = 0; $keyIndex < count($keys); $keyIndex++) {
+        for ($keyIndex = 0; $keyIndex < count($keys); ++$keyIndex) {
             $key = $keys[$keyIndex];
 
             $arguments[$key] = $cleanMatch[$key];
 
             if ($this->isKeyAStringAndNexOneIsAnInteger($keyIndex, $keys)) {
-                $keyIndex += 1;
+                ++$keyIndex;
             }
         }
 
@@ -78,7 +72,7 @@ final class PregMatchArgumentOrganiser implements ArgumentOrganiser
     /**
      * Checks if key at provided index is a string and next key in the array is an integer.
      *
-     * @param integer $keyIndex
+     * @param int     $keyIndex
      * @param mixed[] $keys
      *
      * @return bool

--- a/src/Behat/Testwork/Argument/ServiceContainer/ArgumentExtension.php
+++ b/src/Behat/Testwork/Argument/ServiceContainer/ArgumentExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -61,14 +61,14 @@ final class ArgumentExtension implements Extension
         $definition = new Definition('Behat\Testwork\Argument\MixedArgumentOrganiser');
         $container->setDefinition(self::MIXED_ARGUMENT_ORGANISER_ID, $definition);
 
-        $definition = new Definition('Behat\Testwork\Argument\PregMatchArgumentOrganiser', array(
-            new Reference(self::MIXED_ARGUMENT_ORGANISER_ID)
-        ));
+        $definition = new Definition('Behat\Testwork\Argument\PregMatchArgumentOrganiser', [
+            new Reference(self::MIXED_ARGUMENT_ORGANISER_ID),
+        ]);
         $container->setDefinition(self::PREG_MATCH_ARGUMENT_ORGANISER_ID, $definition);
 
-        $definition = new Definition('Behat\Testwork\Argument\ConstructorArgumentOrganiser', array(
-            new Reference(self::MIXED_ARGUMENT_ORGANISER_ID)
-        ));
+        $definition = new Definition('Behat\Testwork\Argument\ConstructorArgumentOrganiser', [
+            new Reference(self::MIXED_ARGUMENT_ORGANISER_ID),
+        ]);
         $container->setDefinition(self::CONSTRUCTOR_ARGUMENT_ORGANISER_ID, $definition);
     }
 

--- a/src/Behat/Testwork/Argument/Validator.php
+++ b/src/Behat/Testwork/Argument/Validator.php
@@ -11,9 +11,6 @@
 namespace Behat\Testwork\Argument;
 
 use Behat\Testwork\Argument\Exception\UnknownParameterValueException;
-use ReflectionFunctionAbstract;
-use ReflectionMethod;
-use ReflectionParameter;
 
 /**
  * Validates function arguments.
@@ -25,12 +22,11 @@ final class Validator
     /**
      * Validates that all arguments are in place, throws exception otherwise.
      *
-     * @param ReflectionFunctionAbstract $function
-     * @param mixed[]                    $arguments
+     * @param mixed[] $arguments
      *
      * @throws UnknownParameterValueException
      */
-    public function validateArguments(ReflectionFunctionAbstract $function, array $arguments)
+    public function validateArguments(\ReflectionFunctionAbstract $function, array $arguments)
     {
         foreach ($function->getParameters() as $num => $parameter) {
             $this->validateArgument($parameter, $num, $arguments);
@@ -40,11 +36,9 @@ final class Validator
     /**
      * Validates given argument.
      *
-     * @param ReflectionParameter $parameter
-     * @param integer             $parameterIndex
-     * @param array               $givenArguments
+     * @param int $parameterIndex
      */
-    private function validateArgument(ReflectionParameter $parameter, $parameterIndex, array $givenArguments)
+    private function validateArgument(\ReflectionParameter $parameter, $parameterIndex, array $givenArguments)
     {
         if ($parameter->isDefaultValueAvailable()) {
             return;
@@ -68,13 +62,11 @@ final class Validator
     /**
      * Returns function path for a provided reflection.
      *
-     * @param ReflectionFunctionAbstract $function
-     *
      * @return string
      */
-    private function getFunctionPath(ReflectionFunctionAbstract $function)
+    private function getFunctionPath(\ReflectionFunctionAbstract $function)
     {
-        if ($function instanceof ReflectionMethod) {
+        if ($function instanceof \ReflectionMethod) {
             return sprintf(
                 '%s::%s()',
                 $function->getDeclaringClass()->getName(),

--- a/src/Behat/Testwork/Autoloader/Cli/AutoloaderController.php
+++ b/src/Behat/Testwork/Autoloader/Cli/AutoloaderController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -29,9 +29,7 @@ final class AutoloaderController implements Controller
     private $loader;
 
     /**
-     * Initializes controller
-     *
-     * @param ClassLoader $loader
+     * Initializes controller.
      */
     public function __construct(ClassLoader $loader)
     {

--- a/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
+++ b/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -33,14 +33,12 @@ final class AutoloaderExtension implements Extension
     /**
      * @var array
      */
-    private $defaultPaths = array();
+    private $defaultPaths = [];
 
     /**
      * Initializes extension.
-     *
-     * @param array $defaultPaths
      */
-    public function __construct(array $defaultPaths = array())
+    public function __construct(array $defaultPaths = [])
     {
         $this->defaultPaths = $defaultPaths;
     }
@@ -69,15 +67,15 @@ final class AutoloaderExtension implements Extension
     {
         $builder
             ->beforeNormalization()
-                ->ifString()->then(function ($path) {
-                    return array('' => $path);
+            ->ifString()->then(function ($path) {
+                    return ['' => $path];
                 })
             ->end()
 
             ->defaultValue($this->defaultPaths)
             ->treatTrueLike($this->defaultPaths)
-            ->treatNullLike(array())
-            ->treatFalseLike(array())
+            ->treatNullLike([])
+            ->treatFalseLike([])
 
             ->prototype('scalar')->end()
         ;
@@ -103,8 +101,6 @@ final class AutoloaderExtension implements Extension
 
     /**
      * Loads Symfony2 autoloader.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadAutoloader(ContainerBuilder $container)
     {
@@ -114,24 +110,19 @@ final class AutoloaderExtension implements Extension
 
     /**
      * Loads controller.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Autoloader\Cli\AutoloaderController', array(
-            new Reference(self::CLASS_LOADER_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 9999));
+        $definition = new Definition('Behat\Testwork\Autoloader\Cli\AutoloaderController', [
+            new Reference(self::CLASS_LOADER_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 9999]);
 
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.autoloader', $definition);
     }
 
     /**
      * Sets provided prefixes to container.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $prefixes
      */
     private function setLoaderPrefixes(ContainerBuilder $container, array $prefixes)
     {
@@ -140,8 +131,6 @@ final class AutoloaderExtension implements Extension
 
     /**
      * Processes container loader prefixes.
-     *
-     * @param ContainerBuilder $container
      */
     private function processLoaderPrefixes(ContainerBuilder $container)
     {
@@ -149,7 +138,7 @@ final class AutoloaderExtension implements Extension
         $prefixes = $container->getParameter('class_loader.prefixes');
 
         foreach ($prefixes as $prefix => $path) {
-            $loaderDefinition->addMethodCall('add', array($prefix, $path));
+            $loaderDefinition->addMethodCall('add', [$prefix, $path]);
         }
     }
 }

--- a/src/Behat/Testwork/Call/Call.php
+++ b/src/Behat/Testwork/Call/Call.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -41,7 +41,7 @@ interface Call
     /**
      * Returns call error reporting level.
      *
-     * @return null|integer
+     * @return null|int
      */
     public function getErrorReportingLevel();
 }

--- a/src/Behat/Testwork/Call/CallCenter.php
+++ b/src/Behat/Testwork/Call/CallCenter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -17,7 +17,6 @@ use Behat\Testwork\Call\Filter\ResultFilter;
 use Behat\Testwork\Call\Handler\CallHandler;
 use Behat\Testwork\Call\Handler\ExceptionHandler;
 use Exception;
-use Throwable;
 
 /**
  * Makes calls and handles results using registered handlers.
@@ -29,24 +28,25 @@ final class CallCenter
     /**
      * @var CallFilter[]
      */
-    private $callFilters = array();
+    private $callFilters = [];
+
     /**
      * @var CallHandler[]
      */
-    private $callHandlers = array();
+    private $callHandlers = [];
+
     /**
      * @var ResultFilter[]
      */
-    private $resultFilters = array();
+    private $resultFilters = [];
+
     /**
      * @var ExceptionHandler[]
      */
-    private $exceptionHandlers = array();
+    private $exceptionHandlers = [];
 
     /**
      * Registers call filter.
-     *
-     * @param CallFilter $filter
      */
     public function registerCallFilter(CallFilter $filter)
     {
@@ -55,8 +55,6 @@ final class CallCenter
 
     /**
      * Registers call handler.
-     *
-     * @param CallHandler $handler
      */
     public function registerCallHandler(CallHandler $handler)
     {
@@ -65,8 +63,6 @@ final class CallCenter
 
     /**
      * Registers call result filter.
-     *
-     * @param ResultFilter $filter
      */
     public function registerResultFilter(ResultFilter $filter)
     {
@@ -75,8 +71,6 @@ final class CallCenter
 
     /**
      * Registers result exception handler.
-     *
-     * @param ExceptionHandler $handler
      */
     public function registerExceptionHandler(ExceptionHandler $handler)
     {
@@ -86,23 +80,19 @@ final class CallCenter
     /**
      * Handles call and its result using registered filters and handlers.
      *
-     * @param Call $call
-     *
      * @return CallResult
      */
     public function makeCall(Call $call)
     {
         try {
             return $this->filterResult($this->handleCall($this->filterCall($call)));
-        } catch (Throwable $exception) {
+        } catch (\Throwable $exception) {
             return new CallResult($call, null, $this->handleException($exception), null);
         }
     }
 
     /**
      * Filters call using registered filters and returns a filtered one.
-     *
-     * @param Call $call
      *
      * @return Call
      */
@@ -122,11 +112,8 @@ final class CallCenter
     /**
      * Handles call using registered call handlers.
      *
-     * @param Call $call
-     *
-     * @return CallResult
-     *
      * @throws CallHandlingException If call handlers didn't produce call result
+     * @return CallResult
      */
     private function handleCall(Call $call)
     {
@@ -147,8 +134,6 @@ final class CallCenter
     /**
      * Filters call result using registered filters and returns a filtered one.
      *
-     * @param CallResult $result
-     *
      * @return CallResult
      */
     private function filterResult(CallResult $result)
@@ -167,9 +152,9 @@ final class CallCenter
     /**
      * Handles exception using registered handlers and returns a handled one.
      *
-     * @param Throwable $exception
+     * @param \Throwable $exception
      *
-     * @return Throwable
+     * @return \Throwable
      */
     private function handleException($exception)
     {
@@ -181,7 +166,7 @@ final class CallCenter
             $exception = $handler->handleException($exception);
         }
 
-        if ($exception instanceof Throwable) {
+        if ($exception instanceof \Throwable) {
             return new FatalThrowableError($exception);
         }
 

--- a/src/Behat/Testwork/Call/CallResult.php
+++ b/src/Behat/Testwork/Call/CallResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -23,14 +23,17 @@ final class CallResult
      * @var Call
      */
     private $call;
+
     /**
      * @var mixed
      */
     private $return;
+
     /**
-     * @var null|Exception
+     * @var null|\Exception
      */
     private $exception;
+
     /**
      * @var null|string
      */
@@ -39,12 +42,10 @@ final class CallResult
     /**
      * Initializes call result.
      *
-     * @param Call           $call
-     * @param mixed          $return
-     * @param null|Exception $exception
-     * @param null|string    $stdOut
+     * @param mixed       $return
+     * @param null|string $stdOut
      */
-    public function __construct(Call $call, $return, Exception $exception = null, $stdOut = null)
+    public function __construct(Call $call, $return, ?\Exception $exception = null, $stdOut = null)
     {
         $this->call = $call;
         $this->return = $return;
@@ -88,7 +89,7 @@ final class CallResult
     /**
      * Returns exception thrown by call (if any).
      *
-     * @return null|Exception
+     * @return null|\Exception
      */
     public function getException()
     {

--- a/src/Behat/Testwork/Call/CallResults.php
+++ b/src/Behat/Testwork/Call/CallResults.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,16 +10,12 @@
 
 namespace Behat\Testwork\Call;
 
-use ArrayIterator;
-use Countable;
-use IteratorAggregate;
-
 /**
  * Aggregates multiple call results into a collection and provides an informational API on top of that.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class CallResults implements Countable, IteratorAggregate
+final class CallResults implements \Countable, \IteratorAggregate
 {
     /**
      * @var CallResult[]
@@ -31,16 +27,13 @@ final class CallResults implements Countable, IteratorAggregate
      *
      * @param CallResult[] $results
      */
-    public function __construct(array $results = array())
+    public function __construct(array $results = [])
     {
         $this->results = $results;
     }
 
     /**
      * Merges results from provided collection into the current one.
-     *
-     * @param CallResults $first
-     * @param CallResults $second
      *
      * @return CallResults
      */
@@ -83,8 +76,6 @@ final class CallResults implements Countable, IteratorAggregate
 
     /**
      * Returns amount of results.
-     *
-     * @return integer
      */
     public function count(): int
     {
@@ -93,12 +84,10 @@ final class CallResults implements Countable, IteratorAggregate
 
     /**
      * Returns collection iterator.
-     *
-     * @return ArrayIterator
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): \ArrayIterator
     {
-        return new ArrayIterator($this->results);
+        return new \ArrayIterator($this->results);
     }
 
     /**

--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -9,8 +9,6 @@
  */
 
 namespace Behat\Testwork\Call;
-
-use ReflectionFunctionAbstract;
 
 /**
  * Represents callable object.
@@ -57,7 +55,7 @@ interface Callee
     /**
      * Returns callable reflection.
      *
-     * @return ReflectionFunctionAbstract
+     * @return \ReflectionFunctionAbstract
      */
     public function getReflection();
 }

--- a/src/Behat/Testwork/Call/Exception/BadCallbackException.php
+++ b/src/Behat/Testwork/Call/Exception/BadCallbackException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,14 +10,12 @@
 
 namespace Behat\Testwork\Call\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents exception caused by a bad callback.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class BadCallbackException extends InvalidArgumentException implements CallException
+final class BadCallbackException extends \InvalidArgumentException implements CallException
 {
     /**
      * @var callable

--- a/src/Behat/Testwork/Call/Exception/CallErrorException.php
+++ b/src/Behat/Testwork/Call/Exception/CallErrorException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,32 +10,30 @@
 
 namespace Behat\Testwork\Call\Exception;
 
-use ErrorException;
-
 /**
  * Represents catchable errors raised during call execution.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class CallErrorException extends ErrorException
+final class CallErrorException extends \ErrorException
 {
-    private $levels = array(
-        E_WARNING           => 'Warning',
-        E_NOTICE            => 'Notice',
-        E_USER_ERROR        => 'User Error',
-        E_USER_WARNING      => 'User Warning',
-        E_USER_NOTICE       => 'User Notice',
-        E_STRICT            => 'Runtime Notice',
+    private $levels = [
+        E_WARNING => 'Warning',
+        E_NOTICE => 'Notice',
+        E_USER_ERROR => 'User Error',
+        E_USER_WARNING => 'User Warning',
+        E_USER_NOTICE => 'User Notice',
+        E_STRICT => 'Runtime Notice',
         E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
-    );
+    ];
 
     /**
      * Initializes error handler exception.
      *
-     * @param integer $level   error level
-     * @param string  $message error message
-     * @param string  $file    error file
-     * @param integer $line    error line
+     * @param int    $level   error level
+     * @param string $message error message
+     * @param string $file    error file
+     * @param int    $line    error line
      */
     public function __construct($level, $message, $file, $line)
     {

--- a/src/Behat/Testwork/Call/Exception/CallException.php
+++ b/src/Behat/Testwork/Call/Exception/CallException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Call/Exception/CallHandlingException.php
+++ b/src/Behat/Testwork/Call/Exception/CallHandlingException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,14 +11,13 @@
 namespace Behat\Testwork\Call\Exception;
 
 use Behat\Testwork\Call\Call;
-use RuntimeException;
 
 /**
  * Represents exceptions thrown during call handling phase.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class CallHandlingException extends RuntimeException implements CallException
+final class CallHandlingException extends \RuntimeException implements CallException
 {
     /**
      * @var Call
@@ -29,7 +28,6 @@ final class CallHandlingException extends RuntimeException implements CallExcept
      * Initializes exception.
      *
      * @param string $message
-     * @param Call   $callable
      */
     public function __construct($message, Call $callable)
     {

--- a/src/Behat/Testwork/Call/Exception/FatalThrowableError.php
+++ b/src/Behat/Testwork/Call/Exception/FatalThrowableError.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,24 +10,21 @@
 
 namespace Behat\Testwork\Call\Exception;
 
-use ErrorException;
-use ParseError;
 use Throwable;
-use TypeError;
 
 /**
  * Fatal Throwable Error.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class FatalThrowableError extends ErrorException
+class FatalThrowableError extends \ErrorException
 {
-    public function __construct(Throwable $e)
+    public function __construct(\Throwable $e)
     {
-        if ($e instanceof ParseError) {
+        if ($e instanceof \ParseError) {
             $message = 'Parse error: '.$e->getMessage();
             $severity = E_PARSE;
-        } elseif ($e instanceof TypeError) {
+        } elseif ($e instanceof \TypeError) {
             $message = 'Type error: '.$e->getMessage();
             $severity = E_RECOVERABLE_ERROR;
         } else {

--- a/src/Behat/Testwork/Call/Filter/CallFilter.php
+++ b/src/Behat/Testwork/Call/Filter/CallFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -25,16 +25,12 @@ interface CallFilter
     /**
      * Checks if filter supports a call.
      *
-     * @param Call $call
-     *
      * @return bool
      */
     public function supportsCall(Call $call);
 
     /**
      * Filters a call and returns a new one.
-     *
-     * @param Call $call
      *
      * @return Call
      */

--- a/src/Behat/Testwork/Call/Filter/ResultFilter.php
+++ b/src/Behat/Testwork/Call/Filter/ResultFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -25,16 +25,12 @@ interface ResultFilter
     /**
      * Checks if filter supports call result.
      *
-     * @param CallResult $result
-     *
      * @return bool
      */
     public function supportsResult(CallResult $result);
 
     /**
      * Filters call result and returns a new result.
-     *
-     * @param CallResult $result
      *
      * @return CallResult
      */

--- a/src/Behat/Testwork/Call/Handler/CallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/CallHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -26,16 +26,12 @@ interface CallHandler
     /**
      * Checks if handler supports call.
      *
-     * @param Call $call
-     *
      * @return bool
      */
     public function supportsCall(Call $call);
 
     /**
      * Handles call and returns call result.
-     *
-     * @param Call $call
      *
      * @return CallResult
      */

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,7 +11,6 @@
 namespace Behat\Testwork\Call\Handler\Exception;
 
 use Behat\Testwork\Call\Handler\ExceptionHandler;
-use Error;
 
 /**
  * Handles class not found exceptions.
@@ -29,7 +28,7 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
      */
     final public function supportsException($exception)
     {
-        if (!$exception instanceof Error) {
+        if (!$exception instanceof \Error) {
             return false;
         }
 
@@ -56,11 +55,9 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
     /**
      * Extracts missing class name from the exception.
      *
-     * @param Error $exception
-     *
      * @return null|string
      */
-    private function extractNonExistentClass(Error $exception)
+    private function extractNonExistentClass(\Error $exception)
     {
         if (1 === preg_match(self::PATTERN, $exception->getMessage(), $matches)) {
             return $matches[1];

--- a/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,7 +11,6 @@
 namespace Behat\Testwork\Call\Handler\Exception;
 
 use Behat\Testwork\Call\Handler\ExceptionHandler;
-use Error;
 
 /**
  * Handles method not found exceptions.
@@ -29,7 +28,7 @@ abstract class MethodNotFoundHandler implements ExceptionHandler
      */
     final public function supportsException($exception)
     {
-        if (!$exception instanceof Error) {
+        if (!$exception instanceof \Error) {
             return false;
         }
 
@@ -48,22 +47,18 @@ abstract class MethodNotFoundHandler implements ExceptionHandler
 
     /**
      * Override to handle non-existent method.
-     *
-     * @param array $callable
      */
     abstract public function handleNonExistentMethod(array $callable);
 
     /**
      * Extract callable from exception.
      *
-     * @param Error $exception
-     *
      * @return null|array
      */
-    private function extractNonExistentCallable(Error $exception)
+    private function extractNonExistentCallable(\Error $exception)
     {
         if (1 === preg_match(self::PATTERN, $exception->getMessage(), $matches)) {
-            return array($matches[1], $matches[2]);
+            return [$matches[1], $matches[2]];
         }
 
         return null;

--- a/src/Behat/Testwork/Call/Handler/ExceptionHandler.php
+++ b/src/Behat/Testwork/Call/Handler/ExceptionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -14,7 +14,6 @@ use Behat\Testwork\Argument\Validator;
 use Behat\Testwork\Call\Call;
 use Behat\Testwork\Call\CallResult;
 use Behat\Testwork\Call\Exception\CallErrorException;
-use Exception;
 
 /**
  * Handles calls in the current runtime.
@@ -24,13 +23,15 @@ use Exception;
 final class RuntimeCallHandler implements CallHandler
 {
     /**
-     * @var integer
+     * @var int
      */
     private $errorReportingLevel;
+
     /**
      * @var bool
      */
     private $obStarted = false;
+
     /**
      * @var Validator
      */
@@ -39,7 +40,7 @@ final class RuntimeCallHandler implements CallHandler
     /**
      * Initializes executor.
      *
-     * @param integer $errorReportingLevel
+     * @param int $errorReportingLevel
      */
     public function __construct($errorReportingLevel = E_ALL)
     {
@@ -72,14 +73,13 @@ final class RuntimeCallHandler implements CallHandler
      *
      * @see set_error_handler()
      *
-     * @param integer $level
-     * @param string  $message
-     * @param string  $file
-     * @param integer $line
-     *
-     * @return bool
+     * @param int    $level
+     * @param string $message
+     * @param string $file
+     * @param int    $line
      *
      * @throws CallErrorException
+     * @return bool
      */
     public function handleError($level, $message, $file, $line)
     {
@@ -92,8 +92,6 @@ final class RuntimeCallHandler implements CallHandler
 
     /**
      * Executes single call.
-     *
-     * @param Call $call
      *
      * @return CallResult
      */
@@ -108,7 +106,7 @@ final class RuntimeCallHandler implements CallHandler
             $arguments = array_values($arguments);
             $this->validator->validateArguments($reflection, $arguments);
             $return = $callable(...$arguments);
-        } catch (Exception $caught) {
+        } catch (\Exception $caught) {
             $exception = $caught;
         }
 
@@ -129,13 +127,11 @@ final class RuntimeCallHandler implements CallHandler
 
     /**
      * Starts error handler and stdout buffering.
-     *
-     * @param Call $call
      */
     private function startErrorAndOutputBuffering(Call $call)
     {
-        $errorReporting = $call->getErrorReportingLevel() ? : $this->errorReportingLevel;
-        set_error_handler(array($this, 'handleError'), $errorReporting);
+        $errorReporting = $call->getErrorReportingLevel() ?: $this->errorReportingLevel;
+        set_error_handler([$this, 'handleError'], $errorReporting);
         $this->obStarted = ob_start();
     }
 
@@ -153,7 +149,7 @@ final class RuntimeCallHandler implements CallHandler
     /**
      * Checks if provided error level is not reportable.
      *
-     * @param integer $level
+     * @param int $level
      *
      * @return bool
      */

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,9 +11,6 @@
 namespace Behat\Testwork\Call;
 
 use Behat\Testwork\Call\Exception\BadCallbackException;
-use ReflectionFunction;
-use ReflectionFunctionAbstract;
-use ReflectionMethod;
 
 /**
  * Represents callee created and executed in the runtime.
@@ -26,14 +23,17 @@ class RuntimeCallee implements Callee
      * @var callable
      */
     private $callable;
+
     /**
      * @var null|string
      */
     private $description;
+
     /**
-     * @var ReflectionFunctionAbstract
+     * @var \ReflectionFunctionAbstract
      */
     private $reflection;
+
     /**
      * @var string
      */
@@ -58,10 +58,10 @@ class RuntimeCallee implements Callee
         }
 
         if (is_array($callable)) {
-            $this->reflection = new ReflectionMethod($callable[0], $callable[1]);
+            $this->reflection = new \ReflectionMethod($callable[0], $callable[1]);
             $this->path = $callable[0] . '::' . $callable[1] . '()';
         } else {
-            $this->reflection = new ReflectionFunction($callable);
+            $this->reflection = new \ReflectionFunction($callable);
             $this->path = $this->reflection->getFileName() . ':' . $this->reflection->getStartLine();
         }
 
@@ -102,7 +102,7 @@ class RuntimeCallee implements Callee
     /**
      * Returns callable reflection.
      *
-     * @return ReflectionFunctionAbstract
+     * @return \ReflectionFunctionAbstract
      */
     public function getReflection()
     {
@@ -116,7 +116,7 @@ class RuntimeCallee implements Callee
      */
     public function isAMethod()
     {
-        return $this->reflection instanceof ReflectionMethod;
+        return $this->reflection instanceof \ReflectionMethod;
     }
 
     /**
@@ -126,7 +126,7 @@ class RuntimeCallee implements Callee
      */
     public function isAnInstanceMethod()
     {
-        return $this->reflection instanceof ReflectionMethod
+        return $this->reflection instanceof \ReflectionMethod
             && !$this->reflection->isStatic();
     }
 }

--- a/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
+++ b/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -44,12 +44,10 @@ final class CallExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -75,10 +73,10 @@ final class CallExtension implements Extension
         $builder
             ->addDefaultsIfNotSet()
             ->children()
-                ->scalarNode('error_reporting')
-                    ->info('Call executor will catch exceptions matching this level')
-                    ->defaultValue(E_ALL | E_STRICT)
-                ->end()
+            ->scalarNode('error_reporting')
+            ->info('Call executor will catch exceptions matching this level')
+            ->defaultValue(E_ALL | E_STRICT)
+            ->end()
             ->end()
         ;
     }
@@ -105,10 +103,8 @@ final class CallExtension implements Extension
 
     /**
      * Loads call center service.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function loadCallCenter(ContainerBuilder $container)
+    private function loadCallCenter(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Testwork\Call\CallCenter');
         $container->setDefinition(self::CALL_CENTER_ID, $definition);
@@ -117,65 +113,56 @@ final class CallExtension implements Extension
     /**
      * Loads prebuilt call handlers.
      *
-     * @param ContainerBuilder $container
-     * @param integer          $errorReporting
+     * @param int $errorReporting
      */
-    protected function loadCallHandlers(ContainerBuilder $container, $errorReporting)
+    private function loadCallHandlers(ContainerBuilder $container, $errorReporting)
     {
-        $definition = new Definition('Behat\Testwork\Call\Handler\RuntimeCallHandler', array($errorReporting));
-        $definition->addTag(self::CALL_HANDLER_TAG, array('priority' => 50));
+        $definition = new Definition('Behat\Testwork\Call\Handler\RuntimeCallHandler', [$errorReporting]);
+        $definition->addTag(self::CALL_HANDLER_TAG, ['priority' => 50]);
         $container->setDefinition(self::CALL_HANDLER_TAG . '.runtime', $definition);
     }
 
     /**
      * Registers all call filters to the CallCenter.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function processCallFilters(ContainerBuilder $container)
+    private function processCallFilters(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, CallExtension::CALL_FILTER_TAG);
         $definition = $container->getDefinition(CallExtension::CALL_CENTER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerCallFilter', array($reference));
+            $definition->addMethodCall('registerCallFilter', [$reference]);
         }
     }
 
     /**
      * Registers all call handlers to the CallCenter.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function processCallHandlers(ContainerBuilder $container)
+    private function processCallHandlers(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, CallExtension::CALL_HANDLER_TAG);
         $definition = $container->getDefinition(CallExtension::CALL_CENTER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerCallHandler', array($reference));
+            $definition->addMethodCall('registerCallHandler', [$reference]);
         }
     }
 
     /**
      * Registers all call result filters to the CallCenter.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function processResultFilters(ContainerBuilder $container)
+    private function processResultFilters(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, CallExtension::RESULT_FILTER_TAG);
         $definition = $container->getDefinition(CallExtension::CALL_CENTER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerResultFilter', array($reference));
+            $definition->addMethodCall('registerResultFilter', [$reference]);
         }
     }
 
     /**
      * Registers all exception handlers to the CallCenter.
-     *
-     * @param ContainerBuilder $container
      */
     private function processExceptionHandlers(ContainerBuilder $container)
     {
@@ -183,7 +170,7 @@ final class CallExtension implements Extension
         $definition = $container->getDefinition(CallExtension::CALL_CENTER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerExceptionHandler', array($reference));
+            $definition->addMethodCall('registerExceptionHandler', [$reference]);
         }
     }
 }

--- a/src/Behat/Testwork/Cli/Command.php
+++ b/src/Behat/Testwork/Cli/Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -24,7 +24,7 @@ final class Command extends BaseCommand
     /**
      * @var Controller[]
      */
-    private $controllers = array();
+    private $controllers = [];
 
     /**
      * Initializes command.
@@ -55,7 +55,7 @@ final class Command extends BaseCommand
      * @param InputInterface  $input  An InputInterface instance
      * @param OutputInterface $output An OutputInterface instance
      *
-     * @return integer Return code of one of the processors or 0 if none of them returned integer
+     * @return int Return code of one of the processors or 0 if none of them returned integer
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Behat/Testwork/Cli/Controller.php
+++ b/src/Behat/Testwork/Cli/Controller.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -25,18 +25,13 @@ interface Controller
 {
     /**
      * Configures command to be executable by the controller.
-     *
-     * @param SymfonyCommand $command
      */
     public function configure(SymfonyCommand $command);
 
     /**
      * Executes controller.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return null|integer
+     * @return null|int
      */
     public function execute(InputInterface $input, OutputInterface $output);
 }

--- a/src/Behat/Testwork/Cli/DebugCommand.php
+++ b/src/Behat/Testwork/Cli/DebugCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -27,10 +27,12 @@ final class DebugCommand extends BaseCommand
      * @var Application
      */
     private $application;
+
     /**
      * @var ConfigurationLoader
      */
     private $configurationLoader;
+
     /**
      * @var ExtensionManager
      */
@@ -38,10 +40,6 @@ final class DebugCommand extends BaseCommand
 
     /**
      * Initialises command.
-     *
-     * @param Application         $application
-     * @param ConfigurationLoader $configurationLoader
-     * @param ExtensionManager    $extensionManager
      */
     public function __construct(
         Application $application,

--- a/src/Behat/Testwork/Cli/DumpReferenceCommand.php
+++ b/src/Behat/Testwork/Cli/DumpReferenceCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -13,7 +13,6 @@ namespace Behat\Testwork\Cli;
 use Behat\Testwork\ServiceContainer\Configuration\ConfigurationTree;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper;
-use Symfony\Component\Config\Definition\ReferenceDumper;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,8 +31,6 @@ final class DumpReferenceCommand extends BaseCommand
 
     /**
      * Initializes dumper.
-     *
-     * @param ExtensionManager $extensionManager
      */
     public function __construct(ExtensionManager $extensionManager)
     {

--- a/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
+++ b/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -43,10 +43,8 @@ final class CliExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ?: new ServiceProcessor();
     }
@@ -94,17 +92,15 @@ final class CliExtension implements Extension
 
     /**
      * Loads application command.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function loadCommand(ContainerBuilder $container)
+    private function loadCommand(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Cli\Command', array('%cli.command.name%', array()));
+        $definition = new Definition('Behat\Testwork\Cli\Command', ['%cli.command.name%', []]);
         $definition->setPublic(true);
         $container->setDefinition(self::COMMAND_ID, $definition);
     }
 
-    protected function loadSyntheticServices(ContainerBuilder $container)
+    private function loadSyntheticServices(ContainerBuilder $container)
     {
         $container->register(self::INPUT_ID)->setSynthetic(true)->setPublic(true);
         $container->register(self::OUTPUT_ID)->setSynthetic(true)->setPublic(true);
@@ -112,10 +108,8 @@ final class CliExtension implements Extension
 
     /**
      * Processes all controllers in container.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function processControllers(ContainerBuilder $container)
+    private function processControllers(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::CONTROLLER_TAG);
         $container->getDefinition(self::COMMAND_ID)->replaceArgument(1, $references);

--- a/src/Behat/Testwork/Counter/Exception/TimerException.php
+++ b/src/Behat/Testwork/Counter/Exception/TimerException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,13 +11,12 @@
 namespace Behat\Testwork\Counter\Exception;
 
 use Behat\Testwork\Exception\TestworkException;
-use LogicException;
 
 /**
  * Represents exception caused by timer handling.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class TimerException extends LogicException implements TestworkException
+final class TimerException extends \LogicException implements TestworkException
 {
 }

--- a/src/Behat/Testwork/Counter/Memory.php
+++ b/src/Behat/Testwork/Counter/Memory.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -20,17 +20,7 @@ final class Memory
     /**
      * @var string[]
      */
-    private $units = array('B', 'Kb', 'Mb', 'Gb', 'Tb');
-
-    /**
-     * Returns current memory usage.
-     *
-     * @return integer
-     */
-    public function getMemoryUsage()
-    {
-        return memory_get_usage();
-    }
+    private $units = ['B', 'Kb', 'Mb', 'Gb', 'Tb'];
 
     /**
      * Presents memory usage in human-readable form.
@@ -43,9 +33,19 @@ final class Memory
     }
 
     /**
+     * Returns current memory usage.
+     *
+     * @return int
+     */
+    public function getMemoryUsage()
+    {
+        return memory_get_usage();
+    }
+
+    /**
      * Humanizes usage information.
      *
-     * @param integer $bytes
+     * @param int $bytes
      *
      * @return string
      */
@@ -57,6 +57,6 @@ final class Memory
             return 'Can not calculate memory usage';
         }
 
-        return sprintf('%.2f%s', ($bytes / pow(1024, floor($e))), $this->units[$e]);
+        return sprintf('%.2f%s', $bytes / pow(1024, floor($e)), $this->units[$e]);
     }
 }

--- a/src/Behat/Testwork/Counter/Timer.php
+++ b/src/Behat/Testwork/Counter/Timer.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -23,10 +23,25 @@ final class Timer
      * @var null|float
      */
     private $starTime;
+
     /**
      * @var null|float
      */
     private $stopTime;
+
+    /**
+     * Returns string representation of time passed.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (!$this->starTime || !$this->stopTime) {
+            return '0m0s';
+        }
+
+        return sprintf('%dm%.2fs', $this->getMinutes(), $this->getSeconds());
+    }
 
     /**
      * Starts timer.
@@ -51,9 +66,8 @@ final class Timer
     }
 
     /**
-     * @return null|float
-     *
      * @throws TimerException If timer has not been started
+     * @return null|float
      */
     public function getTime()
     {
@@ -72,7 +86,7 @@ final class Timer
     /**
      * Returns number of minutes passed.
      *
-     * @return integer
+     * @return int
      */
     public function getMinutes()
     {
@@ -87,19 +101,5 @@ final class Timer
     public function getSeconds()
     {
         return round($this->getTime() - ($this->getMinutes() * 60), 3);
-    }
-
-    /**
-     * Returns string representation of time passed.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        if (!$this->starTime || !$this->stopTime) {
-            return '0m0s';
-        }
-
-        return sprintf('%dm%.2fs', $this->getMinutes(), $this->getSeconds());
     }
 }

--- a/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
+++ b/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -25,26 +25,26 @@ class EnvironmentCall implements Call
      * @var Environment
      */
     private $environment;
+
     /**
      * @var Callee
      */
     private $callee;
+
     /**
      * @var array
      */
     private $arguments;
+
     /**
-     * @var null|integer
+     * @var null|int
      */
     private $errorReportingLevel;
 
     /**
      * Initializes call.
      *
-     * @param Environment  $environment
-     * @param Callee       $callee
-     * @param array        $arguments
-     * @param null|integer $errorReportingLevel
+     * @param null|int $errorReportingLevel
      */
     public function __construct(
         Environment $environment,

--- a/src/Behat/Testwork/Environment/Environment.php
+++ b/src/Behat/Testwork/Environment/Environment.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -29,8 +29,6 @@ interface Environment
 
     /**
      * Creates callable using provided Callee.
-     *
-     * @param Callee $callee
      *
      * @return callable
      */

--- a/src/Behat/Testwork/Environment/EnvironmentManager.php
+++ b/src/Behat/Testwork/Environment/EnvironmentManager.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -27,16 +27,15 @@ final class EnvironmentManager
     /**
      * @var EnvironmentHandler[]
      */
-    private $handlers = array();
+    private $handlers = [];
+
     /**
      * @var EnvironmentReader[]
      */
-    private $readers = array();
+    private $readers = [];
 
     /**
      * Registers environment handler.
-     *
-     * @param EnvironmentHandler $handler
      */
     public function registerEnvironmentHandler(EnvironmentHandler $handler)
     {
@@ -45,8 +44,6 @@ final class EnvironmentManager
 
     /**
      * Registers environment reader.
-     *
-     * @param EnvironmentReader $reader
      */
     public function registerEnvironmentReader(EnvironmentReader $reader)
     {
@@ -56,11 +53,8 @@ final class EnvironmentManager
     /**
      * Builds new environment for provided test suite.
      *
-     * @param Suite $suite
-     *
-     * @return Environment
-     *
      * @throws EnvironmentBuildException
+     * @return Environment
      */
     public function buildEnvironment(Suite $suite)
     {
@@ -79,12 +73,10 @@ final class EnvironmentManager
     /**
      * Creates new isolated test environment using built one.
      *
-     * @param Environment $environment
-     * @param mixed       $testSubject
-     *
-     * @return Environment
+     * @param mixed $testSubject
      *
      * @throws EnvironmentIsolationException If appropriate environment handler is not found
+     * @return Environment
      */
     public function isolateEnvironment(Environment $environment, $testSubject = null)
     {
@@ -103,13 +95,11 @@ final class EnvironmentManager
     /**
      * Reads all callees from environment using registered environment readers.
      *
-     * @param Environment $environment
-     *
      * @return Callee[]
      */
     public function readEnvironmentCallees(Environment $environment)
     {
-        $callees = array();
+        $callees = [];
         foreach ($this->readers as $reader) {
             if ($reader->supportsEnvironment($environment)) {
                 $callees = array_merge($callees, $reader->readEnvironmentCallees($environment));

--- a/src/Behat/Testwork/Environment/Exception/EnvironmentBuildException.php
+++ b/src/Behat/Testwork/Environment/Exception/EnvironmentBuildException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,14 +11,13 @@
 namespace Behat\Testwork\Environment\Exception;
 
 use Behat\Testwork\Suite\Suite;
-use RuntimeException;
 
 /**
  * Represents exception thrown during an environment build process.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class EnvironmentBuildException extends RuntimeException implements EnvironmentException
+final class EnvironmentBuildException extends \RuntimeException implements EnvironmentException
 {
     /**
      * @var Suite
@@ -29,7 +28,6 @@ final class EnvironmentBuildException extends RuntimeException implements Enviro
      * Initializes exception.
      *
      * @param string $message
-     * @param Suite  $suite
      */
     public function __construct($message, Suite $suite)
     {

--- a/src/Behat/Testwork/Environment/Exception/EnvironmentException.php
+++ b/src/Behat/Testwork/Environment/Exception/EnvironmentException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Environment/Exception/EnvironmentIsolationException.php
+++ b/src/Behat/Testwork/Environment/Exception/EnvironmentIsolationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,19 +11,19 @@
 namespace Behat\Testwork\Environment\Exception;
 
 use Behat\Testwork\Environment\Environment;
-use RuntimeException;
 
 /**
  * Represents exception thrown during environment isolation process.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class EnvironmentIsolationException extends RuntimeException implements EnvironmentException
+final class EnvironmentIsolationException extends \RuntimeException implements EnvironmentException
 {
     /**
      * @var Environment
      */
     private $environment;
+
     /**
      * @var mixed
      */
@@ -32,9 +32,8 @@ final class EnvironmentIsolationException extends RuntimeException implements En
     /**
      * Initializes exception.
      *
-     * @param string      $message
-     * @param Environment $environment
-     * @param mixed       $testSubject
+     * @param string $message
+     * @param mixed  $testSubject
      */
     public function __construct($message, Environment $environment, $testSubject = null)
     {

--- a/src/Behat/Testwork/Environment/Exception/EnvironmentReadException.php
+++ b/src/Behat/Testwork/Environment/Exception/EnvironmentReadException.php
@@ -11,14 +11,13 @@
 namespace Behat\Testwork\Environment\Exception;
 
 use Behat\Testwork\Environment\Environment;
-use RuntimeException;
 
 /**
  * Represents exception thrown during an environment read.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class EnvironmentReadException extends RuntimeException implements EnvironmentException
+final class EnvironmentReadException extends \RuntimeException implements EnvironmentException
 {
     /**
      * @var Environment
@@ -28,8 +27,7 @@ final class EnvironmentReadException extends RuntimeException implements Environ
     /**
      * Initializes exception.
      *
-     * @param string      $message
-     * @param Environment $environment
+     * @param string $message
      */
     public function __construct($message, Environment $environment)
     {

--- a/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
+++ b/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -26,16 +26,12 @@ interface EnvironmentHandler
     /**
      * Checks if handler supports provided suite.
      *
-     * @param Suite $suite
-     *
      * @return bool
      */
     public function supportsSuite(Suite $suite);
 
     /**
      * Builds environment object based on provided suite.
-     *
-     * @param Suite $suite
      *
      * @return Environment
      */
@@ -44,8 +40,7 @@ interface EnvironmentHandler
     /**
      * Checks if handler supports provided environment.
      *
-     * @param Environment $environment
-     * @param mixed       $testSubject
+     * @param mixed $testSubject
      *
      * @return bool
      */
@@ -54,8 +49,7 @@ interface EnvironmentHandler
     /**
      * Isolates provided environment.
      *
-     * @param Environment $environment
-     * @param mixed       $testSubject
+     * @param mixed $testSubject
      *
      * @return Environment
      */

--- a/src/Behat/Testwork/Environment/Handler/StaticEnvironmentHandler.php
+++ b/src/Behat/Testwork/Environment/Handler/StaticEnvironmentHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Environment/Reader/EnvironmentReader.php
+++ b/src/Behat/Testwork/Environment/Reader/EnvironmentReader.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -26,16 +26,12 @@ interface EnvironmentReader
     /**
      * Checks if reader supports an environment.
      *
-     * @param Environment $environment
-     *
      * @return bool
      */
     public function supportsEnvironment(Environment $environment);
 
     /**
      * Reads callees from an environment.
-     *
-     * @param Environment $environment
      *
      * @return Callee[]
      */

--- a/src/Behat/Testwork/Environment/ServiceContainer/EnvironmentExtension.php
+++ b/src/Behat/Testwork/Environment/ServiceContainer/EnvironmentExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -44,12 +44,10 @@ final class EnvironmentExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -94,10 +92,8 @@ final class EnvironmentExtension implements Extension
 
     /**
      * Loads environment manager.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function loadManager(ContainerBuilder $container)
+    private function loadManager(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Testwork\Environment\EnvironmentManager');
         $container->setDefinition(self::MANAGER_ID, $definition);
@@ -105,43 +101,37 @@ final class EnvironmentExtension implements Extension
 
     /**
      * Loads static environments handler.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function loadStaticEnvironmentHandler(ContainerBuilder $container)
+    private function loadStaticEnvironmentHandler(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Testwork\Environment\Handler\StaticEnvironmentHandler');
-        $definition->addTag(self::HANDLER_TAG, array('priority' => 0));
+        $definition->addTag(self::HANDLER_TAG, ['priority' => 0]);
         $container->setDefinition(self::HANDLER_TAG . '.static', $definition);
     }
 
     /**
      * Processes all environment handlers.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function processHandlers(ContainerBuilder $container)
+    private function processHandlers(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::HANDLER_TAG);
         $definition = $container->getDefinition(self::MANAGER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerEnvironmentHandler', array($reference));
+            $definition->addMethodCall('registerEnvironmentHandler', [$reference]);
         }
     }
 
     /**
      * Processes all environment readers.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function processReaders(ContainerBuilder $container)
+    private function processReaders(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::READER_TAG);
         $definition = $container->getDefinition(self::MANAGER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerEnvironmentReader', array($reference));
+            $definition->addMethodCall('registerEnvironmentReader', [$reference]);
         }
     }
 }

--- a/src/Behat/Testwork/Environment/StaticEnvironment.php
+++ b/src/Behat/Testwork/Environment/StaticEnvironment.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -27,8 +27,6 @@ class StaticEnvironment implements Environment
 
     /**
      * Initializes environment.
-     *
-     * @param Suite $suite
      */
     public function __construct(Suite $suite)
     {

--- a/src/Behat/Testwork/Event/Event.php
+++ b/src/Behat/Testwork/Event/Event.php
@@ -1,8 +1,14 @@
 <?php
 
-namespace Behat\Testwork\Event;
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
+namespace Behat\Testwork\Event;
 
 class Event extends \Symfony\Contracts\EventDispatcher\Event
 {

--- a/src/Behat/Testwork/EventDispatcher/Cli/SigintController.php
+++ b/src/Behat/Testwork/EventDispatcher/Cli/SigintController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -13,7 +13,6 @@ namespace Behat\Testwork\EventDispatcher\Cli;
 use Behat\Testwork\Cli\Controller;
 use Behat\Testwork\EventDispatcher\Event\AfterExerciseAborted;
 use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,8 +32,6 @@ final class SigintController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(EventDispatcherInterface $eventDispatcher)
     {
@@ -59,7 +56,7 @@ final class SigintController implements Controller
             /**
              * @psalm-suppress UndefinedConstant (SIGINT is defined in pcntl)
              */
-            pcntl_signal(SIGINT, array($this, 'abortExercise'));
+            pcntl_signal(SIGINT, [$this, 'abortExercise']);
         }
     }
 

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseAborted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseAborted.php
@@ -22,6 +22,6 @@ final class AfterExerciseAborted extends ExerciseCompleted
      */
     public function getSpecificationIterators()
     {
-        return array();
+        return [];
     }
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseCompleted.php
@@ -25,10 +25,12 @@ final class AfterExerciseCompleted extends ExerciseCompleted implements AfterTes
      * @var SpecificationIterator[]
      */
     private $specificationIterators;
+
     /**
      * @var TestResult
      */
     private $result;
+
     /**
      * @var Teardown
      */
@@ -38,8 +40,6 @@ final class AfterExerciseCompleted extends ExerciseCompleted implements AfterTes
      * Initializes event.
      *
      * @param SpecificationIterator[] $specificationIterators
-     * @param TestResult              $result
-     * @param Teardown                $teardown
      */
     public function __construct(array $specificationIterators, TestResult $result, Teardown $teardown)
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseSetup.php
@@ -24,6 +24,7 @@ final class AfterExerciseSetup extends ExerciseCompleted implements AfterSetup
      * @var SpecificationIterator[]
      */
     private $specificationIterators;
+
     /**
      * @var Setup
      */
@@ -33,7 +34,6 @@ final class AfterExerciseSetup extends ExerciseCompleted implements AfterSetup
      * Initializes event.
      *
      * @param SpecificationIterator[] $specificationIterators
-     * @param Setup                   $setup
      */
     public function __construct(array $specificationIterators, Setup $setup)
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteSetup.php
@@ -25,6 +25,7 @@ final class AfterSuiteSetup extends SuiteTested implements AfterSetup
      * @var SpecificationIterator
      */
     private $iterator;
+
     /**
      * @var Setup
      */
@@ -32,10 +33,6 @@ final class AfterSuiteSetup extends SuiteTested implements AfterSetup
 
     /**
      * Initializes event.
-     *
-     * @param Environment           $env
-     * @param SpecificationIterator $iterator
-     * @param Setup                 $setup
      */
     public function __construct(Environment $env, SpecificationIterator $iterator, Setup $setup)
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteTested.php
@@ -26,10 +26,12 @@ final class AfterSuiteTested extends SuiteTested implements AfterTested
      * @var SpecificationIterator
      */
     private $iterator;
+
     /**
      * @var TestResult
      */
     private $result;
+
     /**
      * @var Teardown
      */
@@ -37,11 +39,6 @@ final class AfterSuiteTested extends SuiteTested implements AfterTested
 
     /**
      * Initializes event.
-     *
-     * @param Environment           $env
-     * @param SpecificationIterator $iterator
-     * @param TestResult            $result
-     * @param Teardown              $teardown
      */
     public function __construct(
         Environment $env,

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseTeardown.php
@@ -24,6 +24,7 @@ final class BeforeExerciseTeardown extends ExerciseCompleted implements BeforeTe
      * @var SpecificationIterator[]
      */
     private $specificationIterators;
+
     /**
      * @var TestResult
      */
@@ -33,7 +34,6 @@ final class BeforeExerciseTeardown extends ExerciseCompleted implements BeforeTe
      * Initializes event.
      *
      * @param SpecificationIterator[] $specificationIterators
-     * @param TestResult              $result
      */
     public function __construct(array $specificationIterators, TestResult $result)
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTeardown.php
@@ -25,6 +25,7 @@ final class BeforeSuiteTeardown extends SuiteTested implements BeforeTeardown
      * @var SpecificationIterator
      */
     private $iterator;
+
     /**
      * @var TestResult
      */
@@ -32,10 +33,6 @@ final class BeforeSuiteTeardown extends SuiteTested implements BeforeTeardown
 
     /**
      * Initializes event.
-     *
-     * @param Environment           $env
-     * @param SpecificationIterator $iterator
-     * @param TestResult            $result
      */
     public function __construct(Environment $env, SpecificationIterator $iterator, TestResult $result)
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTested.php
@@ -27,9 +27,6 @@ final class BeforeSuiteTested extends SuiteTested implements BeforeTested
 
     /**
      * Initializes event.
-     *
-     * @param Environment           $env
-     * @param SpecificationIterator $iterator
      */
     public function __construct(Environment $env, SpecificationIterator $iterator)
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -12,7 +12,6 @@ namespace Behat\Testwork\EventDispatcher\Event;
 
 use Behat\Testwork\Event\Event;
 use Behat\Testwork\Specification\SpecificationIterator;
-
 
 /**
  * Represents an exercise event.

--- a/src/Behat/Testwork/EventDispatcher/Event/LifecycleEvent.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/LifecycleEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -28,8 +28,6 @@ abstract class LifecycleEvent extends Event
 
     /**
      * Initializes scenario event.
-     *
-     * @param Environment $env
      */
     public function __construct(Environment $env)
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -44,12 +44,10 @@ class EventDispatcherExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -94,23 +92,19 @@ class EventDispatcherExtension implements Extension
     }
 
     /**
-     * Loads sigint controller
-     *
-     * @param ContainerBuilder $container
+     * Loads sigint controller.
      */
     protected function loadSigintController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\EventDispatcher\Cli\SigintController', array(
-            new Reference(EventDispatcherExtension::DISPATCHER_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 9999));
+        $definition = new Definition('Behat\Testwork\EventDispatcher\Cli\SigintController', [
+            new Reference(EventDispatcherExtension::DISPATCHER_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 9999]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.sigint', $definition);
     }
 
     /**
      * Loads event dispatcher.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatcher(ContainerBuilder $container)
     {
@@ -120,38 +114,32 @@ class EventDispatcherExtension implements Extension
 
     /**
      * Loads event-dispatching exercise.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatchingExercise(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\EventDispatcher\Tester\EventDispatchingExercise', array(
+        $definition = new Definition('Behat\Testwork\EventDispatcher\Tester\EventDispatchingExercise', [
             new Reference(TesterExtension::EXERCISE_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
+            new Reference(self::DISPATCHER_ID),
+        ]);
         $definition->addTag(TesterExtension::EXERCISE_WRAPPER_TAG);
         $container->setDefinition(TesterExtension::EXERCISE_WRAPPER_TAG . '.event_dispatching', $definition);
     }
 
     /**
      * Loads event-dispatching suite tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadEventDispatchingSuiteTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\EventDispatcher\Tester\EventDispatchingSuiteTester', array(
+        $definition = new Definition('Behat\Testwork\EventDispatcher\Tester\EventDispatchingSuiteTester', [
             new Reference(TesterExtension::SUITE_TESTER_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
-        $definition->addTag(TesterExtension::SUITE_TESTER_WRAPPER_TAG, array('priority' => -9999));
+            new Reference(self::DISPATCHER_ID),
+        ]);
+        $definition->addTag(TesterExtension::SUITE_TESTER_WRAPPER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::SUITE_TESTER_WRAPPER_TAG . '.event_dispatching', $definition);
     }
 
     /**
      * Registers all available event subscribers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processSubscribers(ContainerBuilder $container)
     {
@@ -159,7 +147,7 @@ class EventDispatcherExtension implements Extension
         $definition = $container->getDefinition(self::DISPATCHER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('addSubscriber', array($reference));
+            $definition->addMethodCall('addSubscriber', [$reference]);
         }
     }
 }

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -14,7 +14,6 @@ use Behat\Testwork\EventDispatcher\Event\AfterExerciseCompleted;
 use Behat\Testwork\EventDispatcher\Event\AfterExerciseSetup;
 use Behat\Testwork\EventDispatcher\Event\BeforeExerciseCompleted;
 use Behat\Testwork\EventDispatcher\Event\BeforeExerciseTeardown;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Tester\Exercise;
 use Behat\Testwork\Tester\Result\TestResult;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -30,6 +29,7 @@ final class EventDispatchingExercise implements Exercise
      * @var Exercise
      */
     private $baseExercise;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -37,9 +37,6 @@ final class EventDispatchingExercise implements Exercise
 
     /**
      * Initializes exercise.
-     *
-     * @param Exercise                 $baseExercise
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(Exercise $baseExercise, EventDispatcherInterface $eventDispatcher)
     {
@@ -68,14 +65,6 @@ final class EventDispatchingExercise implements Exercise
     /**
      * {@inheritdoc}
      */
-    public function test(array $iterators, $skip = false)
-    {
-        return $this->baseExercise->test($iterators, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(array $iterators, $skip, TestResult $result)
     {
         $event = new BeforeExerciseTeardown($iterators, $result);
@@ -89,5 +78,13 @@ final class EventDispatchingExercise implements Exercise
         $this->eventDispatcher->dispatch($event, $event::AFTER);
 
         return $teardown;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(array $iterators, $skip = false)
+    {
+        return $this->baseExercise->test($iterators, $skip);
     }
 }

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
@@ -15,7 +15,6 @@ use Behat\Testwork\EventDispatcher\Event\AfterSuiteSetup;
 use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
 use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTeardown;
 use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTested;
-use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Result\TestResult;
 use Behat\Testwork\Tester\SuiteTester;
@@ -32,6 +31,7 @@ final class EventDispatchingSuiteTester implements SuiteTester
      * @var SuiteTester
      */
     private $baseTester;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -39,9 +39,6 @@ final class EventDispatchingSuiteTester implements SuiteTester
 
     /**
      * Initializes tester.
-     *
-     * @param SuiteTester              $baseTester
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(SuiteTester $baseTester, EventDispatcherInterface $eventDispatcher)
     {
@@ -70,25 +67,25 @@ final class EventDispatchingSuiteTester implements SuiteTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, SpecificationIterator $iterator, $skip = false)
-    {
-        return $this->baseTester->test($env, $iterator, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
     {
         $event = new BeforeSuiteTeardown($env, $iterator, $result);
-        $this->eventDispatcher->dispatch( $event, $event::BEFORE_TEARDOWN);
+        $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
 
         $teardown = $this->baseTester->tearDown($env, $iterator, $skip, $result);
 
         $event = new AfterSuiteTested($env, $iterator, $result, $teardown);
 
-        $this->eventDispatcher->dispatch( $event, $event::AFTER);
+        $this->eventDispatcher->dispatch($event, $event::AFTER);
 
         return $teardown;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, SpecificationIterator $iterator, $skip = false)
+    {
+        return $this->baseTester->test($env, $iterator, $skip);
     }
 }

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php
@@ -27,7 +27,7 @@ final class TestworkEventDispatcher extends EventDispatcher
     /**
      * {@inheritdoc}
      *
-     * @param string|null $eventName
+     * @param null|string $eventName
      */
     public function getListeners($eventName = null): array
     {

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfony5.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfony5.php
@@ -1,8 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Behat\Testwork\EventDispatcher;
-
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -23,7 +29,7 @@ final class TestworkEventDispatcherSymfony5 extends EventDispatcher
     /**
      * {@inheritdoc}
      */
-    public function dispatch($event, string $eventName = null): object
+    public function dispatch($event, ?string $eventName = null): object
     {
         trigger_error(
             'Class "\Behat\Testwork\EventDispatcher\TestworkEventDispatcherSymfony5" is deprecated ' .
@@ -55,7 +61,7 @@ final class TestworkEventDispatcherSymfony5 extends EventDispatcher
             E_USER_DEPRECATED
         );
 
-        if (null == $eventName || self::BEFORE_ALL_EVENTS === $eventName) {
+        if (null === $eventName || self::BEFORE_ALL_EVENTS === $eventName) {
             return parent::getListeners($eventName);
         }
 

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfonyLegacy.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfonyLegacy.php
@@ -1,8 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Behat\Testwork\EventDispatcher;
-
 
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -23,9 +29,8 @@ final class TestworkEventDispatcherSymfonyLegacy extends EventDispatcher
 
     /**
      * {@inheritdoc}
-     *
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, ?Event $event = null)
     {
         trigger_error(
             'Class "\Behat\Testwork\EventDispatcher\TestworkEventDispatcherSymfonyLegacy" is deprecated ' .
@@ -41,6 +46,7 @@ final class TestworkEventDispatcherSymfonyLegacy extends EventDispatcher
         if (method_exists($event, 'setName')) {
             $event->setName($eventName);
         }
+
         /** @scrutinizer ignore-call */
         $this->doDispatch($this->getListeners($eventName), $eventName, $event);
 
@@ -59,7 +65,7 @@ final class TestworkEventDispatcherSymfonyLegacy extends EventDispatcher
             E_USER_DEPRECATED
         );
 
-        if (null == $eventName || self::BEFORE_ALL_EVENTS === $eventName) {
+        if (null === $eventName || self::BEFORE_ALL_EVENTS === $eventName) {
             return parent::getListeners($eventName);
         }
 

--- a/src/Behat/Testwork/Exception/Cli/VerbosityController.php
+++ b/src/Behat/Testwork/Exception/Cli/VerbosityController.php
@@ -30,8 +30,6 @@ final class VerbosityController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param ExceptionPresenter $exceptionPresenter
      */
     public function __construct(ExceptionPresenter $exceptionPresenter)
     {
@@ -40,8 +38,6 @@ final class VerbosityController implements Controller
 
     /**
      * Configures command to be executable by the controller.
-     *
-     * @param Command $command
      */
     public function configure(Command $command)
     {
@@ -50,10 +46,7 @@ final class VerbosityController implements Controller
     /**
      * Executes controller.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return null|integer
+     * @return null|int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Behat/Testwork/Exception/ExceptionPresenter.php
+++ b/src/Behat/Testwork/Exception/ExceptionPresenter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -30,17 +30,18 @@ final class ExceptionPresenter
     /**
      * @var ExceptionStringer[]
      */
-    private $stringers = array();
+    private $stringers = [];
+
     /**
-     * @var integer
+     * @var int
      */
     private $defaultVerbosity = OutputPrinter::VERBOSITY_NORMAL;
 
     /**
      * Initializes presenter.
      *
-     * @param string  $basePath
-     * @param integer $defaultVerbosity
+     * @param string $basePath
+     * @param int    $defaultVerbosity
      */
     public function __construct($basePath = null, $defaultVerbosity = OutputPrinter::VERBOSITY_NORMAL)
     {
@@ -58,8 +59,6 @@ final class ExceptionPresenter
 
     /**
      * Registers exception stringer.
-     *
-     * @param ExceptionStringer $stringer
      */
     public function registerExceptionStringer(ExceptionStringer $stringer)
     {
@@ -69,7 +68,7 @@ final class ExceptionPresenter
     /**
      * Sets default verbosity to a specified level.
      *
-     * @param integer $defaultVerbosity
+     * @param int $defaultVerbosity
      */
     public function setDefaultVerbosity($defaultVerbosity)
     {
@@ -79,12 +78,11 @@ final class ExceptionPresenter
     /**
      * Presents exception as a string.
      *
-     * @param Exception $exception
-     * @param integer   $verbosity
+     * @param int $verbosity
      *
      * @return string
      */
-    public function presentException(Exception $exception, $verbosity = null)
+    public function presentException(\Exception $exception, $verbosity = null)
     {
         $verbosity = $verbosity ?: $this->defaultVerbosity;
 
@@ -105,7 +103,7 @@ final class ExceptionPresenter
         return trim($this->relativizePaths($exception->getMessage()) . ' (' . get_class($exception) . ')');
     }
 
-    private function removeBehatCallsFromTrace(Exception $exception)
+    private function removeBehatCallsFromTrace(\Exception $exception)
     {
         $traceOutput = '';
         foreach ($exception->getTrace() as $i => $trace) {
@@ -122,7 +120,7 @@ final class ExceptionPresenter
         }
 
         return sprintf(
-            "%s: %s in %s:%d%sStack trace:%s%s",
+            '%s: %s in %s:%d%sStack trace:%s%s',
             get_class($exception),
             $exception->getMessage(),
             $exception->getFile(),

--- a/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
+++ b/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -44,12 +44,10 @@ final class ExceptionExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -75,16 +73,17 @@ final class ExceptionExtension implements Extension
         $builder
             ->addDefaultsIfNotSet()
             ->children()
-                ->scalarNode('verbosity')
-                    ->info('Output verbosity')
-                    ->example(sprintf('%d, %d, %d, %d',
-                        OutputPrinter::VERBOSITY_NORMAL,
-                        OutputPrinter::VERBOSITY_VERBOSE,
-                        OutputPrinter::VERBOSITY_VERY_VERBOSE,
-                        OutputPrinter::VERBOSITY_DEBUG
-                    ))
-                    ->defaultValue(OutputPrinter::VERBOSITY_NORMAL)
-                ->end()
+            ->scalarNode('verbosity')
+            ->info('Output verbosity')
+            ->example(sprintf(
+                '%d, %d, %d, %d',
+                OutputPrinter::VERBOSITY_NORMAL,
+                OutputPrinter::VERBOSITY_VERBOSE,
+                OutputPrinter::VERBOSITY_VERY_VERBOSE,
+                OutputPrinter::VERBOSITY_DEBUG
+            ))
+            ->defaultValue(OutputPrinter::VERBOSITY_NORMAL)
+            ->end()
             ->end()
         ;
     }
@@ -110,46 +109,41 @@ final class ExceptionExtension implements Extension
     /**
      * Loads exception presenter.
      *
-     * @param ContainerBuilder $container
-     * @param integer          $verbosity
+     * @param int $verbosity
      */
-    protected function loadPresenter(ContainerBuilder $container, $verbosity)
+    private function loadPresenter(ContainerBuilder $container, $verbosity)
     {
-        $definition = new Definition('Behat\Testwork\Exception\ExceptionPresenter', array(
+        $definition = new Definition('Behat\Testwork\Exception\ExceptionPresenter', [
             '%paths.base%',
-            $verbosity
-        ));
+            $verbosity,
+        ]);
         $container->setDefinition(self::PRESENTER_ID, $definition);
     }
 
     /**
      * Loads default stringer.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function loadDefaultStringers(ContainerBuilder $container)
+    private function loadDefaultStringers(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Testwork\Exception\Stringer\PHPUnitExceptionStringer');
-        $definition->addTag(self::STRINGER_TAG, array('priority' => 50));
+        $definition->addTag(self::STRINGER_TAG, ['priority' => 50]);
         $container->setDefinition(self::STRINGER_TAG . '.phpunit', $definition);
 
         $definition = new Definition('Behat\Testwork\Exception\Stringer\TestworkExceptionStringer');
-        $definition->addTag(self::STRINGER_TAG, array('priority' => 50));
+        $definition->addTag(self::STRINGER_TAG, ['priority' => 50]);
         $container->setDefinition(self::STRINGER_TAG . '.testwork', $definition);
     }
 
     /**
      * Processes all available exception stringers.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function processStringers(ContainerBuilder $container)
+    private function processStringers(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::STRINGER_TAG);
         $definition = $container->getDefinition(self::PRESENTER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerExceptionStringer', array($reference));
+            $definition->addMethodCall('registerExceptionStringer', [$reference]);
         }
     }
 
@@ -158,12 +152,12 @@ final class ExceptionExtension implements Extension
      *
      * @param ContainerBuilder $container
      */
-    protected function loadVerbosityController($container)
+    private function loadVerbosityController($container)
     {
-        $definition = new Definition('Behat\Testwork\Exception\Cli\VerbosityController', array(
-            new Reference(self::PRESENTER_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 9999));
+        $definition = new Definition('Behat\Testwork\Exception\Cli\VerbosityController', [
+            new Reference(self::PRESENTER_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 9999]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.exception_verbosity', $definition);
     }
 }

--- a/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -25,19 +25,16 @@ interface ExceptionStringer
     /**
      * Checks if stringer supports provided exception.
      *
-     * @param Exception $exception
-     *
      * @return bool
      */
-    public function supportsException(Exception $exception);
+    public function supportsException(\Exception $exception);
 
     /**
      * Strings provided exception.
      *
-     * @param Exception $exception
-     * @param integer   $verbosity
+     * @param int $verbosity
      *
      * @return string
      */
-    public function stringException(Exception $exception, $verbosity);
+    public function stringException(\Exception $exception, $verbosity);
 }

--- a/src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -9,8 +9,6 @@
  */
 
 namespace Behat\Testwork\Exception\Stringer;
-
-use Exception;
 
 /**
  * Strings PHPUnit assertion exceptions.
@@ -24,7 +22,7 @@ final class PHPUnitExceptionStringer implements ExceptionStringer
     /**
      * {@inheritdoc}
      */
-    public function supportsException(Exception $exception)
+    public function supportsException(\Exception $exception)
     {
         return $exception instanceof \PHPUnit_Framework_Exception
             || $exception instanceof \PHPUnit\Framework\Exception;
@@ -33,7 +31,7 @@ final class PHPUnitExceptionStringer implements ExceptionStringer
     /**
      * {@inheritdoc}
      */
-    public function stringException(Exception $exception, $verbosity)
+    public function stringException(\Exception $exception, $verbosity)
     {
         if (class_exists('PHPUnit\\Util\\ThrowableToStringMapper')) {
             return trim(\PHPUnit\Util\ThrowableToStringMapper::map($exception));

--- a/src/Behat/Testwork/Exception/Stringer/TestworkExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/TestworkExceptionStringer.php
@@ -12,7 +12,6 @@ namespace Behat\Testwork\Exception\Stringer;
 
 use Behat\Testwork\Call\Exception\CallErrorException;
 use Behat\Testwork\Exception\TestworkException;
-use Exception;
 
 /**
  * Strings Testwork exceptions.
@@ -24,7 +23,7 @@ final class TestworkExceptionStringer implements ExceptionStringer
     /**
      * {@inheritdoc}
      */
-    public function supportsException(Exception $exception)
+    public function supportsException(\Exception $exception)
     {
         return $exception instanceof TestworkException || $exception instanceof CallErrorException;
     }
@@ -32,7 +31,7 @@ final class TestworkExceptionStringer implements ExceptionStringer
     /**
      * {@inheritdoc}
      */
-    public function stringException(Exception $exception, $verbosity)
+    public function stringException(\Exception $exception, $verbosity)
     {
         return trim($exception->getMessage());
     }

--- a/src/Behat/Testwork/Exception/TestworkException.php
+++ b/src/Behat/Testwork/Exception/TestworkException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Filesystem/ConsoleFilesystemLogger.php
+++ b/src/Behat/Testwork/Filesystem/ConsoleFilesystemLogger.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -23,6 +23,7 @@ final class ConsoleFilesystemLogger implements FilesystemLogger
      * @var string
      */
     private $basePath;
+
     /**
      * @var OutputInterface
      */
@@ -31,8 +32,7 @@ final class ConsoleFilesystemLogger implements FilesystemLogger
     /**
      * Initializes logger.
      *
-     * @param string          $basePath
-     * @param OutputInterface $output
+     * @param string $basePath
      */
     public function __construct($basePath, OutputInterface $output)
     {

--- a/src/Behat/Testwork/Filesystem/FilesystemLogger.php
+++ b/src/Behat/Testwork/Filesystem/FilesystemLogger.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Filesystem/ServiceContainer/FilesystemExtension.php
+++ b/src/Behat/Testwork/Filesystem/ServiceContainer/FilesystemExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -69,15 +69,13 @@ final class FilesystemExtension implements Extension
 
     /**
      * Loads filesystem logger.
-     *
-     * @param ContainerBuilder $container
      */
-    protected function loadFilesystemLogger(ContainerBuilder $container)
+    private function loadFilesystemLogger(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Filesystem\ConsoleFilesystemLogger', array(
+        $definition = new Definition('Behat\Testwork\Filesystem\ConsoleFilesystemLogger', [
             '%paths.base%',
-            new Reference(CliExtension::OUTPUT_ID)
-        ));
+            new Reference(CliExtension::OUTPUT_ID),
+        ]);
         $container->setDefinition(self::LOGGER_ID, $definition);
     }
 }

--- a/src/Behat/Testwork/Hook/Call/AfterSuite.php
+++ b/src/Behat/Testwork/Hook/Call/AfterSuite.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Hook/Call/BeforeSuite.php
+++ b/src/Behat/Testwork/Hook/Call/BeforeSuite.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Hook/Call/HookCall.php
+++ b/src/Behat/Testwork/Hook/Call/HookCall.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -29,13 +29,11 @@ final class HookCall extends EnvironmentCall
     /**
      * Initializes hook call.
      *
-     * @param HookScope    $scope
-     * @param Hook         $hook
-     * @param null|integer $errorReportingLevel
+     * @param null|int $errorReportingLevel
      */
     public function __construct(HookScope $scope, Hook $hook, $errorReportingLevel = null)
     {
-        parent::__construct($scope->getEnvironment(), $hook, array($scope), $errorReportingLevel);
+        parent::__construct($scope->getEnvironment(), $hook, [$scope], $errorReportingLevel);
 
         $this->scope = $scope;
     }

--- a/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -40,6 +40,14 @@ abstract class RuntimeFilterableHook extends RuntimeHook implements FilterableHo
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return trim($this->getName() . ' ' . $this->getFilterString());
+    }
+
+    /**
      * Returns hook filter string (if has one).
      *
      * @return null|string
@@ -47,13 +55,5 @@ abstract class RuntimeFilterableHook extends RuntimeHook implements FilterableHo
     public function getFilterString()
     {
         return $this->filterString;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        return trim($this->getName() . ' ' . $this->getFilterString());
     }
 }

--- a/src/Behat/Testwork/Hook/Call/RuntimeHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeHook.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -42,16 +42,16 @@ abstract class RuntimeHook extends RuntimeCallee implements Hook
     /**
      * {@inheritdoc}
      */
-    public function getScopeName()
+    public function __toString()
     {
-        return $this->scopeName;
+        return $this->getName();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function getScopeName()
     {
-        return $this->getName();
+        return $this->scopeName;
     }
 }

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -67,7 +67,6 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
     /**
      * Checks if Feature matches specified filter.
      *
-     * @param Suite  $suite
      * @param string $filterString
      *
      * @return bool

--- a/src/Behat/Testwork/Hook/FilterableHook.php
+++ b/src/Behat/Testwork/Hook/FilterableHook.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -21,8 +21,6 @@ interface FilterableHook extends Hook
 {
     /**
      * Checks that current hook matches provided hook scope.
-     *
-     * @param HookScope $scope
      *
      * @return bool
      */

--- a/src/Behat/Testwork/Hook/Hook.php
+++ b/src/Behat/Testwork/Hook/Hook.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -20,6 +20,13 @@ use Behat\Testwork\Call\Callee;
 interface Hook extends Callee
 {
     /**
+     * Represents hook as a string.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
      * Returns hook name.
      *
      * @return string
@@ -32,11 +39,4 @@ interface Hook extends Callee
      * @return string
      */
     public function getScopeName();
-
-    /**
-     * Represents hook as a string.
-     *
-     * @return string
-     */
-    public function __toString();
 }

--- a/src/Behat/Testwork/Hook/HookDispatcher.php
+++ b/src/Behat/Testwork/Hook/HookDispatcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -27,6 +27,7 @@ final class HookDispatcher
      * @var HookRepository
      */
     private $repository;
+
     /**
      * @var CallCenter
      */
@@ -34,9 +35,6 @@ final class HookDispatcher
 
     /**
      * Initializes hook dispatcher.
-     *
-     * @param HookRepository $repository
-     * @param CallCenter     $callCenter
      */
     public function __construct(HookRepository $repository, CallCenter $callCenter)
     {
@@ -47,13 +45,11 @@ final class HookDispatcher
     /**
      * Dispatches hooks for a specified event.
      *
-     * @param HookScope $scope
-     *
      * @return CallResults
      */
     public function dispatchScopeHooks(HookScope $scope)
     {
-        $results = array();
+        $results = [];
         foreach ($this->repository->getScopeHooks($scope) as $hook) {
             $results[] = $this->dispatchHook($scope, $hook);
         }
@@ -63,9 +59,6 @@ final class HookDispatcher
 
     /**
      * Dispatches single event hook.
-     *
-     * @param HookScope $scope
-     * @param Hook      $hook
      *
      * @return CallResult
      */

--- a/src/Behat/Testwork/Hook/HookRepository.php
+++ b/src/Behat/Testwork/Hook/HookRepository.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -29,8 +29,6 @@ final class HookRepository
 
     /**
      * Initializes repository.
-     *
-     * @param EnvironmentManager $environmentManager
      */
     public function __construct(EnvironmentManager $environmentManager)
     {
@@ -39,8 +37,6 @@ final class HookRepository
 
     /**
      * Returns all available hooks for a specific environment.
-     *
-     * @param Environment $environment
      *
      * @return Hook[]
      */
@@ -56,8 +52,6 @@ final class HookRepository
 
     /**
      * Returns hooks for a specific event.
-     *
-     * @param HookScope $scope
      *
      * @return Hook[]
      */

--- a/src/Behat/Testwork/Hook/Scope/AfterSuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/AfterSuiteScope.php
@@ -10,8 +10,8 @@
 
 namespace Behat\Testwork\Hook\Scope;
 
-use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Result\TestResult;
 
 /**
@@ -25,10 +25,12 @@ final class AfterSuiteScope implements SuiteScope, AfterTestScope
      * @var Environment
      */
     private $environment;
+
     /**
      * @var SpecificationIterator
      */
     private $iterator;
+
     /**
      * @var TestResult
      */
@@ -36,10 +38,6 @@ final class AfterSuiteScope implements SuiteScope, AfterTestScope
 
     /**
      * Initializes scope.
-     *
-     * @param Environment           $environment
-     * @param SpecificationIterator $iterator
-     * @param TestResult            $result
      */
     public function __construct(Environment $environment, SpecificationIterator $iterator, TestResult $result)
     {

--- a/src/Behat/Testwork/Hook/Scope/BeforeSuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/BeforeSuiteScope.php
@@ -10,8 +10,8 @@
 
 namespace Behat\Testwork\Hook\Scope;
 
-use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\Specification\SpecificationIterator;
 
 /**
  * Represents a scope for BeforeSuite hook.
@@ -24,6 +24,7 @@ final class BeforeSuiteScope implements SuiteScope
      * @var Environment
      */
     private $environment;
+
     /**
      * @var SpecificationIterator
      */
@@ -31,9 +32,6 @@ final class BeforeSuiteScope implements SuiteScope
 
     /**
      * Initializes scope.
-     *
-     * @param Environment           $env
-     * @param SpecificationIterator $iterator
      */
     public function __construct(Environment $env, SpecificationIterator $iterator)
     {

--- a/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
+++ b/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -74,43 +74,37 @@ class HookExtension implements Extension
 
     /**
      * Loads hook dispatcher.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadDispatcher(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Hook\HookDispatcher', array(
+        $definition = new Definition('Behat\Testwork\Hook\HookDispatcher', [
             new Reference(self::REPOSITORY_ID),
-            new Reference(CallExtension::CALL_CENTER_ID)
-        ));
+            new Reference(CallExtension::CALL_CENTER_ID),
+        ]);
         $container->setDefinition(self::DISPATCHER_ID, $definition);
     }
 
     /**
      * Loads hook repository.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadRepository(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Hook\HookRepository', array(
-            new Reference(EnvironmentExtension::MANAGER_ID)
-        ));
+        $definition = new Definition('Behat\Testwork\Hook\HookRepository', [
+            new Reference(EnvironmentExtension::MANAGER_ID),
+        ]);
         $container->setDefinition(self::REPOSITORY_ID, $definition);
     }
 
     /**
      * Loads hookable testers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadHookableTesters(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Hook\Tester\HookableSuiteTester', array(
+        $definition = new Definition('Behat\Testwork\Hook\Tester\HookableSuiteTester', [
             new Reference(TesterExtension::SUITE_TESTER_ID),
-            new Reference(self::DISPATCHER_ID)
-        ));
-        $definition->addTag(TesterExtension::SUITE_TESTER_WRAPPER_TAG, array('priority' => 9999));
+            new Reference(self::DISPATCHER_ID),
+        ]);
+        $definition->addTag(TesterExtension::SUITE_TESTER_WRAPPER_TAG, ['priority' => 9999]);
         $container->setDefinition(TesterExtension::SUITE_TESTER_WRAPPER_TAG . '.hookable', $definition);
     }
 }

--- a/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
+++ b/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
@@ -31,6 +31,7 @@ final class HookableSuiteTester implements SuiteTester
      * @var SuiteTester
      */
     private $baseTester;
+
     /**
      * @var HookDispatcher
      */
@@ -38,9 +39,6 @@ final class HookableSuiteTester implements SuiteTester
 
     /**
      * Initializes tester.
-     *
-     * @param SuiteTester    $baseTester
-     * @param HookDispatcher $hookDispatcher
      */
     public function __construct(SuiteTester $baseTester, HookDispatcher $hookDispatcher)
     {
@@ -68,14 +66,6 @@ final class HookableSuiteTester implements SuiteTester
     /**
      * {@inheritdoc}
      */
-    public function test(Environment $env, SpecificationIterator $iterator, $skip)
-    {
-        return $this->baseTester->test($env, $iterator, $skip);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
     {
         $teardown = $this->baseTester->tearDown($env, $iterator, $skip, $result);
@@ -88,5 +78,13 @@ final class HookableSuiteTester implements SuiteTester
         $hookCallResults = $this->hookDispatcher->dispatchScopeHooks($scope);
 
         return new HookedTeardown($teardown, $hookCallResults);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function test(Environment $env, SpecificationIterator $iterator, $skip)
+    {
+        return $this->baseTester->test($env, $iterator, $skip);
     }
 }

--- a/src/Behat/Testwork/Hook/Tester/Setup/HookedSetup.php
+++ b/src/Behat/Testwork/Hook/Tester/Setup/HookedSetup.php
@@ -24,6 +24,7 @@ final class HookedSetup implements Setup
      * @var Setup
      */
     private $setup;
+
     /**
      * @var CallResults
      */
@@ -31,9 +32,6 @@ final class HookedSetup implements Setup
 
     /**
      * Initializes setup.
-     *
-     * @param Setup       $setup
-     * @param CallResults $hookCallResults
      */
     public function __construct(Setup $setup, CallResults $hookCallResults)
     {

--- a/src/Behat/Testwork/Hook/Tester/Setup/HookedTeardown.php
+++ b/src/Behat/Testwork/Hook/Tester/Setup/HookedTeardown.php
@@ -24,6 +24,7 @@ final class HookedTeardown implements Teardown
      * @var Teardown
      */
     private $teardown;
+
     /**
      * @var CallResults
      */
@@ -31,9 +32,6 @@ final class HookedTeardown implements Teardown
 
     /**
      * Initializes setup.
-     *
-     * @param Teardown    $teardown
-     * @param CallResults $hookCallResults
      */
     public function __construct(Teardown $teardown, CallResults $hookCallResults)
     {

--- a/src/Behat/Testwork/Ordering/Cli/OrderController.php
+++ b/src/Behat/Testwork/Ordering/Cli/OrderController.php
@@ -10,10 +10,10 @@
 
 namespace Behat\Testwork\Ordering\Cli;
 
+use Behat\Testwork\Cli\Controller;
 use Behat\Testwork\Ordering\Exception\InvalidOrderException;
 use Behat\Testwork\Ordering\OrderedExercise;
 use Behat\Testwork\Ordering\Orderer\Orderer;
-use Behat\Testwork\Cli\Controller;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * Preloads scenarios and then modifies the order when --order is passed
+ * Preloads scenarios and then modifies the order when --order is passed.
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
  */
@@ -31,20 +31,19 @@ final class OrderController implements Controller
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
+
     /**
      * @var OrderedExercise
      */
     private $exercise;
+
     /**
      * @var array
      */
-    private $orderers = array();
+    private $orderers = [];
 
     /**
      * Initializes controller.
-     *
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param OrderedExercise $exercise
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, OrderedExercise $exercise)
     {
@@ -54,12 +53,13 @@ final class OrderController implements Controller
 
     /**
      * Configures command to be executable by the controller.
-     *
-     * @param SymfonyCommand $command
      */
     public function configure(SymfonyCommand $command)
     {
-        $command->addOption('--order', null, InputOption::VALUE_REQUIRED,
+        $command->addOption(
+            '--order',
+            null,
+            InputOption::VALUE_REQUIRED,
             'Set an order in which to execute the specifications (this will result in slower feedback).'
         );
     }
@@ -67,10 +67,7 @@ final class OrderController implements Controller
     /**
      * Executes controller.
      *
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     *
-     * @return null|integer
+     * @return null|int
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
@@ -81,16 +78,14 @@ final class OrderController implements Controller
         }
 
         if (!array_key_exists($orderer, $this->orderers)) {
-           throw new InvalidOrderException(sprintf("Order option '%s' was not recognised", $orderer));
+            throw new InvalidOrderException(sprintf("Order option '%s' was not recognised", $orderer));
         }
 
         $this->exercise->setOrderer($this->orderers[$orderer]);
     }
 
     /**
-     * Register a new available controller
-     *
-     * @param Orderer $orderer
+     * Register a new available controller.
      */
     public function registerOrderer(Orderer $orderer)
     {

--- a/src/Behat/Testwork/Ordering/Exception/InvalidOrderException.php
+++ b/src/Behat/Testwork/Ordering/Exception/InvalidOrderException.php
@@ -11,12 +11,12 @@
 namespace Behat\Testwork\Ordering\Exception;
 
 use Behat\Testwork\Exception\TestworkException;
-use RuntimeException;
 
 /**
- * Represents exception throw during attempt to prioritise execution with a non-existent algorithm
+ * Represents exception throw during attempt to prioritise execution with a non-existent algorithm.
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
  */
-final class InvalidOrderException extends RuntimeException implements TestworkException
-{}
+final class InvalidOrderException extends \RuntimeException implements TestworkException
+{
+}

--- a/src/Behat/Testwork/Ordering/OrderedExercise.php
+++ b/src/Behat/Testwork/Ordering/OrderedExercise.php
@@ -19,7 +19,7 @@ use Behat\Testwork\Tester\Setup\Setup;
 use Behat\Testwork\Tester\Setup\Teardown;
 
 /**
- * Exercise that is ordered according to a specified algorithm
+ * Exercise that is ordered according to a specified algorithm.
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
  */
@@ -45,9 +45,6 @@ final class OrderedExercise implements Exercise
      */
     private $decoratedExercise;
 
-    /**
-     * @param Exercise $decoratedExercise
-     */
     public function __construct(Exercise $decoratedExercise)
     {
         $this->orderer = new NoopOrderer();
@@ -58,7 +55,7 @@ final class OrderedExercise implements Exercise
      * Sets up exercise for a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param bool $skip
+     * @param bool                    $skip
      *
      * @return Setup
      */
@@ -68,24 +65,10 @@ final class OrderedExercise implements Exercise
     }
 
     /**
-     * Tests suites specifications.
-     *
-     * @param SpecificationIterator[] $iterators
-     * @param bool $skip
-     *
-     * @return TestResult
-     */
-    public function test(array $iterators, $skip)
-    {
-        return $this->decoratedExercise->test($this->order($iterators), $skip);
-    }
-
-    /**
      * Tears down exercise after a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param bool $skip
-     * @param TestResult $result
+     * @param bool                    $skip
      *
      * @return Teardown
      */
@@ -95,9 +78,20 @@ final class OrderedExercise implements Exercise
     }
 
     /**
-     * Replace the algorithm being used for prioritisation
+     * Tests suites specifications.
      *
-     * @param Orderer $orderer
+     * @param SpecificationIterator[] $iterators
+     * @param bool                    $skip
+     *
+     * @return TestResult
+     */
+    public function test(array $iterators, $skip)
+    {
+        return $this->decoratedExercise->test($this->order($iterators), $skip);
+    }
+
+    /**
+     * Replace the algorithm being used for prioritisation.
      */
     public function setOrderer(Orderer $orderer)
     {
@@ -105,12 +99,12 @@ final class OrderedExercise implements Exercise
     }
 
     /**
-     * @param SpecificationIterator[] $iterators
+     * @param  SpecificationIterator[] $iterators
      * @return SpecificationIterator[]
      */
     private function order(array $iterators)
     {
-        if (!$this->ordered || $this->unordered != $iterators) {
+        if (!$this->ordered || $this->unordered !== $iterators) {
             $this->unordered = $iterators;
             $this->ordered = $this->orderer->order($iterators);
         }

--- a/src/Behat/Testwork/Ordering/Orderer/NoopOrderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/NoopOrderer.php
@@ -13,15 +13,14 @@ namespace Behat\Testwork\Ordering\Orderer;
 use Behat\Testwork\Specification\SpecificationIterator;
 
 /**
- * Null implementation of Orderer that does no ordering
+ * Null implementation of Orderer that does no ordering.
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
  */
 final class NoopOrderer implements Orderer
 {
-
     /**
-     * @param SpecificationIterator[] $scenarioIterators
+     * @param  SpecificationIterator[] $scenarioIterators
      * @return SpecificationIterator[]
      */
     public function order(array $scenarioIterators)

--- a/src/Behat/Testwork/Ordering/Orderer/Orderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/Orderer.php
@@ -13,14 +13,14 @@ namespace Behat\Testwork\Ordering\Orderer;
 use Behat\Testwork\Specification\SpecificationIterator;
 
 /**
- * Algorithm for prioritising Specification execution
+ * Algorithm for prioritising Specification execution.
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
  */
 interface Orderer
 {
     /**
-     * @param SpecificationIterator[] $scenarioIterators
+     * @param  SpecificationIterator[] $scenarioIterators
      * @return SpecificationIterator[]
      */
     public function order(array $scenarioIterators);

--- a/src/Behat/Testwork/Ordering/Orderer/RandomOrderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/RandomOrderer.php
@@ -14,14 +14,14 @@ use Behat\Testwork\Specification\SpecificationArrayIterator;
 use Behat\Testwork\Specification\SpecificationIterator;
 
 /**
- * Prioritises Suites and Features into random order
+ * Prioritises Suites and Features into random order.
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
  */
 final class RandomOrderer implements Orderer
 {
     /**
-     * @param SpecificationIterator[] $scenarioIterators
+     * @param  SpecificationIterator[] $scenarioIterators
      * @return SpecificationIterator[]
      */
     public function order(array $scenarioIterators)
@@ -33,12 +33,19 @@ final class RandomOrderer implements Orderer
     }
 
     /**
-     * @param array $scenarioIterators
+     * @return string
+     */
+    public function getName()
+    {
+        return 'random';
+    }
+
+    /**
      * @return array
      */
     private function orderFeatures(array $scenarioIterators)
     {
-        $orderedSuites = array();
+        $orderedSuites = [];
 
         foreach ($scenarioIterators as $scenarioIterator) {
             $orderedSpecifications = iterator_to_array($scenarioIterator);
@@ -50,13 +57,5 @@ final class RandomOrderer implements Orderer
         }
 
         return $orderedSuites;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'random';
     }
 }

--- a/src/Behat/Testwork/Ordering/Orderer/ReverseOrderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/ReverseOrderer.php
@@ -14,31 +14,37 @@ use Behat\Testwork\Specification\SpecificationArrayIterator;
 use Behat\Testwork\Specification\SpecificationIterator;
 
 /**
- * Prioritises Suites and Features into reverse order
+ * Prioritises Suites and Features into reverse order.
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
  */
 final class ReverseOrderer implements Orderer
 {
     /**
-     * @param SpecificationIterator[] $scenarioIterators
+     * @param  SpecificationIterator[] $scenarioIterators
      * @return SpecificationIterator[]
      */
     public function order(array $scenarioIterators)
     {
         $orderedFeatures = $this->orderFeatures($scenarioIterators);
-        $orderedSuites = $this->orderSuites($orderedFeatures);
 
-        return $orderedSuites;
+        return $this->orderSuites($orderedFeatures);
     }
 
     /**
-     * @param array $scenarioIterators
+     * @return string
+     */
+    public function getName()
+    {
+        return 'reverse';
+    }
+
+    /**
      * @return array
      */
     private function orderFeatures(array $scenarioIterators)
     {
-        $orderedSuites = array();
+        $orderedSuites = [];
 
         foreach ($scenarioIterators as $scenarioIterator) {
             $orderedSpecifications = array_reverse(iterator_to_array($scenarioIterator));
@@ -52,19 +58,10 @@ final class ReverseOrderer implements Orderer
     }
 
     /**
-     * @param $orderedSuites
      * @return array
      */
     private function orderSuites($orderedSuites)
     {
         return array_reverse($orderedSuites);
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'reverse';
     }
 }

--- a/src/Behat/Testwork/Ordering/ServiceContainer/OrderingExtension.php
+++ b/src/Behat/Testwork/Ordering/ServiceContainer/OrderingExtension.php
@@ -37,18 +37,14 @@ final class OrderingExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
      * You can modify the container here before it is dumped to PHP code.
-     *
-     * @param ContainerBuilder $container
      *
      * @api
      */
@@ -58,7 +54,7 @@ final class OrderingExtension implements Extension
         $references = $this->processor->findAndSortTaggedServices($container, self::ORDERER_TAG);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerOrderer', array($reference));
+            $definition->addMethodCall('registerOrderer', [$reference]);
         }
     }
 
@@ -79,8 +75,6 @@ final class OrderingExtension implements Extension
      * before any extension `configure()` method is called. This allows extensions
      * to hook into the configuration of other extensions providing such an
      * extension point.
-     *
-     * @param ExtensionManager $extensionManager
      */
     public function initialize(ExtensionManager $extensionManager)
     {
@@ -88,8 +82,6 @@ final class OrderingExtension implements Extension
 
     /**
      * Setups configuration for the extension.
-     *
-     * @param ArrayNodeDefinition $builder
      */
     public function configure(ArrayNodeDefinition $builder)
     {
@@ -97,9 +89,6 @@ final class OrderingExtension implements Extension
 
     /**
      * Loads extension services into temporary container.
-     *
-     * @param ContainerBuilder $container
-     * @param array $config
      */
     public function load(ContainerBuilder $container, array $config)
     {
@@ -110,47 +99,40 @@ final class OrderingExtension implements Extension
 
     /**
      * Loads order controller.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadOrderController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Ordering\Cli\OrderController', array(
+        $definition = new Definition('Behat\Testwork\Ordering\Cli\OrderController', [
             new Reference(EventDispatcherExtension::DISPATCHER_ID),
-            new Reference(TesterExtension::EXERCISE_WRAPPER_TAG . '.ordering')
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 250));
+            new Reference(TesterExtension::EXERCISE_WRAPPER_TAG . '.ordering'),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 250]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.order', $definition);
     }
 
     /**
-     * Loads exercise wrapper that enables ordering
-     *
-     * @param ContainerBuilder $container
+     * Loads exercise wrapper that enables ordering.
      */
     private function loadOrderedExercise(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Ordering\OrderedExercise', array(
-            new Reference(TesterExtension::EXERCISE_ID)
-        ));
-        $definition->addTag(TesterExtension::EXERCISE_WRAPPER_TAG, array('priority' => -9999));
+        $definition = new Definition('Behat\Testwork\Ordering\OrderedExercise', [
+            new Reference(TesterExtension::EXERCISE_ID),
+        ]);
+        $definition->addTag(TesterExtension::EXERCISE_WRAPPER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::EXERCISE_WRAPPER_TAG . '.ordering', $definition);
     }
 
     /**
-     * Defines default orderers
-     *
-     * @param ContainerBuilder $container
+     * Defines default orderers.
      */
     private function loadDefaultOrderers(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Testwork\Ordering\Orderer\ReverseOrderer');
-        $definition->addTag(self::ORDERER_TAG, array('priority' => -9999));
+        $definition->addTag(self::ORDERER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::EXERCISE_WRAPPER_TAG . '.ordering.reverse', $definition);
 
-
         $definition = new Definition('Behat\Testwork\Ordering\Orderer\RandomOrderer');
-        $definition->addTag(self::ORDERER_TAG, array('priority' => -9999));
+        $definition->addTag(self::ORDERER_TAG, ['priority' => -9999]);
         $container->setDefinition(TesterExtension::EXERCISE_WRAPPER_TAG . '.ordering.random', $definition);
     }
 }

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -32,8 +32,6 @@ class OutputController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param OutputManager $manager
      */
     public function __construct(OutputManager $manager)
     {
@@ -47,19 +45,25 @@ class OutputController implements Controller
     {
         $command
             ->addOption(
-                '--format', '-f', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                '--format',
+                '-f',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'How to format tests output. <comment>pretty</comment> is default.' . PHP_EOL .
                 'Available formats are:' . PHP_EOL . $this->getFormatterDescriptions() .
                 'You can use multiple formats at the same time.'
             )
             ->addOption(
-                '--out', '-o', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                '--out',
+                '-o',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Write format output to a file/directory instead of' . PHP_EOL .
                 'STDOUT <comment>(output_path)</comment>. You can also provide different' . PHP_EOL .
                 'outputs to multiple formats.'
             )
             ->addOption(
-                '--format-settings', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                '--format-settings',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Set formatters parameters using json object.' . PHP_EOL .
                 'Keys are parameter names, values are values.'
             );
@@ -79,10 +83,6 @@ class OutputController implements Controller
 
     /**
      * Configures formatters based on container, input and output configurations.
-     *
-     * @param array           $formats
-     * @param InputInterface  $input
-     * @param OutputInterface $output
      */
     protected function configureFormatters(array $formats, InputInterface $input, OutputInterface $output)
     {
@@ -92,8 +92,6 @@ class OutputController implements Controller
 
     /**
      * Enables formatters.
-     *
-     * @param array $formats
      */
     protected function enableFormatters(array $formats)
     {
@@ -107,9 +105,6 @@ class OutputController implements Controller
 
     /**
      * Sets formatters parameters based on input & output.
-     *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
      */
     protected function setFormattersParameters(InputInterface $input, OutputInterface $output)
     {
@@ -151,13 +146,11 @@ class OutputController implements Controller
     /**
      * Initializes multiple formatters with different outputs.
      *
-     * @param array   $formats
-     * @param array   $outputs
      * @param bool $decorated
      */
     private function configureOutputs(array $formats, array $outputs, $decorated = false)
     {
-        if (1 == count($outputs) && !$this->isStandardOutput($outputs[0])) {
+        if (1 === count($outputs) && !$this->isStandardOutput($outputs[0])) {
             $outputPath = $this->locateOutputPath($outputs[0]);
 
             $this->manager->setFormattersParameter('output_path', $outputPath);
@@ -200,10 +193,11 @@ class OutputController implements Controller
      */
     private function isAbsolutePath($file)
     {
-        if ($file[0] == '/' || $file[0] == '\\'
-            || (strlen($file) > 3 && ctype_alpha($file[0])
-                && $file[1] == ':'
-                && ($file[2] == '\\' || $file[2] == '/')
+        if ($file[0] === '/' || $file[0] === '\\'
+            || (
+                strlen($file) > 3 && ctype_alpha($file[0])
+                && $file[1] === ':'
+                && ($file[2] === '\\' || $file[2] === '/')
             )
             || null !== parse_url($file, PHP_URL_SCHEME)
         ) {
@@ -228,7 +222,8 @@ class OutputController implements Controller
                     $comment .= $formatter->getDescription();
 
                     return $comment;
-                }, $this->manager->getFormatters()
+                },
+                $this->manager->getFormatters()
             )
         ) . PHP_EOL;
     }

--- a/src/Behat/Testwork/Output/Exception/BadOutputPathException.php
+++ b/src/Behat/Testwork/Output/Exception/BadOutputPathException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,14 +10,12 @@
 
 namespace Behat\Testwork\Output\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception thrown because user provided bad output path.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class BadOutputPathException extends InvalidArgumentException implements PrinterException
+class BadOutputPathException extends \InvalidArgumentException implements PrinterException
 {
     /**
      * @var string

--- a/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
+++ b/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,14 +10,12 @@
 
 namespace Behat\Testwork\Output\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents an exception thrown because requested formatter is not found.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class FormatterNotFoundException extends InvalidArgumentException implements OutputException
+class FormatterNotFoundException extends \InvalidArgumentException implements OutputException
 {
     /**
      * @var string

--- a/src/Behat/Testwork/Output/Exception/MissingExtensionException.php
+++ b/src/Behat/Testwork/Output/Exception/MissingExtensionException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,13 +10,11 @@
 
 namespace Behat\Testwork\Output\Exception;
 
-use RuntimeException;
-
 /**
  * Represents an exception thrown when a required extension is missing.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class MissingExtensionException extends RuntimeException implements PrinterException
+class MissingExtensionException extends \RuntimeException implements PrinterException
 {
 }

--- a/src/Behat/Testwork/Output/Exception/OutputException.php
+++ b/src/Behat/Testwork/Output/Exception/OutputException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Output/Exception/PrinterException.php
+++ b/src/Behat/Testwork/Output/Exception/PrinterException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Output/Formatter.php
+++ b/src/Behat/Testwork/Output/Formatter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
@@ -10,18 +10,15 @@
 
 namespace Behat\Testwork\Output\Node\EventListener;
 
-use ArrayIterator;
 use Behat\Testwork\Event\Event;
 use Behat\Testwork\Output\Formatter;
-use Countable;
-use IteratorAggregate;
 
 /**
  * Used to compose formatter event listeners.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class ChainEventListener implements EventListener, Countable, IteratorAggregate
+class ChainEventListener implements EventListener, \Countable, \IteratorAggregate
 {
     /**
      * @var EventListener[]
@@ -59,8 +56,8 @@ class ChainEventListener implements EventListener, Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): \ArrayIterator
     {
-        return new ArrayIterator($this->listeners);
+        return new \ArrayIterator($this->listeners);
     }
 }

--- a/src/Behat/Testwork/Output/Node/EventListener/EventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/EventListener.php
@@ -23,9 +23,7 @@ interface EventListener
     /**
      * Notifies listener about an event.
      *
-     * @param Formatter $formatter
-     * @param Event     $event
-     * @param string    $eventName
+     * @param string $eventName
      */
     public function listenEvent(Formatter $formatter, Event $event, $eventName);
 }

--- a/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
@@ -25,10 +25,12 @@ class FireOnlyIfFormatterParameterListener implements EventListener
      * @var string
      */
     private $name;
+
     /**
      * @var mixed
      */
     private $value;
+
     /**
      * @var EventListener
      */
@@ -37,9 +39,8 @@ class FireOnlyIfFormatterParameterListener implements EventListener
     /**
      * Initializes listener.
      *
-     * @param string        $name
-     * @param mixed         $value
-     * @param EventListener $descendant
+     * @param string $name
+     * @param mixed  $value
      */
     public function __construct($name, $value, EventListener $descendant)
     {

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -26,18 +26,22 @@ final class NodeEventListeningFormatter implements Formatter
      * @var OutputPrinter
      */
     private $printer;
+
     /**
      * @var array
      */
     private $parameters;
+
     /**
      * @var EventListener
      */
     private $listener;
+
     /**
      * @var string
      */
     private $name;
+
     /**
      * @var string
      */
@@ -46,11 +50,8 @@ final class NodeEventListeningFormatter implements Formatter
     /**
      * Initializes formatter.
      *
-     * @param string        $name
-     * @param string        $description
-     * @param array         $parameters
-     * @param OutputPrinter $printer
-     * @param EventListener $listener
+     * @param string $name
+     * @param string $description
      */
     public function __construct($name, $description, array $parameters, OutputPrinter $printer, EventListener $listener)
     {
@@ -68,13 +69,12 @@ final class NodeEventListeningFormatter implements Formatter
      */
     public static function getSubscribedEvents()
     {
-        return array(TestworkEventDispatcher::BEFORE_ALL_EVENTS => 'listenEvent');
+        return [TestworkEventDispatcher::BEFORE_ALL_EVENTS => 'listenEvent'];
     }
 
     /**
      * Proxies event to the listener.
      *
-     * @param Event       $event
      * @param null|string $eventName
      */
     public function listenEvent(Event $event, $eventName = null)

--- a/src/Behat/Testwork/Output/OutputManager.php
+++ b/src/Behat/Testwork/Output/OutputManager.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -24,15 +24,14 @@ final class OutputManager
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
+
     /**
      * @var Formatter[]
      */
-    private $formatters = array();
+    private $formatters = [];
 
     /**
      * Initializes manager.
-     *
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(EventDispatcherInterface $eventDispatcher)
     {
@@ -41,8 +40,6 @@ final class OutputManager
 
     /**
      * Registers formatter.
-     *
-     * @param Formatter $formatter
      */
     public function registerFormatter(Formatter $formatter)
     {
@@ -70,9 +67,8 @@ final class OutputManager
      *
      * @param string $name
      *
-     * @return Formatter
-     *
      * @throws FormatterNotFoundException
+     * @return Formatter
      */
     public function getFormatter($name)
     {
@@ -131,7 +127,7 @@ final class OutputManager
      */
     public function disableAllFormatters()
     {
-        array_map(array($this, 'disableFormatter'), array_keys($this->formatters));
+        array_map([$this, 'disableFormatter'], array_keys($this->formatters));
     }
 
     /**
@@ -151,14 +147,17 @@ final class OutputManager
                 $printer->setOutputVerbosity($parameterValue);
 
                 return;
+
             case 'output_path':
                 $printer->setOutputPath($parameterValue);
 
                 return;
+
             case 'output_decorate':
                 $printer->setOutputDecorated($parameterValue);
 
                 return;
+
             case 'output_styles':
                 $printer->setOutputStyles($parameterValue);
 
@@ -172,7 +171,6 @@ final class OutputManager
      * Sets provided formatter parameters.
      *
      * @param string $formatter
-     * @param array  $parameters
      */
     public function setFormatterParameters($formatter, array $parameters)
     {
@@ -196,8 +194,6 @@ final class OutputManager
 
     /**
      * Sets provided parameters to all registered formatters.
-     *
-     * @param array $parameters
      */
     public function setFormattersParameters(array $parameters)
     {

--- a/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
@@ -25,61 +25,11 @@ use Symfony\Component\Console\Output\StreamOutput;
 class ConsoleOutputFactory extends OutputFactory
 {
     /**
-     * Creates output formatter that is used to create a stream.
-     *
-     * @return OutputFormatter
-     */
-    protected function createOutputFormatter()
-    {
-        return new OutputFormatter();
-    }
-
-    /**
-     * Configure output stream parameters.
-     *
-     * @param OutputInterface $output
-     */
-    protected function configureOutputStream(OutputInterface $output)
-    {
-        $verbosity = $this->getOutputVerbosity() ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL;
-        $output->setVerbosity($verbosity);
-
-        if (null !== $this->isOutputDecorated()) {
-            $output->getFormatter()->setDecorated($this->isOutputDecorated());
-        }
-    }
-
-    /**
-     * Returns new output stream.
-     *
-     * Override this method & call flush() to write output in another stream
-     *
-     * @return resource
-     *
-     * @throws BadOutputPathException
-     */
-    protected function createOutputStream()
-    {
-        if (null === $this->getOutputPath()) {
-            $stream = fopen('php://stdout', 'w');
-        } elseif (!is_dir($this->getOutputPath())) {
-            $stream = fopen($this->getOutputPath(), 'w');
-        } else {
-            throw new BadOutputPathException(sprintf(
-                'Filename expected as `output_path` parameter, but got `%s`.',
-                $this->getOutputPath()
-            ), $this->getOutputPath());
-        }
-
-        return $stream;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function createOutput($stream = null)
     {
-        $stream = $stream ? : $this->createOutputStream();
+        $stream = $stream ?: $this->createOutputStream();
         $format = $this->createOutputFormatter();
 
         // set user-defined styles
@@ -108,5 +58,52 @@ class ConsoleOutputFactory extends OutputFactory
         $this->configureOutputStream($output);
 
         return $output;
+    }
+
+    /**
+     * Creates output formatter that is used to create a stream.
+     *
+     * @return OutputFormatter
+     */
+    protected function createOutputFormatter()
+    {
+        return new OutputFormatter();
+    }
+
+    /**
+     * Configure output stream parameters.
+     */
+    protected function configureOutputStream(OutputInterface $output)
+    {
+        $verbosity = $this->getOutputVerbosity() ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL;
+        $output->setVerbosity($verbosity);
+
+        if (null !== $this->isOutputDecorated()) {
+            $output->getFormatter()->setDecorated($this->isOutputDecorated());
+        }
+    }
+
+    /**
+     * Returns new output stream.
+     *
+     * Override this method & call flush() to write output in another stream
+     *
+     * @throws BadOutputPathException
+     * @return resource
+     */
+    protected function createOutputStream()
+    {
+        if (null === $this->getOutputPath()) {
+            $stream = fopen('php://stdout', 'w');
+        } elseif (!is_dir($this->getOutputPath())) {
+            $stream = fopen($this->getOutputPath(), 'w');
+        } else {
+            throw new BadOutputPathException(sprintf(
+                'Filename expected as `output_path` parameter, but got `%s`.',
+                $this->getOutputPath()
+            ), $this->getOutputPath());
+        }
+
+        return $stream;
     }
 }

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -29,17 +29,6 @@ class FilesystemOutputFactory extends OutputFactory
     }
 
     /**
-     * Configure output stream parameters.
-     *
-     * @param OutputInterface $output
-     */
-    protected function configureOutputStream(OutputInterface $output)
-    {
-        $verbosity = $this->getOutputVerbosity() ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL;
-        $output->setVerbosity($verbosity);
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function createOutput($stream = null)
@@ -49,7 +38,8 @@ class FilesystemOutputFactory extends OutputFactory
                 'Directory expected for the `output_path` option, but a filename was given.',
                 $this->getOutputPath()
             );
-        } elseif (!is_dir($this->getOutputPath())) {
+        }
+        if (!is_dir($this->getOutputPath())) {
             mkdir($this->getOutputPath(), 0777, true);
         }
 
@@ -67,5 +57,14 @@ class FilesystemOutputFactory extends OutputFactory
         $this->configureOutputStream($stream);
 
         return $stream;
+    }
+
+    /**
+     * Configure output stream parameters.
+     */
+    protected function configureOutputStream(OutputInterface $output)
+    {
+        $verbosity = $this->getOutputVerbosity() ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL;
+        $output->setVerbosity($verbosity);
     }
 }

--- a/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
@@ -18,25 +18,28 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class OutputFactory
 {
-    public const VERBOSITY_NORMAL       = 1;
-    public const VERBOSITY_VERBOSE      = 2;
+    public const VERBOSITY_NORMAL = 1;
+    public const VERBOSITY_VERBOSE = 2;
     public const VERBOSITY_VERY_VERBOSE = 3;
-    public const VERBOSITY_DEBUG        = 4;
+    public const VERBOSITY_DEBUG = 4;
 
     /**
      * @var null|string
      */
     private $outputPath;
+
     /**
      * @var array
      */
-    private $outputStyles = array();
+    private $outputStyles = [];
+
     /**
      * @var null|bool
      */
-    private $outputDecorated = null;
+    private $outputDecorated;
+
     /**
-     * @var integer
+     * @var int
      */
     private $verbosityLevel = 0;
 
@@ -62,8 +65,6 @@ abstract class OutputFactory
 
     /**
      * Sets output styles.
-     *
-     * @param array $styles
      */
     public function setOutputStyles(array $styles)
     {
@@ -103,7 +104,7 @@ abstract class OutputFactory
     /**
      * Sets output verbosity level.
      *
-     * @param integer $level
+     * @param int $level
      */
     public function setOutputVerbosity($level)
     {
@@ -113,7 +114,7 @@ abstract class OutputFactory
     /**
      * Returns output verbosity level.
      *
-     * @return integer
+     * @return int
      */
     public function getOutputVerbosity()
     {

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -23,21 +23,24 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class JUnitOutputPrinter extends StreamOutputPrinter
 {
-    public const XML_VERSION  = '1.0';
+    public const XML_VERSION = '1.0';
     public const XML_ENCODING = 'UTF-8';
 
     /**
      * @var \DOMDocument
      */
     private $domDocument;
+
     /**
      * @var \DOMElement
      */
     private $currentTestsuite;
+
     /**
      * @var \DOMElement
      */
     private $currentTestcase;
+
     /**
      * @var \DOMElement
      */
@@ -56,7 +59,7 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
      * @param string $name                 The filename (without extension) and default value of the name attribute
      * @param array  $testsuitesAttributes Attributes for the root element
      */
-    public function createNewFile($name, array $testsuitesAttributes = array())
+    public function createNewFile($name, array $testsuitesAttributes = [])
     {
         // This requires the DOM extension to be enabled.
         if (!extension_loaded('dom')) {
@@ -69,29 +72,24 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
 
         $this->testSuites = $this->domDocument->createElement('testsuites');
         $this->domDocument->appendChild($this->testSuites);
-        $this->addAttributesToNode($this->testSuites, array_merge(array('name' => $name), $testsuitesAttributes));
+        $this->addAttributesToNode($this->testSuites, array_merge(['name' => $name], $testsuitesAttributes));
         $this->flush();
     }
 
     /**
      * Adds a new <testsuite> node.
-     *
-     * @param array $testsuiteAttributes
      */
-    public function addTestsuite(array $testsuiteAttributes = array())
+    public function addTestsuite(array $testsuiteAttributes = [])
     {
         $this->currentTestsuite = $this->domDocument->createElement('testsuite');
         $this->testSuites->appendChild($this->currentTestsuite);
         $this->addAttributesToNode($this->currentTestsuite, $testsuiteAttributes);
     }
 
-
     /**
      * Adds a new <testcase> node.
-     *
-     * @param array $testcaseAttributes
      */
-    public function addTestcase(array $testcaseAttributes = array())
+    public function addTestcase(array $testcaseAttributes = [])
     {
         $this->currentTestcase = $this->domDocument->createElement('testcase');
         $this->currentTestsuite->appendChild($this->currentTestcase);
@@ -102,21 +100,13 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
      * Add a testcase child element.
      *
      * @param string $nodeName
-     * @param array  $nodeAttributes
      * @param string $nodeValue
      */
-    public function addTestcaseChild($nodeName, array $nodeAttributes = array(), $nodeValue = null)
+    public function addTestcaseChild($nodeName, array $nodeAttributes = [], $nodeValue = null)
     {
         $childNode = $this->domDocument->createElement($nodeName, $nodeValue ?? '');
         $this->currentTestcase->appendChild($childNode);
         $this->addAttributesToNode($childNode, $nodeAttributes);
-    }
-
-    private function addAttributesToNode(\DOMElement $node, array $attributes)
-    {
-        foreach ($attributes as $name => $value){
-            $node->setAttribute($name, $value ?? '');
-        }
     }
 
     /**
@@ -136,11 +126,11 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
     }
 
     /**
-     * Generate XML from the DOMDocument and parse to the the writing stream
+     * Generate XML from the DOMDocument and parse to the the writing stream.
      */
     public function flush()
     {
-        if($this->domDocument instanceof \DOMDocument){
+        if ($this->domDocument instanceof \DOMDocument) {
             $this->getWritingStream()->write(
                 $this->domDocument->saveXML(null, LIBXML_NOEMPTYTAG),
                 false,
@@ -149,5 +139,12 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
         }
 
         parent::flush();
+    }
+
+    private function addAttributesToNode(\DOMElement $node, array $attributes)
+    {
+        foreach ($attributes as $name => $value) {
+            $node->setAttribute($name, $value ?? '');
+        }
     }
 }

--- a/src/Behat/Testwork/Output/Printer/OutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/OutputPrinter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -20,19 +20,22 @@ interface OutputPrinter
     /**
      * @deprecated since 3.1, to be removed in 4.0
      */
-    public const VERBOSITY_NORMAL       = 1;
+    public const VERBOSITY_NORMAL = 1;
+
     /**
      * @deprecated since 3.1, to be removed in 4.0
      */
-    public const VERBOSITY_VERBOSE      = 2;
+    public const VERBOSITY_VERBOSE = 2;
+
     /**
      * @deprecated since 3.1, to be removed in 4.0
      */
     public const VERBOSITY_VERY_VERBOSE = 3;
+
     /**
      * @deprecated since 3.1, to be removed in 4.0
      */
-    public const VERBOSITY_DEBUG        = 4;
+    public const VERBOSITY_DEBUG = 4;
 
     /**
      * Sets output path.
@@ -52,8 +55,6 @@ interface OutputPrinter
 
     /**
      * Sets output styles.
-     *
-     * @param array $styles
      */
     public function setOutputStyles(array $styles);
 
@@ -85,14 +86,14 @@ interface OutputPrinter
     /**
      * Sets output verbosity level.
      *
-     * @param integer $level
+     * @param int $level
      */
     public function setOutputVerbosity($level);
 
     /**
      * Returns output verbosity level.
      *
-     * @return integer
+     * @return int
      *
      * @deprecated since 3.1, to be removed in 4.0
      */
@@ -101,14 +102,14 @@ interface OutputPrinter
     /**
      * Writes message(s) to output stream.
      *
-     * @param string|array $messages message or array of messages
+     * @param array|string $messages message or array of messages
      */
     public function write($messages);
 
     /**
      * Writes newlined message(s) to output stream.
      *
-     * @param string|array $messages message or array of messages
+     * @param array|string $messages message or array of messages
      */
     public function writeln($messages = '');
 

--- a/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
@@ -23,6 +23,7 @@ class StreamOutputPrinter implements OutputPrinter
      * @var OutputInterface
      */
     private $output;
+
     /**
      * @var OutputFactory
      */
@@ -31,14 +32,6 @@ class StreamOutputPrinter implements OutputPrinter
     public function __construct(OutputFactory $outputFactory)
     {
         $this->outputFactory = $outputFactory;
-    }
-
-    /**
-     * @return OutputFactory
-     */
-    protected function getOutputFactory()
-    {
-        return $this->outputFactory;
     }
 
     /**
@@ -131,6 +124,14 @@ class StreamOutputPrinter implements OutputPrinter
     public function flush()
     {
         $this->output = null;
+    }
+
+    /**
+     * @return OutputFactory
+     */
+    protected function getOutputFactory()
+    {
+        return $this->outputFactory;
     }
 
     /**

--- a/src/Behat/Testwork/Output/ServiceContainer/Formatter/FormatterFactory.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/Formatter/FormatterFactory.php
@@ -21,15 +21,11 @@ interface FormatterFactory
 {
     /**
      * Builds formatter configuration.
-     *
-     * @param ContainerBuilder $container
      */
     public function buildFormatter(ContainerBuilder $container);
 
     /**
      * Processes formatter configuration.
-     *
-     * @param ContainerBuilder $container
      */
     public function processFormatter(ContainerBuilder $container);
 }

--- a/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -42,10 +42,12 @@ final class OutputExtension implements Extension
      * @var string
      */
     private $defaultFormatter;
+
     /**
      * @var FormatterFactory[]
      */
     private $factories;
+
     /**
      * @var ServiceProcessor
      */
@@ -54,21 +56,18 @@ final class OutputExtension implements Extension
     /**
      * Initializes extension.
      *
-     * @param string                $defaultFormatter
-     * @param FormatterFactory[]    $formatterFactories
-     * @param null|ServiceProcessor $processor
+     * @param string             $defaultFormatter
+     * @param FormatterFactory[] $formatterFactories
      */
-    public function __construct($defaultFormatter, array $formatterFactories, ServiceProcessor $processor = null)
+    public function __construct($defaultFormatter, array $formatterFactories, ?ServiceProcessor $processor = null)
     {
         $this->defaultFormatter = $defaultFormatter;
         $this->factories = $formatterFactories;
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
      * Registers formatter factory.
-     *
-     * @param FormatterFactory $factory
      */
     public function registerFormatterFactory(FormatterFactory $factory)
     {
@@ -96,22 +95,22 @@ final class OutputExtension implements Extension
     public function configure(ArrayNodeDefinition $builder)
     {
         $builder
-            ->defaultValue(array($this->defaultFormatter => array('enabled' => true)))
+            ->defaultValue([$this->defaultFormatter => ['enabled' => true]])
             ->useAttributeAsKey('name')
             ->prototype('array')
-                ->beforeNormalization()
-                    ->ifTrue(function ($a) {
-                        return is_array($a) && !isset($a['enabled']);
-                    })
-                    ->then(function ($a) {
-                        return array_merge($a, array('enabled' => true));
-                    })
-                ->end()
-                ->useAttributeAsKey('name')
-                ->treatTrueLike(array('enabled' => true))
-                ->treatNullLike(array('enabled' => true))
-                ->treatFalseLike(array('enabled' => false))
-                ->prototype('variable')->end()
+            ->beforeNormalization()
+            ->ifTrue(function ($a) {
+                return is_array($a) && !isset($a['enabled']);
+            })
+            ->then(function ($a) {
+                return array_merge($a, ['enabled' => true]);
+            })
+            ->end()
+            ->useAttributeAsKey('name')
+            ->treatTrueLike(['enabled' => true])
+            ->treatNullLike(['enabled' => true])
+            ->treatFalseLike(['enabled' => false])
+            ->prototype('variable')->end()
             ->end()
         ;
     }
@@ -137,39 +136,34 @@ final class OutputExtension implements Extension
 
     /**
      * Loads output controller.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadOutputController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Output\Cli\OutputController', array(
-            new Reference(self::MANAGER_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 1000));
+        $definition = new Definition('Behat\Testwork\Output\Cli\OutputController', [
+            new Reference(self::MANAGER_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 1000]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.output', $definition);
     }
 
     /**
      * Loads output manager.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $formatters
      */
     private function loadManager(ContainerBuilder $container, array $formatters)
     {
-        $definition = new Definition('Behat\Testwork\Output\OutputManager', array(
-            new Reference(EventDispatcherExtension::DISPATCHER_ID)
-        ));
+        $definition = new Definition('Behat\Testwork\Output\OutputManager', [
+            new Reference(EventDispatcherExtension::DISPATCHER_ID),
+        ]);
 
         foreach ($formatters as $name => $parameters) {
             if ($parameters['enabled']) {
-                $definition->addMethodCall('enableFormatter', array($name));
+                $definition->addMethodCall('enableFormatter', [$name]);
             } else {
-                $definition->addMethodCall('disableFormatter', array($name));
+                $definition->addMethodCall('disableFormatter', [$name]);
             }
 
             unset($parameters['enabled']);
-            $definition->addMethodCall('setFormatterParameters', array($name, $parameters));
+            $definition->addMethodCall('setFormatterParameters', [$name, $parameters]);
         }
 
         $container->setDefinition(self::MANAGER_ID, $definition);
@@ -177,8 +171,6 @@ final class OutputExtension implements Extension
 
     /**
      * Loads default formatters using registered factories.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadFormatters(ContainerBuilder $container)
     {
@@ -189,8 +181,6 @@ final class OutputExtension implements Extension
 
     /**
      * Processes formatters using registered factories.
-     *
-     * @param ContainerBuilder $container
      */
     private function processFormatters(ContainerBuilder $container)
     {
@@ -201,8 +191,6 @@ final class OutputExtension implements Extension
 
     /**
      * Processes all available output formatters.
-     *
-     * @param ContainerBuilder $container
      */
     private function processDynamicallyRegisteredFormatters(ContainerBuilder $container)
     {
@@ -213,7 +201,7 @@ final class OutputExtension implements Extension
         $definition->setMethodCalls();
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerFormatter', array($reference));
+            $definition->addMethodCall('registerFormatter', [$reference]);
         }
 
         foreach ($previousCalls as $call) {

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -24,22 +24,25 @@ final class ConfigurationLoader
      * @var null|string
      */
     private $configurationPath;
+
     /**
      * @var null|string
      */
     private $environmentVariable;
+
     /**
      * @var bool
      */
     private $profileFound;
+
     /**
      * @var array
      */
-    private $debugInformation = array(
+    private $debugInformation = [
         'environment_variable_name' => 'none',
         'environment_variable_content' => 'none',
-        'configuration_file_path' => 'none'
-    );
+        'configuration_file_path' => 'none',
+    ];
 
     /**
      * Constructs reader.
@@ -98,13 +101,12 @@ final class ConfigurationLoader
      *
      * @param string $profile Profile name
      *
-     * @return array
-     *
      * @throws ConfigurationLoadingException
+     * @return array
      */
     public function loadConfiguration($profile = 'default')
     {
-        $configs = array();
+        $configs = [];
         $this->profileFound = false;
 
         // first is ENV config
@@ -145,13 +147,12 @@ final class ConfigurationLoader
     /**
      * Loads information from environment variable.
      *
-     * @return array
-     *
      * @throws ConfigurationLoadingException If environment variable environment var is set to invalid JSON
+     * @return array
      */
-    protected function loadEnvironmentConfiguration()
+    private function loadEnvironmentConfiguration()
     {
-        $configs = array();
+        $configs = [];
 
         if (!$this->environmentVariable) {
             return $configs;
@@ -184,11 +185,10 @@ final class ConfigurationLoader
      * @param string $configPath Config file path
      * @param string $profile    Profile name
      *
-     * @return array
-     *
      * @throws ConfigurationLoadingException If config file is not found
+     * @return array
      */
-    protected function loadFileConfiguration($configPath, $profile)
+    private function loadFileConfiguration($configPath, $profile)
     {
         if (!is_file($configPath) || !is_readable($configPath)) {
             throw new ConfigurationLoadingException(sprintf('Configuration file `%s` not found.', $configPath));
@@ -204,14 +204,13 @@ final class ConfigurationLoader
      * Loads configs for provided config and profile.
      *
      * @param string $basePath
-     * @param array  $config
      * @param string $profile
      *
      * @return array
      */
     private function loadConfigs($basePath, array $config, $profile)
     {
-        $configs = array();
+        $configs = [];
 
         // first load default profile from current config, but only if custom profile requested
         if ('default' !== $profile && isset($config['default'])) {
@@ -236,14 +235,13 @@ final class ConfigurationLoader
      * Loads all provided imports.
      *
      * @param string $basePath
-     * @param array  $paths
      * @param string $profile
      *
      * @return array
      */
     private function loadImports($basePath, array $paths, $profile)
     {
-        $configs = array();
+        $configs = [];
         foreach ($paths as $path) {
             foreach ($this->parseImport($basePath, $path, $profile) as $importConfig) {
                 $configs[] = $importConfig;
@@ -260,9 +258,8 @@ final class ConfigurationLoader
      * @param string $path
      * @param string $profile
      *
-     * @return array
-     *
      * @throws ConfigurationLoadingException If import file not found
+     * @return array
      */
     private function parseImport($basePath, $path, $profile)
     {

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationTree.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationTree.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -32,6 +32,7 @@ final class ConfigurationTree
     public function getConfigTree(array $extensions)
     {
         $treeBuilder = new TreeBuilder('testwork');
+
         /** @var ArrayNodeDefinition $rootNode */
         $rootNode = $treeBuilder->getRootNode();
 

--- a/src/Behat/Testwork/ServiceContainer/ContainerLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/ContainerLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -27,10 +27,12 @@ final class ContainerLoader
      * @var ExtensionManager
      */
     private $extensionManager;
+
     /**
      * @var ConfigurationTree
      */
     private $configuration;
+
     /**
      * @var Processor
      */
@@ -38,26 +40,19 @@ final class ContainerLoader
 
     /**
      * Initialize extension.
-     *
-     * @param ExtensionManager       $extensionManager
-     * @param null|ConfigurationTree $configuration
-     * @param null|Processor         $processor
      */
     public function __construct(
         ExtensionManager $extensionManager,
-        ConfigurationTree $configuration = null,
-        Processor $processor = null
+        ?ConfigurationTree $configuration = null,
+        ?Processor $processor = null
     ) {
         $this->extensionManager = $extensionManager;
-        $this->configuration = $configuration ? : new ConfigurationTree();
-        $this->processor = $processor ? : new Processor();
+        $this->configuration = $configuration ?: new ConfigurationTree();
+        $this->processor = $processor ?: new Processor();
     }
 
     /**
      * Loads container extension.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $configs
      */
     public function load(ContainerBuilder $container, array $configs)
     {
@@ -70,8 +65,6 @@ final class ContainerLoader
     /**
      * Processes config against extensions.
      *
-     * @param array $configs
-     *
      * @return array
      */
     private function processConfig(array $configs)
@@ -83,9 +76,6 @@ final class ContainerLoader
 
     /**
      * Initializes extensions using provided config.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $configs
      *
      * @return array
      */
@@ -112,16 +102,13 @@ final class ContainerLoader
     /**
      * Loads all extensions into container using provided config.
      *
-     * @param ContainerBuilder $container
-     * @param array            $config
-     *
      * @throws ExtensionException
      */
     private function loadExtensions(ContainerBuilder $container, array $config)
     {
         // Load default extensions first
         foreach ($this->extensionManager->getExtensions() as $extension) {
-            $extensionConfig = array();
+            $extensionConfig = [];
             if (isset($config[$extension->getConfigKey()])) {
                 $extensionConfig = $config[$extension->getConfigKey()];
                 unset($config[$extension->getConfigKey()]);
@@ -134,7 +121,8 @@ final class ContainerLoader
         foreach ($config as $extensionConfigKey => $extensionConfig) {
             if (null === $extension = $this->extensionManager->getExtension($extensionConfigKey)) {
                 throw new ExtensionException(
-                    sprintf('None of the activated extensions use `%s` config section.', $extensionConfigKey), $extensionConfigKey
+                    sprintf('None of the activated extensions use `%s` config section.', $extensionConfigKey),
+                    $extensionConfigKey
                 );
             }
 
@@ -144,17 +132,13 @@ final class ContainerLoader
 
     /**
      * Loads extension configuration.
-     *
-     * @param ContainerBuilder $container
-     * @param Extension        $extension
-     * @param array            $config
      */
     private function loadExtension(ContainerBuilder $container, Extension $extension, array $config)
     {
-        $tempContainer = new ContainerBuilder(new ParameterBag(array(
+        $tempContainer = new ContainerBuilder(new ParameterBag([
             'paths.base' => $container->getParameter('paths.base'),
             'extensions' => $container->getParameter('extensions'),
-        )));
+        ]));
         $tempContainer->addObjectResource($extension);
         $extension->load($container, $config);
         $container->merge($tempContainer);

--- a/src/Behat/Testwork/ServiceContainer/Exception/ConfigurationLoadingException.php
+++ b/src/Behat/Testwork/ServiceContainer/Exception/ConfigurationLoadingException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,13 +10,11 @@
 
 namespace Behat\Testwork\ServiceContainer\Exception;
 
-use InvalidArgumentException;
-
 /**
  * Represents exception thrown during configuration load.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class ConfigurationLoadingException extends InvalidArgumentException implements ServiceContainerException
+final class ConfigurationLoadingException extends \InvalidArgumentException implements ServiceContainerException
 {
 }

--- a/src/Behat/Testwork/ServiceContainer/Exception/ExtensionException.php
+++ b/src/Behat/Testwork/ServiceContainer/Exception/ExtensionException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,14 +10,12 @@
 
 namespace Behat\Testwork\ServiceContainer\Exception;
 
-use RuntimeException;
-
 /**
  * Extension exception.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class ExtensionException extends RuntimeException implements ServiceContainerException
+class ExtensionException extends \RuntimeException implements ServiceContainerException
 {
     /**
      * @var string

--- a/src/Behat/Testwork/ServiceContainer/Exception/ExtensionInitializationException.php
+++ b/src/Behat/Testwork/ServiceContainer/Exception/ExtensionInitializationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/ServiceContainer/Exception/ProcessingException.php
+++ b/src/Behat/Testwork/ServiceContainer/Exception/ProcessingException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,13 +10,11 @@
 
 namespace Behat\Testwork\ServiceContainer\Exception;
 
-use RuntimeException;
-
 /**
  * Represents an exception thrown during processing phase.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class ProcessingException extends RuntimeException implements ServiceContainerException
+final class ProcessingException extends \RuntimeException implements ServiceContainerException
 {
 }

--- a/src/Behat/Testwork/ServiceContainer/Exception/ServiceContainerException.php
+++ b/src/Behat/Testwork/ServiceContainer/Exception/ServiceContainerException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -38,22 +38,17 @@ interface Extension extends CompilerPassInterface
      * before any extension `configure()` method is called. This allows extensions
      * to hook into the configuration of other extensions providing such an
      * extension point.
-     *
-     * @param ExtensionManager $extensionManager
      */
     public function initialize(ExtensionManager $extensionManager);
 
     /**
      * Setups configuration for the extension.
-     *
-     * @param ArrayNodeDefinition $builder
      */
     public function configure(ArrayNodeDefinition $builder);
 
     /**
      * Loads extension services into temporary container.
      *
-     * @param ContainerBuilder     $container
      * @param array<string, mixed> $config
      */
     public function load(ContainerBuilder $container, array $config);

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -23,17 +23,19 @@ final class ExtensionManager
      * @var string
      */
     private $extensionsPath;
+
     /**
      * @var Extension[]
      */
-    private $extensions = array();
+    private $extensions = [];
+
     /**
      * @var Extension[string]
      */
-    private $locatedExtensions = array();
-    private $debugInformation = array(
-        'extensions_list' => array()
-    );
+    private $locatedExtensions = [];
+    private $debugInformation = [
+        'extensions_list' => [],
+    ];
 
     /**
      * Initializes manager.
@@ -81,7 +83,7 @@ final class ExtensionManager
      *
      * @param string $key
      *
-     * @return Extension|null
+     * @return null|Extension
      */
     public function getExtension($key)
     {
@@ -148,9 +150,8 @@ final class ExtensionManager
      *
      * @param string $locator
      *
-     * @return Extension
-     *
      * @throws ExtensionInitializationException
+     * @return Extension
      */
     private function initialize($locator)
     {
@@ -169,26 +170,25 @@ final class ExtensionManager
      *
      * @param string $locator
      *
-     * @return Extension
-     *
      * @throws ExtensionInitializationException
+     * @return Extension
      */
     private function instantiateExtension($locator)
     {
         if (class_exists($class = $locator)) {
-            return new $class;
+            return new $class();
         }
 
         if (class_exists($class = $this->getFullExtensionClass($locator))) {
-            return new $class;
+            return new $class();
         }
 
         if (file_exists($locator)) {
-            return require($locator);
+            return require $locator;
         }
 
         if (file_exists($path = $this->extensionsPath . DIRECTORY_SEPARATOR . $locator)) {
-            return require($path);
+            return require $path;
         }
 
         throw new ExtensionInitializationException(sprintf(

--- a/src/Behat/Testwork/ServiceContainer/ServiceProcessor.php
+++ b/src/Behat/Testwork/ServiceContainer/ServiceProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -25,24 +25,22 @@ final class ServiceProcessor
     /**
      * Finds and sorts (by priority) service references by provided tag.
      *
-     * @param ContainerBuilder $container
-     * @param string           $tag
+     * @param string $tag
      *
      * @return Reference[]
      */
     public function findAndSortTaggedServices(ContainerBuilder $container, $tag)
     {
-        $serviceTags = array();
+        $serviceTags = [];
         foreach ($container->findTaggedServiceIds($tag) as $id => $tags) {
             $firstTags = current($tags);
 
-            $serviceTags[] = array_merge(array('priority' => 0), $firstTags, array('id' => $id));
+            $serviceTags[] = array_merge(['priority' => 0], $firstTags, ['id' => $id]);
         }
 
         usort($serviceTags, function ($tag1, $tag2) { return $tag2['priority'] - $tag1['priority']; });
-        $serviceReferences = array_map(function ($tag) { return new Reference($tag['id']); }, $serviceTags);
 
-        return $serviceReferences;
+        return array_map(function ($tag) { return new Reference($tag['id']); }, $serviceTags);
     }
 
     /**
@@ -51,9 +49,8 @@ final class ServiceProcessor
      * The wrappers are applied by descending priority.
      * The first argument of the wrapper service receives the inner service.
      *
-     * @param ContainerBuilder $container
-     * @param string           $target     The id of the service being decorated
-     * @param string           $wrapperTag The tag used by wrappers
+     * @param string $target     The id of the service being decorated
+     * @param string $wrapperTag The tag used by wrappers
      */
     public function processWrapperServices(ContainerBuilder $container, $target, $wrapperTag)
     {

--- a/src/Behat/Testwork/Specification/GroupedSpecificationIterator.php
+++ b/src/Behat/Testwork/Specification/GroupedSpecificationIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -23,19 +23,20 @@ final class GroupedSpecificationIterator implements SpecificationIterator
      * @var Suite
      */
     private $suite;
+
     /**
      * @var SpecificationIterator[]
      */
     private $iterators;
+
     /**
-     * @var integer
+     * @var int
      */
     private $position = 0;
 
     /**
      * Initializes iterator.
      *
-     * @param Suite                   $suite
      * @param SpecificationIterator[] $specificationIterators
      */
     public function __construct(Suite $suite, array $specificationIterators)
@@ -53,7 +54,7 @@ final class GroupedSpecificationIterator implements SpecificationIterator
      */
     public static function group(array $specificationIterators)
     {
-        $groupedSpecifications = array();
+        $groupedSpecifications = [];
         foreach ($specificationIterators as $specificationIterator) {
             $groupedSpecifications[$specificationIterator->getSuite()->getName()][] = $specificationIterator;
         }
@@ -86,7 +87,7 @@ final class GroupedSpecificationIterator implements SpecificationIterator
             if ($this->iterators[$this->position]->valid()) {
                 break;
             }
-            $this->position++;
+            ++$this->position;
         }
     }
 
@@ -101,7 +102,7 @@ final class GroupedSpecificationIterator implements SpecificationIterator
 
         $this->iterators[$this->position]->next();
         while (!$this->iterators[$this->position]->valid()) {
-            $this->position++;
+            ++$this->position;
 
             if (!isset($this->iterators[$this->position])) {
                 break;

--- a/src/Behat/Testwork/Specification/Locator/SpecificationLocator.php
+++ b/src/Behat/Testwork/Specification/Locator/SpecificationLocator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -33,7 +33,6 @@ interface SpecificationLocator
     /**
      * Locates specifications and wraps them into iterator.
      *
-     * @param Suite  $suite
      * @param string $locator
      *
      * @return SpecificationIterator

--- a/src/Behat/Testwork/Specification/NoSpecificationsIterator.php
+++ b/src/Behat/Testwork/Specification/NoSpecificationsIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,7 +11,6 @@
 namespace Behat\Testwork\Specification;
 
 use Behat\Testwork\Suite\Suite;
-use EmptyIterator;
 
 /**
  * Represents empty specification iterator.
@@ -20,7 +19,7 @@ use EmptyIterator;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class NoSpecificationsIterator extends EmptyIterator implements SpecificationIterator
+final class NoSpecificationsIterator extends \EmptyIterator implements SpecificationIterator
 {
     /**
      * @var Suite
@@ -29,8 +28,6 @@ final class NoSpecificationsIterator extends EmptyIterator implements Specificat
 
     /**
      * Initializes iterator.
-     *
-     * @param Suite $suite
      */
     public function __construct(Suite $suite)
     {

--- a/src/Behat/Testwork/Specification/ServiceContainer/SpecificationExtension.php
+++ b/src/Behat/Testwork/Specification/ServiceContainer/SpecificationExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -41,12 +41,10 @@ final class SpecificationExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -89,8 +87,6 @@ final class SpecificationExtension implements Extension
 
     /**
      * Loads specification finder.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadFinder(ContainerBuilder $container)
     {
@@ -100,8 +96,6 @@ final class SpecificationExtension implements Extension
 
     /**
      * Processes specification locators.
-     *
-     * @param ContainerBuilder $container
      */
     private function processLocators(ContainerBuilder $container)
     {
@@ -109,7 +103,7 @@ final class SpecificationExtension implements Extension
         $definition = $container->getDefinition(self::FINDER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerSpecificationLocator', array($reference));
+            $definition->addMethodCall('registerSpecificationLocator', [$reference]);
         }
     }
 }

--- a/src/Behat/Testwork/Specification/SpecificationArrayIterator.php
+++ b/src/Behat/Testwork/Specification/SpecificationArrayIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,7 +10,6 @@
 
 namespace Behat\Testwork\Specification;
 
-use ArrayIterator;
 use Behat\Testwork\Suite\Suite;
 
 /**
@@ -20,7 +19,7 @@ use Behat\Testwork\Suite\Suite;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-final class SpecificationArrayIterator extends ArrayIterator implements SpecificationIterator
+final class SpecificationArrayIterator extends \ArrayIterator implements SpecificationIterator
 {
     /**
      * @var Suite
@@ -30,10 +29,9 @@ final class SpecificationArrayIterator extends ArrayIterator implements Specific
     /**
      * Initializes iterator.
      *
-     * @param Suite   $suite
      * @param mixed[] $specifications
      */
-    public function __construct(Suite $suite, $specifications = array())
+    public function __construct(Suite $suite, $specifications = [])
     {
         $this->suite = $suite;
 

--- a/src/Behat/Testwork/Specification/SpecificationFinder.php
+++ b/src/Behat/Testwork/Specification/SpecificationFinder.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -23,12 +23,10 @@ final class SpecificationFinder
     /**
      * @var SpecificationLocator[]
      */
-    private $specificationLocators = array();
+    private $specificationLocators = [];
 
     /**
      * Registers specification locator.
-     *
-     * @param SpecificationLocator $locator
      */
     public function registerSpecificationLocator(SpecificationLocator $locator)
     {
@@ -42,7 +40,7 @@ final class SpecificationFinder
      */
     public function getExampleLocators()
     {
-        $examples = array();
+        $examples = [];
         foreach ($this->specificationLocators as $locator) {
             $examples = array_merge($examples, $locator->getLocatorExamples());
         }
@@ -60,7 +58,7 @@ final class SpecificationFinder
      */
     public function findSuitesSpecifications(array $suites, $locator = null)
     {
-        $iterators = array();
+        $iterators = [];
         foreach ($suites as $suite) {
             $iterators = array_merge($iterators, $this->findSuiteSpecifications($suite, $locator));
         }
@@ -71,14 +69,13 @@ final class SpecificationFinder
     /**
      * Creates suite specification iterator for provided locator.
      *
-     * @param Suite       $suite
      * @param null|string $locator
      *
      * @return SpecificationIterator[]
      */
     private function findSuiteSpecifications(Suite $suite, $locator = null)
     {
-        $iterators = array();
+        $iterators = [];
         foreach ($this->specificationLocators as $specificationLocator) {
             $iterators[] = $specificationLocator->locateSpecifications($suite, $locator);
         }

--- a/src/Behat/Testwork/Specification/SpecificationIterator.php
+++ b/src/Behat/Testwork/Specification/SpecificationIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -11,14 +11,13 @@
 namespace Behat\Testwork\Specification;
 
 use Behat\Testwork\Suite\Suite;
-use Iterator;
 
 /**
  * Iterates over test specifications.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-interface SpecificationIterator extends Iterator
+interface SpecificationIterator extends \Iterator
 {
     /**
      * Returns suite that was used to load specifications.

--- a/src/Behat/Testwork/Suite/Cli/InitializationController.php
+++ b/src/Behat/Testwork/Suite/Cli/InitializationController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -29,6 +29,7 @@ final class InitializationController implements Controller
      * @var SuiteRepository
      */
     private $repository;
+
     /**
      * @var SuiteBootstrapper
      */
@@ -36,9 +37,6 @@ final class InitializationController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param SuiteRepository   $repository
-     * @param SuiteBootstrapper $bootstrapper
      */
     public function __construct(SuiteRepository $repository, SuiteBootstrapper $bootstrapper)
     {
@@ -51,7 +49,10 @@ final class InitializationController implements Controller
      */
     public function configure(Command $command)
     {
-        $command->addOption('--init', null, InputOption::VALUE_NONE,
+        $command->addOption(
+            '--init',
+            null,
+            InputOption::VALUE_NONE,
             'Initialize all registered test suites.'
         );
     }

--- a/src/Behat/Testwork/Suite/Cli/SuiteController.php
+++ b/src/Behat/Testwork/Suite/Cli/SuiteController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -29,16 +29,14 @@ final class SuiteController implements Controller
      * @var SuiteRegistry
      */
     private $registry;
+
     /**
      * @var array
      */
-    private $suiteConfigurations = array();
+    private $suiteConfigurations = [];
 
     /**
      * Initializes controller.
-     *
-     * @param SuiteRegistry $registry
-     * @param array         $suiteConfigurations
      */
     public function __construct(SuiteRegistry $registry, array $suiteConfigurations)
     {
@@ -51,7 +49,10 @@ final class SuiteController implements Controller
      */
     public function configure(Command $command)
     {
-        $command->addOption('--suite', '-s', InputOption::VALUE_REQUIRED,
+        $command->addOption(
+            '--suite',
+            '-s',
+            InputOption::VALUE_REQUIRED,
             'Only execute a specific suite.'
         );
     }
@@ -76,7 +77,9 @@ final class SuiteController implements Controller
             }
 
             $this->registry->registerSuiteConfiguration(
-                $name, $config['type'], $config['settings']
+                $name,
+                $config['type'],
+                $config['settings']
             );
         }
     }

--- a/src/Behat/Testwork/Suite/Exception/ParameterNotFoundException.php
+++ b/src/Behat/Testwork/Suite/Exception/ParameterNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Suite/Exception/SuiteConfigurationException.php
+++ b/src/Behat/Testwork/Suite/Exception/SuiteConfigurationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Suite/Exception/SuiteException.php
+++ b/src/Behat/Testwork/Suite/Exception/SuiteException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -12,14 +12,13 @@ namespace Behat\Testwork\Suite\Exception;
 
 use Behat\Testwork\Exception\TestworkException;
 use Exception;
-use InvalidArgumentException;
 
 /**
  * Represents a suite exception.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class SuiteException extends InvalidArgumentException implements TestworkException
+class SuiteException extends \InvalidArgumentException implements TestworkException
 {
     /**
      * @var string
@@ -29,11 +28,10 @@ class SuiteException extends InvalidArgumentException implements TestworkExcepti
     /**
      * Initializes exception.
      *
-     * @param string         $message
-     * @param string         $name
-     * @param Exception|null $previous
+     * @param string $message
+     * @param string $name
      */
-    public function __construct($message, $name, Exception $previous = null)
+    public function __construct($message, $name, ?\Exception $previous = null)
     {
         $this->name = $name;
 

--- a/src/Behat/Testwork/Suite/Exception/SuiteGenerationException.php
+++ b/src/Behat/Testwork/Suite/Exception/SuiteGenerationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Suite/Exception/SuiteNotFoundException.php
+++ b/src/Behat/Testwork/Suite/Exception/SuiteNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Suite/Exception/SuiteSetupException.php
+++ b/src/Behat/Testwork/Suite/Exception/SuiteSetupException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Suite/Generator/GenericSuiteGenerator.php
+++ b/src/Behat/Testwork/Suite/Generator/GenericSuiteGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -22,14 +22,12 @@ final class GenericSuiteGenerator implements SuiteGenerator
     /**
      * @var array
      */
-    private $defaultSettings = array();
+    private $defaultSettings = [];
 
     /**
      * Initializes suite generator.
-     *
-     * @param array $defaultSettings
      */
-    public function __construct(array $defaultSettings = array())
+    public function __construct(array $defaultSettings = [])
     {
         $this->defaultSettings = $defaultSettings;
     }
@@ -52,8 +50,6 @@ final class GenericSuiteGenerator implements SuiteGenerator
 
     /**
      * Merges provided settings into default ones.
-     *
-     * @param array $settings
      *
      * @return array
      */

--- a/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
+++ b/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -26,7 +26,6 @@ interface SuiteGenerator
      * Checks if generator support provided suite type and settings.
      *
      * @param string $type
-     * @param array  $settings
      *
      * @return bool
      */
@@ -36,7 +35,6 @@ interface SuiteGenerator
      * Generate suite with provided name and settings.
      *
      * @param string $suiteName
-     * @param array  $settings
      *
      * @return Suite
      */

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -23,16 +23,16 @@ final class GenericSuite implements Suite
      * @var string
      */
     private $name;
+
     /**
      * @var array
      */
-    private $settings = array();
+    private $settings = [];
 
     /**
      * Initializes suite.
      *
      * @param string $name
-     * @param array  $settings
      */
     public function __construct($name, array $settings)
     {
@@ -77,9 +77,8 @@ final class GenericSuite implements Suite
      *
      * @param string $key
      *
-     * @return mixed
-     *
      * @throws ParameterNotFoundException If setting is not set
+     * @return mixed
      */
     public function getSetting($key)
     {

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -45,12 +45,10 @@ final class SuiteExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -74,55 +72,55 @@ final class SuiteExtension implements Extension
     public function configure(ArrayNodeDefinition $builder)
     {
         $builder
-            ->defaultValue(array('default' => array(
-                'enabled'    => true,
-                'type'       => null,
-                'settings'   => array()
-            )))
-            ->treatNullLike(array())
-            ->treatFalseLike(array())
+            ->defaultValue(['default' => [
+                'enabled' => true,
+                'type' => null,
+                'settings' => [],
+            ]])
+            ->treatNullLike([])
+            ->treatFalseLike([])
             ->useAttributeAsKey('name')
             ->normalizeKeys(false)
             ->prototype('array')
-                ->beforeNormalization()
-                    ->ifTrue(function ($suite) {
-                        return is_array($suite) && count($suite);
-                    })
-                    ->then(function ($suite) {
-                        $suite['settings'] = $suite['settings'] ?? array();
+            ->beforeNormalization()
+            ->ifTrue(function ($suite) {
+                return is_array($suite) && count($suite);
+            })
+            ->then(function ($suite) {
+                $suite['settings'] = $suite['settings'] ?? [];
 
-                        foreach ($suite as $key => $val) {
-                            $suiteKeys = array('enabled', 'type', 'settings');
-                            if (!in_array($key, $suiteKeys)) {
-                                $suite['settings'][$key] = $val;
-                                unset($suite[$key]);
-                            }
-                        }
+                foreach ($suite as $key => $val) {
+                    $suiteKeys = ['enabled', 'type', 'settings'];
+                    if (!in_array($key, $suiteKeys, true)) {
+                        $suite['settings'][$key] = $val;
+                        unset($suite[$key]);
+                    }
+                }
 
-                        return $suite;
-                    })
-                ->end()
-                ->normalizeKeys(false)
-                ->addDefaultsIfNotSet()
-                ->treatTrueLike(array('enabled' => true))
-                ->treatNullLike(array('enabled' => true))
-                ->treatFalseLike(array('enabled' => false))
-                ->children()
-                    ->booleanNode('enabled')
-                        ->info('Enables/disables suite')
-                        ->defaultTrue()
-                    ->end()
-                    ->scalarNode('type')
-                        ->info('Specifies suite type')
-                        ->defaultValue(null)
-                    ->end()
-                    ->arrayNode('settings')
-                        ->info('Specifies suite extra settings')
-                        ->defaultValue(array())
-                        ->useAttributeAsKey('name')
-                        ->prototype('variable')->end()
-                    ->end()
-                ->end()
+                return $suite;
+            })
+            ->end()
+            ->normalizeKeys(false)
+            ->addDefaultsIfNotSet()
+            ->treatTrueLike(['enabled' => true])
+            ->treatNullLike(['enabled' => true])
+            ->treatFalseLike(['enabled' => false])
+            ->children()
+            ->booleanNode('enabled')
+            ->info('Enables/disables suite')
+            ->defaultTrue()
+            ->end()
+            ->scalarNode('type')
+            ->info('Specifies suite type')
+            ->defaultValue(null)
+            ->end()
+            ->arrayNode('settings')
+            ->info('Specifies suite extra settings')
+            ->defaultValue([])
+            ->useAttributeAsKey('name')
+            ->prototype('variable')->end()
+            ->end()
+            ->end()
             ->end()
         ;
     }
@@ -151,22 +149,19 @@ final class SuiteExtension implements Extension
 
     /**
      * Generates and sets suites parameter to container.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $suites
      */
     private function setSuiteConfigurations(ContainerBuilder $container, array $suites)
     {
-        $configuredSuites = array();
+        $configuredSuites = [];
         foreach ($suites as $name => $config) {
             if (!$config['enabled']) {
                 continue;
             }
 
-            $configuredSuites[$name] = array(
-                'type'     => $config['type'],
+            $configuredSuites[$name] = [
+                'type' => $config['type'],
                 'settings' => $config['settings'],
-            );
+            ];
         }
 
         $container->setParameter('suite.configurations', $configuredSuites);
@@ -174,38 +169,32 @@ final class SuiteExtension implements Extension
 
     /**
      * Loads suite registry controller.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadRegistryController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Suite\Cli\SuiteController', array(
+        $definition = new Definition('Behat\Testwork\Suite\Cli\SuiteController', [
             new Reference(self::REGISTRY_ID),
-            '%suite.configurations%'
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 1100));
+            '%suite.configurations%',
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 1100]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.suite', $definition);
     }
 
     /**
      * Loads suite bootstrap controller.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadBootstrapController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Suite\Cli\InitializationController', array(
+        $definition = new Definition('Behat\Testwork\Suite\Cli\InitializationController', [
             new Reference(self::REGISTRY_ID),
-            new Reference(self::BOOTSTRAPPER_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 900));
+            new Reference(self::BOOTSTRAPPER_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 900]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.initialization', $definition);
     }
 
     /**
      * Loads suite registry.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadRegistry(ContainerBuilder $container)
     {
@@ -215,8 +204,6 @@ final class SuiteExtension implements Extension
 
     /**
      * Loads suite bootstrapper.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadBootstrapper(ContainerBuilder $container)
     {
@@ -226,24 +213,20 @@ final class SuiteExtension implements Extension
 
     /**
      * Loads generic suite generator.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadGenericSuiteGenerator(ContainerBuilder $container)
     {
-        $container->setParameter('suite.generic.default_settings', array());
+        $container->setParameter('suite.generic.default_settings', []);
 
-        $definition = new Definition('Behat\Testwork\Suite\Generator\GenericSuiteGenerator', array(
-            '%suite.generic.default_settings%'
-        ));
-        $definition->addTag(SuiteExtension::GENERATOR_TAG, array('priority' => 50));
+        $definition = new Definition('Behat\Testwork\Suite\Generator\GenericSuiteGenerator', [
+            '%suite.generic.default_settings%',
+        ]);
+        $definition->addTag(SuiteExtension::GENERATOR_TAG, ['priority' => 50]);
         $container->setDefinition(SuiteExtension::GENERATOR_TAG . '.generic', $definition);
     }
 
     /**
      * Processes suite generators.
-     *
-     * @param ContainerBuilder $container
      */
     private function processGenerators(ContainerBuilder $container)
     {
@@ -251,14 +234,12 @@ final class SuiteExtension implements Extension
         $definition = $container->getDefinition(self::REGISTRY_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerSuiteGenerator', array($reference));
+            $definition->addMethodCall('registerSuiteGenerator', [$reference]);
         }
     }
 
     /**
      * Processes suite setups.
-     *
-     * @param ContainerBuilder $container
      */
     private function processSetups(ContainerBuilder $container)
     {
@@ -266,7 +247,7 @@ final class SuiteExtension implements Extension
         $definition = $container->getDefinition(self::BOOTSTRAPPER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerSuiteSetup', array($reference));
+            $definition->addMethodCall('registerSuiteSetup', [$reference]);
         }
     }
 }

--- a/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
+++ b/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -25,16 +25,12 @@ interface SuiteSetup
     /**
      * Checks if setup supports provided suite.
      *
-     * @param Suite $suite
-     *
      * @return bool
      */
     public function supportsSuite(Suite $suite);
 
     /**
      * Sets up provided suite.
-     *
-     * @param Suite $suite
      */
     public function setupSuite(Suite $suite);
 }

--- a/src/Behat/Testwork/Suite/Suite.php
+++ b/src/Behat/Testwork/Suite/Suite.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Suite/SuiteBootstrapper.php
+++ b/src/Behat/Testwork/Suite/SuiteBootstrapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -22,12 +22,10 @@ final class SuiteBootstrapper
     /**
      * @var SuiteSetup[]
      */
-    private $setups = array();
+    private $setups = [];
 
     /**
      * Registers suite setup.
-     *
-     * @param SuiteSetup $setup
      */
     public function registerSuiteSetup(SuiteSetup $setup)
     {
@@ -41,13 +39,11 @@ final class SuiteBootstrapper
      */
     public function bootstrapSuites(array $suites)
     {
-        array_map(array($this, 'bootstrapSuite'), $suites);
+        array_map([$this, 'bootstrapSuite'], $suites);
     }
 
     /**
      * Bootstraps provided suite using registered setup.
-     *
-     * @param Suite $suite
      */
     public function bootstrapSuite(Suite $suite)
     {

--- a/src/Behat/Testwork/Suite/SuiteRegistry.php
+++ b/src/Behat/Testwork/Suite/SuiteRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -26,23 +26,24 @@ final class SuiteRegistry implements SuiteRepository
      * @var bool
      */
     private $suitesGenerated = false;
+
     /**
      * @var SuiteGenerator[]
      */
-    private $generators = array();
+    private $generators = [];
+
     /**
      * @var array
      */
-    private $suiteConfigurations = array();
+    private $suiteConfigurations = [];
+
     /**
      * @var Suite[]
      */
-    private $suites = array();
+    private $suites = [];
 
     /**
      * Registers suite generator.
-     *
-     * @param SuiteGenerator $generator
      */
     public function registerSuiteGenerator(SuiteGenerator $generator)
     {
@@ -55,7 +56,6 @@ final class SuiteRegistry implements SuiteRepository
      *
      * @param string $name
      * @param string $type
-     * @param array  $settings
      *
      * @throws SuiteConfigurationException
      */
@@ -68,7 +68,7 @@ final class SuiteRegistry implements SuiteRepository
             ), $name);
         }
 
-        $this->suiteConfigurations[$name] = array($type, $settings);
+        $this->suiteConfigurations[$name] = [$type, $settings];
         $this->suitesGenerated = false;
     }
 
@@ -83,7 +83,7 @@ final class SuiteRegistry implements SuiteRepository
             return $this->suites;
         }
 
-        $this->suites = array();
+        $this->suites = [];
         foreach ($this->suiteConfigurations as $name => $configuration) {
             list($type, $settings) = $configuration;
 
@@ -100,11 +100,9 @@ final class SuiteRegistry implements SuiteRepository
      *
      * @param string $name
      * @param string $type
-     * @param array  $settings
-     *
-     * @return Suite
      *
      * @throws SuiteGenerationException If no appropriate generator found
+     * @return Suite
      */
     private function generateSuite($name, $type, array $settings)
     {

--- a/src/Behat/Testwork/Suite/SuiteRepository.php
+++ b/src/Behat/Testwork/Suite/SuiteRepository.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE

--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -39,18 +39,22 @@ final class ExerciseController implements Controller
      * @var SuiteRepository
      */
     private $suiteRepository;
+
     /**
      * @var SpecificationFinder
      */
     private $specificationFinder;
+
     /**
      * @var Exercise
      */
     private $exercise;
+
     /**
      * @var ResultInterpreter
      */
     private $resultInterpreter;
+
     /**
      * @var bool
      */
@@ -59,11 +63,7 @@ final class ExerciseController implements Controller
     /**
      * Initializes controller.
      *
-     * @param SuiteRepository     $suiteRepository
-     * @param SpecificationFinder $specificationFinder
-     * @param Exercise            $exercise
-     * @param ResultInterpreter   $resultInterpreter
-     * @param bool             $skip
+     * @param bool $skip
      */
     public function __construct(
         SuiteRepository $suiteRepository,
@@ -87,14 +87,20 @@ final class ExerciseController implements Controller
         $locatorsExamples = implode(PHP_EOL, array_map(
             function ($locator) {
                 return '- ' . $locator;
-            }, $this->specificationFinder->getExampleLocators()
+            },
+            $this->specificationFinder->getExampleLocators()
         ));
 
         $command
-            ->addArgument('paths', InputArgument::OPTIONAL,
+            ->addArgument(
+                'paths',
+                InputArgument::OPTIONAL,
                 'Optional path(s) to execute. Could be:' . PHP_EOL . $locatorsExamples
             )
-            ->addOption('--dry-run', null, InputOption::VALUE_NONE,
+            ->addOption(
+                '--dry-run',
+                null,
+                InputOption::VALUE_NONE,
                 'Invokes formatters without executing the tests and hooks.'
             );
     }
@@ -123,8 +129,6 @@ final class ExerciseController implements Controller
     /**
      * Finds exercise specifications.
      *
-     * @param InputInterface $input
-     *
      * @return SpecificationIterator[]
      */
     private function findSpecifications(InputInterface $input)
@@ -135,7 +139,6 @@ final class ExerciseController implements Controller
     /**
      * Tests exercise specifications.
      *
-     * @param InputInterface          $input
      * @param SpecificationIterator[] $specifications
      *
      * @return TestResult

--- a/src/Behat/Testwork/Tester/Cli/StrictController.php
+++ b/src/Behat/Testwork/Tester/Cli/StrictController.php
@@ -29,6 +29,7 @@ final class StrictController implements Controller
      * @var ResultInterpreter
      */
     private $resultInterpreter;
+
     /**
      * @var bool
      */
@@ -37,8 +38,7 @@ final class StrictController implements Controller
     /**
      * Initializes controller.
      *
-     * @param ResultInterpreter $resultInterpreter
-     * @param bool           $strict
+     * @param bool $strict
      */
     public function __construct(ResultInterpreter $resultInterpreter, $strict = false)
     {
@@ -51,7 +51,10 @@ final class StrictController implements Controller
      */
     public function configure(Command $command)
     {
-        $command->addOption('--strict', null, InputOption::VALUE_NONE,
+        $command->addOption(
+            '--strict',
+            null,
+            InputOption::VALUE_NONE,
             'Passes only if all tests are explicitly passing.'
         );
     }

--- a/src/Behat/Testwork/Tester/Exercise.php
+++ b/src/Behat/Testwork/Tester/Exercise.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -26,30 +26,29 @@ interface Exercise
      * Sets up exercise for a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param bool                 $skip
+     * @param bool                    $skip
      *
      * @return Setup
      */
     public function setUp(array $iterators, $skip);
 
     /**
-     * Tests suites specifications.
-     *
-     * @param SpecificationIterator[] $iterators
-     * @param bool                 $skip
-     *
-     * @return TestResult
-     */
-    public function test(array $iterators, $skip);
-
-    /**
      * Tears down exercise after a test.
      *
      * @param SpecificationIterator[] $iterators
-     * @param bool                 $skip
-     * @param TestResult              $result
+     * @param bool                    $skip
      *
      * @return Teardown
      */
     public function tearDown(array $iterators, $skip, TestResult $result);
+
+    /**
+     * Tests suites specifications.
+     *
+     * @param SpecificationIterator[] $iterators
+     * @param bool                    $skip
+     *
+     * @return TestResult
+     */
+    public function test(array $iterators, $skip);
 }

--- a/src/Behat/Testwork/Tester/Result/ExceptionResult.php
+++ b/src/Behat/Testwork/Tester/Result/ExceptionResult.php
@@ -29,7 +29,7 @@ interface ExceptionResult extends TestResult
     /**
      * Returns exception that test result has.
      *
-     * @return null|Exception
+     * @return null|\Exception
      */
     public function getException();
 }

--- a/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
+++ b/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
@@ -18,14 +18,14 @@ namespace Behat\Testwork\Tester\Result;
 final class IntegerTestResult implements TestResult
 {
     /**
-     * @var integer
+     * @var int
      */
     private $resultCode;
 
     /**
      * Initializes test result.
      *
-     * @param integer $resultCode
+     * @param int $resultCode
      */
     public function __construct($resultCode)
     {
@@ -37,7 +37,7 @@ final class IntegerTestResult implements TestResult
      */
     public function isPassed()
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED === $this->getResultCode();
     }
 
     /**

--- a/src/Behat/Testwork/Tester/Result/Interpretation/ResultInterpretation.php
+++ b/src/Behat/Testwork/Tester/Result/Interpretation/ResultInterpretation.php
@@ -25,8 +25,6 @@ interface ResultInterpretation
     /**
      * Checks if provided test result should be considered as a failure.
      *
-     * @param TestResult $result
-     *
      * @return bool
      */
     public function isFailure(TestResult $result);

--- a/src/Behat/Testwork/Tester/Result/ResultInterpreter.php
+++ b/src/Behat/Testwork/Tester/Result/ResultInterpreter.php
@@ -22,12 +22,10 @@ final class ResultInterpreter
     /**
      * @var ResultInterpretation[]
      */
-    private $interpretations = array();
+    private $interpretations = [];
 
     /**
      * Registers result interpretation.
-     *
-     * @param ResultInterpretation $interpretation
      */
     public function registerResultInterpretation(ResultInterpretation $interpretation)
     {
@@ -37,9 +35,7 @@ final class ResultInterpreter
     /**
      * Interprets result as a UNIX return code (0 for success, 1 for failure).
      *
-     * @param TestResult $result
-     *
-     * @return integer
+     * @return int
      */
     public function interpretResult(TestResult $result)
     {

--- a/src/Behat/Testwork/Tester/Result/TestResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -32,7 +32,7 @@ interface TestResult
     /**
      * Returns tester result code.
      *
-     * @return integer
+     * @return int
      */
     public function getResultCode();
 }

--- a/src/Behat/Testwork/Tester/Result/TestResults.php
+++ b/src/Behat/Testwork/Tester/Result/TestResults.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,16 +10,12 @@
 
 namespace Behat\Testwork\Tester\Result;
 
-use ArrayIterator;
-use Countable;
-use IteratorAggregate;
-
 /**
  * Aggregates multiple test results into a collection and provides informational API on top of that.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-final class TestResults implements TestResult, Countable, IteratorAggregate
+final class TestResults implements TestResult, \Countable, \IteratorAggregate
 {
     public const NO_TESTS = -100;
 
@@ -33,7 +29,7 @@ final class TestResults implements TestResult, Countable, IteratorAggregate
      *
      * @param TestResult[] $results
      */
-    public function __construct(array $results = array())
+    public function __construct(array $results = [])
     {
         $this->results = $results;
     }
@@ -43,7 +39,7 @@ final class TestResults implements TestResult, Countable, IteratorAggregate
      */
     public function isPassed()
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED === $this->getResultCode();
     }
 
     /**
@@ -70,9 +66,9 @@ final class TestResults implements TestResult, Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): \ArrayIterator
     {
-        return new ArrayIterator($this->results);
+        return new \ArrayIterator($this->results);
     }
 
     /**

--- a/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
@@ -24,10 +24,12 @@ final class TestWithSetupResult implements TestResult
      * @var Setup
      */
     private $setup;
+
     /**
      * @var TestResult
      */
     private $result;
+
     /**
      * @var Teardown
      */
@@ -35,10 +37,6 @@ final class TestWithSetupResult implements TestResult
 
     /**
      * Initializes test result.
-     *
-     * @param Setup      $setup
-     * @param TestResult $result
-     * @param Teardown   $teardown
      */
     public function __construct(Setup $setup, TestResult $result, Teardown $teardown)
     {
@@ -52,7 +50,7 @@ final class TestWithSetupResult implements TestResult
      */
     public function isPassed()
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED === $this->getResultCode();
     }
 
     /**

--- a/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php
+++ b/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -32,6 +32,7 @@ final class RuntimeExercise implements Exercise
      * @var EnvironmentManager
      */
     private $envManager;
+
     /**
      * @var SuiteTester
      */
@@ -39,9 +40,6 @@ final class RuntimeExercise implements Exercise
 
     /**
      * Initializes tester.
-     *
-     * @param EnvironmentManager $envManager
-     * @param SuiteTester        $suiteTester
      */
     public function __construct(EnvironmentManager $envManager, SuiteTester $suiteTester)
     {
@@ -60,9 +58,17 @@ final class RuntimeExercise implements Exercise
     /**
      * {@inheritdoc}
      */
+    public function tearDown(array $iterators, $skip, TestResult $result)
+    {
+        return new SuccessfulTeardown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function test(array $iterators, $skip = false)
     {
-        $results = array();
+        $results = [];
         foreach (GroupedSpecificationIterator::group($iterators) as $iterator) {
             $environment = $this->envManager->buildEnvironment($iterator->getSuite());
 
@@ -76,13 +82,5 @@ final class RuntimeExercise implements Exercise
         }
 
         return new TestResults($results);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function tearDown(array $iterators, $skip, TestResult $result)
-    {
-        return new SuccessfulTeardown();
     }
 }

--- a/src/Behat/Testwork/Tester/Runtime/RuntimeSuiteTester.php
+++ b/src/Behat/Testwork/Tester/Runtime/RuntimeSuiteTester.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -35,8 +35,6 @@ final class RuntimeSuiteTester implements SuiteTester
 
     /**
      * Initializes tester.
-     *
-     * @param SpecificationTester $specTester
      */
     public function __construct(SpecificationTester $specTester)
     {
@@ -54,9 +52,17 @@ final class RuntimeSuiteTester implements SuiteTester
     /**
      * {@inheritdoc}
      */
+    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
+    {
+        return new SuccessfulTeardown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function test(Environment $env, SpecificationIterator $iterator, $skip = false)
     {
-        $results = array();
+        $results = [];
         foreach ($iterator as $specification) {
             $setup = $this->specTester->setUp($env, $specification, $skip);
             $localSkip = !$setup->isSuccessful() || $skip;
@@ -68,13 +74,5 @@ final class RuntimeSuiteTester implements SuiteTester
         }
 
         return new TestResults($results);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
-    {
-        return new SuccessfulTeardown();
     }
 }

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -38,7 +38,7 @@ abstract class TesterExtension implements Extension
     public const RESULT_INTERPRETER_ID = 'tester.result.interpreter';
 
     /**
-     * Available extension points
+     * Available extension points.
      */
     public const EXERCISE_WRAPPER_TAG = 'tester.exercise.wrapper';
     public const SUITE_TESTER_WRAPPER_TAG = 'tester.suite.wrapper';
@@ -52,12 +52,10 @@ abstract class TesterExtension implements Extension
 
     /**
      * Initializes extension.
-     *
-     * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
-        $this->processor = $processor ? : new ServiceProcessor();
+        $this->processor = $processor ?: new ServiceProcessor();
     }
 
     /**
@@ -83,14 +81,14 @@ abstract class TesterExtension implements Extension
         $builder
             ->addDefaultsIfNotSet()
             ->children()
-                ->booleanNode('strict')
-                    ->info('Sets the strict mode for result interpretation')
-                    ->defaultFalse()
-                ->end()
-                ->booleanNode('skip')
-                    ->info('Tells tester to skip all tests')
-                    ->defaultFalse()
-                ->end()
+            ->booleanNode('strict')
+            ->info('Sets the strict mode for result interpretation')
+            ->defaultFalse()
+            ->end()
+            ->booleanNode('skip')
+            ->info('Tells tester to skip all tests')
+            ->defaultFalse()
+            ->end()
             ->end()
         ;
     }
@@ -122,42 +120,38 @@ abstract class TesterExtension implements Extension
     /**
      * Loads exercise cli controllers.
      *
-     * @param ContainerBuilder $container
-     * @param bool          $skip
+     * @param bool $skip
      */
     protected function loadExerciseController(ContainerBuilder $container, $skip = false)
     {
-        $definition = new Definition('Behat\Testwork\Tester\Cli\ExerciseController', array(
+        $definition = new Definition('Behat\Testwork\Tester\Cli\ExerciseController', [
             new Reference(SuiteExtension::REGISTRY_ID),
             new Reference(SpecificationExtension::FINDER_ID),
             new Reference(self::EXERCISE_ID),
             new Reference(self::RESULT_INTERPRETER_ID),
-            $skip
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 0));
+            $skip,
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 0]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.exercise', $definition);
     }
 
     /**
      * Loads exercise cli controllers.
      *
-     * @param ContainerBuilder $container
-     * @param bool          $strict
+     * @param bool $strict
      */
     protected function loadStrictController(ContainerBuilder $container, $strict = false)
     {
-        $definition = new Definition('Behat\Testwork\Tester\Cli\StrictController', array(
+        $definition = new Definition('Behat\Testwork\Tester\Cli\StrictController', [
             new Reference(self::RESULT_INTERPRETER_ID),
-            $strict
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 300));
+            $strict,
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 300]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.strict', $definition);
     }
 
     /**
-     * Loads result interpreter controller
-     *
-     * @param ContainerBuilder $container
+     * Loads result interpreter controller.
      */
     protected function loadResultInterpreter(ContainerBuilder $container)
     {
@@ -171,42 +165,34 @@ abstract class TesterExtension implements Extension
 
     /**
      * Loads exercise tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadExercise(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Tester\Runtime\RuntimeExercise', array(
+        $definition = new Definition('Behat\Testwork\Tester\Runtime\RuntimeExercise', [
             new Reference(EnvironmentExtension::MANAGER_ID),
-            new Reference(self::SUITE_TESTER_ID)
-        ));
+            new Reference(self::SUITE_TESTER_ID),
+        ]);
         $container->setDefinition(self::EXERCISE_ID, $definition);
     }
 
     /**
      * Loads suite tester.
-     *
-     * @param ContainerBuilder $container
      */
     protected function loadSuiteTester(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Tester\Runtime\RuntimeSuiteTester', array(
-            new Reference(self::SPECIFICATION_TESTER_ID)
-        ));
+        $definition = new Definition('Behat\Testwork\Tester\Runtime\RuntimeSuiteTester', [
+            new Reference(self::SPECIFICATION_TESTER_ID),
+        ]);
         $container->setDefinition(self::SUITE_TESTER_ID, $definition);
     }
 
     /**
      * Loads specification tester.
-     *
-     * @param ContainerBuilder $container
      */
     abstract protected function loadSpecificationTester(ContainerBuilder $container);
 
     /**
      * Processes all registered exercise wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processExerciseWrappers(ContainerBuilder $container)
     {
@@ -215,8 +201,6 @@ abstract class TesterExtension implements Extension
 
     /**
      * Processes all registered suite tester wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processSuiteTesterWrappers(ContainerBuilder $container)
     {
@@ -225,8 +209,6 @@ abstract class TesterExtension implements Extension
 
     /**
      * Processes all registered specification tester wrappers.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processSpecificationTesterWrappers(ContainerBuilder $container)
     {
@@ -235,8 +217,6 @@ abstract class TesterExtension implements Extension
 
     /**
      * Processes all registered result interpretations.
-     *
-     * @param ContainerBuilder $container
      */
     protected function processResultInterpretations(ContainerBuilder $container)
     {
@@ -244,7 +224,7 @@ abstract class TesterExtension implements Extension
         $definition = $container->getDefinition(self::RESULT_INTERPRETER_ID);
 
         foreach ($references as $reference) {
-            $definition->addMethodCall('registerResultInterpretation', array($reference));
+            $definition->addMethodCall('registerResultInterpretation', [$reference]);
         }
     }
 }

--- a/src/Behat/Testwork/Tester/SpecificationTester.php
+++ b/src/Behat/Testwork/Tester/SpecificationTester.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -25,34 +25,30 @@ interface SpecificationTester
     /**
      * Sets up specification for a test.
      *
-     * @param Environment $env
-     * @param mixed       $spec
-     * @param bool     $skip
+     * @param mixed $spec
+     * @param bool  $skip
      *
      * @return Setup
      */
     public function setUp(Environment $env, $spec, $skip);
 
     /**
-     * Tests provided specification.
-     *
-     * @param Environment $env
-     * @param mixed       $spec
-     * @param bool     $skip
-     *
-     * @return TestResult
-     */
-    public function test(Environment $env, $spec, $skip);
-
-    /**
      * Tears down specification after a test.
      *
-     * @param Environment $env
-     * @param mixed       $spec
-     * @param bool     $skip
-     * @param TestResult  $result
+     * @param mixed $spec
+     * @param bool  $skip
      *
      * @return Teardown
      */
     public function tearDown(Environment $env, $spec, $skip, TestResult $result);
+
+    /**
+     * Tests provided specification.
+     *
+     * @param mixed $spec
+     * @param bool  $skip
+     *
+     * @return TestResult
+     */
+    public function test(Environment $env, $spec, $skip);
 }

--- a/src/Behat/Testwork/Tester/SuiteTester.php
+++ b/src/Behat/Testwork/Tester/SuiteTester.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -26,34 +26,27 @@ interface SuiteTester
     /**
      * Sets up suite for a test.
      *
-     * @param Environment           $env
-     * @param SpecificationIterator $iterator
-     * @param bool               $skip
+     * @param bool $skip
      *
      * @return Setup
      */
     public function setUp(Environment $env, SpecificationIterator $iterator, $skip);
 
     /**
-     * Tests provided suite specifications.
-     *
-     * @param Environment           $env
-     * @param SpecificationIterator $iterator
-     * @param bool               $skip
-     *
-     * @return TestResult
-     */
-    public function test(Environment $env, SpecificationIterator $iterator, $skip);
-
-    /**
      * Tears down suite after a test.
      *
-     * @param Environment           $env
-     * @param SpecificationIterator $iterator
-     * @param bool               $skip
-     * @param TestResult            $result
+     * @param bool $skip
      *
      * @return Teardown
      */
     public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result);
+
+    /**
+     * Tests provided suite specifications.
+     *
+     * @param bool $skip
+     *
+     * @return TestResult
+     */
+    public function test(Environment $env, SpecificationIterator $iterator, $skip);
 }

--- a/src/Behat/Testwork/Translator/Cli/LanguageController.php
+++ b/src/Behat/Testwork/Translator/Cli/LanguageController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -31,8 +31,6 @@ final class LanguageController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param Translator $translator
      */
     public function __construct(Translator $translator)
     {
@@ -44,7 +42,10 @@ final class LanguageController implements Controller
      */
     public function configure(Command $command)
     {
-        $command->addOption('--lang', null, InputOption::VALUE_REQUIRED,
+        $command->addOption(
+            '--lang',
+            null,
+            InputOption::VALUE_REQUIRED,
             'Print output in particular language.'
         );
     }

--- a/src/Behat/Testwork/Translator/ServiceContainer/TranslatorExtension.php
+++ b/src/Behat/Testwork/Translator/ServiceContainer/TranslatorExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Behat Testwork.
+ * This file is part of the Behat.
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -55,14 +55,14 @@ final class TranslatorExtension implements Extension
         $builder
             ->addDefaultsIfNotSet()
             ->children()
-                ->scalarNode('locale')
-                    ->info('Sets output locale for the tester')
-                    ->defaultValue($defaultLanguage)
-                ->end()
-                ->scalarNode('fallback_locale')
-                    ->info('Sets fallback output locale for the tester')
-                    ->defaultValue('en')
-                ->end()
+            ->scalarNode('locale')
+            ->info('Sets output locale for the tester')
+            ->defaultValue($defaultLanguage)
+            ->end()
+            ->scalarNode('fallback_locale')
+            ->info('Sets fallback output locale for the tester')
+            ->defaultValue('en')
+            ->end()
             ->end();
     }
 
@@ -85,54 +85,55 @@ final class TranslatorExtension implements Extension
     /**
      * Loads translator service.
      *
-     * @param ContainerBuilder $container
-     * @param string           $locale
-     * @param string           $fallbackLocale
+     * @param string $locale
+     * @param string $fallbackLocale
      */
     private function loadTranslator(ContainerBuilder $container, $locale, $fallbackLocale)
     {
-        $definition = new Definition('Behat\Behat\Definition\Translator\Translator', array($locale));
+        $definition = new Definition('Behat\Behat\Definition\Translator\Translator', [$locale]);
         $container->setDefinition(self::TRANSLATOR_ID, $definition);
 
-        $definition->addMethodCall('setFallbackLocales', array(array($fallbackLocale)));
+        $definition->addMethodCall('setFallbackLocales', [[$fallbackLocale]]);
         $definition->addMethodCall(
-            'addLoader', array(
+            'addLoader',
+            [
                 'xliff',
-                new Definition('Symfony\Component\Translation\Loader\XliffFileLoader')
-            )
+                new Definition('Symfony\Component\Translation\Loader\XliffFileLoader'),
+            ]
         );
         $definition->addMethodCall(
-            'addLoader', array(
+            'addLoader',
+            [
                 'yaml',
-                new Definition('Symfony\Component\Translation\Loader\YamlFileLoader')
-            )
+                new Definition('Symfony\Component\Translation\Loader\YamlFileLoader'),
+            ]
         );
         $definition->addMethodCall(
-            'addLoader', array(
+            'addLoader',
+            [
                 'php',
-                new Definition('Symfony\Component\Translation\Loader\PhpFileLoader')
-            )
+                new Definition('Symfony\Component\Translation\Loader\PhpFileLoader'),
+            ]
         );
         $definition->addMethodCall(
-            'addLoader', array(
+            'addLoader',
+            [
                 'array',
-                new Definition('Symfony\Component\Translation\Loader\ArrayLoader')
-            )
+                new Definition('Symfony\Component\Translation\Loader\ArrayLoader'),
+            ]
         );
         $container->setDefinition(self::TRANSLATOR_ID, $definition);
     }
 
     /**
      * Loads translator controller.
-     *
-     * @param ContainerBuilder $container
      */
     private function loadController(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Testwork\Translator\Cli\LanguageController', array(
-            new Reference(self::TRANSLATOR_ID)
-        ));
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 800));
+        $definition = new Definition('Behat\Testwork\Translator\Cli\LanguageController', [
+            new Reference(self::TRANSLATOR_ID),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 800]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.translator', $definition);
     }
 
@@ -145,9 +146,7 @@ final class TranslatorExtension implements Extension
     {
         $defaultLanguage = null;
         if (($locale = getenv('LANG')) && preg_match('/^([a-z]{2})/', $locale, $matches)) {
-            $defaultLanguage = $matches[1];
-
-            return $defaultLanguage;
+            return $matches[1];
         }
 
         return $defaultLanguage;

--- a/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
+++ b/tests/Behat/Tests/Definition/Pattern/PatternTransformerTest.php
@@ -1,13 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Behat\Tests\Definition\Pattern;
 
 use Behat\Behat\Definition\Pattern\PatternTransformer;
-use Behat\Behat\Definition\Pattern\Policy\PatternPolicy;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class PatternTransformerTest
+ * Class PatternTransformerTest.
  * @author Julien Deniau <julien.deniau@mapado.com>
  */
 class PatternTransformerTest extends TestCase
@@ -74,11 +81,10 @@ class PatternTransformerTest extends TestCase
         $policy1Prophecy->transformPatternToRegex('hello world')
             ->shouldNotBeCalled();
 
-
         $testedInstance = new PatternTransformer();
         $testedInstance->registerPatternPolicy($policy1Prophecy->reveal());
         $this->expectException('\Behat\Behat\Definition\Exception\UnknownPatternException');
-        $this->expectExceptionMessage("Can not find policy for a pattern `hello world`.");
+        $this->expectExceptionMessage('Can not find policy for a pattern `hello world`.');
         $regex = $testedInstance->transformPatternToRegex('hello world');
     }
 }

--- a/tests/Behat/Tests/Testwork/Argument/MixedArgumentOrganiserTest.php
+++ b/tests/Behat/Tests/Testwork/Argument/MixedArgumentOrganiserTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Behat\Tests\Testwork\Argument;
 
 use Behat\Testwork\Argument\MixedArgumentOrganiser;
@@ -9,16 +17,16 @@ final class MixedArgumentOrganiserTest extends TestCase
 {
     private $organiser;
 
-    function setUp() : void
+    public function setUp(): void
     {
         $this->organiser = new MixedArgumentOrganiser();
     }
 
     /** @test */
-    function it_organises_nothing_if_no_args()
+    public function itOrganisesNothingIfNoArgs()
     {
         $r = new \ReflectionFunction(
-            function(\DateTimeInterface $d) {}
+            function (\DateTimeInterface $d) {}
         );
         $args = [];
 
@@ -28,31 +36,31 @@ final class MixedArgumentOrganiserTest extends TestCase
     }
 
     /** @test */
-    function it_matches_args_by_position()
+    public function itMatchesArgsByPosition()
     {
         $r = new \ReflectionFunction(
-            function($x, $y) {}
+            function ($x, $y) {}
         );
         $args = [
             1,
             2,
-            3
+            3,
         ];
 
         $organised = $this->organiser->organiseArguments($r, $args);
 
-        $this->assertSame([1,2], $organised);
+        $this->assertSame([1, 2], $organised);
     }
 
     /** @test */
-    function it_matches_args_by_name()
+    public function itMatchesArgsByName()
     {
         $r = new \ReflectionFunction(
-            function($date) {}
+            function ($date) {}
         );
         $args = [
             'date' => $date = new \DateTime(),
-            'x' => new \stdClass()
+            'x' => new \stdClass(),
         ];
 
         $organised = $this->organiser->organiseArguments($r, $args);
@@ -61,14 +69,14 @@ final class MixedArgumentOrganiserTest extends TestCase
     }
 
     /** @test */
-    function it_matches_args_by_type()
+    public function itMatchesArgsByType()
     {
         $r = new \ReflectionFunction(
-            function(\DateTimeInterface $d) {}
+            function (\DateTimeInterface $d) {}
         );
         $args = [
             'x' => $date = new \DateTime(),
-            'y' => new \stdClass()
+            'y' => new \stdClass(),
         ];
 
         $organised = $this->organiser->organiseArguments($r, $args);
@@ -77,14 +85,14 @@ final class MixedArgumentOrganiserTest extends TestCase
     }
 
     /** @test */
-    function it_matches_args_by_name_over_type()
+    public function itMatchesArgsByNameOverType()
     {
         $r = new \ReflectionFunction(
-            function(\DateTimeInterface $a, $date) {}
+            function (\DateTimeInterface $a, $date) {}
         );
         $args = [
             'date' => $date = new \DateTime(),
-            'x' => 1
+            'x' => 1,
         ];
 
         $organised = $this->organiser->organiseArguments($r, $args);
@@ -96,17 +104,17 @@ final class MixedArgumentOrganiserTest extends TestCase
      * @test
      * @requires PHP >= 8.0
      */
-    function it_matches_union_types()
+    public function itMatchesUnionTypes()
     {
-        $r = eval(<<<CODE
+        $r = eval(<<<'CODE'
             return new \ReflectionFunction(
-              function(int|\DateTimeInterface \$a) {}
+              function(int|\DateTimeInterface $a) {}
             );
 CODE
         );
         $args = [
             'date' => $date = new \DateTime(),
-            'x' => 1
+            'x' => 1,
         ];
 
         $organised = $this->organiser->organiseArguments($r, $args);

--- a/tests/Behat/Tests/Testwork/EventDispatcher/TestworkEventDispatcherTest.php
+++ b/tests/Behat/Tests/Testwork/EventDispatcher/TestworkEventDispatcherTest.php
@@ -19,7 +19,7 @@ class TestworkEventDispatcherTest extends TestCase
     public function testDispatchLegacyCall(): void
     {
         $dispatcher = new TestworkEventDispatcher();
-        $event = new class extends Event {};
+        $event = new class() extends Event {};
         $eventName = 'TEST_EVENT';
         $listener = $this->createListenerSpy();
 
@@ -33,7 +33,7 @@ class TestworkEventDispatcherTest extends TestCase
     public function testDispatchCurrentCall(): void
     {
         $dispatcher = new TestworkEventDispatcher();
-        $event = new class extends Event {};
+        $event = new class() extends Event {};
         $listener = $this->createListenerSpy();
 
         $dispatcher->addListener(get_class($event), $listener);
@@ -46,8 +46,9 @@ class TestworkEventDispatcherTest extends TestCase
     public function testSetNameOnEvent(): void
     {
         $dispatcher = new TestworkEventDispatcher();
-        $event = new class extends Event {
+        $event = new class() extends Event {
             public $name;
+
             public function setName($name): void
             {
                 $this->name = $name;
@@ -66,7 +67,7 @@ class TestworkEventDispatcherTest extends TestCase
     public function testBeforeAllListener(): void
     {
         $dispatcher = new TestworkEventDispatcher();
-        $event = new class extends Event {};
+        $event = new class() extends Event {};
         $listener = $this->createListenerSpy();
 
         $dispatcher->addListener(TestworkEventDispatcher::BEFORE_ALL_EVENTS, $listener);
@@ -79,7 +80,7 @@ class TestworkEventDispatcherTest extends TestCase
     public function testAfterAllListener(): void
     {
         $dispatcher = new TestworkEventDispatcher();
-        $event = new class extends Event {};
+        $event = new class() extends Event {};
         $listener = $this->createListenerSpy();
 
         $dispatcher->addListener(TestworkEventDispatcher::AFTER_ALL_EVENTS, $listener);

--- a/tests/Behat/Tests/Testwork/Subject/GroupedSubjectIteratorTest.php
+++ b/tests/Behat/Tests/Testwork/Subject/GroupedSubjectIteratorTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Behat\Tests\Testwork\Subject;
 
 use Behat\Testwork\Specification\GroupedSpecificationIterator;
@@ -13,10 +21,10 @@ class GroupedSubjectIteratorTest extends TestCase
     {
         $suite = $this->prophesize('Behat\Testwork\Suite\Suite')->reveal();
 
-        $iterator = new GroupedSpecificationIterator($suite, array(
+        $iterator = new GroupedSpecificationIterator($suite, [
             new NoSpecificationsIterator($suite),
-            new SpecificationArrayIterator($suite, array($this->prophesize()->reveal())),
-        ));
+            new SpecificationArrayIterator($suite, [$this->prophesize()->reveal()]),
+        ]);
 
         $this->assertEquals(1, iterator_count($iterator));
     }
@@ -25,11 +33,11 @@ class GroupedSubjectIteratorTest extends TestCase
     {
         $suite = $this->prophesize('Behat\Testwork\Suite\Suite')->reveal();
 
-        $iterator = new GroupedSpecificationIterator($suite, array(
-            new SpecificationArrayIterator($suite, array($this->prophesize()->reveal())),
+        $iterator = new GroupedSpecificationIterator($suite, [
+            new SpecificationArrayIterator($suite, [$this->prophesize()->reveal()]),
             new NoSpecificationsIterator($suite),
-            new SpecificationArrayIterator($suite, array($this->prophesize()->reveal())),
-        ));
+            new SpecificationArrayIterator($suite, [$this->prophesize()->reveal()]),
+        ]);
 
         $this->assertEquals(2, iterator_count($iterator));
     }


### PR DESCRIPTION
Hello everyone

I'm very found of this project and try to convert everyone I know to use it when it's necessary
I've long wanted to do a contribution, and this is a complicated one (to me at list).
But beforehand I've noticed numerous inconsistencies in the coding styles files are using or use of syntax that are kinda old fashioned.

Such as array() which is useful for backward compatibility yes, but do we want to keep using it when using typed parameters in some files ?

Anyway this PR is here to discuss about this topic, and once this one will be settled I'll gladly make another one to uniformise all the typed parameters and attribute in all files.

Here are a few rule I've set using cs-fixer:
no_superfluous_phpdoc_tags: It's kind of pointless to comment the type of a typed parameter
array_syntax: use [] instead of array()
blank_line_before_statement: Some blank lines were missing between attributes
header_comment: Some file are missing the header comment
single_quote: Some file are using double quote when single is enough
visibility_required: Some function visibility were not declared
php_unit_method_casing: Enforce CamelCase case even for tests

Anyway I'll be glad to here from you before spending more time on this !

Cheers