### PR TITLE
bug: Fix error when attempting to format long output messages

### DIFF
--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -30,7 +30,7 @@ final class ConsoleFormatter extends BaseOutputFormatter
      */
     public function format($message): string
     {
-        return preg_replace_callback(self::CUSTOM_PATTERN, array($this, 'replaceStyle'), $message);
+        return preg_replace_callback(self::CUSTOM_PATTERN, array($this, 'replaceStyle'), $message) ?? '';
     }
 
     /**

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -30,7 +30,8 @@ final class ConsoleFormatter extends BaseOutputFormatter
      */
     public function format($message): string
     {
-        return preg_replace_callback(self::CUSTOM_PATTERN, array($this, 'replaceStyle'), $message) ?? '';
+        return preg_replace_callback(self::CUSTOM_PATTERN, array($this, 'replaceStyle'), $message) ??
+            'Error formatting output: ' . preg_last_error_msg();
     }
 
     /**

--- a/tests/Behat/Tests/Output/Printer/Formatter/ConsoleFormatterTest.php
+++ b/tests/Behat/Tests/Output/Printer/Formatter/ConsoleFormatterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Behat\Tests\Output\Printer\Formatter;
+
+use Behat\Behat\Output\Printer\Formatter\ConsoleFormatter;
+use PHPUnit\Framework\TestCase;
+
+class ConsoleFormatterTest extends TestCase
+{
+    public function testFormatValidMessageWithoutDecoration(): void
+    {
+        $consoleFormatter = new ConsoleFormatter();
+
+        $formattedText = $consoleFormatter->format('{+info}Info:{-info}');
+
+        $this->assertEquals('Info:', $formattedText);
+    }
+
+    public function testFormatValidMessageWithDecoration(): void
+    {
+        $consoleFormatter = new ConsoleFormatter(true);
+
+        $formattedText = $consoleFormatter->format('{+info}Info:{-info}');
+
+        $this->assertEquals('[32mInfo:[39m', $formattedText);
+    }
+
+    public function testFormatInvalidMessage(): void
+    {
+        $consoleFormatter = new ConsoleFormatter(true);
+
+        $original_backtrack_limit = ini_get('pcre.backtrack_limit');
+
+        ini_set('pcre.backtrack_limit', '100');
+
+        $formattedText = $consoleFormatter->format('{+info}' . str_repeat('a', 1000) . '{-info}');
+
+        ini_set('pcre.backtrack_limit', $original_backtrack_limit);
+
+        $this->assertEquals('Error formatting output: Backtrack limit exhausted', $formattedText);
+    }
+}


### PR DESCRIPTION
I am getting a strange failure when testing some old Drupal code:

> TypeError: Behat\Behat\Output\Printer\Formatter\ConsoleFormatter::format(): Return value must be of type string, null returned in Behat\Behat\Output\Printer\Formatter\ConsoleFormatter->format() (line 33 of /usr/share/devshop/src/DevShop/Control/vendor/behat/behat/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php).

Looking into it, I discovered format() calls `preg_replace_callback`, which returns null|string|string[].

This change returns an empty string if preg_replace_callback returns null.

Should we check for an array as well?

