### PR TITLE
GH Actions: start running the tests against PHP 8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+                php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
                 os: [ubuntu-latest]
                 composer-mode: [update]
                 symfony-version: ['']
@@ -82,7 +82,7 @@ jobs:
                 if: matrix.composer-mode == 'update'
                 env:
                     SYMFONY_REQUIRE: ${{ matrix.symfony-version }}.*
-                run: composer update
+                run: composer update ${{ matrix.php == '8.3' && '--ignore-platform-req=php+' || '' }}
 
             -   name: Install lowest dependencies
                 if: matrix.composer-mode == 'lowest'


### PR DESCRIPTION
PHP 8.3 is nearing the RC phase. As this tool is used in the build processes of plenty of other PHP packages, I believe it would be beneficial to start supporting PHP 8.3 officially sooner rather than later.

This commit adds PHP 8.3 to the build matrix to start running the tests against PHP 8.3.

As the build currently passes against PHP 8.3, I've not added a `continue-on-error` for PHP 8.3.