### PR TITLE
Fix a bug around maximum token length in turnip notation implementation.

### DIFF
--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -220,7 +220,7 @@ Feature: Step Definition Pattern
       class FeatureContext implements Context
       {
           /**
-           * @Given I provide parameter :too1234567891123456789012345678901
+           * @Given I provide parameter :too12345678911234567890123456789012
            */
           public function parameterCouldBeNull($param) {}
       }

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -140,7 +140,7 @@ final class TurnipPatternPolicy implements PatternPolicy
 
     private function replaceTokenWithRegexCaptureGroup($tokenMatch)
     {
-        if (strlen($tokenMatch[1]) >= 32) {
+        if (strlen($tokenMatch[1]) > 32) {
             throw new InvalidPatternException(
                 "Token name should not exceed 32 characters, but `{$tokenMatch[1]}` was used."
             );


### PR DESCRIPTION
PHP allows up to 32 characters (inclusive) for the pattern name. 
The error message from Behat is correct: `Token name should not exceed 32 characters, but {$tokenMatch[1]} was used.`.
However, the code itself is not correct, because it allows up to 31 character, not 32 characters.

This PR provides a fix.

Originally this check was introduced [here](https://github.com/Behat/Behat/pull/904), triggered by [this issue](https://github.com/Behat/Behat/issues/872).