### PR TITLE
Display outline values instead of index in junit output

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -394,18 +394,19 @@ EOL;
      */
     public function itShouldFail($success)
     {
+        $message = '';
         if ('fail' === $success) {
             if (0 === $this->getExitCode()) {
-                echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
+                $message = 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            Assert::assertNotEquals(0, $this->getExitCode());
+            Assert::assertNotEquals(0, $this->getExitCode(), $message);
         } else {
             if (0 !== $this->getExitCode()) {
-                echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
+                $message = 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            Assert::assertEquals(0, $this->getExitCode());
+            Assert::assertEquals(0, $this->getExitCode(), $message);
         }
     }
 

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -114,15 +114,15 @@
           <testcase name="Failed" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
             <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #1" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
+          <testcase name="Passed &amp; Failed (value: 5, result: 16)" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
             <failure message="Then I must have 16: Failed asserting that 15 matches expected '16'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #2" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature"/>
-          <testcase name="Passed &amp; Failed #3" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
+          <testcase name="Passed &amp; Failed (value: 10, result: 20)" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features\World.feature"></testcase>
+          <testcase name="Passed &amp; Failed (value: 23, result: 32)" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features\World.feature">
             <failure message="Then I must have 32: Failed asserting that 33 matches expected '32'."/>
           </testcase>
-          <testcase name="Another Outline #1" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature"/>
-          <testcase name="Another Outline #2" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature"/>
+          <testcase name="Another Outline (value: 5, result: 15)" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features\World.feature"></testcase>
+          <testcase name="Another Outline (value: 10, result: 20)" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features\World.feature"></testcase>
         </testsuite>
       </testsuites>
       """

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
@@ -10,12 +10,10 @@
 
 namespace Behat\Behat\Output\Node\Printer\JUnit;
 
-use Behat\Behat\Output\Node\EventListener\JUnit\JUnitOutlineStoreListener;
 use Behat\Behat\Output\Node\EventListener\JUnit\JUnitDurationListener;
 use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
 use Behat\Gherkin\Node\ExampleNode;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\JUnitOutputPrinter;
@@ -34,44 +32,26 @@ final class JUnitScenarioPrinter
     private $resultConverter;
 
     /**
-     * @var JUnitOutlineStoreListener
-     */
-    private $outlineStoreListener;
-
-    /**
-     * @var OutlineNode
-     */
-    private $lastOutline;
-
-    /**
-     * @var int
-     */
-    private $outlineStepCount;
-
-    /**
      * @var JUnitDurationListener|null
      */
     private $durationListener;
 
-    public function __construct(ResultToStringConverter $resultConverter, JUnitOutlineStoreListener $outlineListener, JUnitDurationListener $durationListener = null)
+    public function __construct(ResultToStringConverter $resultConverter, JUnitDurationListener $durationListener = null)
     {
         $this->resultConverter = $resultConverter;
-        $this->outlineStoreListener = $outlineListener;
         $this->durationListener = $durationListener;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result, string $file = null)
+    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result, string $file = null): void
     {
-        $name = implode(' ', array_map(function ($l) {
-            return trim($l);
-        }, explode("\n", $scenario->getTitle())));
-
-        if ($scenario instanceof ExampleNode) {
-            $name = $this->buildExampleName($scenario);
-        }
+        $name = $this->convertMultipleLinesToOne(
+            $scenario instanceof ExampleNode
+                ? $this->buildExampleName($scenario)
+                : $scenario->getTitle()
+        );
 
         /** @var JUnitOutputPrinter $outputPrinter */
         $outputPrinter = $formatter->getOutputPrinter();
@@ -85,29 +65,42 @@ final class JUnitScenarioPrinter
 
         if ($file) {
             $cwd = realpath(getcwd());
-            $testCaseAttributes['file'] =
-                substr($file, 0, strlen($cwd)) === $cwd ?
-                    ltrim(substr($file, strlen($cwd)), DIRECTORY_SEPARATOR) : $file;
+            $testCaseAttributes['file'] = substr($file, 0, strlen($cwd)) === $cwd
+                ? ltrim(substr($file, strlen($cwd)), DIRECTORY_SEPARATOR)
+                : $file;
         }
 
         $outputPrinter->addTestcase($testCaseAttributes);
     }
 
-    /**
-     * @param ExampleNode $scenario
-     * @return string
-     */
-    private function buildExampleName(ExampleNode $scenario)
+    private function buildExampleName(ExampleNode $scenario): string
     {
-        $currentOutline = $this->outlineStoreListener->getCurrentOutline($scenario);
-        if ($currentOutline === $this->lastOutline) {
-            $this->outlineStepCount++;
-        } else {
-            $this->lastOutline = $currentOutline;
-            $this->outlineStepCount = 1;
-        }
+        return sprintf(
+            '%s (%s)',
+            $scenario->getOutlineTitle(),
+            implode(
+                ', ',
+                array_map(
+                    static function ($key, $val) {
+                        return "$key: $val";
+                    },
+                    array_keys($scenario->getTokens()),
+                    array_values($scenario->getTokens())
+                )
+            )
+        );
+    }
 
-        $name = $currentOutline->getTitle() . ' #' . $this->outlineStepCount;
-        return $name;
+    private function convertMultipleLinesToOne(string $string): string
+    {
+        return implode(
+            ' ',
+            array_map(
+                static function ($line) {
+                    return trim($line);
+                },
+                explode("\n", $string)
+            )
+        );
     }
 }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
@@ -79,7 +79,6 @@ final class JUnitFormatterFactory implements FormatterFactory
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\JUnit\JUnitScenarioPrinter', array(
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
-            new Reference('output.node.listener.junit.outline'),
             new Reference('output.node.listener.junit.duration')
         ));
         $container->setDefinition('output.node.printer.junit.scenario', $definition);


### PR DESCRIPTION
Replaces "example name #N" with "example name (XX)" in JUnit output.

Closes #1448 