### PR TITLE
Update PHAR creation to more up-to-date version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,11 @@ jobs:
                     composer install --no-dev -o &&
                     box build
 
+            -   name: Test the PHAR
+                if: matrix.publish-phar == true
+                run: |
+                    behat.phar --version
+
             -   uses: actions/upload-artifact@v3
                 name: Publish the PHAR
                 if: matrix.publish-phar == true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
                     php-version: "${{ matrix.php }}"
                     ini-values: "phar.readonly=0,zend.exception_ignore_args=Off"
                     coverage: none
+                    tools: box
 
             -   name: Install symfony/flex
                 if: matrix.symfony-version != ''
@@ -110,11 +111,8 @@ jobs:
             -   name: Build the PHAR
                 if: matrix.publish-phar == true
                 run: |
-                    curl -LSs https://box-project.github.io/box2/installer.php | php &&
-                    export PATH=.:$PATH &&
-                    rm -Rf ./vendor &&
                     composer install --no-dev -o &&
-                    box.phar build
+                    box build
 
             -   uses: actions/upload-artifact@v3
                 name: Publish the PHAR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
                 composer-mode: [update]
                 symfony-version: ['']
                 include:
-                    # Get the existing 7.2 to publish the phar
-                    -   php: 7.2
+                    # Get the latest stable PHP to publish the phar
+                    -   php: 8.3
                         os: ubuntu-latest
                         composer-mode: update
                         publish-phar: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,6 @@ jobs:
               run: ./vendor/bin/psalm --output-format=github
 
     build-phar:
-        needs: tests
         runs-on: ubuntu-latest
         name: Build PHAR file
         steps:
@@ -184,7 +183,7 @@ jobs:
     publish-phar:
         runs-on: ubuntu-latest
         name: Publish the PHAR for release
-        needs: test-phar
+        needs: [test-phar, tests]
         if: github.event_name == 'release'
         steps:
             -   uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,8 +180,6 @@ jobs:
         - name: Test the PHAR
           run: |
             php ./behat.phar --version
-            php ./behat.phar
-
 
     publish-phar:
         runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         defaults:
             run:
                 shell: bash
-        name: Build and test
+        name: Test
         strategy:
             fail-fast: false
             matrix:
@@ -75,7 +75,6 @@ jobs:
                     php-version: "${{ matrix.php }}"
                     ini-values: "phar.readonly=0,zend.exception_ignore_args=Off"
                     coverage: none
-                    tools: box
 
             -   name: Install symfony/flex
                 if: matrix.symfony-version != ''
@@ -108,24 +107,6 @@ jobs:
                 if: matrix.php >= 8.0
                 run: ./bin/behat -fprogress --strict --tags=@php8
 
-            -   name: Build the PHAR
-                if: matrix.publish-phar == true
-                run: |
-                    composer install --no-dev -o &&
-                    box build
-
-            -   name: Test the PHAR
-                if: matrix.publish-phar == true
-                run: |
-                    behat.phar --version
-
-            -   uses: actions/upload-artifact@v3
-                name: Publish the PHAR
-                if: matrix.publish-phar == true
-                with:
-                    name: behat.phar
-                    path: behat.phar
-
     static-analysis:
         runs-on: ubuntu-latest
         name: Static analysis
@@ -145,10 +126,42 @@ jobs:
             - name: Run Psalm
               run: ./vendor/bin/psalm --output-format=github
 
+    build-phar:
+        needs: tests
+        runs-on: ubuntu-latest
+        name: Build PHAR file
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "8.3"
+                  ini-values: "phar.readonly=0,zend.exception_ignore_args=Off"
+                  coverage: none
+                  tools: box
+
+            - name: Build the PHAR
+              run: |
+                  composer config platform.php ^7.2.34 
+                  composer update --no-dev -o
+                  box build
+
+            - name: Test the PHAR
+              run: |
+                  behat.phar --version
+
+            - uses: actions/upload-artifact@v3
+              name: Upload PHAR artifact
+              with:
+                  name: behat.phar
+                  path: behat.phar
+
+
     publish-phar:
         runs-on: ubuntu-latest
         name: Publish the PHAR for release
-        needs: tests
+        needs: build-phar
         if: github.event_name == 'release'
         steps:
             -   uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,6 @@ jobs:
                 composer-mode: [update]
                 symfony-version: ['']
                 include:
-                    # Get the latest stable PHP to publish the phar
-                    -   php: 8.3
-                        os: ubuntu-latest
-                        composer-mode: update
-                        publish-phar: true
-                        symfony-version: ''
-
                     # 7.2 build with lowest dependencies
                     -   php: 7.2
                         os: ubuntu-latest
@@ -144,25 +137,56 @@ jobs:
 
             - name: Build the PHAR
               run: |
-                  composer config platform.php ^7.2.34 
+                  composer config platform.php 7.2.34
                   composer update --no-dev -o
-                  box build
+                  box compile
 
-            - name: Test the PHAR
-              run: |
-                  behat.phar --version
-
-            - uses: actions/upload-artifact@v3
-              name: Upload PHAR artifact
+            - name: cache artifact
+              uses: actions/upload-artifact@v4
               with:
-                  name: behat.phar
-                  path: behat.phar
+                name: behat.phar
+                path: behat.phar
+
+
+    test-phar:
+      needs: build-phar
+      runs-on: ubuntu-latest
+      name: test PHAR file
+      strategy:
+        fail-fast: false
+        matrix:
+          php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+      steps:
+        - uses: actions/checkout@v4
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: "${{ matrix.php }}"
+            ini-values: "phar.readonly=0,zend.exception_ignore_args=Off"
+            coverage: none
+
+        - name: Install dependencies
+          run: composer install
+
+
+        - uses: actions/download-artifact@v4
+          with:
+            name: behat.phar
+
+        - name: "Check content"
+          run: |
+            ls -R .
+
+        - name: Test the PHAR
+          run: |
+            php ./behat.phar --version
+            php ./behat.phar
 
 
     publish-phar:
         runs-on: ubuntu-latest
         name: Publish the PHAR for release
-        needs: build-phar
+        needs: test-phar
         if: github.event_name == 'release'
         steps:
             -   uses: actions/download-artifact@v4

--- a/box.json
+++ b/box.json
@@ -1,19 +1,10 @@
 {
-    "chmod": "0755",
-    "directories": ["src"],
     "files": [
         "LICENSE",
         "i18n.php"
     ],
-    "finder": [
-        {
-            "name": ["*.php", "*.xsd", "LICENSE"],
-            "exclude": ["Tests", "tests", "sebastian", "phpunit", "phpspec", "process", "filesystem"],
-            "in": "vendor"
-        }
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\Php"
     ],
-    "compactors": "Herrera\\Box\\Compactor\\Php",
-    "main": "bin/behat",
-    "output": "behat.phar",
-    "stub": true
+    "output": "behat.phar"
 }


### PR DESCRIPTION
This PR updates the PHAR creation process to use a rather current version of box.

It moves 
a) from the old box2 to the current box 
b) from downloading and preparing the build-tools ourselves to using the build-tools provided by shivamatur
c) towards using more internal logic from box to determine which files are to be included into the PHAR

The config file has been cleaned up and the github-action files have been updated accordingly.

Note: This just replaces the old process with an updated one. The PHAR file is still unscoped which might cause problems when the application executes code that calls classes that are available in the PHAR as well as in the tested codes dependencies as the ones from the PHAR will be used. But that is a separate issue from the update