### PR TITLE
Adds void return type to generated snippets

### DIFF
--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -185,7 +185,7 @@ Feature: Append snippets option
           /**
            * @Then /^do something undefined with \$$/
            */
-          public function doSomethingUndefinedWith2()
+          public function doSomethingUndefinedWith2(): void
           {
               throw new PendingException();
           }
@@ -193,7 +193,7 @@ Feature: Append snippets option
           /**
            * @Then /^do something undefined with \\(\d+)$/
            */
-          public function doSomethingUndefinedWith3($arg1)
+          public function doSomethingUndefinedWith3($arg1): void
           {
               throw new PendingException();
           }
@@ -201,7 +201,7 @@ Feature: Append snippets option
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -209,7 +209,7 @@ Feature: Append snippets option
           /**
            * @Given /^pystring (\d+):$/
            */
-          public function pystring2($arg1, PyStringNode $string)
+          public function pystring2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -217,7 +217,7 @@ Feature: Append snippets option
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -355,7 +355,7 @@ Feature: Append snippets option
           /**
            * @Then /^do something undefined with \$$/
            */
-          public function doSomethingUndefinedWith2()
+          public function doSomethingUndefinedWith2(): void
           {
               throw new PendingException();
           }
@@ -363,7 +363,7 @@ Feature: Append snippets option
           /**
            * @Then /^do something undefined with \\(\d+)$/
            */
-          public function doSomethingUndefinedWith3($arg1)
+          public function doSomethingUndefinedWith3($arg1): void
           {
               throw new PendingException();
           }
@@ -371,7 +371,7 @@ Feature: Append snippets option
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -379,7 +379,7 @@ Feature: Append snippets option
           /**
            * @Given /^pystring (\d+):$/
            */
-          public function pystring2($arg1, PyStringNode $string)
+          public function pystring2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -387,7 +387,7 @@ Feature: Append snippets option
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -523,7 +523,7 @@ Feature: Append snippets option
           /**
            * @Then /^do something undefined with \$$/
            */
-          public function doSomethingUndefinedWith2()
+          public function doSomethingUndefinedWith2(): void
           {
               throw new PendingException();
           }
@@ -531,7 +531,7 @@ Feature: Append snippets option
           /**
            * @Then /^do something undefined with \\(\d+)$/
            */
-          public function doSomethingUndefinedWith3($arg1)
+          public function doSomethingUndefinedWith3($arg1): void
           {
               throw new PendingException();
           }
@@ -539,7 +539,7 @@ Feature: Append snippets option
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -547,7 +547,7 @@ Feature: Append snippets option
           /**
            * @Given /^pystring (\d+):$/
            */
-          public function pystring2($arg1, PyStringNode $string)
+          public function pystring2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -555,7 +555,7 @@ Feature: Append snippets option
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -652,7 +652,7 @@ Feature: Append snippets option
           /**
            * @Given /^I have (\d+) apples$/
            */
-          public function iHaveApples($arg1)
+          public function iHaveApples($arg1): void
           {
               throw new PendingException();
           }
@@ -660,7 +660,7 @@ Feature: Append snippets option
           /**
            * @When /^I ate (\d+) apple$/
            */
-          public function iAteApple($arg1)
+          public function iAteApple($arg1): void
           {
               throw new PendingException();
           }
@@ -668,7 +668,7 @@ Feature: Append snippets option
           /**
            * @Then /^I should have (\d+) apples$/
            */
-          public function iShouldHaveApples($arg1)
+          public function iShouldHaveApples($arg1): void
           {
               throw new PendingException();
           }
@@ -676,7 +676,7 @@ Feature: Append snippets option
           /**
            * @When /^I found (\d+) apples$/
            */
-          public function iFoundApples($arg1)
+          public function iFoundApples($arg1): void
           {
               throw new PendingException();
           }
@@ -684,7 +684,7 @@ Feature: Append snippets option
           /**
            * @Then /^do something undefined with \$$/
            */
-          public function doSomethingUndefinedWith()
+          public function doSomethingUndefinedWith(): void
           {
               throw new PendingException();
           }
@@ -692,7 +692,7 @@ Feature: Append snippets option
           /**
            * @When /^I ate (\d+) apples$/
            */
-          public function iAteApples($arg1)
+          public function iAteApples($arg1): void
           {
               throw new PendingException();
           }
@@ -700,7 +700,7 @@ Feature: Append snippets option
           /**
            * @Then /^do something undefined with \\(\d+)$/
            */
-          public function doSomethingUndefinedWith2($arg1)
+          public function doSomethingUndefinedWith2($arg1): void
           {
               throw new PendingException();
           }
@@ -708,7 +708,7 @@ Feature: Append snippets option
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -716,7 +716,7 @@ Feature: Append snippets option
           /**
            * @Given /^pystring (\d+):$/
            */
-          public function pystring2($arg1, PyStringNode $string)
+          public function pystring2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -724,7 +724,7 @@ Feature: Append snippets option
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }

--- a/features/context.feature
+++ b/features/context.feature
@@ -275,7 +275,7 @@ Feature: Context consistency
         /**
          * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
          */
-        public function contextParameterShouldBeEqualTo($arg1, $arg2)
+        public function contextParameterShouldBeEqualTo($arg1, $arg2): void
         {
             throw new PendingException();
         }
@@ -283,7 +283,7 @@ Feature: Context consistency
         /**
          * @Then /^context parameter "([^"]*)" should be array with (\d+) elements$/
          */
-        public function contextParameterShouldBeArrayWithElements($arg1, $arg2)
+        public function contextParameterShouldBeArrayWithElements($arg1, $arg2): void
         {
             throw new PendingException();
         }

--- a/features/format_options.feature
+++ b/features/format_options.feature
@@ -171,7 +171,7 @@ Feature: Format options
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -179,7 +179,7 @@ Feature: Format options
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -187,7 +187,7 @@ Feature: Format options
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -254,7 +254,7 @@ Feature: Format options
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -262,7 +262,7 @@ Feature: Format options
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -270,7 +270,7 @@ Feature: Format options
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -402,7 +402,7 @@ Feature: Format options
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -410,7 +410,7 @@ Feature: Format options
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -418,7 +418,7 @@ Feature: Format options
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -482,7 +482,7 @@ Feature: Format options
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -490,7 +490,7 @@ Feature: Format options
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -498,7 +498,7 @@ Feature: Format options
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -140,7 +140,7 @@ Feature: I18n
           /**
            * @Then /^Добавить "([^"]*)" число$/
            */
-          public function dobavitChislo($arg1)
+          public function dobavitChislo($arg1): void
           {
               throw new PendingException();
           }
@@ -180,7 +180,7 @@ Feature: I18n
           /**
            * @Then /^Добавить "([^"]*)" число$/
            */
-          public function dobavitChislo($arg1)
+          public function dobavitChislo($arg1): void
           {
               throw new PendingException();
           }
@@ -220,7 +220,7 @@ Feature: I18n
           /**
            * @Then /^Добавить "([^"]*)" число$/
            */
-          public function dobavitChislo($arg1)
+          public function dobavitChislo($arg1): void
           {
               throw new PendingException();
           }
@@ -260,7 +260,7 @@ Feature: I18n
           /**
            * @Then /^Добавить "([^"]*)" число$/
            */
-          public function dobavitChislo($arg1)
+          public function dobavitChislo($arg1): void
           {
               throw new PendingException();
           }

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -95,7 +95,7 @@
           /**
            * @Then /^Something new$/
            */
-          public function somethingNew()
+          public function somethingNew(): void
           {
               throw new PendingException();
           }

--- a/features/legacy_snippets.feature
+++ b/features/legacy_snippets.feature
@@ -64,7 +64,7 @@ Feature: Legacy Snippets
           /**
            * @Given /^I have magically created (\d+)\$$/
            */
-          public function iHaveMagicallyCreated($arg1)
+          public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
@@ -72,7 +72,7 @@ Feature: Legacy Snippets
           /**
            * @When /^I have chose '([^']*)' in coffee machine$/
            */
-          public function iHaveChoseCoffeeWithTurkeyInCoffeeMachine($arg1)
+          public function iHaveChoseCoffeeWithTurkeyInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -80,7 +80,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should have '([^']*)'$/
            */
-          public function iShouldHaveTurkeyWithCoffeeSauce($arg1)
+          public function iShouldHaveTurkeyWithCoffeeSauce($arg1): void
           {
               throw new PendingException();
           }
@@ -88,7 +88,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should get a '([^']*)':$/
            */
-          public function iShouldGetASuperString($arg1, PyStringNode $string)
+          public function iShouldGetASuperString($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -96,7 +96,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should get a simple string:$/
            */
-          public function iShouldGetASimpleString(PyStringNode $string)
+          public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -104,7 +104,7 @@ Feature: Legacy Snippets
           /**
            * @When /^I have chose "([^"]*)" in coffee machine$/
            */
-          public function iHaveChoseInCoffeeMachine($arg1)
+          public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -112,7 +112,7 @@ Feature: Legacy Snippets
           /**
            * @When /^do something undefined with \\(\d+)$/
            */
-          public function doSomethingUndefinedWith($arg1)
+          public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
           }
@@ -120,7 +120,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should have "([^"]*)"$/
            */
-          public function iShouldHave($arg1)
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -128,7 +128,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should get a "([^"]*)":$/
            */
-          public function iShouldGetA($arg1, PyStringNode $string)
+          public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -193,7 +193,7 @@ Feature: Legacy Snippets
           /**
            * @Given I have magically created :arg1$
            */
-          public function iHaveMagicallyCreated($arg1)
+          public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
@@ -201,7 +201,7 @@ Feature: Legacy Snippets
           /**
            * @When I have chose :arg1 in coffee machine
            */
-          public function iHaveChoseInCoffeeMachine($arg1)
+          public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -209,7 +209,7 @@ Feature: Legacy Snippets
           /**
            * @Then I should have :arg1
            */
-          public function iShouldHave($arg1)
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -217,7 +217,7 @@ Feature: Legacy Snippets
           /**
            * @Then I should get a :arg1:
            */
-          public function iShouldGetA($arg1, PyStringNode $string)
+          public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -225,7 +225,7 @@ Feature: Legacy Snippets
           /**
            * @Then I should get a simple string:
            */
-          public function iShouldGetASimpleString(PyStringNode $string)
+          public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -233,7 +233,7 @@ Feature: Legacy Snippets
           /**
            * @When do something undefined with \:arg1
            */
-          public function doSomethingUndefinedWith($arg1)
+          public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
           }
@@ -333,7 +333,7 @@ Feature: Legacy Snippets
           /**
            * @Given I have a package v2.5
            */
-          public function iHaveAPackageV()
+          public function iHaveAPackageV(): void
           {
               throw new PendingException();
           }
@@ -370,7 +370,7 @@ Feature: Legacy Snippets
           /**
            * @Then images should be uploaded to web\/uploads\/media\/default\/:arg1\/:arg2\/
            */
-          public function imagesShouldBeUploadedToWebUploadsMediaDefault($arg1, $arg2)
+          public function imagesShouldBeUploadedToWebUploadsMediaDefault($arg1, $arg2): void
           {
               throw new PendingException();
           }

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -182,7 +182,7 @@ Feature: Multiple formats
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -190,7 +190,7 @@ Feature: Multiple formats
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -198,7 +198,7 @@ Feature: Multiple formats
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -276,7 +276,7 @@ Feature: Multiple formats
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -284,7 +284,7 @@ Feature: Multiple formats
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -292,7 +292,7 @@ Feature: Multiple formats
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -322,7 +322,7 @@ Feature: Multiple formats
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -330,7 +330,7 @@ Feature: Multiple formats
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -338,7 +338,7 @@ Feature: Multiple formats
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -453,7 +453,7 @@ Feature: Multiple formats
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -461,7 +461,7 @@ Feature: Multiple formats
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -469,7 +469,7 @@ Feature: Multiple formats
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }
@@ -501,7 +501,7 @@ Feature: Multiple formats
           /**
            * @Then /^do something undefined$/
            */
-          public function doSomethingUndefined()
+          public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
@@ -509,7 +509,7 @@ Feature: Multiple formats
           /**
            * @Given /^pystring:$/
            */
-          public function pystring(PyStringNode $string)
+          public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -517,7 +517,7 @@ Feature: Multiple formats
           /**
            * @Given /^table:$/
            */
-          public function table(TableNode $table)
+          public function table(TableNode $table): void
           {
               throw new PendingException();
           }

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -137,7 +137,7 @@ Feature: Pretty Formatter
           /**
            * @Then /^Something new$/
            */
-          public function somethingNew()
+          public function somethingNew(): void
           {
               throw new PendingException();
           }

--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -47,7 +47,7 @@ Feature: Different result types
           /**
            * @Given /^I have magically created (\d+)\$$/
            */
-          public function iHaveMagicallyCreated($arg1)
+          public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
@@ -55,7 +55,7 @@ Feature: Different result types
           /**
            * @When /^I have chose "([^"]*)" in coffee machine$/
            */
-          public function iHaveChoseInCoffeeMachine($arg1)
+          public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -63,7 +63,7 @@ Feature: Different result types
           /**
            * @Then /^I should have "([^"]*)"$/
            */
-          public function iShouldHave($arg1)
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -81,7 +81,7 @@ Feature: Different result types
           /**
            * @Given /^I have magically created (\d+)\$$/
            */
-          public function iHaveMagicallyCreated($arg1)
+          public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
@@ -89,7 +89,7 @@ Feature: Different result types
           /**
            * @When /^I have chose "([^"]*)" in coffee machine$/
            */
-          public function iHaveChoseInCoffeeMachine($arg1)
+          public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -97,7 +97,7 @@ Feature: Different result types
           /**
            * @Then /^I should have "([^"]*)"$/
            */
-          public function iShouldHave($arg1)
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -132,14 +132,14 @@ Feature: Different result types
           /**
            * @Given /^human have ordered very very very hot "([^"]*)"$/
            */
-          public function humanOrdered($arg1) {
+          public function humanOrdered($arg1): void {
               throw new PendingException;
           }
 
           /**
            * @When the coffee will be ready
            */
-          public function theCoffeeWillBeReady() {
+          public function theCoffeeWillBeReady(): void {
               throw new PendingException;
           }
       }
@@ -163,7 +163,7 @@ Feature: Different result types
           /**
            * @Then /^I should say "([^"]*)"$/
            */
-          public function iShouldSay($arg1)
+          public function iShouldSay($arg1): void
           {
               throw new PendingException();
           }
@@ -187,7 +187,7 @@ Feature: Different result types
           /**
            * @Then /^I should say "([^"]*)"$/
            */
-          public function iShouldSay($arg1)
+          public function iShouldSay($arg1): void
           {
               throw new PendingException();
           }
@@ -371,19 +371,19 @@ Feature: Different result types
       class FeatureContext implements Context
       {
           /** @Given /^human have chosen "([^"]*)"$/ */
-          public function chosen($arg1) {
+          public function chosen($arg1): void {
               throw new PendingException;
           }
 
           /** @Given /^human have chosen "Latte"$/ */
-          public function chosenLatte() {
+          public function chosenLatte(): void {
               throw new PendingException;
           }
 
           /**
            * @Then /^I should make him "([^"]*)"$/
            */
-          public function iShouldSee($money) {
+          public function iShouldSee($money): void {
               throw new PendingException;
           }
       }

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -62,7 +62,7 @@ Feature: Snippets generation and addition
           /**
            * @Given /^I have magically created (\d+)\$$/
            */
-          public function iHaveMagicallyCreated($arg1)
+          public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
@@ -70,7 +70,7 @@ Feature: Snippets generation and addition
           /**
            * @When /^I have chose '([^']*)' in coffee machine$/
            */
-          public function iHaveChoseCoffeeWithTurkeyInCoffeeMachine($arg1)
+          public function iHaveChoseCoffeeWithTurkeyInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -78,7 +78,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should have '([^']*)'$/
            */
-          public function iShouldHaveTurkeyWithCoffeeSauce($arg1)
+          public function iShouldHaveTurkeyWithCoffeeSauce($arg1): void
           {
               throw new PendingException();
           }
@@ -86,7 +86,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should get a '([^']*)':$/
            */
-          public function iShouldGetASuperString($arg1, PyStringNode $string)
+          public function iShouldGetASuperString($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -94,7 +94,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should get a simple string:$/
            */
-          public function iShouldGetASimpleString(PyStringNode $string)
+          public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -102,7 +102,7 @@ Feature: Snippets generation and addition
           /**
            * @When /^I have chose "([^"]*)" in coffee machine$/
            */
-          public function iHaveChoseInCoffeeMachine($arg1)
+          public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -110,7 +110,7 @@ Feature: Snippets generation and addition
           /**
            * @When /^do something undefined with \\(\d+)$/
            */
-          public function doSomethingUndefinedWith($arg1)
+          public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
           }
@@ -118,7 +118,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should have "([^"]*)"$/
            */
-          public function iShouldHave($arg1)
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -126,7 +126,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should get a "([^"]*)":$/
            */
-          public function iShouldGetA($arg1, PyStringNode $string)
+          public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -189,7 +189,7 @@ Feature: Snippets generation and addition
           /**
            * @Given I have magically created :arg1$
            */
-          public function iHaveMagicallyCreated($arg1)
+          public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
@@ -197,7 +197,7 @@ Feature: Snippets generation and addition
           /**
            * @When I have chose :arg1 in coffee machine
            */
-          public function iHaveChoseInCoffeeMachine($arg1)
+          public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -205,7 +205,7 @@ Feature: Snippets generation and addition
           /**
            * @Then I should have :arg1
            */
-          public function iShouldHave($arg1)
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -213,7 +213,7 @@ Feature: Snippets generation and addition
           /**
            * @Then I should get a :arg1:
            */
-          public function iShouldGetA($arg1, PyStringNode $string)
+          public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -221,7 +221,7 @@ Feature: Snippets generation and addition
           /**
            * @Then I should get a simple string:
            */
-          public function iShouldGetASimpleString(PyStringNode $string)
+          public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -229,7 +229,7 @@ Feature: Snippets generation and addition
           /**
            * @When do something undefined with \:arg1
            */
-          public function doSomethingUndefinedWith($arg1)
+          public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
           }
@@ -326,7 +326,7 @@ Feature: Snippets generation and addition
           /**
            * @Given I have a package v2.5
            */
-          public function iHaveAPackageV()
+          public function iHaveAPackageV(): void
           {
               throw new PendingException();
           }
@@ -360,7 +360,7 @@ Feature: Snippets generation and addition
           /**
            * @Then images should be uploaded to web\/uploads\/media\/default\/:arg1\/:arg2\/
            */
-          public function imagesShouldBeUploadedToWebUploadsMediaDefault($arg1, $arg2)
+          public function imagesShouldBeUploadedToWebUploadsMediaDefault($arg1, $arg2): void
           {
               throw new PendingException();
           }
@@ -387,7 +387,7 @@ Feature: Snippets generation and addition
           /**
            * @Given I have magically created :arg1$
            */
-          public function iHaveMagicallyCreated($arg1)
+          public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
@@ -395,7 +395,7 @@ Feature: Snippets generation and addition
           /**
            * @When I have chose :arg1 in coffee machine
            */
-          public function iHaveChoseInCoffeeMachine($arg1)
+          public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -403,7 +403,7 @@ Feature: Snippets generation and addition
           /**
            * @Then I should have :arg1
            */
-          public function iShouldHave($arg1)
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -411,7 +411,7 @@ Feature: Snippets generation and addition
           /**
            * @Then I should get a :arg1:
            */
-          public function iShouldGetA($arg1, PyStringNode $string)
+          public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -419,7 +419,7 @@ Feature: Snippets generation and addition
           /**
            * @Then I should get a simple string:
            */
-          public function iShouldGetASimpleString(PyStringNode $string)
+          public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -427,7 +427,7 @@ Feature: Snippets generation and addition
           /**
            * @When do something undefined with \:arg1
            */
-          public function doSomethingUndefinedWith($arg1)
+          public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
           }
@@ -463,7 +463,7 @@ Feature: Snippets generation and addition
           /**
            * @Given that it's eleven o'clock
            */
-          public function thatItsElevenOclock()
+          public function thatItsElevenOclock(): void
           {
               throw new PendingException();
           }
@@ -471,7 +471,7 @@ Feature: Snippets generation and addition
           /**
            * @When the guest's taxi has arrived
            */
-          public function theGuestsTaxiHasArrived()
+          public function theGuestsTaxiHasArrived(): void
           {
               throw new PendingException();
           }
@@ -479,7 +479,7 @@ Feature: Snippets generation and addition
           /**
            * @Then the guest says :arg1
            */
-          public function theGuestSays($arg1)
+          public function theGuestSays($arg1): void
           {
               throw new PendingException();
           }

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -39,7 +39,7 @@ final class ContextSnippetGenerator implements SnippetGenerator
     /**
      * @%%s %s
      */
-    public function %s(%s)
+    public function %s(%s): void
     {
         throw new PendingException();
     }


### PR DESCRIPTION
Add `void` return type to the snippets that are generated when a step definition is missing. Even though this return type does not offer any runtime advantage and is of limited use for static analysis, it provides completeness if, for example, we are calculating the type coverage of our application