### PR TITLE
Support behat.dist.y[a]ml format

### DIFF
--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -117,10 +117,14 @@ final class ApplicationFactory extends BaseFactory
             $cwd . 'behat.yml',
             $cwd . 'behat.yaml.dist',
             $cwd . 'behat.yml.dist',
+            $cwd . 'behat.dist.yaml',
+            $cwd . 'behat.dist.yml',
             $configDir . 'behat.yaml',
             $configDir . 'behat.yml',
             $configDir . 'behat.yaml.dist',
             $configDir . 'behat.yml.dist',
+            $configDir . 'behat.dist.yaml',
+            $configDir . 'behat.dist.yml',
         );
 
         foreach ($paths as $path) {


### PR DESCRIPTION
Many common tools (phpunit, phpstan, php-cs-fixer) use config files like `<toolname>.<ext>`. To ease collaboration, they and Behat support checking for and using `<toolname>.<ext>.dist`.

However, those tools also support the `<toolname>.dist.<ext>`, which is arguably superior when it comes to extension conventions (e.g. IDEs need to be taught that `.<ext>.dist` is really of type `.<ext>`). This PR adds support for that format to Behat too.

----

On a sidenote: none of those alternatives are mentioned in any Behat documentation - it seems to be limited to [`behat.yml`](https://behat.org/en/latest/user_guide/configuration.html#behat-yml).