### PR TITLE
Feature/option rerun only

### DIFF
--- a/features/rerun-only.feature
+++ b/features/rerun-only.feature
@@ -1,0 +1,180 @@
+Feature: Rerun
+  In order to test only failed scenarios and exit if none is found
+  As a feature developer
+  I need to have an ability to rerun failed previously scenarios
+
+  Background:
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          private $apples = 0;
+          private $parameters;
+
+          public function __construct(array $parameters = array()) {
+              $this->parameters = $parameters;
+          }
+
+          /**
+           * @Given /^I have (\d+) apples?$/
+           */
+          public function iHaveApples($count) {
+              $this->apples = intval($count);
+          }
+
+          /**
+           * @When /^I ate (\d+) apples?$/
+           */
+          public function iAteApples($count) {
+              $this->apples -= intval($count);
+          }
+
+          /**
+           * @When /^I found (\d+) apples?$/
+           */
+          public function iFoundApples($count) {
+              $this->apples += intval($count);
+          }
+
+          /**
+           * @Then /^I should have (\d+) apples$/
+           */
+          public function iShouldHaveApples($count) {
+              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
+          }
+
+          /**
+           * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
+           */
+          public function contextParameterShouldBeEqualTo($key, $val) {
+              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
+          }
+
+          /**
+           * @Given /^context parameter "([^"]*)" should be array with (\d+) elements$/
+           */
+          public function contextParameterShouldBeArrayWithElements($key, $count) {
+              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
+              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
+          }
+      }
+      """
+    And a file named "features/apples.feature" with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Background:
+          Given I have 3 apples
+
+        Scenario: I'm little hungry
+          When I ate 1 apple
+          Then I should have 3 apples
+
+        Scenario: Found more apples
+          When I found 5 apples
+          Then I should have 8 apples
+
+        Scenario: Found more apples
+          When I found 2 apples
+          Then I should have 5 apples
+
+        Scenario Outline: Other situations
+          When I ate <ate> apples
+          And I found <found> apples
+          Then I should have <result> apples
+
+          Examples:
+            | ate | found | result |
+            | 3   | 1     | 1      |
+            | 0   | 4     | 8      |
+            | 2   | 2     | 3      |
+      """
+
+  Scenario: Run one feature with 2 failed and 3 passing scenarios
+    When I run "behat --no-colors -f progress features/apples.feature"
+    Then it should fail with:
+      """
+      ..F.............F....
+
+      --- Failed steps:
+
+      001 Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+            Then I should have 8 apples     # features/apples.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      6 scenarios (4 passed, 2 failed)
+      21 steps (19 passed, 2 failed)
+      """
+
+  Scenario: Rerun only failed scenarios
+    Given I run "behat --no-colors -f progress features/apples.feature"
+    When I run "behat --no-colors -f progress features/apples.feature --rerun-only"
+    Then it should fail with:
+    """
+    ..F...F
+
+    --- Failed steps:
+
+    001 Scenario: I'm little hungry   # features/apples.feature:9
+          Then I should have 3 apples # features/apples.feature:11
+            Failed asserting that 2 matches expected 3.
+
+    002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+          Then I should have 8 apples     # features/apples.feature:24
+            Failed asserting that 7 matches expected 8.
+
+    2 scenarios (2 failed)
+    7 steps (5 passed, 2 failed)
+    """
+
+  Scenario: Fixing scenario removes it from the rerun log
+    Given I run "behat --no-colors -f progress features/apples.feature"
+    And there is a file named "features/apples.feature" with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Background:
+          Given I have 3 apples
+
+        Scenario: I'm little hungry
+          When I ate 1 apple
+          Then I should have 2 apples
+
+        Scenario: Found more apples
+          When I found 5 apples
+          Then I should have 8 apples
+
+        Scenario: Found more apples
+          When I found 2 apples
+          Then I should have 5 apples
+
+        Scenario Outline: Other situations
+          When I ate <ate> apples
+          And I found <found> apples
+          Then I should have <result> apples
+
+          Examples:
+            | ate | found | result |
+            | 3   | 1     | 1      |
+            | 0   | 4     | 7      |
+            | 2   | 2     | 3      |
+      """
+    When I run "behat --no-colors -f progress features/apples.feature"
+    And I run "behat --no-colors -f progress features/apples.feature --rerun-only"
+    Then it should pass with:
+    """
+    """

--- a/features/rerun-only.feature
+++ b/features/rerun-only.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Rerun
   In order to test only failed scenarios and exit if none is found
   As a feature developer
@@ -139,7 +140,7 @@ Feature: Rerun
     """
 
   Scenario: Fixing scenario removes it from the rerun log
-    Given I run "behat --no-colors -f progress features/apples.feature"
+    Given I run "behat --no-colors -f progress features/apples.feature --rerun-only"
     And there is a file named "features/apples.feature" with:
       """
       Feature: Apples story
@@ -177,4 +178,5 @@ Feature: Rerun
     And I run "behat --no-colors -f progress features/apples.feature --rerun-only"
     Then it should pass with:
     """
+    No failure found, exiting
     """

--- a/features/rerun-only.feature
+++ b/features/rerun-only.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Rerun
   In order to test only failed scenarios and exit if none is found
   As a feature developer

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -74,6 +74,9 @@ final class RerunController implements Controller
         $command->addOption('--rerun', null, InputOption::VALUE_NONE,
             'Re-run scenarios that failed during last execution.'
         );
+        $command->addOption('--rerun-only', null, InputOption::VALUE_NONE,
+            'Re-run scenarios that failed during last execution or exit if no file is found.'
+        );
     }
 
     /**
@@ -92,12 +95,12 @@ final class RerunController implements Controller
 
         $this->key = $this->generateKey($input);
 
-        if (!$input->getOption('rerun')) {
+        if (!$input->getOption('rerun') && !$input->getOption('rerun-only')) {
             return;
         }
 
         if (!$this->getFileName() || !file_exists($this->getFileName())) {
-            return;
+            return $input->getOption('rerun-only') ? 0: null;
         }
 
         $input->setArgument('paths', $this->getFileName());

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -75,7 +75,7 @@ final class RerunController implements Controller
             'Re-run scenarios that failed during last execution.'
         );
         $command->addOption('--rerun-only', null, InputOption::VALUE_NONE,
-            'Re-run scenarios that failed during last execution or exit if no file is found.'
+            'Re-run scenarios that failed during last execution, or exit if there were no failures.'
         );
     }
 

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -71,10 +71,16 @@ final class RerunController implements Controller
      */
     public function configure(Command $command)
     {
-        $command->addOption('--rerun', null, InputOption::VALUE_NONE,
+        $command->addOption(
+            '--rerun',
+            null,
+            InputOption::VALUE_NONE,
             'Re-run scenarios that failed during last execution.'
         );
-        $command->addOption('--rerun-only', null, InputOption::VALUE_NONE,
+        $command->addOption(
+            '--rerun-only',
+            null,
+            InputOption::VALUE_NONE,
             'Re-run scenarios that failed during last execution, or exit if there were no failures.'
         );
     }
@@ -100,7 +106,12 @@ final class RerunController implements Controller
         }
 
         if (!$this->getFileName() || !file_exists($this->getFileName())) {
-            return $input->getOption('rerun-only') ? 0 : null;
+            if ($input->getOption('rerun-only')) {
+                $output->writeln('No failure found, exiting.');
+                return 0;
+            }
+
+            return null;
         }
 
         $input->setArgument('paths', $this->getFileName());
@@ -159,12 +170,12 @@ final class RerunController implements Controller
     {
         return md5(
             $input->getParameterOption(array('--profile', '-p')) .
-            $input->getOption('suite') .
-            implode(' ', $input->getOption('name')) .
-            implode(' ', $input->getOption('tags')) .
-            $input->getOption('role') .
-            $input->getArgument('paths') .
-            $this->basepath
+                $input->getOption('suite') .
+                implode(' ', $input->getOption('name')) .
+                implode(' ', $input->getOption('tags')) .
+                $input->getOption('role') .
+                $input->getArgument('paths') .
+                $this->basepath
         );
     }
 

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -100,7 +100,7 @@ final class RerunController implements Controller
         }
 
         if (!$this->getFileName() || !file_exists($this->getFileName())) {
-            return $input->getOption('rerun-only') ? 0: null;
+            return $input->getOption('rerun-only') ? 0 : null;
         }
 
         $input->setArgument('paths', $this->getFileName());

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -71,16 +71,10 @@ final class RerunController implements Controller
      */
     public function configure(Command $command)
     {
-        $command->addOption(
-            '--rerun',
-            null,
-            InputOption::VALUE_NONE,
-            'Re-run scenarios that failed during last execution.'
+        $command->addOption('--rerun', null, InputOption::VALUE_NONE,
+            'Re-run scenarios that failed during last execution, or run everything if there were no failures.'
         );
-        $command->addOption(
-            '--rerun-only',
-            null,
-            InputOption::VALUE_NONE,
+        $command->addOption('--rerun-only', null, InputOption::VALUE_NONE,
             'Re-run scenarios that failed during last execution, or exit if there were no failures.'
         );
     }
@@ -170,12 +164,12 @@ final class RerunController implements Controller
     {
         return md5(
             $input->getParameterOption(array('--profile', '-p')) .
-                $input->getOption('suite') .
-                implode(' ', $input->getOption('name')) .
-                implode(' ', $input->getOption('tags')) .
-                $input->getOption('role') .
-                $input->getArgument('paths') .
-                $this->basepath
+            $input->getOption('suite') .
+            implode(' ', $input->getOption('name')) .
+            implode(' ', $input->getOption('tags')) .
+            $input->getOption('role') .
+            $input->getArgument('paths') .
+            $this->basepath
         );
     }
 


### PR DESCRIPTION
This PR adds a new CLI option: `--rerun-only`

The purpose of the command is the same as `--rerun`, but currently, if there is no `.rerun` file for the current test, all tests are executed.

Instead, this command exits with a code 0 if this is the case.