### PR TITLE
perf: add an array cache for callees

### DIFF
--- a/src/Behat/Testwork/Environment/EnvironmentManager.php
+++ b/src/Behat/Testwork/Environment/EnvironmentManager.php
@@ -32,6 +32,10 @@ final class EnvironmentManager
      * @var EnvironmentReader[]
      */
     private $readers = array();
+    /**
+     * @var array<string,Callee[]>
+     */
+    private $callees = array();
 
     /**
      * Registers environment handler.
@@ -109,12 +113,20 @@ final class EnvironmentManager
      */
     public function readEnvironmentCallees(Environment $environment)
     {
+        $suiteName = $environment->getSuite()->getName();
+
+        if (isset($this->callees[$suiteName])) {
+            return $this->callees[$suiteName];
+        }
+
         $callees = array();
         foreach ($this->readers as $reader) {
             if ($reader->supportsEnvironment($environment)) {
                 $callees = array_merge($callees, $reader->readEnvironmentCallees($environment));
             }
         }
+
+        $this->callees[$suiteName] = $callees;
 
         return $callees;
     }


### PR DESCRIPTION
The more context we have the more `EnvironmentManager::readEnvironmentCallees()` method take time.

The aim is to avoid doing the work several time by run.