### PR TITLE
[Chore]: Fixed redirect to documentation URL in readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Useful Links
 ------------
 
 - The main website is at [http://behat.org](http://behat.org)
-- The documentation is at [http://docs.behat.org/en/latest/](http://docs.behat.org/en/latest/)
+- The documentation is at [https://docs.behat.org/en/latest/guides.html](https://docs.behat.org/en/latest/guides.html)
 - Official Google Group is at [http://groups.google.com/group/behat](http://groups.google.com/group/behat)
 - IRC channel on [#freenode](http://freenode.net/) is `#behat`
 - [Note on Patches/Pull Requests](CONTRIBUTING.md)


### PR DESCRIPTION
Dear Behat Team,

I am writing to express my heartfelt gratitude for the incredible work you have done in developing and maintaining the Behat framework. Your dedication and innovation in creating this Behavior-Driven Development (BDD) tool have made a significant impact on the PHP community and on countless projects around the world.

Behat has been an invaluable asset in helping us align our development efforts with business expectations. The clarity and precision it brings to our testing processes have not only improved our code quality but also enhanced collaboration between developers and stakeholders. Your commitment to making BDD accessible and effective has truly set a high standard in the industry.

Thank you for your hard work, continuous improvements, and the support you provide to the community. Your contributions are deeply appreciated, and we look forward to seeing how Behat continues to evolve and inspire better software development practices.

With sincere thanks,

Arshia Montakhabi

Backend dev.

G2Tech

Change log:
- Fixed redirect to the documentation of Behat URL in the readme file.