### PR TITLE
FEATURE: Output custom stdout in `--format progress` mode when very verbose

### DIFF
--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
@@ -52,6 +52,17 @@ final class ProgressStepPrinter implements StepPrinter
         $printer = $formatter->getOutputPrinter();
         $style = $this->resultConverter->convertResultToString($result);
 
+        // FIXME when refactored to symphony output use OutputInterface->getVerbosity() here instead of the magic global
+        $isVeryVerbose = $_SERVER['SHELL_VERBOSITY'] ?? 0 >= 2;
+        if (
+            $isVeryVerbose
+            && $result instanceof ExecutedStepResult
+            && ($callResult = $result->getCallResult())
+            && $callResult->hasStdOut()
+        ) {
+            $printer->writeln(['', $callResult->getStdOut()]);
+        }
+
         switch ($result->getResultCode()) {
             case TestResult::PASSED:
                 $printer->write("{+$style}.{-$style}");


### PR DESCRIPTION
Currently the progress formatter completely omits the possible stdout from the executed step. This makes debugging harder than it needs.

I know the default 'pretty' output dumps the stdout by default, but i dont like to use it as its tooo verbose for 10000+ steps and even imo for 5.