### PR TITLE
Remove deprecations in PHP8.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+                php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
                 os: [ubuntu-latest]
                 composer-mode: [update]
                 symfony-version: ['']

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -64,7 +64,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
     /**
      * {@inheritdoc}
      */
-    public function setServiceContainer(ContainerInterface $container = null)
+    public function setServiceContainer(?ContainerInterface $container = null)
     {
         $this->serviceContainer = $container;
     }

--- a/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
@@ -39,7 +39,7 @@ final class UninitializedContextEnvironment extends StaticEnvironment implements
      * @throws ContextNotFoundException   If class does not exist
      * @throws WrongContextClassException if class does not implement Context interface
      */
-    public function registerContextClass($contextClass, array $arguments = null)
+    public function registerContextClass($contextClass, ?array $arguments = null)
     {
         if (!class_exists($contextClass)) {
             throw new ContextNotFoundException(sprintf(

--- a/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
+++ b/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
@@ -71,7 +71,7 @@ final class ContextExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
+++ b/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
@@ -37,7 +37,7 @@ final class ContextSnippetAppender implements SnippetAppender
      *
      * @param null|FilesystemLogger $logger
      */
-    public function __construct(FilesystemLogger $logger = null)
+    public function __construct(?FilesystemLogger $logger = null)
     {
         $this->logger = $logger;
     }

--- a/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
+++ b/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
@@ -44,7 +44,7 @@ final class SuiteWithContextsSetup implements SuiteSetup
      * @param ClassLoader           $autoloader
      * @param null|FilesystemLogger $logger
      */
-    public function __construct(ClassLoader $autoloader, FilesystemLogger $logger = null)
+    public function __construct(ClassLoader $autoloader, ?FilesystemLogger $logger = null)
     {
         $this->autoloader = $autoloader;
         $this->logger = $logger;

--- a/src/Behat/Behat/Definition/SearchResult.php
+++ b/src/Behat/Behat/Definition/SearchResult.php
@@ -37,7 +37,7 @@ final class SearchResult
      * @param null|string     $matchedText
      * @param null|array      $arguments
      */
-    public function __construct(Definition $definition = null, $matchedText = null, array $arguments = null)
+    public function __construct(?Definition $definition = null, $matchedText = null, ?array $arguments = null)
     {
         $this->definition = $definition;
         $this->matchedText = $matchedText;

--- a/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
+++ b/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
@@ -58,7 +58,7 @@ final class DefinitionExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -54,7 +54,7 @@ final class GherkinExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
+++ b/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
@@ -36,7 +36,7 @@ final class SuiteWithPathsSetup implements SuiteSetup
      * @param string                $basePath
      * @param null|FilesystemLogger $logger
      */
-    public function __construct($basePath, FilesystemLogger $logger = null)
+    public function __construct($basePath, ?FilesystemLogger $logger = null)
     {
         $this->basePath = $basePath;
         $this->logger = $logger;

--- a/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
+++ b/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
@@ -27,7 +27,7 @@ interface ServiceContainerEnvironment extends Environment
      *
      * @param ContainerInterface|null $container
      */
-    public function setServiceContainer(ContainerInterface $container = null);
+    public function setServiceContainer(?ContainerInterface $container = null);
 
     /**
      * Returns environment service container if set.

--- a/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
+++ b/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
@@ -45,7 +45,7 @@ final class HelperContainerExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Behat/Output/Node/EventListener/AST/ScenarioNodeListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/ScenarioNodeListener.php
@@ -55,7 +55,7 @@ final class ScenarioNodeListener implements EventListener
         $beforeEventName,
         $afterEventName,
         ScenarioPrinter $scenarioPrinter,
-        SetupPrinter $setupPrinter = null
+        ?SetupPrinter $setupPrinter = null
     ) {
         $this->beforeEventName = $beforeEventName;
         $this->afterEventName = $afterEventName;

--- a/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
@@ -48,7 +48,7 @@ final class StepListener implements EventListener
      * @param StepPrinter       $stepPrinter
      * @param null|SetupPrinter $setupPrinter
      */
-    public function __construct(StepPrinter $stepPrinter, SetupPrinter $setupPrinter = null)
+    public function __construct(StepPrinter $stepPrinter, ?SetupPrinter $setupPrinter = null)
     {
         $this->stepPrinter = $stepPrinter;
         $this->setupPrinter = $setupPrinter;

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
@@ -181,7 +181,7 @@ final class StepStatsListener implements EventListener
      *
      * @return string
      */
-    private function getStepPath(AfterStepTested $event, Exception $exception = null)
+    private function getStepPath(AfterStepTested $event, ?Exception $exception = null)
     {
         $path = sprintf('%s:%d', $this->currentFeaturePath, $event->getStep()->getLine());
 

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitFeaturePrinter.php
@@ -36,7 +36,7 @@ final class JUnitFeaturePrinter implements FeaturePrinter
      */
     private $durationListener;
 
-    public function __construct(PhaseStatistics $statistics, JUnitDurationListener $durationListener = null)
+    public function __construct(PhaseStatistics $statistics, ?JUnitDurationListener $durationListener = null)
     {
         $this->statistics = $statistics;
         $this->durationListener = $durationListener;

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
@@ -53,7 +53,7 @@ final class JUnitScenarioPrinter
      */
     private $durationListener;
 
-    public function __construct(ResultToStringConverter $resultConverter, JUnitOutlineStoreListener $outlineListener, JUnitDurationListener $durationListener = null)
+    public function __construct(ResultToStringConverter $resultConverter, JUnitOutlineStoreListener $outlineListener, ?JUnitDurationListener $durationListener = null)
     {
         $this->resultConverter = $resultConverter;
         $this->outlineStoreListener = $outlineListener;
@@ -63,7 +63,7 @@ final class JUnitScenarioPrinter
     /**
      * {@inheritDoc}
      */
-    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result, string $file = null)
+    public function printOpenTag(Formatter $formatter, FeatureNode $feature, ScenarioLikeInterface $scenario, TestResult $result, ?string $file = null)
     {
         $name = implode(' ', array_map(function ($l) {
             return trim($l);

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSuitePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSuitePrinter.php
@@ -28,7 +28,7 @@ final class JUnitSuitePrinter implements SuitePrinter
      */
     private $statistics;
 
-    public function __construct(PhaseStatistics $statistics = null)
+    public function __construct(?PhaseStatistics $statistics = null)
     {
         $this->statistics = $statistics;
     }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -51,7 +51,7 @@ class PrettyFormatterFactory implements FormatterFactory
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -47,7 +47,7 @@ class ProgressFormatterFactory implements FormatterFactory
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -50,7 +50,7 @@ class SnippetExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -58,7 +58,7 @@ class TesterExtension extends BaseExtension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
 

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -52,7 +52,7 @@ class TransformationExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ?: new ServiceProcessor();
     }

--- a/src/Behat/Testwork/Call/CallResult.php
+++ b/src/Behat/Testwork/Call/CallResult.php
@@ -44,7 +44,7 @@ final class CallResult
      * @param null|Exception $exception
      * @param null|string    $stdOut
      */
-    public function __construct(Call $call, $return, Exception $exception = null, $stdOut = null)
+    public function __construct(Call $call, $return, ?Exception $exception = null, $stdOut = null)
     {
         $this->call = $call;
         $this->return = $return;

--- a/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
+++ b/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
@@ -47,7 +47,7 @@ final class CallExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
+++ b/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
@@ -46,7 +46,7 @@ final class CliExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ?: new ServiceProcessor();
     }

--- a/src/Behat/Testwork/Environment/ServiceContainer/EnvironmentExtension.php
+++ b/src/Behat/Testwork/Environment/ServiceContainer/EnvironmentExtension.php
@@ -47,7 +47,7 @@ final class EnvironmentExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -47,7 +47,7 @@ class EventDispatcherExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfony5.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfony5.php
@@ -23,7 +23,7 @@ final class TestworkEventDispatcherSymfony5 extends EventDispatcher
     /**
      * {@inheritdoc}
      */
-    public function dispatch($event, string $eventName = null): object
+    public function dispatch($event, ?string $eventName = null): object
     {
         trigger_error(
             'Class "\Behat\Testwork\EventDispatcher\TestworkEventDispatcherSymfony5" is deprecated ' .

--- a/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfonyLegacy.php
+++ b/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfonyLegacy.php
@@ -25,7 +25,7 @@ final class TestworkEventDispatcherSymfonyLegacy extends EventDispatcher
      * {@inheritdoc}
      *
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, ?Event $event = null)
     {
         trigger_error(
             'Class "\Behat\Testwork\EventDispatcher\TestworkEventDispatcherSymfonyLegacy" is deprecated ' .

--- a/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
+++ b/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
@@ -47,7 +47,7 @@ final class ExceptionExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Testwork/Ordering/ServiceContainer/OrderingExtension.php
+++ b/src/Behat/Testwork/Ordering/ServiceContainer/OrderingExtension.php
@@ -40,7 +40,7 @@ final class OrderingExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ?: new ServiceProcessor();
     }

--- a/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
@@ -58,7 +58,7 @@ final class OutputExtension implements Extension
      * @param FormatterFactory[]    $formatterFactories
      * @param null|ServiceProcessor $processor
      */
-    public function __construct($defaultFormatter, array $formatterFactories, ServiceProcessor $processor = null)
+    public function __construct($defaultFormatter, array $formatterFactories, ?ServiceProcessor $processor = null)
     {
         $this->defaultFormatter = $defaultFormatter;
         $this->factories = $formatterFactories;

--- a/src/Behat/Testwork/ServiceContainer/ContainerLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/ContainerLoader.php
@@ -45,8 +45,8 @@ final class ContainerLoader
      */
     public function __construct(
         ExtensionManager $extensionManager,
-        ConfigurationTree $configuration = null,
-        Processor $processor = null
+        ?ConfigurationTree $configuration = null,
+        ?Processor $processor = null
     ) {
         $this->extensionManager = $extensionManager;
         $this->configuration = $configuration ? : new ConfigurationTree();

--- a/src/Behat/Testwork/Specification/ServiceContainer/SpecificationExtension.php
+++ b/src/Behat/Testwork/Specification/ServiceContainer/SpecificationExtension.php
@@ -44,7 +44,7 @@ final class SpecificationExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Testwork/Suite/Exception/SuiteException.php
+++ b/src/Behat/Testwork/Suite/Exception/SuiteException.php
@@ -33,7 +33,7 @@ class SuiteException extends InvalidArgumentException implements TestworkExcepti
      * @param string         $name
      * @param Exception|null $previous
      */
-    public function __construct($message, $name, Exception $previous = null)
+    public function __construct($message, $name, ?Exception $previous = null)
     {
         $this->name = $name;
 

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -48,7 +48,7 @@ final class SuiteExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -55,7 +55,7 @@ abstract class TesterExtension implements Extension
      *
      * @param null|ServiceProcessor $processor
      */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }


### PR DESCRIPTION
PHP8.4 has deprecated implicit nullable parameters. Some of those are used within Behat and now render a lot of deprecation messages.

This PR replaces the implicit nullables with an explicit nullable wherever they are encountered. This should not have any influence on the code-execution but merely updates the function signature to make more explicit what is expected.