### PR TITLE
GH Actions/tests: fix workflow issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
                 if: matrix.composer-mode == 'update'
                 env:
                     SYMFONY_REQUIRE: ${{ matrix.symfony-version }}.*
-                run: composer update ${{ matrix.php == '8.3' && '--ignore-platform-req=php+' || '' }}
+                run: composer update ${{ matrix.php == '8.4' && '--ignore-platform-req=php+' || '' }}
 
             -   name: Install lowest dependencies
                 if: matrix.composer-mode == 'lowest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: "${{ matrix.php }}"
+                    ini-file: "development"
                     ini-values: "phar.readonly=0,zend.exception_ignore_args=Off"
                     coverage: none
 


### PR DESCRIPTION
### GH Actions/tests: use "develop" ini file

By default setupPHP uses the `production` ini file, which silences some errors.
Changing this to the `development` ini file should surface all errors when running the tests.

### GH Actions/test: use ignore-platform-reqs

... on "PHP next", not on "PHP latest".

This should fix the `composer install` failure on PHP 8.4.