### PR TITLE
PHP 8.4 | CallExtension: remove use of `E_STRICT` [1]

### DIFF
--- a/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
+++ b/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
@@ -77,7 +77,7 @@ final class CallExtension implements Extension
             ->children()
                 ->scalarNode('error_reporting')
                     ->info('Call executor will catch exceptions matching this level')
-                    ->defaultValue(E_ALL | E_STRICT)
+                    ->defaultValue(E_ALL)
                 ->end()
             ->end()
         ;


### PR DESCRIPTION
The `E_STRICT` constant is deprecated as of PHP 8.4 and will be removed in PHP 9.0.

The error level hasn't been in use since PHP 8.0 anyway and was only barely still used in PHP 7.x, so removing the exclusion from the default value in the `CallExtension` script shouldn't really make any difference in practice.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant