### PR TITLE
PHP 8.4 | CallErrorException: prevent deprecation for `E_STRICT` [2]

### DIFF
--- a/src/Behat/Testwork/Call/Exception/CallErrorException.php
+++ b/src/Behat/Testwork/Call/Exception/CallErrorException.php
@@ -25,7 +25,6 @@ final class CallErrorException extends ErrorException
         E_USER_ERROR        => 'User Error',
         E_USER_WARNING      => 'User Warning',
         E_USER_NOTICE       => 'User Notice',
-        E_STRICT            => 'Runtime Notice',
         E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
     );
 
@@ -39,6 +38,11 @@ final class CallErrorException extends ErrorException
      */
     public function __construct($level, $message, $file, $line)
     {
+        // E_STRICT is deprecated since PHP 8.4.
+        if (defined('E_STRICT') && $level === @E_STRICT) {
+            $this->levels[@E_STRICT] = 'Runtime Notice';
+        }
+
         parent::__construct(
             sprintf(
                 '%s: %s in %s line %d',


### PR DESCRIPTION
The `E_STRICT` constant is deprecated as of PHP 8.4 and will be removed in PHP 9.0.

The error level hasn't been in use since PHP 8.0 anyway and was only barely still used in PHP 7.x.

All the same as this is an error handling class, I'm proposing to still handle it, but conditionally to prevent the deprecation notice.

The solution applied is inspired by a similar fix made in PHPUnit by @sebastianbergmann.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant