### PR TITLE
PHP 8.4 | Fix passing E_USER_ERROR to trigger_error()

### DIFF
--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -446,11 +446,11 @@ Feature: Different result types
       Step "/^customer bought coffee$/" is already defined in FeatureContext::chosen()
       """
 
-  Scenario: Error-containing steps
+  Scenario: Warning-containing steps
     Given a file named "features/coffee.feature" with:
       """
       Feature: Redundant actions
-        In order to be able to know about errors in definitions as soon as possible
+        In order to be able to know about warnings in definitions as soon as possible
         As a coffee machine mechanic
         I need to be able to know about redundant menu definitions
 
@@ -471,7 +471,7 @@ Feature: Different result types
       {
           /** @Given /^customer bought coffee$/ */
           public function chosen() {
-              trigger_error("some error", E_USER_ERROR);
+              trigger_error("some warning", E_USER_WARNING);
           }
 
           /** @Given /^customer bought another one coffee$/ */
@@ -490,7 +490,7 @@ Feature: Different result types
 
       001 Scenario: Redundant menu       # features/coffee.feature:6
             Given customer bought coffee # features/coffee.feature:7
-              User Error: some error in features/bootstrap/FeatureContext.php line 12
+              User Warning: some warning in features/bootstrap/FeatureContext.php line 12
 
       1 scenario (1 failed)
       2 steps (1 failed, 1 skipped)


### PR DESCRIPTION
PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`, with the recommendation being to replace these type of calls with either an Exception or an `exit` statement.

This commit fixes the one instance found in this codebase.

Based on my reading of this test, the test is not so much about the error _level_, but about the error _handling_. Given that, changing the error level from `E_USER_ERROR` to `E_USER_WARNING` preserves the value of the test while avoiding the PHP 8.4 deprecation notice.

Ref: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error