### PR TITLE
Fix expected assertion failure for max token length test

### DIFF
--- a/features/definitions_patterns.feature
+++ b/features/definitions_patterns.feature
@@ -234,7 +234,7 @@ Feature: Step Definition Pattern
     When I run "behat -f progress --no-colors"
     Then it should fail with:
       """
-      Token name should not exceed 32 characters, but `too1234567891123456789012345678901` was used.
+      Token name should not exceed 32 characters, but `too12345678911234567890123456789012` was used.
       """
 
   Scenario: Multiline definitions


### PR DESCRIPTION
#1457 updated the policy for token lengths, and updated the test to trigger the assertion, but it missed changing the expected error message so master is now failing builds.

Looks like we missed this before the merge, because the PR was so stale that the CI either hadn't run on the commit, or ran but has since been archived from github.