### PR TITLE
Avoid arbitrary output in tests

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -394,18 +394,20 @@ EOL;
      */
     public function itShouldFail($success)
     {
+        $message = '';
+
         if ('fail' === $success) {
             if (0 === $this->getExitCode()) {
-                echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
+                $message = 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            Assert::assertNotEquals(0, $this->getExitCode());
+            Assert::assertNotEquals(0, $this->getExitCode(), $message);
         } else {
             if (0 !== $this->getExitCode()) {
-                echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
+                $message = 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            Assert::assertEquals(0, $this->getExitCode());
+            Assert::assertEquals(0, $this->getExitCode(), $message);
         }
     }
 


### PR DESCRIPTION
When the relevant tests failed, the output was hidden since echo/output is not the right way to influence PHPUnit test results (the `$message` assertion parameter should be used instead).

