### PR TITLE
docs: update the "Submitting a Pull Request" section of the "contributing" docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,18 +26,16 @@ us reduce the clutter of "silent issues"
 ## Submitting a Pull Request
 
 1. Make your feature addition, bug fix or refactoring
-2. Add new `Scenario` into [one of existing features](features) or create a new `.feature` file describing
+2. Add a new `Scenario` into [one of the existing features](features) or create a new `.feature` file describing
 the changes. Check the [features/](features) folder for examples. This is important so we don't break the
 changes you introduced in a future version unintentionally
-3. Make sure your changes adhere to [Backwards Compatibility](#backwards-compatibility) rules. This is important
+3. Make sure your changes adhere to the [Backwards Compatibility](#backwards-compatibility) rules. This is important
 so that we adhere to [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html)
-4. Explain the kind of change you made under the [`[Unreleased]`](CHANGELOG.md#unreleased) section of the
-[CHANGELOG.md](CHANGELOG.md). You'd make our life even easier if you stick to [Keep a Changelog](http://keepachangelog.com/en/0.3.0/) format
 5. Do not mess with the [`BehatApplication::VERSION`](src/Behat/Behat/ApplicationFactory.php#L48) version
-6. Make sure you [ran tests](#running-tests) and didn't break anything. That will save some time for
-[GitHub](https://github.com/Behat/Behat/actions)
-7. Commit your code and submit a Pull Request, providing a clear description of a change,
-similar to the one you did in the changelog
+6. Make sure you [ran the tests](#running-tests) and didn't break anything. That will save some time on
+[GitHub actions](https://github.com/Behat/Behat/actions)
+7. Commit your code and submit a Pull Request, providing a clear description of the change, including
+the motivation for the proposal
 
 ## Backwards compatibility
 


### PR DESCRIPTION
Removes the requirement to add an entry in the "Unreleased" section of the Changelog document as we will be taking care of the Changelog separately as part of our new release process.

I used the opportunity to tidy up a little bit the text in the "Submitting a Pull Request" section.

@acoulton I think it is better if this reviewed by a native English speaker (I am not) so would be grateful if you could take a look