### PR TITLE
chore: Update links in README to https, drop dead channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,24 @@ Before contributing to Behat, please take a look at the [CONTRIBUTING.md](CONTRI
 Versioning
 ----------
 
-Starting from `v3.0.0`, Behat is following [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.html).
+Starting from `v3.0.0`, Behat is following [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 This basically means that if all you do is implement interfaces (like [this one](https://github.com/Behat/Behat/blob/v3.1.0/src/Behat/Behat/Context/ContextClass/ClassResolver.php#L15-L22))
 and use service constants (like [this one](https://github.com/Behat/Behat/blob/v3.1.0/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php#L46)),
 you would not have any backwards compatibility issues with Behat up until `v4.0.0` (or later major)
 is released. Exception could be an extremely rare case where BC break is introduced as a measure
 to fix a serious issue.
 
-You can read detailed guidance on what BC means in [Symfony BC guide](http://symfony.com/doc/current/contributing/code/bc.html).
+You can read detailed guidance on what BC means in [Symfony BC guide](https://symfony.com/doc/current/contributing/code/bc.html).
 
 Useful Links
 ------------
 
-- The main website is at [http://behat.org](http://behat.org)
-- The documentation is at [http://docs.behat.org/en/latest/](http://docs.behat.org/en/latest/)
-- Official Google Group is at [http://groups.google.com/group/behat](http://groups.google.com/group/behat)
-- IRC channel on [#freenode](http://freenode.net/) is `#behat`
+- The main website is at [https://behat.org](https://behat.org)
+- The documentation is at [https://docs.behat.org/en/latest/](https://docs.behat.org/en/latest/)
 - [Note on Patches/Pull Requests](CONTRIBUTING.md)
 
 Contributors
 ------------
 
-- Konstantin Kudryashov [everzet](http://github.com/everzet) [lead developer]
+- Konstantin Kudryashov [everzet](https://github.com/everzet) [lead developer]
 - Other [awesome developers](https://github.com/Behat/Behat/graphs/contributors)


### PR DESCRIPTION
The freenode IRC no longer exists (as far as I know), and the google group exists but appears to be entirely spam emails.

Neither of these are likely to be good destinations for community / support in 2024 so I have removed them.

All other links are now https (some were http).

Replaces #1468