### PR TITLE
Removes the unnecessary alias of the ScenarioInterface as it just causes confusion

### DIFF
--- a/src/Behat/Behat/Hook/Scope/AfterScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterScenarioScope.php
@@ -11,7 +11,7 @@
 namespace Behat\Behat\Hook\Scope;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioInterface as Scenario;
+use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Hook\Scope\AfterTestScope;
 use Behat\Testwork\Suite\Suite;
@@ -33,7 +33,7 @@ final class AfterScenarioScope implements ScenarioScope, AfterTestScope
      */
     private $feature;
     /**
-     * @var Scenario
+     * @var ScenarioInterface
      */
     private $scenario;
     /**
@@ -46,10 +46,10 @@ final class AfterScenarioScope implements ScenarioScope, AfterTestScope
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param Scenario    $scenario
+     * @param ScenarioInterface $scenario
      * @param TestResult  $result
      */
-    public function __construct(Environment $env, FeatureNode $feature, Scenario $scenario, TestResult $result)
+    public function __construct(Environment $env, FeatureNode $feature, ScenarioInterface $scenario, TestResult $result)
     {
         $this->environment = $env;
         $this->feature = $feature;
@@ -100,7 +100,7 @@ final class AfterScenarioScope implements ScenarioScope, AfterTestScope
     /**
      * Returns scenario.
      *
-     * @return Scenario
+     * @return ScenarioInterface
      */
     public function getScenario()
     {

--- a/src/Behat/Behat/Hook/Scope/BeforeScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeScenarioScope.php
@@ -11,7 +11,7 @@
 namespace Behat\Behat\Hook\Scope;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioInterface as Scenario;
+use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Suite\Suite;
 
@@ -31,7 +31,7 @@ final class BeforeScenarioScope implements ScenarioScope
      */
     private $feature;
     /**
-     * @var Scenario
+     * @var ScenarioInterface
      */
     private $scenario;
 
@@ -40,9 +40,9 @@ final class BeforeScenarioScope implements ScenarioScope
      *
      * @param Environment $env
      * @param FeatureNode $feature
-     * @param Scenario    $scenario
+     * @param ScenarioInterface $scenario
      */
-    public function __construct(Environment $env, FeatureNode $feature, Scenario $scenario)
+    public function __construct(Environment $env, FeatureNode $feature, ScenarioInterface $scenario)
     {
         $this->environment = $env;
         $this->feature = $feature;
@@ -92,7 +92,7 @@ final class BeforeScenarioScope implements ScenarioScope
     /**
      * Returns scenario.
      *
-     * @return Scenario
+     * @return ScenarioInterface
      */
     public function getScenario()
     {

--- a/src/Behat/Behat/Hook/Scope/ScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/ScenarioScope.php
@@ -11,7 +11,7 @@
 namespace Behat\Behat\Hook\Scope;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioInterface as Scenario;
+use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Testwork\Hook\Scope\HookScope;
 
 /**
@@ -34,7 +34,7 @@ interface ScenarioScope extends HookScope
     /**
      * Returns scenario.
      *
-     * @return Scenario
+     * @return ScenarioInterface
      */
     public function getScenario();
 }


### PR DESCRIPTION
In the ScenarioScope classes the `ScenarioInterface` interface had been aliased as `Scenario`. This alias is unnecessary and just causes confusion on people expecting a specific class and not a class that implements this interface, see issue https://github.com/Behat/Behat/issues/1470 for an example.

This PR just removes this alias in all these classes