### PR TITLE
Fix phar upload for the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,10 +195,9 @@ jobs:
           path: .
 
       - name: Upload behat.phar
-        uses: basefas/upload-release-asset-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: svenstaro/upload-release-action@v2
         with:
-          release_id: ${{ github.event.release.id }}
-          asset_path: behat.phar
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: behat.phar
           asset_name: behat.phar
+          tag: ${{ github.ref }}


### PR DESCRIPTION
The phar file uploaded for the 3.15.0 release did not work correctly, it threw an error when you tried to use it. Using my fork to perform some checks I confirmed that the problem happens in the job that uploads the created phar to the release which somehow seems to bork it. To fix this, I have changed our actions code to use a different "upload to release" action. Testing with my fork, it seems to work fine.

(The new action seems to be much more popular, it has more than 600 GH stars while the one we were using previously only has one)

Fixes https://github.com/Behat/Behat/issues/1507