### PR TITLE
handle --strict option with stop_on_failure config

### DIFF
--- a/features/stop_on_failure_config.feature
+++ b/features/stop_on_failure_config.feature
@@ -57,6 +57,24 @@ Feature: Stop on failure via config
            And I have another step that passes
           Then I should have a scenario that passed
       """
+    And a file named "features/missing-step.feature" with:
+      """
+      Feature: Missing Step Feature
+        In order to test the stop-on-failure and strict features
+        As a behat developer
+        I need to have a feature with a missing step
+
+        Background:
+          Given I have a step that passes
+
+        Scenario: 1st Failing
+          When I have a step that is missing
+          Then I should have a scenario that failed
+
+        Scenario: 1st Passing
+          When I have a step that passes
+          Then I should have a scenario that passed
+      """
 
   Scenario: with stop_on_failure set to false
    Given a file named "behat.yml" with:
@@ -110,6 +128,35 @@ Feature: Stop on failure via config
 
       2 scenarios (1 passed, 1 failed)
       7 steps (5 passed, 1 failed, 1 skipped)
+      """
+      
+  Scenario: with stop_on_failure set to true and a missing step
+   Given a file named "behat.yml" with:
+      """
+      default:
+        config:
+          stop_on_failure: true
+      """
+    When I run "behat --no-colors --format-settings='{\"paths\": false}' features/missing-step.feature"
+    Then it should pass with:
+      """
+      2 scenarios (1 passed, 1 undefined)
+      6 steps (4 passed, 1 undefined, 1 skipped)
+      """
+      
+  Scenario: with stop_on_failure set to true and a missing step in strict mode
+   Given a file named "behat.yml" with:
+      """
+      default:
+        config:
+          stop_on_failure: true
+      """
+      
+    When I run "behat --no-colors --format-settings='{\"paths\": false}' --strict features/missing-step.feature"
+    Then it should fail with:
+      """
+      1 scenario (1 undefined)
+      3 steps (1 passed, 1 undefined, 1 skipped)
       """
 
   Scenario: with stop_on_failure set to false, but cli option set to true

--- a/src/Behat/Behat/Config/Handler/StopOnFailureHandler.php
+++ b/src/Behat/Behat/Config/Handler/StopOnFailureHandler.php
@@ -18,7 +18,7 @@ use Behat\Testwork\EventDispatcher\Event\AfterSuiteAborted;
 use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
 use Behat\Testwork\EventDispatcher\Event\SuiteTested;
 use Behat\Testwork\Tester\Result\Interpretation\ResultInterpretation;
-use Behat\Testwork\Tester\Result\Interpretation\StrictInterpretation;
+use Behat\Testwork\Tester\Result\Interpretation\SoftInterpretation;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -40,18 +40,16 @@ final class StopOnFailureHandler
     public function __construct(EventDispatcherInterface $eventDispatcher)
     {
         $this->eventDispatcher = $eventDispatcher;
-        $this->resultInterpretation = new StrictInterpretation();
+        $this->resultInterpretation = new SoftInterpretation();
+    }
+
+    public function setResultInterpretation(ResultInterpretation $resultInterpretation)
+    {
+        $this->resultInterpretation = $resultInterpretation;
     }
     
-    /**
-     * @param ?ResultInterpretation $resultInterpretation 
-     */
-    public function registerListeners($resultInterpretation = null)
+    public function registerListeners()
     {
-        if ($resultInterpretation) {
-            $this->resultInterpretation = $resultInterpretation;
-        }
-
         $this->eventDispatcher->addListener(ScenarioTested::AFTER, array($this, 'exitOnFailure'), -100);
         $this->eventDispatcher->addListener(ExampleTested::AFTER, array($this, 'exitOnFailure'), -100);
     }

--- a/src/Behat/Behat/EventDispatcher/Cli/StopOnFailureController.php
+++ b/src/Behat/Behat/EventDispatcher/Cli/StopOnFailureController.php
@@ -87,18 +87,15 @@ final class StopOnFailureController implements Controller
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($input->getOption('strict')) {
+            $this->stopOnFailureHandler->setResultInterpretation(new StrictInterpretation());
+        }
+        
         if (!$input->getOption('stop-on-failure')) {
             return null;
         }
 
-        
-        if ($input->getOption('strict')) {
-            $resultInterpretation = new StrictInterpretation();
-        } else {
-            $resultInterpretation = new SoftInterpretation();
-        }
-
-        $this->stopOnFailureHandler->registerListeners($resultInterpretation);
+        $this->stopOnFailureHandler->registerListeners();
     }
 
 }


### PR DESCRIPTION
With the new config parameter, the "strict" mode was not handled correctly : 

The default mode is a `SoftInterpretation` and is "strictified" with the `--stict` cli parameter.

The difference between the two interpretation is how we handled the undefined steps: SoftInterpretation does not fail if a step is missing, but do fail otherwise.

https://github.com/Behat/Behat/pull/1501/files wrongly set the default interpreter to the `Strict` one, and even if the right interpreter was set with the cli parameters, it was not with the `config:` one.

This PR does fix that, and it will be followed by another one implementing `strict` in the config.