### PR TITLE
Handle "strict" in behat configuration file

### DIFF
--- a/features/config_strict.feature
+++ b/features/config_strict.feature
@@ -1,0 +1,65 @@
+Feature: Strict type defined in configuration file
+  As a feature writer
+  I need to be able to configure "strict" option in behat.yml config file
+
+  Scenario: Undefined steps
+    Given a file named "features/coffee.feature" with:
+      """
+      Feature: Undefined coffee machine actions
+        In order to make clients happy
+        As a coffee machine factory
+        We need to be able to tell customers
+        about what coffee type is supported
+
+        Background:
+          Given I have magically created 10$
+
+        Scenario: Buy incredible coffee
+          When I have chose "coffee with turkey" in coffee machine
+          Then I should have "turkey with coffee sauce"
+
+        Scenario: Buy incredible tea
+          When I have chose "pizza tea" in coffee machine
+          Then I should have "pizza tea"
+      """
+    And a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context,
+          Behat\Behat\Tester\Exception\PendingException;
+      use Behat\Gherkin\Node\PyStringNode,
+          Behat\Gherkin\Node\TableNode;
+
+      class FeatureContext implements Context {}
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+        config:
+          strict: false
+      """
+    When I run "behat --no-colors -f progress features/coffee.feature"
+    Then it should pass with:
+      """
+      UUUUUU
+
+      2 scenarios (2 undefined)
+      6 steps (6 undefined)
+      """
+
+    Given a file named "behat.yml" with:
+      """
+      default:
+        config:
+          strict: true
+      """
+    When I run "behat --no-colors -f progress features/coffee.feature"
+    Then it should fail with:
+      """
+      UUUUUU
+
+      2 scenarios (2 undefined)
+      6 steps (6 undefined)
+
+      """

--- a/src/Behat/Behat/Config/Handler/StopOnFailureHandler.php
+++ b/src/Behat/Behat/Config/Handler/StopOnFailureHandler.php
@@ -27,22 +27,19 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 final class StopOnFailureHandler
 {
-    
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $eventDispatcher;
+    private ResultInterpretation $resultInterpretation;
 
-    /**
-     * @var ResultInterpretation
-     */
-    private $resultInterpretation;
-
-    public function __construct(EventDispatcherInterface $eventDispatcher, bool $strict)
-    {
-        $this->eventDispatcher = $eventDispatcher;
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        bool $strict
+    ) {
         $this->resultInterpretation = $strict ? new StrictInterpretation() : new SoftInterpretation();
 
+    }
+
+    public function setResultInterpretation(ResultInterpretation $resultInterpretation)
+    {
+        $this->resultInterpretation = $resultInterpretation;
     }
     
     public function registerListeners()
@@ -53,8 +50,6 @@ final class StopOnFailureHandler
 
     /**
      * Exits if scenario is a failure and if stopper is enabled.
-     *
-     * @param AfterScenarioTested $event
      */
     public function exitOnFailure(AfterScenarioTested $event)
     {

--- a/src/Behat/Behat/Config/Handler/StopOnFailureHandler.php
+++ b/src/Behat/Behat/Config/Handler/StopOnFailureHandler.php
@@ -19,6 +19,7 @@ use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
 use Behat\Testwork\EventDispatcher\Event\SuiteTested;
 use Behat\Testwork\Tester\Result\Interpretation\ResultInterpretation;
 use Behat\Testwork\Tester\Result\Interpretation\SoftInterpretation;
+use Behat\Testwork\Tester\Result\Interpretation\StrictInterpretation;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -37,15 +38,11 @@ final class StopOnFailureHandler
      */
     private $resultInterpretation;
 
-    public function __construct(EventDispatcherInterface $eventDispatcher)
+    public function __construct(EventDispatcherInterface $eventDispatcher, bool $strict)
     {
         $this->eventDispatcher = $eventDispatcher;
-        $this->resultInterpretation = new SoftInterpretation();
-    }
+        $this->resultInterpretation = $strict ? new StrictInterpretation() : new SoftInterpretation();
 
-    public function setResultInterpretation(ResultInterpretation $resultInterpretation)
-    {
-        $this->resultInterpretation = $resultInterpretation;
     }
     
     public function registerListeners()

--- a/src/Behat/Behat/Config/Handler/StrictHandler.php
+++ b/src/Behat/Behat/Config/Handler/StrictHandler.php
@@ -18,14 +18,9 @@ use Behat\Testwork\Tester\Result\ResultInterpreter;
  */
 final class StrictHandler
 {
-    /**
-     * @var ResultInterpreter
-     */
-    private $resultInterpreter;
-
-    public function __construct(ResultInterpreter $resultInterpreter)
-    {
-        $this->resultInterpreter = $resultInterpreter;
+    public function __construct(
+        private readonly ResultInterpreter $resultInterpreter
+    ) {
     }
 
     public function registerStrictInterpretation()

--- a/src/Behat/Behat/Config/Handler/StrictHandler.php
+++ b/src/Behat/Behat/Config/Handler/StrictHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Config\Handler;
+
+use Behat\Testwork\Tester\Result\Interpretation\StrictInterpretation;
+use Behat\Testwork\Tester\Result\ResultInterpreter;
+
+/**
+ * Enables strict mode via config.
+ */
+final class StrictHandler
+{
+    /**
+     * @var ResultInterpreter
+     */
+    private $resultInterpreter;
+
+    public function __construct(ResultInterpreter $resultInterpreter)
+    {
+        $this->resultInterpreter = $resultInterpreter;
+    }
+
+    public function registerStrictInterpretation()
+    {
+        $this->resultInterpreter->registerResultInterpretation(new StrictInterpretation());
+    }
+}

--- a/src/Behat/Behat/Config/ServiceContainer/ConfigExtension.php
+++ b/src/Behat/Behat/Config/ServiceContainer/ConfigExtension.php
@@ -13,6 +13,7 @@ namespace Behat\Behat\Config\ServiceContainer;
 use Behat\Testwork\EventDispatcher\ServiceContainer\EventDispatcherExtension;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Behat\Testwork\Tester\ServiceContainer\TesterExtension;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -24,6 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
 final class ConfigExtension implements Extension
 {
     public const STOP_ON_FAILURE_ID = 'config.stop_on_failure';
+    public const STRICT_ID = 'config.strict';
 
     /**
      * {@inheritdoc}
@@ -51,6 +53,9 @@ final class ConfigExtension implements Extension
                 ->scalarNode('stop_on_failure')
                     ->defaultValue(null)
                 ->end()
+                ->booleanNode('strict')
+                    ->defaultFalse()
+                ->end()
             ->end()
         ;
     }
@@ -61,6 +66,7 @@ final class ConfigExtension implements Extension
     public function load(ContainerBuilder $container, array $config)
     {
         $this->loadStopOnFailureHandler($container, $config);
+        $this->loadStrictHandler($container, $config);
     }
 
     /**
@@ -77,11 +83,27 @@ final class ConfigExtension implements Extension
     private function loadStopOnFailureHandler(ContainerBuilder $container, array $config)
     {
         $definition = new Definition('Behat\Behat\Config\Handler\StopOnFailureHandler', array(
-            new Reference(EventDispatcherExtension::DISPATCHER_ID)
+            new Reference(EventDispatcherExtension::DISPATCHER_ID),
+            $config['strict']
         ));
         if ($config['stop_on_failure'] === true) {
             $definition->addMethodCall('registerListeners');
         }
         $container->setDefinition(self::STOP_ON_FAILURE_ID, $definition);
+    }
+
+    /**
+     * Loads strict handler.
+     */
+    private function loadStrictHandler(ContainerBuilder $container, array $config)
+    {
+        $definition = new Definition('Behat\Behat\Config\Handler\StrictHandler', array(
+            new Reference(TesterExtension::RESULT_INTERPRETER_ID)
+        ));
+        if ($config['strict'] === true) {
+            $definition->addMethodCall('registerStrictInterpretation');
+        }
+
+        $container->setDefinition(self::STRICT_ID, $definition);
     }
 }

--- a/src/Behat/Testwork/Tester/Cli/StrictController.php
+++ b/src/Behat/Testwork/Tester/Cli/StrictController.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\Tester\Cli;
 
+use Behat\Behat\Config\Handler\StrictHandler;
 use Behat\Testwork\Cli\Controller;
 use Behat\Testwork\Tester\Result\Interpretation\StrictInterpretation;
 use Behat\Testwork\Tester\Result\ResultInterpreter;
@@ -26,6 +27,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class StrictController implements Controller
 {
     /**
+      * @deprecated resultInterpreter is handled in StrictHandler
      * @var ResultInterpreter
      */
     private $resultInterpreter;
@@ -33,6 +35,11 @@ final class StrictController implements Controller
      * @var bool
      */
     private $strict;
+
+    /**
+     * @var StrictHandler
+     */
+    private $strictHandler;
 
     /**
      * Initializes controller.
@@ -44,6 +51,12 @@ final class StrictController implements Controller
     {
         $this->resultInterpreter = $resultInterpreter;
         $this->strict = $strict;
+    }
+
+    /** @required */
+    public function setStrictHandler(StrictHandler $strictHandler)
+    {
+        $this->strictHandler = $strictHandler;
     }
 
     /**
@@ -65,6 +78,6 @@ final class StrictController implements Controller
             return;
         }
 
-        $this->resultInterpreter->registerResultInterpretation(new StrictInterpretation());
+        $this->strictHandler->registerStrictInterpretation();
     }
 }

--- a/src/Behat/Testwork/Tester/Cli/StrictController.php
+++ b/src/Behat/Testwork/Tester/Cli/StrictController.php
@@ -36,10 +36,7 @@ final class StrictController implements Controller
      */
     private $strict;
 
-    /**
-     * @var StrictHandler
-     */
-    private $strictHandler;
+    private StrictHandler $strictHandler;
 
     /**
      * Initializes controller.

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -151,7 +151,7 @@ abstract class TesterExtension implements Extension
             new Reference(self::RESULT_INTERPRETER_ID),
             $strict
         ));
-        $definition->addMethodCall(('setStrictHandler'), array(new Reference(ConfigExtension::STRICT_ID)));
+        $definition->addMethodCall('setStrictHandler', array(new Reference(ConfigExtension::STRICT_ID)));
         $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 300));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.strict', $definition);
     }

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\Tester\ServiceContainer;
 
+use Behat\Behat\Config\ServiceContainer\ConfigExtension;
 use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\Environment\ServiceContainer\EnvironmentExtension;
 use Behat\Testwork\ServiceContainer\Extension;
@@ -150,6 +151,7 @@ abstract class TesterExtension implements Extension
             new Reference(self::RESULT_INTERPRETER_ID),
             $strict
         ));
+        $definition->addMethodCall(('setStrictHandler'), array(new Reference(ConfigExtension::STRICT_ID)));
         $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 300));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.strict', $definition);
     }


### PR DESCRIPTION
Follows https://github.com/Behat/Behat/pull/1501 and #1512 

Implement the fact that we can set the `strict` settings in the behat.yml in `config:` section. 