### PR TITLE
test: Improve output when behat's own tests pass or fail unexpectedly

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -263,13 +263,12 @@ EOL;
      *
      * @Then /^it should (fail|pass) with:$/
      *
-     * @param string       $success "fail" or "pass"
-     * @param PyStringNode $text    PyString text instance
+     * @param 'pass'|'fail' $success
      */
-    public function itShouldPassWith($success, PyStringNode $text)
+    public function itShouldPassOrFailWith($success, PyStringNode $text)
     {
         $this->theOutputShouldContain($text);
-        $this->itShouldFail($success);
+        $this->itShouldPassOrFail($success);
     }
 
     /**
@@ -277,12 +276,12 @@ EOL;
      *
      * @Then /^it should (fail|pass) with no output$/
      *
-     * @param string $success "fail" or "pass"
+     * @param 'pass'|'fail' $success
      */
-    public function itShouldPassWithNoOutput($success)
+    public function itShouldPassOrFailWithNoOutput($success)
     {
         Assert::assertEmpty($this->getOutput());
-        $this->itShouldFail($success);
+        $this->itShouldPassOrFail($success);
     }
 
     /**
@@ -390,30 +389,26 @@ EOL;
      *
      * @Then /^it should (fail|pass)$/
      *
-     * @param string $success "fail" or "pass"
+     * @param 'pass'|'fail' $success  
      */
-    public function itShouldFail($success)
+    public function itShouldPassOrFail($success)
     {
-        $message = '';
-
-        if ('fail' === $success) {
-            Assert::assertNotEquals(0, $this->getExitCode(), 'Step should FAIL but it PASS.');
-
-            if (0 === $this->getExitCode()) {
-                $message = 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
-            }
-
-            Assert::assertNotEquals(0, $this->getExitCode(), $message);
-        } else {
-            Assert::assertEquals(0, $this->getExitCode(), 'Step should PASS but it FAIL.');
-
-
-            if (0 !== $this->getExitCode()) {
-                $message = 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
-            }
-
-            Assert::assertEquals(0, $this->getExitCode(), $message);
-        }
+        $is_correct = match($success) {
+            'fail' => 0 !== $this->getExitCode(),
+            'pass' => 0 === $this->getExitCode(),
+       };
+     
+       if ($is_correct) {
+          return;
+       }
+    
+       throw new UnexpectedValueException(
+            'Expected previous command to ' . strtoupper($success) . ' but got exit code ' . $this->getExitCode() . PHP_EOL
+            . PHP_EOL
+            . '##### Actual output #####' . PHP_EOL
+            . '> ' . str_replace(PHP_EOL, PHP_EOL  .  '> ', $this->getOutput()) . PHP_EOL
+            . '##### End of output #####'
+        );
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -397,12 +397,17 @@ EOL;
         $message = '';
 
         if ('fail' === $success) {
+            Assert::assertNotEquals(0, $this->getExitCode(), 'Step should FAIL but it PASS.');
+
             if (0 === $this->getExitCode()) {
                 $message = 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
             Assert::assertNotEquals(0, $this->getExitCode(), $message);
         } else {
+            Assert::assertEquals(0, $this->getExitCode(), 'Step should PASS but it FAIL.');
+
+
             if (0 !== $this->getExitCode()) {
                 $message = 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }


### PR DESCRIPTION
### Current

When the expected "pass" or "fail" result is wrong, it's quite difficult to understand what is going on.

Imagine a step that should fail but is actually passing, the output is the following:

```gherkin
    Then it should pass with:                                                                                        # FeatureContext::itShouldPassWith()
      """
      Feature: Failing Feature
        In order to test the stop-on-failure feature
        As a behat developer
        I need to have a feature that fails
      
        Background:
          Given I have a step that passes
      
        Scenario: 1st Passing
          When I have a step that passes
          Then I should have a scenario that passed
      
        Scenario: 2nd Passing
          When I have a step that passes
          And I have another step that passes
          Then I should have a scenario that passed
      
        Scenario: 1st Failing
          When I have a step that passes
          And I have another step that fails
            step failed as supposed (Exception)
          Then I should have a scenario that failed
      
      --- Failed scenarios:
      
          features/failing.feature:18
      
      3 scenarios (2 passed, 1 failed)
      11 steps (9 passed, 1 failed, 1 skipped)
      """
      Actual output:
      
      Feature: Failing Feature
        In order to test the stop-on-failure feature
        As a behat developer
        I need to have a feature that fails
      
        Background:
          Given I have a step that passes
      
        Scenario: 1st Passing
          When I have a step that passes
          Then I should have a scenario that passed
      
        Scenario: 2nd Passing
          When I have a step that passes
          And I have another step that passes
          Then I should have a scenario that passed
      
        Scenario: 1st Failing
          When I have a step that passes
          And I have another step that fails
            step failed as supposed (Exception)
          Then I should have a scenario that failed
      
      --- Failed scenarios:
      
          features/failing.feature:18
      
      3 scenarios (2 passed, 1 failed)
      11 steps (9 passed, 1 failed, 1 skipped)
      Failed asserting that 1 matches expected 0.

--- Scénarios échoués:

    features/stop_on_failure.feature:114
```

The `Actual Output` is exactly the same as the expected one, but the fact is that we do test two things:
- the actual output
- the fact that the step is passing or failing !

When I did implement my latest PR, I really got stucked with that output, doing manual diff, trying to clear some cache etc.

## Proposed improvement

I propose to first test the "fail" / "pass" status, before testing the content.

This way the ouput will be the following:

```gherkin
    Then it should pass with:                                                                                        # FeatureContext::itShouldPassWith()
      """
      Feature: Failing Feature
        In order to test the stop-on-failure feature
        As a behat developer
        I need to have a feature that fails
      
        Background:
          Given I have a step that passes
      
        Scenario: 1st Passing
          When I have a step that passes
          Then I should have a scenario that passed
      
        Scenario: 2nd Passing
          When I have a step that passes
          And I have another step that passes
          Then I should have a scenario that passed
      
        Scenario: 1st Failing
          When I have a step that passes
          And I have another step that fails
            step failed as supposed (Exception)
          Then I should have a scenario that failed
      
      --- Failed scenarios:
      
          features/failing.feature:18
      
      3 scenarios (2 passed, 1 failed)
      11 steps (9 passed, 1 failed, 1 skipped)
      """
      Step should PASS but it FAIL.
      Failed asserting that false is true.

--- Scénarios échoués:

    features/stop_on_failure.feature:114
```

In this case, we now understand that the step is passing when we expect it to fail. If the content is not the same, it will be displayed only if the `$success` value is in a correct state.

Here is a diff of the two output to understand easily what did change in the following outputs:

![image](https://github.com/user-attachments/assets/80b88224-f534-4a53-9eb3-5a52539db621)
