### PR TITLE
chore: Update CHANGELOG to mention behaviour change in Gherkin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.15.0] - 2024-10-29
 
+***Note:** This release also bumps the minor version of behat/gherkin to 4.10.0, which was released on 2024-10-19 with
+  a behaviour-changing bugfix related to the parsing of `\` characters in scenarios.
+  See [the Behat/Gherkin CHANGELOG](https://github.com/Behat/Gherkin/blob/master/CHANGES.md#4100--2024-10-19).*
+
 ### Added
 
 * PHP 8.4 support by @heiglandreas in [#1473](https://github.com/Behat/Behat/pull/1473), @jrfnl in [#1478](https://github.com/Behat/Behat/pull/1478),


### PR DESCRIPTION
Further to #1514 and Behat/Gherkin#269, add a note to Behat's own CHANGELOG to mention the behaviour change in gherkin 4.10.0.

I don't think we should set a precedent of incorporating the changelog for other packages into the change for this repo. Not least because the release timings are often going to be different (people would have got the problematic Gherkin update on their next composer update even if Behat hadn't bumped the minimum version).

However in this case given that behat packages have been infrequently released for a while, the releases were close in time so people might have got them both at once and assumed the problem was from Behat rather than Gherkin, and the Behat/Gherkin changelog was not clear originally, I agree we should make an exception and point people in the right direction.