### PR TITLE
change: Rerun all tests that should be considered failed (including undefined, when strict)

### DIFF
--- a/features/rerun_strict.feature
+++ b/features/rerun_strict.feature
@@ -1,0 +1,77 @@
+Feature: Rerun with strict
+  In order to test only failed scenarios with the strict option
+  As a feature developer
+  I need to have an ability to rerun failed previously scenarios, including those which failed due to the strict option
+
+  Background:
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @When I have a failing step
+           */
+          public function iHaveAFailingStep(): void
+          {
+              throw new \Exception();
+          }
+
+          /**
+           * @When I have a passing step
+           */
+          public function iHaveAPassingStep(): void
+          {
+          }
+      }
+      """
+    And a file named "features/rerun_strict.feature" with:
+      """
+      Feature: test
+
+        Scenario: missing step
+          When I have a missing step
+
+        Scenario: failing step
+          When I have a failing step
+
+        Scenario: passing step
+          When I have a passing step
+      """
+
+  Scenario: Rerun feature without strict option
+    When I run "behat --no-colors -f progress -n features/rerun_strict.feature"
+    And I run "behat  --rerun --no-colors -f progress -n features/rerun_strict.feature"
+    Then it should fail with:
+      """
+      F
+
+      --- Failed steps:
+
+      001 Scenario: failing step       # features/rerun_strict.feature:6
+            When I have a failing step # features/rerun_strict.feature:7
+              (Exception)
+
+      1 scenario (1 failed)
+      1 step (1 failed)
+      """
+
+    Scenario: Rerun feature with strict option
+        When I run "behat --strict --no-colors -f progress -n features/rerun_strict.feature"
+        And I run "behat --strict --rerun --no-colors -f progress --rerun -n features/rerun_strict.feature"
+        Then it should fail with:
+      """
+      UF
+
+      --- Failed steps:
+
+      001 Scenario: failing step       # features/rerun_strict.feature:6
+            When I have a failing step # features/rerun_strict.feature:7
+              (Exception)
+
+      2 scenarios (1 failed, 1 undefined)
+      2 steps (1 failed, 1 undefined)
+      """

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -15,6 +15,7 @@ use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Testwork\Cli\Controller;
 use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
+use Behat\Testwork\Tester\Result\ResultInterpreter;
 use Behat\Testwork\Tester\Result\TestResult;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -50,6 +51,8 @@ final class RerunController implements Controller
      */
     private $basepath;
 
+    private ResultInterpreter $resultInterpreter;
+
     /**
      * Initializes controller.
      *
@@ -62,6 +65,11 @@ final class RerunController implements Controller
         $this->eventDispatcher = $eventDispatcher;
         $this->cachePath = null !== $cachePath ? rtrim($cachePath, DIRECTORY_SEPARATOR) : null;
         $this->basepath = $basepath;
+    }
+
+    public function setResultInterpreter(ResultInterpreter $resultInterpreter)
+    {
+        $this->resultInterpreter = $resultInterpreter;
     }
 
     /**
@@ -122,7 +130,7 @@ final class RerunController implements Controller
             return;
         }
 
-        if ($event->getTestResult()->getResultCode() !== TestResult::FAILED) {
+        if ($this->resultInterpreter->interpretResult($event->getTestResult()) === 0) {
             return;
         }
 

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -130,7 +130,7 @@ final class RerunController implements Controller
             return;
         }
 
-        if ($this->resultInterpreter->interpretResult($event->getTestResult()) === 0) {
+        if ($this->resultInterpreter->interpretResult($event->getTestResult()) === ResultInterpreter::PASS) {
             return;
         }
 

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -31,10 +31,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 final class RerunController implements Controller
 {
     /**
-     * @var EventDispatcherInterface
-     */
-    private $eventDispatcher;
-    /**
      * @var null|string
      */
     private $cachePath;
@@ -46,12 +42,6 @@ final class RerunController implements Controller
      * @var string[]
      */
     private $lines = array();
-    /**
-     * @var string
-     */
-    private $basepath;
-
-    private ResultInterpreter $resultInterpreter;
 
     /**
      * Initializes controller.
@@ -60,16 +50,13 @@ final class RerunController implements Controller
      * @param null|string              $cachePath
      * @param string                   $basepath
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher, $cachePath, $basepath)
-    {
-        $this->eventDispatcher = $eventDispatcher;
+    public function __construct(
+        private EventDispatcherInterface $eventDispatcher,
+        private ResultInterpreter $resultInterpreter,
+        private string $basepath,
+        $cachePath,
+    ) {
         $this->cachePath = null !== $cachePath ? rtrim($cachePath, DIRECTORY_SEPARATOR) : null;
-        $this->basepath = $basepath;
-    }
-
-    public function setResultInterpreter(ResultInterpreter $resultInterpreter)
-    {
-        $this->resultInterpreter = $resultInterpreter;
     }
 
     /**

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -248,6 +248,9 @@ class TesterExtension extends BaseExtension
             $container->getParameter('paths.base')
         ));
         $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 200));
+        $definition->addMethodCall('setResultInterpreter', array(
+            new Reference(TesterExtension::RESULT_INTERPRETER_ID)
+        ));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.rerun', $definition);
     }
 

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -244,13 +244,11 @@ class TesterExtension extends BaseExtension
     {
         $definition = new Definition('Behat\Behat\Tester\Cli\RerunController', array(
             new Reference(EventDispatcherExtension::DISPATCHER_ID),
-            $cachePath,
-            $container->getParameter('paths.base')
+            new Reference(TesterExtension::RESULT_INTERPRETER_ID),
+            $container->getParameter('paths.base'),
+            $cachePath
         ));
         $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 200));
-        $definition->addMethodCall('setResultInterpreter', array(
-            new Reference(TesterExtension::RESULT_INTERPRETER_ID)
-        ));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.rerun', $definition);
     }
 

--- a/src/Behat/Testwork/Tester/Result/ResultInterpreter.php
+++ b/src/Behat/Testwork/Tester/Result/ResultInterpreter.php
@@ -19,6 +19,9 @@ use Behat\Testwork\Tester\Result\Interpretation\ResultInterpretation;
  */
 final class ResultInterpreter
 {
+    public const PASS = 0;
+    public const FAIL = 1;
+
     /**
      * @var ResultInterpretation[]
      */
@@ -45,10 +48,10 @@ final class ResultInterpreter
     {
         foreach ($this->interpretations as $interpretation) {
             if ($interpretation->isFailure($result)) {
-                return 1;
+                return self::FAIL;
             }
         }
 
-        return 0;
+        return self::PASS;
     }
 }


### PR DESCRIPTION
We were saving in the rerun file only the tests that strictly failed. We should be saving any test that the result interpreter considers failed so that they can be rerun. This will include unimplemented tests if the strict option is used.

Fixes https://github.com/Behat/Behat/issues/1065