### PR TITLE
change: deprecate ApplicationFactory::VERSION, auto-detect behat version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "ext-mbstring": "*",
         "behat/gherkin": "^4.10.0",
         "behat/transliterator": "^1.5",
+        "composer-runtime-api": "^2.2",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",

--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -39,6 +39,7 @@ use Behat\Testwork\ServiceContainer\ServiceProcessor;
 use Behat\Testwork\Specification\ServiceContainer\SpecificationExtension;
 use Behat\Testwork\Suite\ServiceContainer\SuiteExtension;
 use Behat\Testwork\Translator\ServiceContainer\TranslatorExtension;
+use Composer\InstalledVersions;
 
 /**
  * Defines the way behat is created.
@@ -47,6 +48,11 @@ use Behat\Testwork\Translator\ServiceContainer\TranslatorExtension;
  */
 final class ApplicationFactory extends BaseFactory
 {
+    /**
+     * @deprecated this constant will not be updated for releases after 3.13.0 and will be removed in the next major.
+     * You can use composer's runtime API to get the behat version if you need it - see getVersion() in this class for
+     * an example. Note that composer's versions will not always be simple numeric values.
+     */
     public const VERSION = '3.13.0';
 
     /**
@@ -62,7 +68,8 @@ final class ApplicationFactory extends BaseFactory
      */
     protected function getVersion()
     {
-        return self::VERSION;
+        // Get the currently installed behat version from composer's runtime API
+        return InstalledVersions::getVersion('behat/behat');
     }
 
     /**


### PR DESCRIPTION
As discussed in https://github.com/Behat/Behat/discussions/1484#discussioncomment-11141724

The ApplicationFactory::VERSION constant has not been bumped for the last couple of releases, and updating it manually every time is an avoidable maintenance burden.

Deprecate the constant - it will not be updated in the future, and will be removed in next major.

Instead, use composer's runtime API to detect the version at runtime (only really used for inclusion in tool output). This follows the pattern used by e.g. [doctrine](
https://github.com/doctrine/orm/blob/44fa8bbde87238ad9b574e87325c7ff89c75837e/src/Tools/Console/ConsoleRunner.php#L45-L46)

Composer's version is generated to a file at the time of `composer install` and therefore is baked into the `.phar` so that also works as expected.

Note that in some cases composer versions are non-numeric (e.g. a dev branch may report a version of `dev-c629b4a773cf2dc11e0930bd8930adf22eae5031`).