### PR TITLE
bug: Improve handling exceptions from unsupported PHPUnit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
 
     "require-dev": {
+        "symfony/polyfill-php84": "^1.31",
         "symfony/process": "^5.4 || ^6.4 || ^7.0",
         "phpunit/phpunit": "^9.6",
         "herrera-io/box": "~1.6.1",

--- a/features/phpunit_exceptions.feature
+++ b/features/phpunit_exceptions.feature
@@ -1,0 +1,244 @@
+Feature: Stringifying PHPUnit exceptions
+  In order to understand why a step has failed
+  As a feature developer
+  I need to see the details of failed PHPUnit assertions if I am using a supported version
+
+  Background:
+      Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+      use Behat\Hook\BeforeFeature;
+      use Behat\Hook\BeforeSuite;
+      use Behat\Step\Then;
+      use PHPUnit\Framework\Assert;
+
+      class FeatureContext implements Context
+      {
+
+          #[BeforeSuite]
+          public static function beforeSuiteEnableNativeAssert(): void
+          {
+              // Enforce native assertions during this run, so we can use them to check state without using PHPUnit classes.
+              ini_set('assert.active', true);
+              ini_set('assert.exception', true);
+          }
+
+          #[BeforeFeature('@phpunit_10_broken')]
+          public static function beforeFeatureBreakPHPUnit10(): void
+          {
+              // Note this test proves both that we're handling exceptions, and that Behat will use the PHPUnit 10
+              // ThrowableToStringMapper class if it's present - even though at the moment we're installing PHPUnit 9.
+              static::assertClassNotLoaded(\PHPUnit\Util\ThrowableToStringMapper::class);
+              require_once(__DIR__.'/IncompatibleThrowableToStringMapper.php');
+              class_alias(IncompatibleThrowableToStringMapper::class, \PHPUnit\Util\ThrowableToStringMapper::class);
+          }
+
+          #[BeforeFeature('@phpunit_incompatible')]
+          public static function beforeFeatureRemoveKnownPHPUnit(): void
+          {
+              // At the start of the feature, this Behat process should not have referenced any PHPUnit classes.
+              // So the easiest way to simulate an incompatible PHPUnit version is to wrap the registered autoloader(s)
+              // and prevent PHP from finding the exception formatting classes we support.
+              // This will only affect the Behat process we're testing - the outer test runner will find them as usual.
+              static::assertClassNotLoaded(\PHPUnit\Util\ThrowableToStringMapper::class);
+              static::assertClassNotLoaded(\PHPUnit\Framework\TestFailure::class);
+
+              if (PHP_VERSION_ID < 80400) {
+                  // Trigger loading array_find from symfony/polyfill-php84 before our autoloader tries to use it
+                  array_find([], fn() => true);
+              }
+
+              $autoloaders = spl_autoload_functions();
+              array_walk($autoloaders, fn($l) => spl_autoload_unregister($l));
+
+              spl_autoload_register(
+                  function (string $class) use ($autoloaders) {
+                      return match ($class) {
+                          \PHPUnit\Framework\TestFailure::class => null,
+                          \PHPUnit\Util\ThrowableToStringMapper::class => null,
+                          default => array_find($autoloaders, fn($loader) => $loader($class))
+                      };
+                  },
+              );
+          }
+
+          private static function assertClassNotLoaded(string $class): void
+          {
+              assert(!class_exists($class, autoload: false), 'Should not have already loaded ' . $class);
+          }
+
+          #[Then('/^an array (?P<actual_json>.+?) should equal (?P<expected_json>.+)$/')]
+          public function arrayShouldMatch(string $actual_json, string $expected_json): void
+          {
+              // To prove the output with more complex diffs
+              Assert::assertEquals(
+                  json_decode($expected_json, true),
+                  json_decode($actual_json, true),
+                  'Should get the right value'
+              );
+          }
+
+          #[Then('an integer :actual should equal :expected')]
+          public function intShouldMatch(int $actual, int $expected): void
+          {
+              Assert::assertSame($expected, $actual, 'check the ints');
+          }
+      }
+      """
+      And a file named "features/bootstrap/IncompatibleThrowableToStringMapper.php" with:
+      """
+      <?php
+
+      class IncompatibleThrowableToStringMapper
+      {
+          public static function map($thing): string
+          {
+              // Simulates what happens if the PHPUnit ThrowableToStringMapper class does not behave / take the types
+              // that we expect
+              throw new RuntimeException('Some internal problem');
+          }
+      }
+      """
+
+  Scenario: With PHPUnit 9 working correctly
+      Given a file named "features/with_phpunit_9.feature" with:
+      """
+      Feature: Values do not match
+        In order to test the stringification of PHPUnit assertions
+        As a contributor of behat
+        I need to have a scenario that demonstrates failing assertions
+
+        Scenario: Compare mismatched array
+          Then an array {"value": "foo"} should equal {"value": "bar"}
+
+        Scenario: Compare matching array
+          Then an array {"value": "foo"} should equal {"value": "foo"}
+
+        Scenario: Compare mismatched ints
+          Then an integer 1 should equal 2
+
+        Scenario: Compare matching ints
+          Then an integer 1 should equal 1
+      """
+      When I run "behat -f progress --no-colors features/with_phpunit_9.feature"
+      Then it should fail with:
+      """
+      --- Failed steps:
+
+      001 Scenario: Compare mismatched array                             # features/with_phpunit_9.feature:6
+            Then an array {"value": "foo"} should equal {"value": "bar"} # features/with_phpunit_9.feature:7
+              Should get the right value
+              Failed asserting that two arrays are equal.
+              --- Expected
+              +++ Actual
+              @@ @@
+               Array (
+              -    'value' => 'bar'
+              +    'value' => 'foo'
+               )
+
+      002 Scenario: Compare mismatched ints  # features/with_phpunit_9.feature:12
+            Then an integer 1 should equal 2 # features/with_phpunit_9.feature:13
+              check the ints
+              Failed asserting that 1 is identical to 2.
+
+      4 scenarios (2 passed, 2 failed)
+      4 steps (2 passed, 2 failed)
+      """
+
+  Scenario: With a theoretically-supported PHPUnit that causes errors during stringification
+      # Because the classes we're calling are marked as internal and not guaranteed to provide BC
+      Given a file named "features/with_phpunit_10_broken.feature" with:
+      """
+      @phpunit_10_broken
+      Feature: Values do not match
+        In order to test the stringification of PHPUnit assertions
+        As a contributor of behat
+        I need to have a scenario that demonstrates failing assertions
+
+        Scenario: Compare mismatched array
+          Then an array {"value": "foo"} should equal {"value": "bar"}
+
+        Scenario: Compare matching array
+          Then an array {"value": "foo"} should equal {"value": "foo"}
+
+        Scenario: Compare mismatched ints
+          Then an integer 1 should equal 2
+
+        Scenario: Compare matching ints
+          Then an integer 1 should equal 1
+      """
+      When I run "behat -f progress --no-colors features/with_phpunit_10_broken.feature"
+      Then it should fail with:
+      """
+      --- Failed steps:
+
+      001 Scenario: Compare mismatched array                             # features/with_phpunit_10_broken.feature:7
+            Then an array {"value": "foo"} should equal {"value": "bar"} # features/with_phpunit_10_broken.feature:8
+              Should get the right value
+              Failed asserting that two arrays are equal.
+              !! There was an error trying to render more details of this PHPUnit\Framework\ExpectationFailedException.
+                 You are probably using a PHPUnit version that Behat cannot automatically display failures for.
+                 See Behat\Testwork\Exception\Stringer\PHPUnitExceptionStringer for details of PHPUnit support.
+                 [RuntimeException] Some internal problem at features/bootstrap/IncompatibleThrowableToStringMapper.php:9
+
+      002 Scenario: Compare mismatched ints  # features/with_phpunit_10_broken.feature:13
+            Then an integer 1 should equal 2 # features/with_phpunit_10_broken.feature:14
+              check the ints
+              Failed asserting that 1 is identical to 2.
+              !! There was an error trying to render more details of this PHPUnit\Framework\ExpectationFailedException.
+                 You are probably using a PHPUnit version that Behat cannot automatically display failures for.
+                 See Behat\Testwork\Exception\Stringer\PHPUnitExceptionStringer for details of PHPUnit support.
+                 [RuntimeException] Some internal problem at features/bootstrap/IncompatibleThrowableToStringMapper.php:9
+
+      4 scenarios (2 passed, 2 failed)
+      4 steps (2 passed, 2 failed)
+      """
+
+    Scenario: With unsupported PHPUnit
+      Given a file named "features/with_unknown_phpunit_version.feature" with:
+      """
+      @phpunit_incompatible
+      Feature: Values do not match
+        In order to test the stringification of PHPUnit assertions
+        As a contributor of behat
+        I need to have a scenario that demonstrates failing assertions
+
+        Scenario: Compare mismatched array
+          Then an array {"value": "foo"} should equal {"value": "bar"}
+
+        Scenario: Compare matching array
+          Then an array {"value": "foo"} should equal {"value": "foo"}
+
+        Scenario: Compare mismatched ints
+          Then an integer 1 should equal 2
+
+        Scenario: Compare matching ints
+          Then an integer 1 should equal 1
+      """
+      When I run "behat -f progress --no-colors features/with_unknown_phpunit_version.feature"
+      Then it should fail with:
+      """
+      --- Failed steps:
+
+      001 Scenario: Compare mismatched array                             # features/with_unknown_phpunit_version.feature:7
+            Then an array {"value": "foo"} should equal {"value": "bar"} # features/with_unknown_phpunit_version.feature:8
+              Should get the right value
+              Failed asserting that two arrays are equal.
+              !! Could not render more details of this PHPUnit\Framework\ExpectationFailedException.
+                 Behat does not support automatically formatting assertion failures for your PHPUnit version.
+                 See Behat\Testwork\Exception\Stringer\PHPUnitExceptionStringer for details.
+
+      002 Scenario: Compare mismatched ints  # features/with_unknown_phpunit_version.feature:13
+            Then an integer 1 should equal 2 # features/with_unknown_phpunit_version.feature:14
+              check the ints
+              Failed asserting that 1 is identical to 2.
+              !! Could not render more details of this PHPUnit\Framework\ExpectationFailedException.
+                 Behat does not support automatically formatting assertion failures for your PHPUnit version.
+                 See Behat\Testwork\Exception\Stringer\PHPUnitExceptionStringer for details.
+
+      4 scenarios (2 passed, 2 failed)
+      4 steps (2 passed, 2 failed)
+      """

--- a/src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
@@ -11,6 +11,7 @@
 namespace Behat\Testwork\Exception\Stringer;
 
 use Exception;
+use Throwable;
 
 /**
  * Strings PHPUnit assertion exceptions.
@@ -35,17 +36,89 @@ final class PHPUnitExceptionStringer implements ExceptionStringer
      */
     public function stringException(Exception $exception, $verbosity)
     {
-        if (class_exists('PHPUnit\\Util\\ThrowableToStringMapper')) {
-            return trim(\PHPUnit\Util\ThrowableToStringMapper::map($exception));
-        }
+        // PHPUnit assertion exceptions do not include detailed expected / observed info in their messages. Instead,
+        // test result printers within PHPUnit are expected to format and present that information separately. The
+        // mechanism for this varies between PHPUnit major versions, and all the implementations are tagged with:
+        //
+        //   *  @internal This class is not covered by the backward compatibility promise for PHPUnit`
+        //
+        // Behat itself does not use PHPUnit at runtime, and user projects may use PHPUnit solely for unit tests with
+        // a completely separate assertion mechanism for their Behat steps.
+        //
+        // Therefore, Behat does not impose any formal PHPUnit version constraints.
+        //
+        // Instead, we make a best effort to render as much detail of a PHPUnit assertion failure as we can, without
+        // masking that the ultimate problem was caused by a failed assertion in the user's own code.
+        //
+        // **
+        // * We cannot guarantee that this will work, or produce the same output, even across minor PHPUnit versions.
+        // * That said, historically this has been relatively stable for a given major version series.
+        // **
+        //
+        // If you encounter a problem rendering PHPUnit assertions in your project, you have three options:
+        //
+        // * Roll back to a PHPUnit minor / patch version that you know works for you.
+        // * Catch the failures within your Context classes and format them yourself. For example, you could implement
+        //   a generic wrapper to call like `MyClass::formatFailure(fn () => Assert::assertSame(1, 2, 'Uh-oh'))`.
+        // * Contribute a PR to Behat to add support for the newer PHPUnit version :)
 
-        if (!class_exists('PHPUnit\\Framework\\TestFailure')) {
-            return trim(\PHPUnit_Framework_TestFailure::exceptionToString($exception));
-        }
+        try {
+            // Class names are intentionally fully qualified here to maximise clarity - particularly because a future
+            // PHPUnit version may reuse a class name in a different namespace.
 
-        // PHPUnit assertion exceptions do not include expected / observed info in their
-        // messages, but expect the test listeners to format that info like the following
-        // (see e.g. PHPUnit_TextUI_ResultPrinter::printDefectTrace)
-        return trim(\PHPUnit\Framework\TestFailure::exceptionToString($exception));
+            if (class_exists(\PHPUnit\Util\ThrowableToStringMapper::class)) {
+                // PHPUnit 10.0.0 onwards
+                return trim(\PHPUnit\Util\ThrowableToStringMapper::map($exception));
+            }
+
+            if (class_exists(\PHPUnit\Framework\TestFailure::class)) {
+                // PHPUnit 6.0.0 - 9.x
+                return trim(\PHPUnit\Framework\TestFailure::exceptionToString($exception));
+            }
+
+            if (class_exists(\PHPUnit_Framework_TestFailure::class)) {
+                // PHPUnit < 6 (support ended in 2016)
+                return trim(\PHPUnit_Framework_TestFailure::exceptionToString($exception));
+            }
+
+            // PHPUnit must be present, because we got a PHPUnit exception. So it must be a newer version with a
+            // formatter class / method we don't know about.
+            return sprintf(
+                <<<TEXT
+                %s
+                !! Could not render more details of this %s.
+                   Behat does not support automatically formatting assertion failures for your PHPUnit version.
+                   See %s for details.
+                TEXT,
+                $exception->getMessage(),
+                $exception::class,
+                self::class,
+            );
+        } catch (Throwable $phpunitException) {
+            // PHPUnit does not guarantee BC on the classes / methods we're calling.
+            //
+            // So it is likely that it looked like a version we expected, but the method signature or internal typing
+            // has changed, causing an error at runtime.
+            //
+            // It is also possible that there's something in the user input (e.g. a value passed to $expect) that is
+            // causing an error when PHPUnit tries to stringify it - but PHPUnit is generally quite robust about
+            // catching those situations and reporting them within the message body.
+            return sprintf(
+                <<<TEXT
+                %s
+                !! There was an error trying to render more details of this %s.
+                   You are probably using a PHPUnit version that Behat cannot automatically display failures for.
+                   See %s for details of PHPUnit support.
+                   [%s] %s at %s:%s
+                TEXT,
+                $exception->getMessage(),
+                $exception::class,
+                self::class,
+                $phpunitException::class,
+                $phpunitException->getMessage(),
+                $phpunitException->getFile(),
+                $phpunitException->getLine(),
+            );
+        }
     }
 }


### PR DESCRIPTION
This is an alternative fix for #1421, based partly on the useful work done by and discussion with @uuf6429 in #1426.

Attempting to render PHPUnit assertion failures is brittle, because:

a) we (intentionally) don't impose any PHPUnit version constraints in composer.json and 
b) PHPUnit's code for rendering exceptions is not covered by their BC promise.

I've added tests that cover both the absence of PHPUnit classes, and the presence of a PHPUnit class that works differently to how we expect, causing an error. These demonstrate the current total failure and early termination of Behat in both these scenarios (and show that throwing our own exception here will behave the same, just with a different message).

The second commit updates the PHPUnitExceptionStringer to ensure that we always render something useful for any past or future PHPUnit version. This prioritises communicating that an assertion has failed and in many cases will still have as much detail as usual (see e.g. the examples of the failing int comparison in the feature file).