### PR TITLE
fix: regex snippet generation for steps defined with single quotes

### DIFF
--- a/features/legacy_snippets.feature
+++ b/features/legacy_snippets.feature
@@ -12,7 +12,7 @@ Feature: Legacy Snippets
           Given I have magically created 10$
 
         Scenario: Single quotes
-          When I have chose 'coffee with turkey' in coffee machine
+          When I have chosen 'coffee with turkey' in coffee machine
           Then I should have 'turkey with coffee sauce'
           And I should get a 'super/string':
             '''
@@ -24,7 +24,7 @@ Feature: Legacy Snippets
             '''
 
         Scenario: Double quotes
-          When I have chose "pizza tea" in coffee machine
+          When I have chosen "pizza tea" in coffee machine
           And do something undefined with \1
           Then I should have "pizza tea"
           And I should get a "super/string":
@@ -70,9 +70,9 @@ Feature: Legacy Snippets
           }
 
           /**
-           * @When /^I have chose '([^']*)' in coffee machine$/
+           * @When /^I have chosen '([^']*)' in coffee machine$/
            */
-          public function iHaveChoseCoffeeWithTurkeyInCoffeeMachine($arg1): void
+          public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -80,7 +80,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should have '([^']*)'$/
            */
-          public function iShouldHaveTurkeyWithCoffeeSauce($arg1): void
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -88,7 +88,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should get a '([^']*)':$/
            */
-          public function iShouldGetASuperString($arg1, PyStringNode $string): void
+          public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -102,9 +102,9 @@ Feature: Legacy Snippets
           }
 
           /**
-           * @When /^I have chose "([^"]*)" in coffee machine$/
+           * @When /^I have chosen "([^"]*)" in coffee machine$/
            */
-          public function iHaveChoseInCoffeeMachine($arg1): void
+          public function iHaveChosenInCoffeeMachine2($arg1): void
           {
               throw new PendingException();
           }
@@ -120,7 +120,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should have "([^"]*)"$/
            */
-          public function iShouldHave($arg1): void
+          public function iShouldHave2($arg1): void
           {
               throw new PendingException();
           }
@@ -128,7 +128,7 @@ Feature: Legacy Snippets
           /**
            * @Then /^I should get a "([^"]*)":$/
            */
-          public function iShouldGetA($arg1, PyStringNode $string): void
+          public function iShouldGetA2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -199,9 +199,9 @@ Feature: Legacy Snippets
           }
 
           /**
-           * @When I have chose :arg1 in coffee machine
+           * @When I have chosen :arg1 in coffee machine
            */
-          public function iHaveChoseInCoffeeMachine($arg1): void
+          public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -12,7 +12,7 @@ Feature: Snippets generation and addition
           Given I have magically created 10$
 
         Scenario: Single quotes
-          When I have chose 'coffee with turkey' in coffee machine
+          When I have chosen 'coffee with turkey' in coffee machine
           Then I should have 'turkey with coffee sauce'
           And I should get a 'super/string':
             '''
@@ -24,7 +24,7 @@ Feature: Snippets generation and addition
             '''
 
         Scenario: Double quotes
-          When I have chose "pizza tea" in coffee machine
+          When I have chosen "pizza tea" in coffee machine
           And do something undefined with \1
           Then I should have "pizza tea"
           And I should get a "super/string":
@@ -68,9 +68,9 @@ Feature: Snippets generation and addition
           }
 
           /**
-           * @When /^I have chose '([^']*)' in coffee machine$/
+           * @When /^I have chosen '([^']*)' in coffee machine$/
            */
-          public function iHaveChoseCoffeeWithTurkeyInCoffeeMachine($arg1): void
+          public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -78,7 +78,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should have '([^']*)'$/
            */
-          public function iShouldHaveTurkeyWithCoffeeSauce($arg1): void
+          public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
@@ -86,7 +86,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should get a '([^']*)':$/
            */
-          public function iShouldGetASuperString($arg1, PyStringNode $string): void
+          public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -100,9 +100,9 @@ Feature: Snippets generation and addition
           }
 
           /**
-           * @When /^I have chose "([^"]*)" in coffee machine$/
+           * @When /^I have chosen "([^"]*)" in coffee machine$/
            */
-          public function iHaveChoseInCoffeeMachine($arg1): void
+          public function iHaveChosenInCoffeeMachine2($arg1): void
           {
               throw new PendingException();
           }
@@ -118,7 +118,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should have "([^"]*)"$/
            */
-          public function iShouldHave($arg1): void
+          public function iShouldHave2($arg1): void
           {
               throw new PendingException();
           }
@@ -126,7 +126,7 @@ Feature: Snippets generation and addition
           /**
            * @Then /^I should get a "([^"]*)":$/
            */
-          public function iShouldGetA($arg1, PyStringNode $string): void
+          public function iShouldGetA2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
@@ -195,9 +195,9 @@ Feature: Snippets generation and addition
           }
 
           /**
-           * @When I have chose :arg1 in coffee machine
+           * @When I have chosen :arg1 in coffee machine
            */
-          public function iHaveChoseInCoffeeMachine($arg1): void
+          public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
@@ -393,9 +393,9 @@ Feature: Snippets generation and addition
           }
 
           /**
-           * @When I have chose :arg1 in coffee machine
+           * @When I have chosen :arg1 in coffee machine
            */
-          public function iHaveChoseInCoffeeMachine($arg1): void
+          public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -98,7 +98,7 @@ final class RegexPatternPolicy implements PatternPolicy
      */
     private function generateCanonicalText($stepText)
     {
-        $canonicalText = preg_replace(array_keys(self::$replacePatterns), '', $stepText);
+        $canonicalText = preg_replace(array_keys(self::$replacePatterns), '', $this->escapeStepText($stepText));
         $canonicalText = Transliterator::transliterate($canonicalText, ' ');
         $canonicalText = preg_replace('/[^a-zA-Z\_\ ]/', '', $canonicalText);
         $canonicalText = str_replace(' ', '', ucwords($canonicalText));


### PR DESCRIPTION
The regex expressions used when generating the regex step definition expected that the step text had been "escaped" (`\` character added before all regex characters). But when trying to extract the canonical text for the function name these regex expressions were applied to the unescaped text. This meant that it failed to properly ignore the values within single quotes and they ended up being part of the function name. So for example a step like `When I run 'foo'` created a function named `iRunFoo`. This PR fixes this by making sure that the regex expression is applied to the escaped text and thus correctly removes the parameter text.

One thing that this PR does not do is to change our code so that steps like `When I run 'foo'` and `When I run "foo"` generate the same function when using regex as it happens when using turnip. This would have required that our regex expressions were more complex and I think we should avoid that. If you have those two steps it will generate an `iRun` function and an `iRun2` function. I don't expect this to be a problem as users will probably stick to one style or the other

Modifies the tests to take into account this new behaviour. 

Note: this will not constitute a BC break. Users who have generated tests with the old functionality will continue to have functions incorrectly named but they will continue to work

Fixes https://github.com/Behat/Behat/issues/1257