### PR TITLE
Bugfix: Deprecated passing null to `explode()`

### DIFF
--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
@@ -67,7 +67,7 @@ final class JUnitScenarioPrinter
     {
         $name = implode(' ', array_map(function ($l) {
             return trim($l);
-        }, explode("\n", $scenario->getTitle())));
+        }, explode("\n", $scenario->getTitle() ?? '')));
 
         if ($scenario instanceof ExampleNode) {
             $name = $this->buildExampleName($scenario);


### PR DESCRIPTION
I just ran into this issue, running my behat suite lately.

> PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in /home/meh/projects/protas/orf/vendor/behat/behat/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php on line 70

This was already mentioned in https://github.com/Behat/Behat/pull/1410#issuecomment-1273207509 but somehow never hit `master` :-D 