### PR TITLE
feature: display hook failures location in progress printer

### DIFF
--- a/features/hooks_failures.feature
+++ b/features/hooks_failures.feature
@@ -1,0 +1,213 @@
+Feature: Display hook failures location in progress printer
+  In order to be able to locate the code that generated a failure
+  As a feature developer using the progress printer
+  When a hook throws an error I want to see the related item where the code failed
+
+  Background:
+    Given a file named "features/simple.feature" with:
+      """
+      Feature: Simple feature
+
+        Scenario: Simple scenario
+          When I have a simple step
+      """
+
+  Scenario: Handling of a error in beforeSuite hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @BeforeSuite
+           */
+          public static function beforeSuiteHook()
+          {
+              throw new \Exception('Error in beforeSuite hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail
+    And the output should contain:
+      """
+      BeforeSuite "default" # FeatureContext::beforeSuiteHook()
+      """
+
+  Scenario: Handling of a error in afterSuite hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @AfterSuite
+           */
+          public static function afterSuiteHook()
+          {
+              throw new \Exception('Error in afterSuite hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail
+    And the output should contain:
+      """
+      AfterSuite "default" # FeatureContext::afterSuiteHook()
+      """
+
+  Scenario: Handling of a error in beforeFeature hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @BeforeFeature
+           */
+          public static function beforeFeatureHook()
+          {
+              throw new \Exception('Error in beforeFeature hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail
+    And the output should contain:
+      """
+      BeforeFeature "features/simple.feature" # FeatureContext::beforeFeatureHook()
+      """
+
+  Scenario: Handling of a error in afterFeature hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @AfterFeature
+           */
+          public static function afterFeatureHook()
+          {
+              throw new \Exception('Error in afterFeature hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail
+    And the output should contain:
+      """
+      AfterFeature "features/simple.feature" # FeatureContext::afterFeatureHook()
+      """
+
+  Scenario: Handling of a error in beforeScenario hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @BeforeScenario
+           */
+          public function beforeScenarioHook()
+          {
+              throw new \Exception('Error in beforeScenario hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail
+    And the output should contain:
+      """
+      BeforeScenario "features/simple.feature:3" # FeatureContext::beforeScenarioHook()
+      """
+
+  Scenario: Handling of a error in afterScenario hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @AfterScenario
+           */
+          public function afterScenarioHook()
+          {
+              throw new \Exception('Error in afterScenario hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail
+    And the output should contain:
+      """
+      AfterScenario "features/simple.feature:3" # FeatureContext::afterScenarioHook()
+      """
+
+  Scenario: Handling of a error in beforeStep hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @BeforeStep
+           */
+          public function beforeStepHook()
+          {
+              throw new \Exception('Error in beforeStep hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail
+    And the output should contain:
+      """
+      BeforeStep "features/simple.feature:4" # FeatureContext::beforeStepHook()
+      """
+
+  Scenario: Handling of a error in afterStep hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @AfterStep
+           */
+          public function afterStepHook()
+          {
+              throw new \Exception('Error in afterStep hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail
+    And the output should contain:
+      """
+      AfterStep "features/simple.feature:4" # FeatureContext::afterStepHook()
+      """

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
@@ -109,8 +109,10 @@ final class HookStatsListener implements EventListener
      */
     private function captureHookStat(CallResult $hookCallResult)
     {
-        $callee = $hookCallResult->getCall()->getCallee();
+        $call = $hookCallResult->getCall();
+        $callee = $call->getCallee();
         $hook = (string) $callee;
+        $scope = $call->getScope();
         $path = $callee->getPath();
         $stdOut = $hookCallResult->getStdOut();
         $error = $hookCallResult->getException()
@@ -118,6 +120,7 @@ final class HookStatsListener implements EventListener
             : null;
 
         $stat = new HookStat($hook, $path, $error, $stdOut);
+        $stat->setScope($scope);
         $this->statistics->registerHookStat($stat);
     }
 }

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
@@ -120,7 +120,9 @@ final class HookStatsListener implements EventListener
             : null;
 
         $stat = new HookStat($hook, $path, $error, $stdOut);
-        $stat->setScope($scope);
+        if (!$stat->isSuccessful()) {
+            $stat->setScope($scope);
+        }
         $this->statistics->registerHookStat($stat);
     }
 }

--- a/src/Behat/Behat/Output/Statistics/HookStat.php
+++ b/src/Behat/Behat/Output/Statistics/HookStat.php
@@ -10,6 +10,8 @@
 
 namespace Behat\Behat\Output\Statistics;
 
+use Behat\Testwork\Hook\Scope\HookScope;
+
 /**
  * Represents hook stat.
  *
@@ -33,6 +35,10 @@ final class HookStat
      * @var string|null
      */
     private $stdOut;
+    /**
+     * @var HookScope|null
+     */
+    private $scope;
 
     /**
      * Initializes hook stat.
@@ -48,6 +54,11 @@ final class HookStat
         $this->path = $path;
         $this->error = $error;
         $this->stdOut = $stdOut;
+    }
+
+    public function setScope(HookScope $scope)
+    {
+        $this->scope = $scope;
     }
 
     /**
@@ -94,5 +105,10 @@ final class HookStat
     public function getPath()
     {
         return $this->path;
+    }
+
+    public function getScope(): HookScope
+    {
+        return $this->scope;
     }
 }


### PR DESCRIPTION
When an error happens in a hook, in the pretty printer it is very easy to see where the error originated because the hook output is interleaved with the pretty output. However, in the progress printer, hook errors are only printed at the end of the run and they only reference the hook function where the error happened. If the function depends on the specific item (suite, feature, scenario or step) for which the hook is called, it is not possible to see this "location", which makes debugging the issue much more difficult.

In this PR we print the "location" of the call to the hook as part of the hook results printed at the end of the progress run. This location is:
- For suite hooks, the name of the suite
- For feature hooks, the path of the feature file
- For scenario and step hooks, the path of the feature file and the line number in that file

One example output is:
```
--- Failed hooks:

    BeforeScenario "features/append_snippets.feature:120" # FeatureContext::prepareTestFolders()
      Error in scenario (Exception)
```

Fixes https://github.com/Behat/Behat/issues/1495