### PR TITLE
feature: print failed hooks summary at the end of the pretty format run

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -383,6 +383,11 @@ Feature: hooks
       │
       └─ @AfterFeature # FeatureContext::doSomethingAfterFeature()
 
+      --- Failed hooks:
+
+          BeforeScenario @exception "features/background.feature:4" # FeatureContext::beforeScenarioException()
+          BeforeScenario @exception "features/background.feature:11" # FeatureContext::beforeScenarioException()
+
       --- Skipped scenarios:
 
           features/background.feature:4
@@ -545,6 +550,11 @@ Feature: hooks
         @failing-before-hook
         Scenario:            # features/test.feature:13
           Given passing step # FeatureContext::passingStep()
+
+      --- Failed hooks:
+
+          BeforeStep passing step with failing hook "features/test.feature:10" # FeatureContext::failingBeforeStep()
+          BeforeScenario @failing-before-hook "features/test.feature:13" # FeatureContext::failingBeforeScenarioHook()
 
       --- Skipped scenarios:
 

--- a/features/hooks_failures.feature
+++ b/features/hooks_failures.feature
@@ -12,6 +12,7 @@ Feature: Display hook failures location in progress printer
           When I have a simple step
       """
 
+  #progress format
   Scenario: Handling of a error in beforeSuite hook
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
@@ -211,3 +212,205 @@ Feature: Display hook failures location in progress printer
       """
       AfterStep "features/simple.feature:4" # FeatureContext::afterStepHook()
       """
+
+  #pretty format
+  Scenario: Handling of a error in beforeSuite hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @BeforeSuite
+           */
+          public static function beforeSuiteHook()
+          {
+              throw new \Exception('Error in beforeSuite hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      BeforeSuite "default" # FeatureContext::beforeSuiteHook()
+      """
+
+  Scenario: Handling of a error in afterSuite hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @AfterSuite
+           */
+          public static function afterSuiteHook()
+          {
+              throw new \Exception('Error in afterSuite hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      AfterSuite "default" # FeatureContext::afterSuiteHook()
+      """
+
+  Scenario: Handling of a error in beforeFeature hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @BeforeFeature
+           */
+          public static function beforeFeatureHook()
+          {
+              throw new \Exception('Error in beforeFeature hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      BeforeFeature "features/simple.feature" # FeatureContext::beforeFeatureHook()
+      """
+
+  Scenario: Handling of a error in afterFeature hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @AfterFeature
+           */
+          public static function afterFeatureHook()
+          {
+              throw new \Exception('Error in afterFeature hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      AfterFeature "features/simple.feature" # FeatureContext::afterFeatureHook()
+      """
+
+  Scenario: Handling of a error in beforeScenario hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @BeforeScenario
+           */
+          public function beforeScenarioHook()
+          {
+              throw new \Exception('Error in beforeScenario hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      BeforeScenario "features/simple.feature:3" # FeatureContext::beforeScenarioHook()
+      """
+
+  Scenario: Handling of a error in afterScenario hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @AfterScenario
+           */
+          public function afterScenarioHook()
+          {
+              throw new \Exception('Error in afterScenario hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      AfterScenario "features/simple.feature:3" # FeatureContext::afterScenarioHook()
+      """
+
+  Scenario: Handling of a error in beforeStep hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @BeforeStep
+           */
+          public function beforeStepHook()
+          {
+              throw new \Exception('Error in beforeStep hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      BeforeStep "features/simple.feature:4" # FeatureContext::beforeStepHook()
+      """
+
+  Scenario: Handling of a error in afterStep hook
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /**
+           * @AfterStep
+           */
+          public function afterStepHook()
+          {
+              throw new \Exception('Error in afterStep hook');
+          }
+      }
+      """
+    When I run "behat --no-colors --format=pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      AfterStep "features/simple.feature:4" # FeatureContext::afterStepHook()
+      """
+

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -130,12 +130,14 @@ final class ListPrinter
     /**
      * Prints failed hooks list.
      *
-     * @param OutputPrinter $printer
-     * @param string        $intro
      * @param HookStat[]    $failedHookStats
      */
-    public function printFailedHooksList(OutputPrinter $printer, $intro, array $failedHookStats)
-    {
+    public function printFailedHooksList(
+        OutputPrinter $printer,
+        string $intro,
+        array $failedHookStats,
+        bool $simple = false
+    ): void {
         if (!count($failedHookStats)) {
             return;
         }
@@ -145,7 +147,10 @@ final class ListPrinter
 
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
         foreach ($failedHookStats as $hookStat) {
-            $this->printHookStat($printer, $hookStat, $style);
+            $this->printHookStat($printer, $hookStat, $style, $simple);
+        }
+        if ($simple) {
+            $printer->writeln();
         }
     }
 
@@ -184,12 +189,8 @@ final class ListPrinter
 
     /**
      * Prints hook stat.
-     *
-     * @param OutputPrinter $printer
-     * @param HookStat      $hookStat
-     * @param string        $style
      */
-    private function printHookStat(OutputPrinter $printer, HookStat $hookStat, $style)
+    private function printHookStat(OutputPrinter $printer, HookStat $hookStat, string $style, bool $simple): void
     {
         $location = $this->getLocationFromScope($hookStat->getScope());
         $printer->writeln(
@@ -202,6 +203,9 @@ final class ListPrinter
             )
         );
 
+        if ($simple) {
+            return;
+        }
         $pad = function ($line) { return '      ' . $line; };
 
         if (null !== $hookStat->getStdOut()) {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStatisticsPrinter.php
@@ -52,6 +52,9 @@ final class PrettyStatisticsPrinter implements StatisticsPrinter
     {
         $printer = $formatter->getOutputPrinter();
 
+        $hookStats = $statistics->getFailedHookStats();
+        $this->listPrinter->printFailedHooksList($printer, 'failed_hooks_title', $hookStats, true);
+
         $scenarioStats = $statistics->getSkippedScenarios();
         $this->listPrinter->printScenariosList($printer, 'skipped_scenarios_title', TestResult::SKIPPED, $scenarioStats);
 

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -196,6 +196,10 @@ class PrettyFormatterFactory implements FormatterFactory
                             new Reference('output.pretty.statistics'),
                             new Reference(ExceptionExtension::PRESENTER_ID)
                         )),
+                        new Definition('Behat\Behat\Output\Node\EventListener\Statistics\HookStatsListener', array(
+                            new Reference('output.pretty.statistics'),
+                            new Reference(ExceptionExtension::PRESENTER_ID)
+                        )),
                     )
                 )
             )


### PR DESCRIPTION
As a continuation of https://github.com/Behat/Behat/issues/1495, currently when you run your tests using the pretty formatter, the output of failed hooks is interleaved with the output of the printer, which is fine. But these failures are not included in the summary that is printed at the end of the run. So, if nothing else fails, you may not notice that something has failed if you only look at the final summary. And if you realize that something has failed, you will need to go through all the output to find out exactly what. This PR modifies the pretty printer statistics so that they also record the failed hooks and they print a summary of the failed hooks (with just a single line for each failed hook, no output or exception details, you can find those in the previous output of each test)

The output looks like this:
```
--- Failed hooks:

    AfterScenario "features/append_snippets.feature:120" # FeatureContext::afterScenario()
    AfterScenario "features/arguments.feature:145" # FeatureContext::afterScenario()
    ...
```    