### PR TITLE
DX: better output for wrong status code or unexpected output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,11 @@
     },
 
     "require-dev": {
+        "herrera-io/box": "~1.6.1",
+        "phpunit/phpunit": "^9.6",
+        "sebastian/diff": "^4.0",
         "symfony/polyfill-php84": "^1.31",
         "symfony/process": "^5.4 || ^6.4 || ^7.0",
-        "phpunit/phpunit": "^9.6",
-        "herrera-io/box": "~1.6.1",
         "vimeo/psalm": "^4.8"
     },
 


### PR DESCRIPTION
Fixes #1522

### Then it should pass/fail with: + expected status code + wrong output

![image](https://github.com/user-attachments/assets/44816f29-81d0-4359-b34c-821d1ec624d3)

### Then it should pass/fail with: + wrong status code + wrong output

![image](https://github.com/user-attachments/assets/d9ccb989-0c8a-4fbd-865b-30a0aa957c1b)

### Then it should pass/fail with: + wrong status code + expected output

![image](https://github.com/user-attachments/assets/c4fe56c4-b0f9-4c9e-966b-4be9ce381001)

### Then the output should contain with unexpected value

![image](https://github.com/user-attachments/assets/524b6944-ef03-4a51-91f9-2c48b869d895)

### Then it should pass/fail

![image](https://github.com/user-attachments/assets/fa383814-aa92-425a-acf1-36e9e2682d06)
