### PR TITLE
fix: show more meaningful message if no `output_path` is specified for the junit formatter

### DIFF
--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -56,7 +56,7 @@ class OutputController implements Controller
                 '--out', '-o', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Write format output to a file/directory instead of' . PHP_EOL .
                 'STDOUT <comment>(output_path)</comment>. You can also provide different' . PHP_EOL .
-                'outputs to multiple formats.'
+                'outputs to multiple formats. This option is mandatory for the junit formatter.'
             )
             ->addOption(
                 '--format-settings', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,

--- a/src/Behat/Testwork/Output/Exception/MissingOutputPathException.php
+++ b/src/Behat/Testwork/Output/Exception/MissingOutputPathException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\Output\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Represents an exception thrown because user did not provide an output path.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+class MissingOutputPathException extends InvalidArgumentException implements PrinterException
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -11,6 +11,7 @@
 namespace Behat\Testwork\Output\Printer\Factory;
 
 use Behat\Testwork\Output\Exception\BadOutputPathException;
+use Behat\Testwork\Output\Exception\MissingOutputPathException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -44,6 +45,11 @@ class FilesystemOutputFactory extends OutputFactory
      */
     public function createOutput($stream = null)
     {
+        if ($this->getOutputPath() === null) {
+            throw new MissingOutputPathException(
+                'The `output_path` option must be specified.',
+            );
+        }
         if (is_file($this->getOutputPath())) {
             throw new BadOutputPathException(
                 'Directory expected for the `output_path` option, but a filename was given.',

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -11,6 +11,7 @@
 namespace Behat\Testwork\Output\Printer;
 
 use Behat\Testwork\Output\Exception\MissingExtensionException;
+use Behat\Testwork\Output\Exception\MissingOutputPathException;
 use Behat\Testwork\Output\Printer\Factory\FilesystemOutputFactory;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -151,11 +152,17 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
     public function flush()
     {
         if($this->domDocument instanceof \DOMDocument){
-            $this->getWritingStream()->write(
-                $this->domDocument->saveXML(null, LIBXML_NOEMPTYTAG),
-                false,
-                OutputInterface::OUTPUT_RAW
-            );
+            try {
+                $this->getWritingStream()->write(
+                    $this->domDocument->saveXML(null, LIBXML_NOEMPTYTAG),
+                    false,
+                    OutputInterface::OUTPUT_RAW
+                );
+            } catch (MissingOutputPathException) {
+                throw new MissingOutputPathException(
+                    'The `output_path` option must be specified for the junit formatter.',
+                );
+            }
         }
 
         parent::flush();


### PR DESCRIPTION
Previously it would throw a cryptic `The StreamOutput class needs a stream as its first argument` exception.

Fixes https://github.com/Behat/Behat/issues/1408