### PR TITLE
Php config imports

### DIFF
--- a/features/import_suites.feature
+++ b/features/import_suites.feature
@@ -1,0 +1,180 @@
+Feature: Import suites
+  In order to add more suites
+  As a feature writer
+  I need an ability to import external suite configuration files
+
+  Background:
+    Given a file named "features/bootstrap/FirstContext.php" with:
+      """
+      <?php
+
+      class FirstContext implements \Behat\Behat\Context\Context
+      {
+          /** @Given I have :count apple(s) */
+          public function iHaveApples($count) { }
+
+          /** @When I ate :count apple(s) */
+          public function iAteApples($count) { }
+
+          /** @Then I should have :count apple(s) */
+          public function iShouldHaveApples($count) { }
+      }
+      """
+    And a file named "features/bootstrap/SecondContext.php" with:
+      """
+      <?php
+
+      class SecondContext implements \Behat\Behat\Context\Context
+      {
+          /** @Given I have :count apple(s) */
+          public function iHaveApples($count) { }
+
+          /** @When I ate :count apple(s) */
+          public function iAteApples($count) { }
+
+          /** @Then I should have :count apple(s) */
+          public function iShouldHaveApples($count) { }
+      }
+      """
+    And a file named "features/some.feature" with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry
+          Given I have 3 apples
+          When I ate 1 apple
+          Then I should have 2 apples
+      """
+    And a file named "config/suites/first.php" with:
+      """
+      <?php
+
+      $config = new Behat\Config\Config([
+        'default' => [
+          'suites' => [
+            'first' => [
+              'contexts' => [ 'FirstContext' ],
+            ],
+          ],
+        ],
+      ]);
+
+      return $config;
+
+      """
+    And a file named "config/suites/second.php" with:
+      """
+      <?php
+
+      $config = new Behat\Config\Config([
+        'default' => [
+          'suites' => [
+            'second' => [
+              'contexts' => [ 'SecondContext' ],
+            ],
+          ],
+        ],
+      ]);
+
+      return $config;
+
+      """
+
+  Scenario: Importing one suite
+    Given a file named "behat.php" with:
+      """
+      <?php
+
+      $config = new Behat\Config\Config();
+      $config->import('config/suites/first.php');
+
+      return $config;
+
+      """
+    When I run "behat --suite=first --no-colors -fpretty --format-settings='{\"paths\": true}' features"
+    Then it should pass with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry   # features/some.feature:6
+          Given I have 3 apples       # FirstContext::iHaveApples()
+          When I ate 1 apple          # FirstContext::iAteApples()
+          Then I should have 2 apples # FirstContext::iShouldHaveApples()
+
+      1 scenario (1 passed)
+      3 steps (3 passed)
+      """
+
+  Scenario: Importing two suites, running one
+    Given a file named "behat.php" with:
+      """
+      <?php
+
+      $config = new Behat\Config\Config();
+      $config->import('config/suites/first.php');
+      $config->import('config/suites/second.php');
+
+      return $config;
+
+      """
+    When I run "behat --suite=first --no-colors -fpretty --format-settings='{\"paths\": true}' features"
+    Then it should pass with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry   # features/some.feature:6
+          Given I have 3 apples       # FirstContext::iHaveApples()
+          When I ate 1 apple          # FirstContext::iAteApples()
+          Then I should have 2 apples # FirstContext::iShouldHaveApples()
+
+      1 scenario (1 passed)
+      3 steps (3 passed)
+      """
+
+  Scenario: Importing two suites, running all
+    Given a file named "behat.php" with:
+      """
+      <?php
+
+      $config = new Behat\Config\Config();
+      $config->import('config/suites/first.php');
+      $config->import('config/suites/second.php');
+
+      return $config;
+
+      """
+    When I run "behat --no-colors -fpretty --format-settings='{\"paths\": true}' features"
+    Then it should pass with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry   # features/some.feature:6
+          Given I have 3 apples       # FirstContext::iHaveApples()
+          When I ate 1 apple          # FirstContext::iAteApples()
+          Then I should have 2 apples # FirstContext::iShouldHaveApples()
+
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry   # features/some.feature:6
+          Given I have 3 apples       # SecondContext::iHaveApples()
+          When I ate 1 apple          # SecondContext::iAteApples()
+          Then I should have 2 apples # SecondContext::iShouldHaveApples()
+
+      2 scenarios (2 passed)
+      6 steps (6 passed)
+      """

--- a/features/importing_suites.feature
+++ b/features/importing_suites.feature
@@ -1,4 +1,4 @@
-Feature: Import suites
+Feature: Importing suites
   In order to add more suites
   As a feature writer
   I need an ability to import external suite configuration files
@@ -117,8 +117,10 @@ Feature: Import suites
       <?php
 
       $config = new Behat\Config\Config();
-      $config->import('config/suites/first.php');
-      $config->import('config/suites/second.php');
+      $config
+        ->import('config/suites/first.php')
+        ->import('config/suites/second.php')
+      ;
 
       return $config;
 
@@ -146,8 +148,7 @@ Feature: Import suites
       <?php
 
       $config = new Behat\Config\Config();
-      $config->import('config/suites/first.php');
-      $config->import('config/suites/second.php');
+      $config->import(['config/suites/first.php', 'config/suites/second.php']);
 
       return $config;
 

--- a/src/Behat/Config/Config.php
+++ b/src/Behat/Config/Config.php
@@ -13,6 +13,7 @@ final class Config implements ConfigInterface
     ) {
     }
 
+    /** @param string|string[] $resource **/
     public function import(string|array $resource): self
     {
         $resources = is_string($resource) ? [$resource] : $resource;

--- a/src/Behat/Config/Config.php
+++ b/src/Behat/Config/Config.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Behat\Config;
 
+use function is_string;
+
 final class Config implements ConfigInterface
 {
     public function __construct(
@@ -11,9 +13,13 @@ final class Config implements ConfigInterface
     ) {
     }
 
-    public function import(string $file): self
+    public function import(string|array $resource): self
     {
-        $this->settings['imports'][] = $file;
+        $resources = is_string($resource) ? [$resource] : $resource;
+
+        foreach ($resources as $resource) {
+            $this->settings['imports'][] = $resource;
+        }
 
         return $this;
     }

--- a/src/Behat/Config/Config.php
+++ b/src/Behat/Config/Config.php
@@ -11,6 +11,13 @@ final class Config implements ConfigInterface
     ) {
     }
 
+    public function import(string $file): self
+    {
+        $this->settings['imports'][] = $file;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->settings;

--- a/tests/Behat/Tests/Config/ConfigTest.php
+++ b/tests/Behat/Tests/Config/ConfigTest.php
@@ -30,4 +30,20 @@ final class ConfigTest extends TestCase
 
         $this->assertEquals($settings, $config->toArray());
     }
+
+    public function testAddingImports(): void
+    {
+        $config = new Config();
+        $config
+            ->import('config/first_suite.php')
+            ->import('config/second_suite.php')
+        ;
+
+        $this->assertEquals([
+            'imports' => [
+                'config/first_suite.php',
+                'config/second_suite.php',
+            ],
+        ], $config->toArray());
+    }
 }


### PR DESCRIPTION
Referenced issue : #1539 
Based on #1537 

Several proposals for this importing feature.

**Use variadic**
```php
use Behat\Config\Config;

$config = new Config();
$config->import('first_file.php', 'second_file.php', ...);
```

If we have too much files to imports, using multiple lines is still possible.

```php
use Behat\Config\Config;

$config = new Config();
$config->import(
    'first_file.php', 
    'second_file.php', 
    ...,
    ...,
    'another_file.php', 
);
```

**Use array**
```php
use Behat\Config\Config;

$config = new Config();
$config->import(['first_file.php', 'second_file.php', ...]);
```

**[Current state of this PR] Use simple way (and even support array or string at the same time)**
```php
use Behat\Config\Config;

$config = new Config();
$config
    ->import('first_file.php') 
    ->import('second_file.php')
    // ...
;
```

OR

```php
use Behat\Config\Config;

$config = new Config();
$config->import(['first_file.php', 'second_file.php', ...]) ;
```

One of the benefits of this way is that we can add optional arguments later.

```php
public function import(string|array $resource, string $type = null, bool $ignoreErrors = false): self
```

Moreover, we need to think about an implementation for importing using a pattern. 

**Using pattern**
```php
use Behat\Config\Config;

$config = new Config();
$config->import('config/../..php');
```

**Symfony way**

_Dependency Injection_
https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php#L64

_Routing_
The routing way is also interesting
https://github.com/symfony/routing/blob/7.1/Loader/Configurator/RoutingConfigurator.php#L37