### PR TITLE
DX: Use real files instead of generated files in local tests

### DIFF
--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -1,88 +1,22 @@
   Feature: JUnit Formatter
-  In order integrate with other development tools
+  In order to integrate with other development tools
   As a developer
   I need to be able to generate a JUnit-compatible report
 
-  Scenario: Normal Scenario's
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
+  Background:
+    Given I set the working directory to the "JunitFormat" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option          | value            |
+      | --no-colors     |                  |
+      | --snippets-type | regex            |
+      | --format        | junit            |
+      | --out           | {SYSTEM_TMP_DIR} |
 
-      use Behat\Behat\Context\Context,
-          Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-      use Behat\Step\When;
-
-      class FeatureContext implements Context
-      {
-          private $value;
-
-          #[Given('/I have entered (\d+)/')]
-          public function iHaveEntered($num) {
-              $this->value = $num;
-          }
-
-          #[Then('/I must have (\d+)/')]
-          public function iMustHave($num) {
-              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
-          }
-
-          #[When('/I add (\d+)/')]
-          public function iAdd($num) {
-              $this->value += $num;
-          }
-
-          #[When('/^Something not done yet$/')]
-          public function somethingNotDoneYet() {
-              throw new PendingException();
-          }
-      }
-      """
-    And a file named "features/World.feature" with:
-      """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-
-        Background:
-          Given I have entered 10
-
-        Scenario: Undefined
-          Then I must have 10
-          And Something new
-          Then I must have 10
-
-        Scenario: Pending
-          Then I must have 10
-          And Something not done yet
-          Then I must have 10
-
-        Scenario: Failed
-          When I add 4
-          Then I must have 13
-
-        Scenario Outline: Passed & Failed
-          When I add <value>
-          Then I must have <result>
-
-          Examples:
-            | value | result |
-            |  5    | 16     |
-            |  10   | 20     |
-            |  23   | 32     |
-
-      Scenario Outline: Another Outline
-        When I add <value>
-        Then I must have <result>
-
-        Examples:
-          | value | result |
-          | 5     | 15     |
-          | 10    | 20     |
-      """
-    When I run "behat --no-colors -f junit -o junit --snippets-for=FeatureContext --snippets-type=regex"
+    Scenario: Run a single feature
+    When I run behat with the following additional options:
+      | option         | value          |
+      | --snippets-for | FeatureContext |
+      | --suite        | single_feature |
     Then it should fail with:
       """
       --- FeatureContext has missing steps. Define them with these snippets:
@@ -93,491 +27,154 @@
               throw new PendingException();
           }
       """
-    And "junit/default.xml" file xml should be like:
+    And the temp "single_feature.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default">
-        <testsuite name="World consistency" tests="8" skipped="0" failures="3" errors="2" time="-IGNORE-VALUE-">
-          <testcase name="Undefined" classname="World consistency" status="undefined" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
+      <testsuites name="single_feature">
+        <testsuite name="Adding numbers" tests="9" skipped="0" failures="3" errors="2" time="-IGNORE-VALUE-">
+          <testcase name="Passed" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature"></testcase>
+          <testcase name="Undefined" classname="Adding numbers" status="undefined" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
             <error message="And Something new" type="undefined"/>
           </testcase>
-          <testcase name="Pending" classname="World consistency" status="pending" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
+          <testcase name="Pending" classname="Adding numbers" status="pending" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
             <error message="And Something not done yet: TODO: write pending definition" type="pending"/>
           </testcase>
-          <testcase name="Failed" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
+          <testcase name="Failed" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
             <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #1" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
+          <testcase name="Passed &amp; Failed #1" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
             <failure message="Then I must have 16: Failed asserting that 15 matches expected '16'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #2" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature"/>
-          <testcase name="Passed &amp; Failed #3" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
+          <testcase name="Passed &amp; Failed #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature"/>
+          <testcase name="Passed &amp; Failed #3" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
             <failure message="Then I must have 32: Failed asserting that 33 matches expected '32'."/>
           </testcase>
-          <testcase name="Another Outline #1" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature"/>
-          <testcase name="Another Outline #2" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature"/>
+          <testcase name="Another Outline #1" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature"/>
+          <testcase name="Another Outline #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature"/>
         </testsuite>
       </testsuites>
       """
-    And the file "junit/default.xml" should be a valid document according to "junit.xsd"
+    And the temp file "single_feature.xml" should be a valid document according to "junit.xsd"
 
-  Scenario: Multiple Features
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-    """
-      <?php
-
-      use Behat\Behat\Context\Context,
-          Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-      use Behat\Step\When;
-
-      class FeatureContext implements Context
-      {
-          private $value;
-
-          #[Given('/I have entered (\d+)/')]
-          public function iHaveEntered($num) {
-              $this->value = $num;
-          }
-
-          #[Then('/I must have (\d+)/')]
-          public function iMustHave($num) {
-              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
-          }
-
-          #[When('/I add (\d+)/')]
-          public function iAdd($num) {
-              $this->value += $num;
-          }
-      }
-      """
-    And a file named "features/adding_feature_1.feature" with:
-      """
-      Feature: Adding Feature 1
-        In order to add number together
-        As a mathematician
-        I want, something that acts like a calculator
-
-        Scenario: Adding 4 to 10
-          Given I have entered 10
-          When I add 4
-          Then I must have 14
-      """
-    And a file named "features/adding_feature_2.feature" with:
-      """
-      Feature: Adding Feature 2
-        In order to add number together
-        As a mathematician
-        I want, something that acts like a calculator
-
-        Scenario: Adding 8 to 10
-          Given I have entered 10
-          When I add 8
-          Then I must have 18
-      """
-    When I run "behat --no-colors -f junit -o junit"
-    And "junit/default.xml" file xml should be like:
+  Scenario: Run multiple Features
+    When I run behat with the following additional options:
+      | option  | value             |
+      | --suite | multiple_features |
+    Then it should pass with no output
+    And the temp "multiple_features.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default">
+      <testsuites name="multiple_features">
         <testsuite name="Adding Feature 1" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding 4 to 10" classname="Adding Feature 1" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-adding_feature_1.feature"></testcase>
+          <testcase name="Adding 4 to 10" classname="Adding Feature 1" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_features_1.feature"></testcase>
         </testsuite>
         <testsuite name="Adding Feature 2" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding 8 to 10" classname="Adding Feature 2" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-adding_feature_2.feature"></testcase>
+          <testcase name="Adding 8 to 10" classname="Adding Feature 2" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_features_2.feature"></testcase>
         </testsuite>
       </testsuites>
       """
-    And the file "junit/default.xml" should be a valid document according to "junit.xsd"
+    And the temp file "multiple_features.xml" should be a valid document according to "junit.xsd"
 
-  Scenario: Multiline titles
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-      use Behat\Step\When;
-
-      class FeatureContext implements Context
-      {
-          private $value;
-
-          #[Given('/I have entered (\d+)/')]
-          public function iHaveEntered($num) {
-              $this->value = $num;
-          }
-
-          #[Then('/I must have (\d+)/')]
-          public function iMustHave($num) {
-              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
-          }
-
-          #[When('/I (add|subtract) the value (\d+)/')]
-          public function iAddOrSubstact($op, $num) {
-              if ($op == 'add')
-                $this->value += $num;
-              elseif ($op == 'subtract')
-                $this->value -= $num;
-          }
-      }
-      """
-    And a file named "features/World.feature" with:
-      """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-
-        Background:
-          Given I have entered 10
-
-        Scenario: Adding some interesting
-                  value
-          Then I must have 10
-          And I add the value 6
-          Then I must have 16
-
-        Scenario: Subtracting
-                  some
-                  value
-          Then I must have 10
-          And I subtract the value 6
-          Then I must have 4
-      """
-    When I run "behat --no-colors -f junit -o junit"
+  Scenario: Confirm multiline scenario titles are printed correctly
+    When I run behat with the following additional options:
+      | option  | value            |
+      | --suite | multiline_titles |
     Then it should pass with no output
-    And "junit/default.xml" file xml should be like:
+    And the temp "multiline_titles.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default">
-        <testsuite name="World consistency" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding some interesting value" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature"/>
-          <testcase name="Subtracting some value" classname="World consistency" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature"/>
+      <testsuites name="multiline_titles">
+        <testsuite name="Use multiline titles" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="Adding some interesting value" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature"/>
+          <testcase name="Adding another value" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature"/>
         </testsuite>
       </testsuites>
       """
-    And the file "junit/default.xml" should be a valid document according to "junit.xsd"
+    And the temp file "multiline_titles.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Multiple suites
-    Given a file named "features/bootstrap/SmallKidContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-      use Behat\Step\When;
-
-      class SmallKidContext implements Context
-      {
-          protected $strongLevel;
-
-          #[Given('I am not strong')]
-          public function iAmNotStrong() {
-              $this->strongLevel = 0;
-          }
-
-          #[When('/I eat an apple/')]
-          public function iEatAnApple() {
-              $this->strongLevel += 2;
-          }
-
-          #[Then('/I will be stronger/')]
-          public function iWillBeStronger() {
-              PHPUnit\Framework\Assert::assertNotEquals(0, $this->strongLevel);
-          }
-      }
-      """
-    And a file named "features/bootstrap/OldManContext.php" with:
-    """
-      <?php
-
-      use Behat\Behat\Context\Context;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-      use Behat\Step\When;
-
-      class OldManContext implements Context
-      {
-          protected $strongLevel;
-
-          #[Given('I am not strong')]
-          public function iAmNotStrong() {
-              $this->strongLevel = 0;
-          }
-
-          #[When('/I eat an apple/')]
-          public function iEatAnApple() { }
-
-          #[Then('/I will be stronger/')]
-          public function iWillBeStronger() {
-              PHPUnit\Framework\Assert::assertNotEquals(0, $this->strongLevel);
-          }
-      }
-      """
-    And a file named "features/apple_eating_smallkid.feature" with:
-      """
-      Feature: Apple Eating
-        In order to be stronger
-        As a small kid
-        I want to get stronger from eating apples
-
-        Background:
-          Given I am not strong
-
-        Scenario: Eating one apple
-          When I eat an apple
-          Then I will be stronger
-      """
-    And a file named "features/apple_eating_oldmen.feature" with:
-    """
-      Feature: Apple Eating
-        In order to be stronger
-        As an old man
-        I want to get stronger from eating apples
-
-        Background:
-          Given I am not strong
-
-        Scenario: Eating one apple
-          When I eat an apple
-          Then I will be stronger
-      """
-    And a file named "behat.yml" with:
-      """
-      default:
-          suites:
-              small_kid:
-                  contexts: [SmallKidContext]
-                  filters:
-                    role: small kid
-                  path: '%paths.base%/features'
-              old_man:
-                  contexts: [OldManContext]
-                  path: '%paths.base%/features'
-                  filters:
-                    role: old man
-      """
-    When I run "behat --no-colors -f junit -o junit"
+    When I run behat with the following additional options:
+      | option   | value          |
+      | --config | two_suites.php |
     Then it should fail with no output
-    And "junit/small_kid.xml" file xml should be like:
+    And the temp "small_kid.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="small_kid">
-        <testsuite name="Apple Eating" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Eating one apple" classname="Apple Eating" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-apple_eating_smallkid.feature"/>
+        <testsuite name="Adding easy numbers" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="Easy sum" classname="Adding easy numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_suites_1.feature"/>
         </testsuite>
       </testsuites>
       """
-    And the file "junit/small_kid.xml" should be a valid document according to "junit.xsd"
-    And "junit/old_man.xml" file xml should be like:
+    And the temp file "small_kid.xml" should be a valid document according to "junit.xsd"
+    And the temp "old_man.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="old_man">
-        <testsuite name="Apple Eating" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Eating one apple" classname="Apple Eating" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-apple_eating_oldmen.feature">
-            <failure message="Then I will be stronger: Failed asserting that 0 is not equal to 0."/>
+        <testsuite name="Adding difficult numbers" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="Difficult sum" classname="Adding difficult numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_suites_2.feature">
+            <failure message="Then I must have 477: Failed asserting that 378 matches expected '477'."/>
           </testcase>
         </testsuite>
       </testsuites>
       """
-    And the file "junit/old_man.xml" should be a valid document according to "junit.xsd"
+    And the temp file "old_man.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Report skipped testcases
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-    """
-      <?php
-
-      use Behat\Behat\Context\Context,
-          Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Hook\BeforeScenario;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-
-      class FeatureContext implements Context
-      {
-          private $value;
-
-          #[BeforeScenario]
-          public function setup() {
-            throw new \Exception();
-          }
-
-          #[Given('/I have entered (\d+)/')]
-          #[Then('/^I must have (\d+)$/')]
-          public function action($num)
-          {
-          }
-      }
-      """
-    And a file named "features/World.feature" with:
-    """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-
-        Background:
-          Given I have entered 10
-
-        Scenario: Skipped
-          Then I must have 10
-
-        Scenario: Another skipped
-          Then I must have 10
-
-      """
-    When I run "behat --no-colors -f junit -o junit"
-    And "junit/default.xml" file xml should be like:
+    When I run behat with the following additional options:
+      | option  | value              |
+      | --suite | skipped_test_cases |
+    Then it should fail with no output
+    And the temp "skipped_test_cases.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default">
-        <testsuite name="World consistency" tests="2" skipped="2" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Skipped" classname="World consistency" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
-            <failure message="BeforeScenario: (Exception)" type="setup"></failure>
+      <testsuites name="skipped_test_cases">
+        <testsuite name="Skipped test cases" tests="2" skipped="2" failures="0" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="Skipped" classname="Skipped test cases" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-skipped_test_cases.feature">
+            <failure message="BeforeScenario: This scenario has a failed setup (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Another skipped" classname="World consistency" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
-            <failure message="BeforeScenario: (Exception)" type="setup"></failure>
+          <testcase name="Another skipped" classname="Skipped test cases" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-skipped_test_cases.feature">
+            <failure message="BeforeScenario: This scenario has a failed setup (Exception)" type="setup"></failure>
           </testcase>
         </testsuite>
       </testsuites>
       """
-    And the file "junit/default.xml" should be a valid document according to "junit.xsd"
+    And the temp file "skipped_test_cases.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Stop on Failure
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context,
-          Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-      use Behat\Step\When;
-
-      class FeatureContext implements Context
-      {
-          private $value;
-
-          #[Given('/I have entered (\d+)/')]
-          public function iHaveEntered($num) {
-              $this->value = $num;
-          }
-
-          #[Then('/I must have (\d+)/')]
-          public function iMustHave($num) {
-              PHPUnit\Framework\Assert::assertEquals($num, $this->value);
-          }
-
-          #[When('/I add (\d+)/')]
-          public function iAdd($num) {
-              $this->value += $num;
-          }
-      }
-      """
-    And a file named "features/World.feature" with:
-      """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-
-        Background:
-          Given I have entered 10
-
-        Scenario: Failed
-          When I add 4
-          Then I must have 13
-      """
-    When I run "behat --no-colors -f junit -o junit"
+    When I run behat with the following additional options:
+      | option  | value           |
+      | --suite | stop_on_failure |
     Then it should fail with no output
-    And "junit/default.xml" file xml should be like:
+    And the temp "stop_on_failure.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default">
-        <testsuite name="World consistency" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Failed" classname="World consistency" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-World.feature">
+      <testsuites name="stop_on_failure">
+        <testsuite name="Stop on failure" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="Failed" classname="Stop on failure" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-stop_on_failure.feature">
             <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
           </testcase>
         </testsuite>
       </testsuites>
       """
-    And the file "junit/default.xml" should be a valid document according to "junit.xsd"
+    And the temp file "stop_on_failure.xml" should be a valid document according to "junit.xsd"
 
-    Scenario: Aborting due to PHP error
-      Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-      use Behat\Behat\Context\Context,
-          Behat\Behat\Tester\Exception\PendingException;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-      use Behat\Step\When;
-
-      class Foo {}
-
-      class FeatureContext implements Context
-      {
-          private $value;
-
-          #[Given('/I have entered (\d+)/')]
-          public function iHaveEntered($num) {
-              $this->value = $num;
-          }
-
-          #[Then('/I must have (\d+)/')]
-          public function iMustHave($num) {
-              $foo = new class extends Foo implements Foo {};
-          }
-
-          #[When('/I add (\d+)/')]
-          public function iAdd($num) {
-              $this->value += $num;
-          }
-      }
-      """
-      And a file named "features/World.feature" with:
-      """
-      Feature: World consistency
-        In order to maintain stable behaviors
-        As a features developer
-        I want, that "World" flushes between scenarios
-        Background:
-          Given I have entered 10
-        Scenario: Failed
-          When I add 4
-          Then I must have 14
-      """
-      When I run "behat --no-colors -f junit -o junit"
-      Then it should fail with:
-      """
-      cannot implement Foo - it is not an interface
-      """
-      And "junit/default.xml" file xml should be like:
-      """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <testsuites name="default"/>
-      """
+  Scenario: Aborting due to PHP error
+    When I run behat with the following additional options:
+      | option  | value              |
+      | --suite | abort_on_php_error |
+    Then it should fail with:
+    """
+    cannot extend interface Behat\Behat\Context\Context
+    """
+    And the temp "abort_on_php_error.xml" file xml should be like:
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="abort_on_php_error"/>
+    """
 
   Scenario: Aborting due invalid output path
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context,
-          Behat\Behat\Tester\Exception\PendingException;
-
-      class FeatureContext implements Context
-      {
-      }
-      """
-    And a file named "junit.txt" with:
-      """
-      """
-    When I run "behat --no-colors -f junit -o junit.txt"
+    When I run "behat -o behat.php"
     Then it should fail with:
       """
       Directory expected for the `output_path` option, but a filename was given.

--- a/tests/Fixtures/JunitFormat/behat.php
+++ b/tests/Fixtures/JunitFormat/behat.php
@@ -1,0 +1,40 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+return (new Config())
+    ->withProfile((new Profile('default'))
+        ->withSuite((new Suite('single_feature'))
+            ->withPaths(
+                'features/single_feature.feature'
+            )
+        )
+        ->withSuite((new Suite('multiple_features'))
+            ->withPaths(
+                'features/multiple_features_1.feature',
+                'features/multiple_features_2.feature'
+            )
+        )
+        ->withSuite((new Suite('multiline_titles'))
+            ->withPaths(
+                'features/multiline_titles.feature'
+            )
+        )
+        ->withSuite((new Suite('skipped_test_cases'))
+            ->withPaths(
+                'features/skipped_test_cases.feature'
+            )
+        )
+        ->withSuite((new Suite('stop_on_failure'))
+            ->withPaths(
+                'features/stop_on_failure.feature'
+            )
+        )
+        ->withSuite((new Suite('abort_on_php_error'))
+            ->withPaths(
+                'features/abort_on_php_error.feature'
+            )
+        )
+    );

--- a/tests/Fixtures/JunitFormat/features/abort_on_php_error.feature
+++ b/tests/Fixtures/JunitFormat/features/abort_on_php_error.feature
@@ -1,0 +1,11 @@
+Feature: Abort on PHP error
+  In order to see correct information
+  As a features developer
+  I want to see the right output in JUnit when I abort due to a PHP error
+
+  Background:
+    Given I have entered 10
+
+  Scenario: Failed
+    When I have a PHP error
+    Then I must have 14

--- a/tests/Fixtures/JunitFormat/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/JunitFormat/features/bootstrap/FeatureContext.php
@@ -1,0 +1,43 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Hook\BeforeScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+
+class FeatureContext implements Context
+{
+    private $value;
+
+    #[Given('/I have entered (\d+)/')]
+    public function iHaveEntered($num) {
+        $this->value = $num;
+    }
+
+    #[When('/I add (\d+)/')]
+    public function iAdd($num) {
+        $this->value += $num;
+    }
+
+    #[When('/^Something not done yet$/')]
+    public function somethingNotDoneYet() {
+        throw new PendingException();
+    }
+
+    #[Then('/I must have (\d+)/')]
+    public function iMustHave($num) {
+        PHPUnit\Framework\Assert::assertEquals($num, $this->value);
+    }
+
+    #[BeforeScenario('@setup-error')]
+    public function setup() {
+        throw new Exception('This scenario has a failed setup');
+    }
+
+    #[When('/^I have a PHP error$/')]
+    public function iHaveAPHPError() {
+        $foo = new class extends Context {};
+    }
+}

--- a/tests/Fixtures/JunitFormat/features/multiline_titles.feature
+++ b/tests/Fixtures/JunitFormat/features/multiline_titles.feature
@@ -1,0 +1,20 @@
+Feature: Use multiline titles
+  In order to keep all information
+  As a features developer
+  I want that the full text of multiline titles is kept in JUnit reports
+
+  Background:
+    Given I have entered 10
+
+  Scenario: Adding some interesting
+  value
+    Then I must have 10
+    And I add 6
+    Then I must have 16
+
+  Scenario: Adding
+  another
+  value
+    Then I must have 10
+    And I add 8
+    Then I must have 18

--- a/tests/Fixtures/JunitFormat/features/multiple_features_1.feature
+++ b/tests/Fixtures/JunitFormat/features/multiple_features_1.feature
@@ -1,0 +1,9 @@
+Feature: Adding Feature 1
+  In order to add numbers together
+  As a mathematician
+  I want something that acts like a calculator
+
+  Scenario: Adding 4 to 10
+    Given I have entered 10
+    When I add 4
+    Then I must have 14

--- a/tests/Fixtures/JunitFormat/features/multiple_features_2.feature
+++ b/tests/Fixtures/JunitFormat/features/multiple_features_2.feature
@@ -1,0 +1,9 @@
+Feature: Adding Feature 2
+  In order to add numbers together
+  As a mathematician
+  I want something that acts like a calculator
+
+  Scenario: Adding 8 to 10
+    Given I have entered 10
+    When I add 8
+    Then I must have 18

--- a/tests/Fixtures/JunitFormat/features/multiple_suites_1.feature
+++ b/tests/Fixtures/JunitFormat/features/multiple_suites_1.feature
@@ -1,0 +1,11 @@
+Feature: Adding easy numbers
+  In order to add numbers together
+  As a small kid
+  I want something that acts like a calculator for easy sums
+
+  Background:
+    Given I have entered 1
+
+  Scenario: Easy sum
+    When I add 2
+    Then I must have 3

--- a/tests/Fixtures/JunitFormat/features/multiple_suites_2.feature
+++ b/tests/Fixtures/JunitFormat/features/multiple_suites_2.feature
@@ -1,0 +1,11 @@
+Feature: Adding difficult numbers
+  In order to add numbers together
+  As an old man
+  I want something that acts like a calculator for difficult sums
+
+  Background:
+    Given I have entered 131
+
+  Scenario: Difficult sum
+    When I add 247
+    Then I must have 477

--- a/tests/Fixtures/JunitFormat/features/single_feature.feature
+++ b/tests/Fixtures/JunitFormat/features/single_feature.feature
@@ -1,0 +1,44 @@
+Feature: Adding numbers
+  In order to add numbers together
+  As a mathematician
+  I want something that acts like a calculator
+
+  Background:
+    Given I have entered 10
+
+  Scenario: Passed
+    When I add 4
+    Then I must have 14
+
+  Scenario: Undefined
+    Then I must have 10
+    And Something new
+    Then I must have 10
+
+  Scenario: Pending
+    Then I must have 10
+    And Something not done yet
+    Then I must have 10
+
+  Scenario: Failed
+    When I add 4
+    Then I must have 13
+
+  Scenario Outline: Passed & Failed
+    When I add <value>
+    Then I must have <result>
+
+    Examples:
+      | value | result |
+      |  5    | 16     |
+      |  10   | 20     |
+      |  23   | 32     |
+
+  Scenario Outline: Another Outline
+    When I add <value>
+    Then I must have <result>
+
+    Examples:
+      | value | result |
+      | 5     | 15     |
+      | 10    | 20     |

--- a/tests/Fixtures/JunitFormat/features/skipped_test_cases.feature
+++ b/tests/Fixtures/JunitFormat/features/skipped_test_cases.feature
@@ -1,0 +1,16 @@
+Feature: Skipped test cases
+  In order to see all information
+  As a features developer
+  I want to see skipped test cases in JUnit reports
+
+  Background:
+    Given I have entered 10
+
+  @setup-error
+  Scenario: Skipped
+    Then I must have 10
+
+  @setup-error
+  Scenario: Another skipped
+    Then I must have 10
+

--- a/tests/Fixtures/JunitFormat/features/stop_on_failure.feature
+++ b/tests/Fixtures/JunitFormat/features/stop_on_failure.feature
@@ -1,0 +1,11 @@
+Feature: Stop on failure
+  In order to see test information
+  As a features developer
+  I want to see the right output in JUnit when I stop on a failure
+
+  Background:
+    Given I have entered 10
+
+  Scenario: Failed
+    When I add 4
+    Then I must have 13

--- a/tests/Fixtures/JunitFormat/two_suites.php
+++ b/tests/Fixtures/JunitFormat/two_suites.php
@@ -1,0 +1,28 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Filter\RoleFilter;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+return (new Config())
+    ->withProfile((new Profile('default'))
+        ->withSuite((new Suite('small_kid'))
+            ->withPaths(
+                'features/multiple_suites_1.feature',
+                'features/multiple_suites_2.feature'
+            )
+            ->withFilter(
+                new RoleFilter('small kid')
+            )
+        )
+        ->withSuite((new Suite('old_man'))
+            ->withPaths(
+                'features/multiple_suites_1.feature',
+                'features/multiple_suites_2.feature'
+            )
+            ->withFilter(
+                new RoleFilter('old man')
+            )
+        )
+    );


### PR DESCRIPTION
I made a first stab at what we discussed here: https://github.com/Behat/Behat/issues/1527

I choose one example test which used multiple feature and context files. Instead of generating them on the fly these are real files saved in the repository.
I created a new `Fixtures` folder in the `tests` folder to hold these files. To use them you can use a step that will set the folder to run Behat to a specific folder, instead of a temporary one.
Then to choose which features/contexts you need to use for a specific test you use suites defined in the config file. If you need to run several suites you can use a different config file. I used the new Php config file format. Since it is important to show what is specific in a test, I created new steps that let you clearly mark that you are running a specific suite or config file
The tests may need to create temporary files, so I created a `temp` folder in this `fixtures` folder that gets cleared at the beginning and end of each test run.
Naming is very important so that you can easily see which files are being used for each test case, so I tried to give all these files significant names.