### PR TITLE
PHP Config extensions

### DIFF
--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -9,16 +9,15 @@ Feature: Extensions
       <?php
 
       use Behat\Config\Config;
+      use Behat\Config\Extension;
       use Behat\Config\Profile;
 
-      $profile = new Profile('default', [
-        'extensions' => [
-          'custom_extension.php' => [
-            'param1' => 'val1',
-            'param2' => 'val2',
-          ],
-        ],
-      ]);
+      $profile = (new Profile('default'))
+        ->withExtension(new Extension('custom_extension.php', [
+          'param1' => 'val1',
+          'param2' => 'val2',
+        ])
+      );
 
       $config = new Config();
       $config->withProfile($profile);

--- a/src/Behat/Config/Extension.php
+++ b/src/Behat/Config/Extension.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Config;
+
+final class Extension implements ExtensionConfigInterface
+{
+    public function __construct(
+        private string $name,
+        private array $settings = [],
+    ) {
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function toArray(): array
+    {
+        return $this->settings;
+    }
+}

--- a/src/Behat/Config/ExtensionConfigInterface.php
+++ b/src/Behat/Config/ExtensionConfigInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Config;
+
+interface ExtensionConfigInterface extends ConfigInterface
+{
+    public function name(): string;
+}

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -32,6 +32,10 @@ final class Profile
 
     public function withExtension(ExtensionConfigInterface $extension): self
     {
+        if (array_key_exists($extension->name(), $this->settings['extensions'] ?? [])) {
+            throw new ConfigurationLoadingException(sprintf('The extension "%s" already exists.', $extension->name()));
+        }
+
         $this->settings['extensions'][$extension->name()] = $extension->toArray();
 
         return $this;

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -30,6 +30,13 @@ final class Profile
         return $this->name;
     }
 
+    public function withExtension(ExtensionConfigInterface $extension): self
+    {
+        $this->settings['extensions'][$extension->name()] = $extension->toArray();
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->settings;

--- a/tests/Behat/Tests/Config/ExtensionTest.php
+++ b/tests/Behat/Tests/Config/ExtensionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Behat\Tests\Config;
+
+use Behat\Config\Config;
+use Behat\Config\Extension;
+use PHPUnit\Framework\TestCase;
+
+final class ExtensionTest extends TestCase
+{
+    public function testExtensionCanBeConvertedIntoAnArray(): void
+    {
+        $extension = new Extension('custom_extension');
+
+        $this->assertIsArray($extension->toArray());
+    }
+
+    public function testItReturnsSettings(): void
+    {
+        $settings = [
+            'base_url' => 'https://127.0.0.1:8080',
+        ];
+
+        $extension = new Extension('Behat\MinkExtension', $settings);
+
+        $this->assertEquals($settings, $extension->toArray());
+    }
+}

--- a/tests/Behat/Tests/Config/ProfileTest.php
+++ b/tests/Behat/Tests/Config/ProfileTest.php
@@ -50,6 +50,18 @@ final class ProfileTest extends TestCase
         ], $profile->toArray());
     }
 
+    public function testItThrowsAnExceptionWhenAddingExistingExtension(): void
+    {
+        $profile = new Profile('default');
+
+        $profile->withExtension(new Extension('custom_extension'));
+
+        $this->expectException(ConfigurationLoadingException::class);
+        $this->expectExceptionMessage('The extension "custom_extension" already exists.');
+
+        $profile->withExtension(new Extension('custom_extension'));
+    }
+
     public function testAddingSuites(): void
     {
         $profile = new Profile('default');

--- a/tests/Behat/Tests/Config/ProfileTest.php
+++ b/tests/Behat/Tests/Config/ProfileTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Behat\Tests\Config;
 
-use Behat\Config\Config;
+use Behat\Config\Extension;
 use Behat\Config\Profile;
 use Behat\Config\Suite;
 use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
@@ -30,6 +30,24 @@ final class ProfileTest extends TestCase
         $profile = new Profile('default', $settings);
 
         $this->assertEquals($settings, $profile->toArray());
+    }
+
+    public function testAddingExtensions(): void
+    {
+        $profile = new Profile('default');
+        $profile->withExtension(new Extension('Behat\MinkExtension', ['base_url' => 'https://127.0.0.1:8080']));
+        $profile->withExtension(new Extension('FriendsOfBehat\MinkDebugExtension', ['directory' => 'etc/build']));
+
+        $this->assertEquals([
+            'extensions' => [
+                'Behat\MinkExtension' => [
+                    'base_url' => 'https://127.0.0.1:8080',
+                ],
+                'FriendsOfBehat\MinkDebugExtension' => [
+                    'directory' => 'etc/build',
+                ],
+            ],
+        ], $profile->toArray());
     }
 
     public function testAddingSuites(): void


### PR DESCRIPTION
Referenced issue #1539

Example:
```php
use Behat\Config\Config;
use Behat\Config\Profile;
use Behat\Config\Suite;
use Behat\MinkExtension;
use FriendsOfBehat\MinkDebugExtension;

$profile = (new Profile())
    ->withExtension(new Extension(MinkExtension::class, [
        'base_url' => 'https://127.0.0.1:8080',
    ]))
    ->withExtension(new Extension(MinkDebugExtension::class, [
        'directory' => 'etc/build',
    ]))
;

return (new Config)->withProfile($profile);
```