### PR TITLE
PHP Config profiles

### DIFF
--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -4,13 +4,26 @@ Feature: Extensions
   I need to be able to write simple extensions
 
   Background:
-    Given a file named "behat.yml" with:
+    Given a file named "behat.php" with:
       """
-      default:
-        extensions:
-          custom_extension.php:
-            param1: val1
-            param2: val2
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
+
+      $profile = new Profile('default', [
+        'extensions' => [
+          'custom_extension.php' => [
+            'param1' => 'val1',
+            'param2' => 'val2',
+          ],
+        ],
+      ]);
+
+      $config = new Config();
+      $config->withProfile($profile);
+
+      return $config;
       """
     And a file named "features/bootstrap/FeatureContext.php" with:
       """

--- a/features/profiles.feature
+++ b/features/profiles.feature
@@ -80,21 +80,32 @@ Feature: Profiles
           progress: false
           pretty: ~
       """
-    And a file named "behat.yml" with:
+    And a file named "behat.php" with:
       """
-      default:
-        formatters:
-          pretty:   false
-          progress: ~
+      <?php
 
-      pretty_without_paths:
-        formatters:
-          progress: false
-          pretty:
-            paths: false
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
 
-      imports:
-        - pretty.yml
+      $config = new Config(['imports' => ['pretty.yml']]);
+      $config
+        ->withProfile(new Profile('default', [
+          'formatters' => [
+            'pretty' => false,
+            'progress' => null,
+          ],
+        ]))
+        ->withProfile(new Profile('pretty_without_paths', [
+          'formatters' => [
+            'progress' => false,
+            'pretty' => [
+              'paths' => false,
+            ],
+          ],
+        ]))
+      ;
+
+      return $config;
       """
 
   Scenario:

--- a/src/Behat/Config/Config.php
+++ b/src/Behat/Config/Config.php
@@ -25,6 +25,13 @@ final class Config implements ConfigInterface
         return $this;
     }
 
+    public function withProfile(Profile $profile): self
+    {
+        $this->settings[$profile->name()] = $profile->toArray();
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->settings;

--- a/src/Behat/Config/Config.php
+++ b/src/Behat/Config/Config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Behat\Config;
 
+use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use function is_string;
 
 final class Config implements ConfigInterface
@@ -27,6 +28,10 @@ final class Config implements ConfigInterface
 
     public function withProfile(Profile $profile): self
     {
+        if (array_key_exists($profile->name(), $this->settings)) {
+            throw new ConfigurationLoadingException(sprintf('The profile "%s" already exists.', $profile->name()));
+        }
+
         $this->settings[$profile->name()] = $profile->toArray();
 
         return $this;

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Config;
+
+final class Profile
+{
+    public function __construct(
+        private string $name,
+        private array $settings = []
+    ) {
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function toArray(): array
+    {
+        return $this->settings;
+    }
+}

--- a/tests/Behat/Tests/Config/ConfigTest.php
+++ b/tests/Behat/Tests/Config/ConfigTest.php
@@ -6,6 +6,7 @@ namespace Behat\Tests\Config;
 
 use Behat\Config\Config;
 use Behat\Config\Profile;
+use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
@@ -67,5 +68,21 @@ final class ConfigTest extends TestCase
                 ],
             ],
         ], $config->toArray());
+    }
+
+    public function testItThrowsAnExceptionWhenAddingExistingProfile(): void
+    {
+        $config = new Config();
+
+        $config->withProfile(new Profile('default'));
+
+        $this->expectException(ConfigurationLoadingException::class);
+        $this->expectExceptionMessage('The profile "default" already exists.');
+
+        $config->withProfile(new Profile('default', [
+            'extensions' => [
+                'some_extension' => [],
+            ],
+        ]));
     }
 }

--- a/tests/Behat/Tests/Config/ConfigTest.php
+++ b/tests/Behat/Tests/Config/ConfigTest.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Behat\Tests\Config;
 
 use Behat\Config\Config;
+use Behat\Config\Profile;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
@@ -43,6 +46,25 @@ final class ConfigTest extends TestCase
             'imports' => [
                 'config/first_suite.php',
                 'config/second_suite.php',
+            ],
+        ], $config->toArray());
+    }
+
+    public function testAddingProfile(): void
+    {
+        $config = new Config();
+
+        $config->withProfile(new Profile('default', [
+            'extensions' => [
+                'some_extension' => [],
+            ],
+        ]));
+
+        $this->assertEquals([
+            'default' => [
+                'extensions' => [
+                    'some_extension' => [],
+                ],
             ],
         ], $config->toArray());
     }

--- a/tests/Behat/Tests/Config/ProfileTest.php
+++ b/tests/Behat/Tests/Config/ProfileTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Tests\Config;
+
+use Behat\Config\Profile;
+use PHPUnit\Framework\TestCase;
+
+final class ProfileTest extends TestCase
+{
+    public function testProfileCanBeConvertedIntoAnArray(): void
+    {
+        $profile = new Profile('default');
+
+        $this->assertIsArray($profile->toArray());
+    }
+
+    public function testItReturnsSettings(): void
+    {
+        $settings = [
+            'extensions' => [
+                'some_extension' => [],
+            ],
+        ];
+
+        $profile = new Profile('default', $settings);
+
+        $this->assertEquals($settings, $profile->toArray());
+    }
+}


### PR DESCRIPTION
Referenced issue #1539

Example:
```php
use Behat\Config\Config;
use Behat\Config\Profile;

$config = new Config();
$config->withProfile(new Profile('default', [
    'extensions' => [
        'some_extension' => [],
    ],
]));

return $config;
```

```php
use Behat\Config\Config;
use Behat\Config\Profile;

$config = new Config(['imports' => ['pretty.yml']]);
$config
    ->withProfile(new Profile('default', [
        'formatters' => [
            'pretty' => false,
            'progress' => null,
        ],
    ]))
    ->withProfile(new Profile('pretty_without_paths', [
        'formatters' => [
            'progress' => false,
            'pretty' => [
                'paths' => false,
            ],
        ],
    ]))
;
return $config;
```
