### PR TITLE
Add possibility to use attributes for Context snippets

### DIFF
--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -123,6 +123,8 @@ Feature: Append snippets option
       """
       <?php
 
+      use Behat\Step\Given;
+      use Behat\Step\Then;
       use Behat\Behat\Context\Context,
           Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode,
@@ -182,41 +184,31 @@ Feature: Append snippets option
 
           private function doSomethingUndefinedWith() {}
 
-          /**
-           * @Then /^do something undefined with \$$/
-           */
+          #[Then('/^do something undefined with \$$/')]
           public function doSomethingUndefinedWith2(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^do something undefined with \\(\d+)$/
-           */
+          #[Then('/^do something undefined with \\\\(\d+)$/')]
           public function doSomethingUndefinedWith3($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring (\d+):$/
-           */
+          #[Given('/^pystring (\d+):$/')]
           public function pystring2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -293,6 +285,8 @@ Feature: Append snippets option
       """
       <?php
 
+      use Behat\Step\Given;
+      use Behat\Step\Then;
       use Behat\Behat\Tester\Exception\PendingException;
       use Behat\Behat\Context\Context;
       use Behat\Gherkin\Node\PyStringNode,
@@ -352,41 +346,31 @@ Feature: Append snippets option
 
           private function doSomethingUndefinedWith() {}
 
-          /**
-           * @Then /^do something undefined with \$$/
-           */
+          #[Then('/^do something undefined with \$$/')]
           public function doSomethingUndefinedWith2(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^do something undefined with \\(\d+)$/
-           */
+          #[Then('/^do something undefined with \\\\(\d+)$/')]
           public function doSomethingUndefinedWith3($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring (\d+):$/
-           */
+          #[Given('/^pystring (\d+):$/')]
           public function pystring2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -463,6 +447,8 @@ Feature: Append snippets option
 
       use Behat\Gherkin\Node\TableNode;
       use Behat\Gherkin\Node\PyStringNode;
+      use Behat\Step\Given;
+      use Behat\Step\Then;
       use Behat\Behat\Tester\Exception\PendingException;
       use Behat\Behat\Context\Context;
 
@@ -520,41 +506,31 @@ Feature: Append snippets option
 
           private function doSomethingUndefinedWith() {}
 
-          /**
-           * @Then /^do something undefined with \$$/
-           */
+          #[Then('/^do something undefined with \$$/')]
           public function doSomethingUndefinedWith2(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^do something undefined with \\(\d+)$/
-           */
+          #[Then('/^do something undefined with \\\\(\d+)$/')]
           public function doSomethingUndefinedWith3($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring (\d+):$/
-           */
+          #[Given('/^pystring (\d+):$/')]
           public function pystring2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -641,6 +617,9 @@ Feature: Append snippets option
       """
       <?php
 
+      use Behat\Step\Then;
+      use Behat\Step\When;
+      use Behat\Step\Given;
       use Behat\Behat\Tester\Exception\PendingException;
       use Behat\Behat\Context\Context;
       use Behat\Gherkin\Node\TableNode;
@@ -649,81 +628,61 @@ Feature: Append snippets option
       class FirstContext implements Context
       {
 
-          /**
-           * @Given /^I have (\d+) apples$/
-           */
+          #[Given('/^I have (\d+) apples$/')]
           public function iHaveApples($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I ate (\d+) apple$/
-           */
+          #[When('/^I ate (\d+) apple$/')]
           public function iAteApple($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should have (\d+) apples$/
-           */
+          #[Then('/^I should have (\d+) apples$/')]
           public function iShouldHaveApples($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I found (\d+) apples$/
-           */
+          #[When('/^I found (\d+) apples$/')]
           public function iFoundApples($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^do something undefined with \$$/
-           */
+          #[Then('/^do something undefined with \$$/')]
           public function doSomethingUndefinedWith(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I ate (\d+) apples$/
-           */
+          #[When('/^I ate (\d+) apples$/')]
           public function iAteApples($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^do something undefined with \\(\d+)$/
-           */
+          #[Then('/^do something undefined with \\\\(\d+)$/')]
           public function doSomethingUndefinedWith2($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring (\d+):$/
-           */
+          #[Given('/^pystring (\d+):$/')]
           public function pystring2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();

--- a/features/context.feature
+++ b/features/context.feature
@@ -272,17 +272,13 @@ Feature: Context consistency
 
     --- CustomContext has missing steps. Define them with these snippets:
 
-        /**
-         * @Then /^context parameter "([^"]*)" should be equal to "([^"]*)"$/
-         */
+        #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]
         public function contextParameterShouldBeEqualTo($arg1, $arg2): void
         {
             throw new PendingException();
         }
 
-        /**
-         * @Then /^context parameter "([^"]*)" should be array with (\d+) elements$/
-         */
+        #[Then('/^context parameter "([^"]*)" should be array with (\d+) elements$/')]
         public function contextParameterShouldBeArrayWithElements($arg1, $arg2): void
         {
             throw new PendingException();

--- a/features/format_options.feature
+++ b/features/format_options.feature
@@ -168,25 +168,19 @@ Feature: Format options
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -251,25 +245,19 @@ Feature: Format options
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -399,25 +387,19 @@ Feature: Format options
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -479,25 +461,19 @@ Feature: Format options
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -137,9 +137,7 @@ Feature: I18n
 
       --- FeatureContext не содержит необходимых определений. Вы можете добавить их используя шаблоны:
 
-          /**
-           * @Then /^Добавить "([^"]*)" число$/
-           */
+          #[Then('/^Добавить "([^"]*)" число$/')]
           public function dobavitChislo($arg1): void
           {
               throw new PendingException();
@@ -177,9 +175,7 @@ Feature: I18n
 
       --- FeatureContext не содержит необходимых определений. Вы можете добавить их используя шаблоны:
 
-          /**
-           * @Then /^Добавить "([^"]*)" число$/
-           */
+          #[Then('/^Добавить "([^"]*)" число$/')]
           public function dobavitChislo($arg1): void
           {
               throw new PendingException();
@@ -217,9 +213,7 @@ Feature: I18n
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^Добавить "([^"]*)" число$/
-           */
+          #[Then('/^Добавить "([^"]*)" число$/')]
           public function dobavitChislo($arg1): void
           {
               throw new PendingException();
@@ -257,9 +251,7 @@ Feature: I18n
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^Добавить "([^"]*)" число$/
-           */
+          #[Then('/^Добавить "([^"]*)" число$/')]
           public function dobavitChislo($arg1): void
           {
               throw new PendingException();

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -142,6 +142,11 @@ Feature: I18n
           {
               throw new PendingException();
           }
+
+      --- Не забудьте эти 2 use утверждения:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Then;
       """
 
   Scenario: Progress
@@ -180,6 +185,11 @@ Feature: I18n
           {
               throw new PendingException();
           }
+
+      --- Не забудьте эти 2 use утверждения:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Then;
       """
 
   Scenario: Progress with unexisting locale
@@ -218,6 +228,11 @@ Feature: I18n
           {
               throw new PendingException();
           }
+
+      --- Don't forget these 2 use statements:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Then;
       """
 
   Scenario: Progress with unexisting locale
@@ -256,4 +271,9 @@ Feature: I18n
           {
               throw new PendingException();
           }
+
+      --- Don't forget these 2 use statements:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Then;
       """

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -92,9 +92,7 @@
       """
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^Something new$/
-           */
+          #[Then('/^Something new$/')]
           public function somethingNew(): void
           {
               throw new PendingException();

--- a/features/legacy_snippets.feature
+++ b/features/legacy_snippets.feature
@@ -61,73 +61,55 @@ Feature: Legacy Snippets
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given /^I have magically created (\d+)\$$/
-           */
+          #[Given('/^I have magically created (\d+)\$$/')]
           public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I have chosen '([^']*)' in coffee machine$/
-           */
+          #[When('/^I have chosen \'([^\']*)\' in coffee machine$/')]
           public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should have '([^']*)'$/
-           */
+          #[Then('/^I should have \'([^\']*)\'$/')]
           public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should get a '([^']*)':$/
-           */
+          #[Then('/^I should get a \'([^\']*)\':$/')]
           public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should get a simple string:$/
-           */
+          #[Then('/^I should get a simple string:$/')]
           public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I have chosen "([^"]*)" in coffee machine$/
-           */
+          #[When('/^I have chosen "([^"]*)" in coffee machine$/')]
           public function iHaveChosenInCoffeeMachine2($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^do something undefined with \\(\d+)$/
-           */
+          #[When('/^do something undefined with \\\\(\d+)$/')]
           public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should have "([^"]*)"$/
-           */
+          #[Then('/^I should have "([^"]*)"$/')]
           public function iShouldHave2($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should get a "([^"]*)":$/
-           */
+          #[Then('/^I should get a "([^"]*)":$/')]
           public function iShouldGetA2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
@@ -190,49 +172,37 @@ Feature: Legacy Snippets
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given I have magically created :arg1$
-           */
+          #[Given('I have magically created :arg1$')]
           public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When I have chosen :arg1 in coffee machine
-           */
+          #[When('I have chosen :arg1 in coffee machine')]
           public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should have :arg1
-           */
+          #[Then('I should have :arg1')]
           public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should get a :arg1:
-           */
+          #[Then('I should get a :arg1:')]
           public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should get a simple string:
-           */
+          #[Then('I should get a simple string:')]
           public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When do something undefined with \:arg1
-           */
+          #[When('do something undefined with \:arg1')]
           public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
@@ -330,9 +300,7 @@ Feature: Legacy Snippets
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given I have a package v2.5
-           */
+          #[Given('I have a package v2.5')]
           public function iHaveAPackageV(): void
           {
               throw new PendingException();
@@ -367,9 +335,7 @@ Feature: Legacy Snippets
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then images should be uploaded to web\/uploads\/media\/default\/:arg1\/:arg2\/
-           */
+          #[Then('images should be uploaded to web\/uploads\/media\/default\/:arg1\/:arg2\/')]
           public function imagesShouldBeUploadedToWebUploadsMediaDefault($arg1, $arg2): void
           {
               throw new PendingException();

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -179,25 +179,19 @@ Feature: Multiple formats
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -273,25 +267,19 @@ Feature: Multiple formats
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -319,25 +307,19 @@ Feature: Multiple formats
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -450,25 +432,19 @@ Feature: Multiple formats
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();
@@ -498,25 +474,19 @@ Feature: Multiple formats
       """
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^do something undefined$/
-           */
+          #[Then('/^do something undefined$/')]
           public function doSomethingUndefined(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^pystring:$/
-           */
+          #[Given('/^pystring:$/')]
           public function pystring(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Given /^table:$/
-           */
+          #[Given('/^table:$/')]
           public function table(TableNode $table): void
           {
               throw new PendingException();

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -134,9 +134,7 @@ Feature: Pretty Formatter
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^Something new$/
-           */
+          #[Then('/^Something new$/')]
           public function somethingNew(): void
           {
               throw new PendingException();

--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -44,25 +44,19 @@ Feature: Different result types
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given /^I have magically created (\d+)\$$/
-           */
+          #[Given('/^I have magically created (\d+)\$$/')]
           public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I have chose "([^"]*)" in coffee machine$/
-           */
+          #[When('/^I have chose "([^"]*)" in coffee machine$/')]
           public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should have "([^"]*)"$/
-           */
+          #[Then('/^I should have "([^"]*)"$/')]
           public function iShouldHave($arg1): void
           {
               throw new PendingException();
@@ -78,25 +72,19 @@ Feature: Different result types
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given /^I have magically created (\d+)\$$/
-           */
+          #[Given('/^I have magically created (\d+)\$$/')]
           public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I have chose "([^"]*)" in coffee machine$/
-           */
+          #[When('/^I have chose "([^"]*)" in coffee machine$/')]
           public function iHaveChoseInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should have "([^"]*)"$/
-           */
+          #[Then('/^I should have "([^"]*)"$/')]
           public function iShouldHave($arg1): void
           {
               throw new PendingException();
@@ -160,9 +148,7 @@ Feature: Different result types
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^I should say "([^"]*)"$/
-           */
+          #[Then('/^I should say "([^"]*)"$/')]
           public function iShouldSay($arg1): void
           {
               throw new PendingException();
@@ -184,9 +170,7 @@ Feature: Different result types
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then /^I should say "([^"]*)"$/
-           */
+          #[Then('/^I should say "([^"]*)"$/')]
           public function iShouldSay($arg1): void
           {
               throw new PendingException();

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -112,6 +112,14 @@ Feature: Snippets generation and addition
           {
               throw new PendingException();
           }
+
+      --- Don't forget these 5 use statements:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Given;
+          use Behat\Step\When;
+          use Behat\Step\Then;
+          use Behat\Gherkin\Node\PyStringNode;
       """
 
   Scenario: Appending regex snippets to a particular context
@@ -203,6 +211,14 @@ Feature: Snippets generation and addition
           {
               throw new PendingException();
           }
+
+      --- Don't forget these 5 use statements:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Given;
+          use Behat\Step\When;
+          use Behat\Step\Then;
+          use Behat\Gherkin\Node\PyStringNode;
       """
 
   Scenario: Appending turnip snippets to a particular context
@@ -298,6 +314,11 @@ Feature: Snippets generation and addition
           {
               throw new PendingException();
           }
+
+      --- Don't forget these 2 use statements:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Given;
       """
 
   Scenario: Generating snippets for steps with slashes
@@ -330,6 +351,11 @@ Feature: Snippets generation and addition
           {
               throw new PendingException();
           }
+
+      --- Don't forget these 2 use statements:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Then;
       """
 
   Scenario: Generating snippets using interactive --snippets-for
@@ -385,6 +411,14 @@ Feature: Snippets generation and addition
           {
               throw new PendingException();
           }
+
+      --- Don't forget these 5 use statements:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Given;
+          use Behat\Step\When;
+          use Behat\Step\Then;
+          use Behat\Gherkin\Node\PyStringNode;
       """
 
   Scenario: Generating snippets for steps with apostrophes
@@ -431,4 +465,11 @@ Feature: Snippets generation and addition
           {
               throw new PendingException();
           }
+
+      --- Don't forget these 4 use statements:
+
+          use Behat\Behat\Tester\Exception\PendingException;
+          use Behat\Step\Given;
+          use Behat\Step\When;
+          use Behat\Step\Then;
       """

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -59,73 +59,55 @@ Feature: Snippets generation and addition
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given /^I have magically created (\d+)\$$/
-           */
+          #[Given('/^I have magically created (\d+)\$$/')]
           public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I have chosen '([^']*)' in coffee machine$/
-           */
+          #[When('/^I have chosen \'([^\']*)\' in coffee machine$/')]
           public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should have '([^']*)'$/
-           */
+          #[Then('/^I should have \'([^\']*)\'$/')]
           public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should get a '([^']*)':$/
-           */
+          #[Then('/^I should get a \'([^\']*)\':$/')]
           public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should get a simple string:$/
-           */
+          #[Then('/^I should get a simple string:$/')]
           public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^I have chosen "([^"]*)" in coffee machine$/
-           */
+          #[When('/^I have chosen "([^"]*)" in coffee machine$/')]
           public function iHaveChosenInCoffeeMachine2($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When /^do something undefined with \\(\d+)$/
-           */
+          #[When('/^do something undefined with \\\\(\d+)$/')]
           public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should have "([^"]*)"$/
-           */
+          #[Then('/^I should have "([^"]*)"$/')]
           public function iShouldHave2($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then /^I should get a "([^"]*)":$/
-           */
+          #[Then('/^I should get a "([^"]*)":$/')]
           public function iShouldGetA2($arg1, PyStringNode $string): void
           {
               throw new PendingException();
@@ -186,49 +168,37 @@ Feature: Snippets generation and addition
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given I have magically created :arg1$
-           */
+          #[Given('I have magically created :arg1$')]
           public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When I have chosen :arg1 in coffee machine
-           */
+          #[When('I have chosen :arg1 in coffee machine')]
           public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should have :arg1
-           */
+          #[Then('I should have :arg1')]
           public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should get a :arg1:
-           */
+          #[Then('I should get a :arg1:')]
           public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should get a simple string:
-           */
+          #[Then('I should get a simple string:')]
           public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When do something undefined with \:arg1
-           */
+          #[When('do something undefined with \:arg1')]
           public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
@@ -323,9 +293,7 @@ Feature: Snippets generation and addition
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given I have a package v2.5
-           */
+          #[Given('I have a package v2.5')]
           public function iHaveAPackageV(): void
           {
               throw new PendingException();
@@ -357,9 +325,7 @@ Feature: Snippets generation and addition
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Then images should be uploaded to web\/uploads\/media\/default\/:arg1\/:arg2\/
-           */
+          #[Then('images should be uploaded to web\/uploads\/media\/default\/:arg1\/:arg2\/')]
           public function imagesShouldBeUploadedToWebUploadsMediaDefault($arg1, $arg2): void
           {
               throw new PendingException();
@@ -384,49 +350,37 @@ Feature: Snippets generation and addition
       """
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given I have magically created :arg1$
-           */
+          #[Given('I have magically created :arg1$')]
           public function iHaveMagicallyCreated($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When I have chosen :arg1 in coffee machine
-           */
+          #[When('I have chosen :arg1 in coffee machine')]
           public function iHaveChosenInCoffeeMachine($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should have :arg1
-           */
+          #[Then('I should have :arg1')]
           public function iShouldHave($arg1): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should get a :arg1:
-           */
+          #[Then('I should get a :arg1:')]
           public function iShouldGetA($arg1, PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then I should get a simple string:
-           */
+          #[Then('I should get a simple string:')]
           public function iShouldGetASimpleString(PyStringNode $string): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When do something undefined with \:arg1
-           */
+          #[When('do something undefined with \:arg1')]
           public function doSomethingUndefinedWith($arg1): void
           {
               throw new PendingException();
@@ -460,25 +414,19 @@ Feature: Snippets generation and addition
 
       --- FeatureContext has missing steps. Define them with these snippets:
 
-          /**
-           * @Given that it's eleven o'clock
-           */
+          #[Given('that it\'s eleven o\'clock')]
           public function thatItsElevenOclock(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @When the guest's taxi has arrived
-           */
+          #[When('the guest\'s taxi has arrived')]
           public function theGuestsTaxiHasArrived(): void
           {
               throw new PendingException();
           }
 
-          /**
-           * @Then the guest says :arg1
-           */
+          #[Then('the guest says :arg1')]
           public function theGuestSays($arg1): void
           {
               throw new PendingException();

--- a/i18n.php
+++ b/i18n.php
@@ -2,6 +2,7 @@
     'en'    => array(
         'snippet_context_choice'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> suite has undefined steps. Please choose the context to generate snippets:</snippet_undefined>',
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> has missing steps. Define them with these snippets:</snippet_undefined>',
+        'snippet_proposal_use'    => 'Don\'t forget these %count% use statements:',
         'snippet_missing_title'   => '<snippet_undefined>Use <snippet_keyword>--snippets-for</snippet_keyword> CLI option to generate snippets for following <snippet_keyword>%count%</snippet_keyword> suite steps:</snippet_undefined>',
         'skipped_scenarios_title' => 'Skipped scenarios:',
         'failed_scenarios_title'  => 'Failed scenarios:',
@@ -20,6 +21,7 @@
     'bg'    => array(
         'snippet_context_choice'  => 'В сет <snippet_undefined><snippet_keyword>%count%</snippet_keyword> има недекларирани стъпки. Изберете в кой Context да бъдат създадени:</snippet_undefined>',
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> има липсващи стъпки. Можете да ги създадете чрез:</snippet_undefined>',
+        'snippet_proposal_use'    => 'Не забравяйте тези %count% use изрази:',
         'snippet_missing_title'   => '<snippet_undefined>Използвайте този снипет <snippet_keyword>--snippets-for</snippet_keyword> за да генерирате кода за следните стъпки <snippet_keyword>%count%</snippet_keyword> през конзолата:</snippet_undefined>',
         'skipped_scenarios_title' => 'Пропуснати сценарии:',
         'failed_scenarios_title'  => 'Провалени сценарии:',
@@ -37,6 +39,7 @@
     ),
     'cs'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> obsahuje chybné kroky. Definujte je za použití následujícího kódu:</snippet_undefined>',
+        'snippet_proposal_use'   => 'Nezapomeňte na těchto %count% use příkazů:',
         'snippet_missing_title'  => '<snippet_undefined>Snippety pro následující kroky v sadě <snippet_keyword>%count%</snippet_keyword> nebyly vygenerovány (zkontrolujte správnost konfigurace):</snippet_undefined>',
         'failed_scenarios_title' => 'Chybné scénáře:',
         'failed_hooks_title'     => 'Chybné hooky:',
@@ -53,6 +56,7 @@
     ),
     'de'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> hat fehlende Schritte. Definiere diese mit den folgenden Snippets:</snippet_undefined>',
+        'snippet_proposal_use'   => 'Vergessen Sie nicht diese %count% use-Anweisungen:',
         'snippet_missing_title'  => '<snippet_undefined>Snippets für die folgenden Schritte in der <snippet_keyword>%count%</snippet_keyword> Suite wurden nicht generiert (Konfiguration überprüfen):</snippet_undefined>',
         'failed_scenarios_title' => 'Fehlgeschlagene Szenarien:',
         'failed_hooks_title'     => 'Fehlgeschlagene Hooks:',
@@ -69,6 +73,7 @@
     ),
     'es'    => array(
         'snippet_proposal_title' => '<snippet_undefined>A <snippet_keyword>%count%</snippet_keyword> le faltan pasos. Defínelos con estos pasos:</snippet_undefined>',
+        'snippet_proposal_use'   => 'No olvides estas %count% declaraciones de use:',
         'snippet_missing_title'  => '<snippet_undefined>Las plantillas para los siguientes pasos en <snippet_keyword>%count%</snippet_keyword> no fueron generadas (revisa tu configuración):</snippet_undefined>',
         'failed_scenarios_title' => 'Escenarios fallidos:',
         'failed_hooks_title'     => 'Hooks fallidos:',
@@ -85,6 +90,7 @@
     ),
     'fr'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> a des étapes manquantes. Définissez-les avec les modèles suivants :</snippet_undefined>',
+        'snippet_proposal_use'   => 'N\'oubliez pas d\'ajouter ces %count% use :',
         'snippet_missing_title'  => '<snippet_undefined>Les modèles des étapes de la suite <snippet_keyword>%count%</snippet_keyword> n\'ont pas été générés (vérifiez votre configuration):</snippet_undefined>',
         'failed_scenarios_title' => 'Scénarios échoués:',
         'failed_hooks_title'     => 'Hooks échoués:',
@@ -102,6 +108,7 @@
     'hu'    => array(
         'snippet_context_choice'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> sorozat meghatározatlan lépéseket tartalmaz. Válaszd ki a környezetet kódrészlet készítéséhez:</snippet_undefined>',
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> lépései hiányosak. Hozd létre az alábbi kódrészletekkel:</snippet_undefined>',
+        'snippet_proposal_use'    => 'Ne felejtsd el ezeket a %count% use utasításokat:',
         'snippet_missing_title'   => '<snippet_undefined>Használd a <snippet_keyword>--snippets-for</snippet_keyword> parancssori kapcsolót kódrészletek készítéséhez a <snippet_keyword>%count%</snippet_keyword> sorozat lépéseihez:</snippet_undefined>',
         'skipped_scenarios_title' => 'Kihagyott forgatókönyvek:',
         'failed_scenarios_title'  => 'Sikertelen forgatókönyvek:',
@@ -120,6 +127,7 @@
     'it'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> ha dei passaggi mancanti. Definiscili con questi snippet:</snippet_undefined>',
         'snippet_missing_title'  => '<snippet_undefined>Gli snippet per i seguenti passaggi della suite <snippet_keyword>%count%</snippet_keyword> non sono stati generati (verifica la configurazione):</snippet_undefined>',
+        'snippet_proposal_use'   => 'Non dimenticare queste %count% istruzioni di use:',
         'failed_scenarios_title' => 'Scenari falliti:',
         'failed_hooks_title'     => 'Hook falliti:',
         'failed_steps_title'     => 'Passaggi falliti:',
@@ -136,6 +144,7 @@
     'ja'    => array(
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> のステップが見つかりません。 次のスニペットで定義できます:</snippet_undefined>',
         'snippet_missing_title'   => '<snippet_undefined>以下のステップのスニペットは<snippet_keyword>%count%</snippet_keyword>スイートに生成されませんでした(設定を確認してください):</snippet_undefined>',
+        'snippet_proposal_use'    => 'これらの %count% use 文を忘れずに:',
         'skipped_scenarios_title' => 'スキップした シナリオ:',
         'failed_scenarios_title'  => '失敗した シナリオ:',
         'failed_hooks_title'      => '失敗した フック:',
@@ -153,6 +162,7 @@
     'ko'    => array(
         'snippet_proposal_title'  => '<snippet_keyword>%count%</snippet_keyword> <snippet_undefined> 정의가 되지 않았습니다. 스니펫을 생성할 컨텍스트를 선택하십시오:</snippet_undefined>',
         'snippet_missing_title'   => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> 단계가 누락되었습니다. 스니펫을 정의해주세요:</snippet_undefined>',
+        'snippet_proposal_use'    => '이 %count% 개의 use 문을 잊지 마세요:',
         'skipped_scenarios_title' => '건너뛴 시나리오:',
         'failed_scenarios_title'  => '실패한 시나리오:',
         'failed_hooks_title'      => '실패한 훅 연결:',
@@ -170,6 +180,7 @@
     'nl'    => array(
         'snippet_proposal_title' => '<snippet_undefined>Ontbrekende stappen in <snippet_keyword>%count%</snippet_keyword>. Definieer ze met de volgende fragmenten:</snippet_undefined>',
         'snippet_missing_title'  => '<snippet_undefined>Fragmenten voor de volgende stappen in de <snippet_keyword>%count%</snippet_keyword> suite werden niet gegenereerd (controleer de configuratie):</snippet_undefined>',
+        'snippet_proposal_use'   => 'Vergeet deze %count% use-verklaringen niet:',
         'failed_scenarios_title' => 'Gefaalde scenario\'s:',
         'failed_hooks_title'     => 'Gefaalde hooks:',
         'failed_steps_title'     => 'Gefaalde stappen:',
@@ -186,6 +197,7 @@
     'no'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> mangler steg. Definer dem med disse snuttene:</snippet_undefined>',
         'snippet_missing_title'  => '<snippet_undefined>Snutter for de følgende stegene i <snippet_keyword>%count%</snippet_keyword>-samlingen ble ikke laget. (Sjekk konfigurasjonen din.):</snippet_undefined>',
+        'snippet_proposal_use'   => 'Ikke glem disse %count% use-setningene:',
         'failed_scenarios_title' => 'Feilende scenarier:',
         'failed_hooks_title'     => 'Feilende hooks:',
         'failed_steps_title'     => 'Feilende steg:',
@@ -202,6 +214,7 @@
     'pl'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> zawiera brakujące kroki. Utwórz je korzystając z tych fragmentów kodu:</snippet_undefined>',
         'snippet_missing_title'  => '<snippet_undefined>Fragmenty kodu dla następujących kroków <snippet_keyword>%count%</snippet_keyword> nie zostały wygenerowane (sprawdź swoją konfigurację):</snippet_undefined>',
+        'snippet_proposal_use'   => 'Nie zapomnij o tych %count% wpisach use:',
         'failed_scenarios_title' => 'Nieudane scenariusze:',
         'failed_hooks_title'     => 'Nieudane hooki:',
         'failed_steps_title'     => 'Nieudane kroki',
@@ -218,6 +231,7 @@
     'pt'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> contém definições em falta. Defina-as com estes exemplos:</snippet_undefined>',
         'snippet_missing_title'  => '<snippet_undefined>Os exemplos para as seguintes definições da suite <snippet_keyword>%count%</snippet_keyword> não foram gerados (verifique a configuração):</snippet_undefined>',
+        'snippet_proposal_use'   => 'Não te esqueças destas %count% declarações de use:',
         'failed_scenarios_title' => 'Cenários que falharam:',
         'failed_hooks_title'     => 'Hooks que falharam:',
         'failed_steps_title'     => 'Definições que falharam:',
@@ -234,6 +248,7 @@
     'pt-BR' => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> possue etapas faltando. Defina elas com esse(s) trecho(s) de código:</snippet_undefined>',
         'snippet_missing_title'  => '<snippet_undefined>Trecho de códigos para as seguintes etapas em <snippet_keyword>%count%</snippet_keyword> suite não foram geradas (verique sua configuração):</snippet_undefined>',
+        'snippet_proposal_use'   => 'Não se esqueça destas %count% declarações de use:',
         'failed_scenarios_title' => 'Cenários falhados:',
         'failed_hooks_title'     => 'Hooks falhados:',
         'failed_steps_title'     => 'Etapas falhadas:',
@@ -250,6 +265,7 @@
     'ro'    => array(
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> are pași lipsa. Puteți implementa pașii cu ajutorul acestor fragmente de cod:</snippet_undefined>',
         'snippet_missing_title'   => '<snippet_undefined>Fragmentele de cod pentru urmatorii pași din suita <snippet_keyword>%count%</snippet_keyword> nu au fost generate (contextul tau implementeaza interfata SnippetAcceptingContext?):</snippet_undefined>',
+        'snippet_proposal_use'    => 'Nu uitați aceste %count% instrucțiuni de use:',
         'skipped_scenarios_title' => 'Scenarii omise:',
         'failed_scenarios_title'  => 'Scenarii eșuate:',
         'failed_hooks_title'      => 'Hook-uri eșuate:',
@@ -267,6 +283,7 @@
     'ru'    => array(
         'snippet_proposal_title'  => '<snippet_keyword>%count%</snippet_keyword> <snippet_undefined>не содержит необходимых определений. Вы можете добавить их используя шаблоны:</snippet_undefined>',
         'snippet_missing_title'   => '<snippet_undefined>Шаблоны для следующих шагов в среде <snippet_keyword>%count%</snippet_keyword> не были сгенерированы (проверьте ваши настройки):</snippet_undefined>',
+        'snippet_proposal_use'    => 'Не забудьте эти %count% use утверждения:',
         'skipped_scenarios_title' => 'Пропущенные сценарии:',
         'failed_scenarios_title'  => 'Проваленные сценарии:',
         'failed_hooks_title'      => 'Проваленные хуки:',
@@ -284,6 +301,7 @@
     'zh'    => array(
         'snippet_context_choice'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> 有新的场景步骤， 请选择要生成代码片段的ContextClass:</snippet_undefined>',
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> 已经更新。 请检查生成片段:</snippet_undefined>',
+        'snippet_proposal_use'    => '别忘了这 %count% 个 use 声明:',
         'snippet_missing_title'   => '<snippet_undefined>您可以使用 <snippet_keyword>--snippets-for</snippet_keyword> CLI命令更新 <snippet_keyword>%count%</snippet_keyword> 的ContextClass:</snippet_undefined>',
         'skipped_scenarios_title' => '跳过场景:',
         'failed_scenarios_title'  => '失败的场景:',

--- a/src/Behat/Behat/Context/Snippet/ContextSnippet.php
+++ b/src/Behat/Behat/Context/Snippet/ContextSnippet.php
@@ -20,32 +20,23 @@ use Behat\Gherkin\Node\StepNode;
  */
 final class ContextSnippet implements Snippet
 {
-    /**
-     * @var StepNode
-     */
-    private $step;
-    /**
-     * @var string
-     */
-    private $template;
-    /**
-     * @var string
-     */
-    private $contextClass;
+    private StepNode $step;
+
+    private string $template;
+
+    private string $contextClass;
+
     /**
      * @var string[]
      */
-    private $usedClasses;
+    private array $usedClasses;
 
     /**
      * Initializes definition snippet.
      *
-     * @param StepNode $step
-     * @param string   $template
-     * @param string   $contextClass
      * @param string[] $usedClasses
      */
-    public function __construct(StepNode $step, $template, $contextClass, array $usedClasses = array())
+    public function __construct(StepNode $step, string $template, string $contextClass, array $usedClasses = [])
     {
         $this->step = $step;
         $this->template = $template;
@@ -56,7 +47,7 @@ final class ContextSnippet implements Snippet
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function getType(): string
     {
         return 'context';
     }
@@ -64,7 +55,7 @@ final class ContextSnippet implements Snippet
     /**
      * {@inheritdoc}
      */
-    public function getHash()
+    public function getHash(): string
     {
         return md5($this->template);
     }
@@ -72,7 +63,7 @@ final class ContextSnippet implements Snippet
     /**
      * {@inheritdoc}
      */
-    public function getSnippet()
+    public function getSnippet(): string
     {
         return sprintf($this->template, $this->step->getKeywordType());
     }
@@ -80,7 +71,7 @@ final class ContextSnippet implements Snippet
     /**
      * {@inheritdoc}
      */
-    public function getStep()
+    public function getStep(): StepNode
     {
         return $this->step;
     }
@@ -88,7 +79,7 @@ final class ContextSnippet implements Snippet
     /**
      * {@inheritdoc}
      */
-    public function getTarget()
+    public function getTarget(): string
     {
         return $this->contextClass;
     }
@@ -98,7 +89,7 @@ final class ContextSnippet implements Snippet
      *
      * @return string[]
      */
-    public function getUsedClasses()
+    public function getUsedClasses(): array
     {
         return $this->usedClasses;
     }

--- a/src/Behat/Behat/Context/Snippet/ContextSnippet.php
+++ b/src/Behat/Behat/Context/Snippet/ContextSnippet.php
@@ -20,28 +20,17 @@ use Behat\Gherkin\Node\StepNode;
  */
 final class ContextSnippet implements Snippet
 {
-    private StepNode $step;
-
-    private string $template;
-
-    private string $contextClass;
-
-    /**
-     * @var string[]
-     */
-    private array $usedClasses;
-
     /**
      * Initializes definition snippet.
      *
      * @param string[] $usedClasses
      */
-    public function __construct(StepNode $step, string $template, string $contextClass, array $usedClasses = [])
-    {
-        $this->step = $step;
-        $this->template = $template;
-        $this->contextClass = $contextClass;
-        $this->usedClasses = $usedClasses;
+    public function __construct(
+        private readonly StepNode $step,
+        private readonly string $template,
+        private readonly string $contextClass,
+        private readonly array $usedClasses = [],
+    ) {
     }
 
     /**

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -194,7 +194,7 @@ TPL;
     private function preparePattern(string $pattern): string
     {
         $pattern = str_replace('%', '%%', $pattern);
-
+        $pattern = str_replace('\\\\', '\\\\\\\\', $pattern);
         return str_replace("'", "\'", $pattern);
     }
 

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedContextIdentifier.php
@@ -19,17 +19,12 @@ use Behat\Behat\Context\Environment\ContextEnvironment;
  */
 final class FixedContextIdentifier implements TargetContextIdentifier
 {
-    /**
-     * @var
-     */
-    private $contextClass;
+    private ?string $contextClass;
 
     /**
      * Initialises identifier.
-     *
-     * @param string $contextClass
      */
-    public function __construct($contextClass)
+    public function __construct(?string $contextClass = null)
     {
         $this->contextClass = $contextClass;
     }
@@ -37,7 +32,7 @@ final class FixedContextIdentifier implements TargetContextIdentifier
     /**
      * {@inheritdoc}
      */
-    public function guessTargetContextClass(ContextEnvironment $environment)
+    public function guessTargetContextClass(ContextEnvironment $environment): ?string
     {
         if ($environment->hasContextClass($this->contextClass)) {
             return $this->contextClass;

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedContextIdentifier.php
@@ -19,14 +19,12 @@ use Behat\Behat\Context\Environment\ContextEnvironment;
  */
 final class FixedContextIdentifier implements TargetContextIdentifier
 {
-    private ?string $contextClass;
-
     /**
      * Initialises identifier.
      */
-    public function __construct(?string $contextClass = null)
-    {
-        $this->contextClass = $contextClass;
+    public function __construct(
+        private readonly ?string $contextClass = null
+    ) {
     }
 
     /**

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
@@ -17,14 +17,12 @@ namespace Behat\Behat\Context\Snippet\Generator;
  */
 final class FixedPatternIdentifier implements PatternIdentifier
 {
-    private ?string $patternType;
-
     /**
      * Initialises identifier.
      */
-    public function __construct(?string $patternType = null)
-    {
-        $this->patternType = $patternType;
+    public function __construct(
+        private readonly ?string $patternType = null
+    ) {
     }
 
     /**

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
@@ -10,8 +10,6 @@
 
 namespace Behat\Behat\Context\Snippet\Generator;
 
-use Behat\Behat\Context\Context;
-
 /**
  * Identifier that always returns same pattern type.
  *
@@ -19,17 +17,12 @@ use Behat\Behat\Context\Context;
  */
 final class FixedPatternIdentifier implements PatternIdentifier
 {
-    /**
-     * @var string
-     */
-    private $patternType;
+    private ?string $patternType;
 
     /**
      * Initialises identifier.
-     *
-     * @param string $patternType
      */
-    public function __construct($patternType)
+    public function __construct(?string $patternType = null)
     {
         $this->patternType = $patternType;
     }
@@ -37,7 +30,7 @@ final class FixedPatternIdentifier implements PatternIdentifier
     /**
      * {@inheritdoc}
      */
-    public function guessPatternType($contextClass)
+    public function guessPatternType($contextClass): ?string
     {
         return $this->patternType;
     }

--- a/src/Behat/Behat/Definition/Call/Given.php
+++ b/src/Behat/Behat/Definition/Call/Given.php
@@ -17,15 +17,15 @@ namespace Behat\Behat\Definition\Call;
  */
 final class Given extends RuntimeDefinition
 {
+    public const KEYWORD = 'Given';
+
     /**
      * Initializes definition.
      *
-     * @param string      $pattern
-     * @param callable    $callable
-     * @param null|string $description
+     * @param array<object|string, string>|callable $callable
      */
-    public function __construct($pattern, $callable, $description = null)
+    public function __construct(string $pattern, $callable, ?string $description = null)
     {
-        parent::__construct('Given', $pattern, $callable, $description);
+        parent::__construct(self::KEYWORD, $pattern, $callable, $description);
     }
 }

--- a/src/Behat/Behat/Definition/Call/Then.php
+++ b/src/Behat/Behat/Definition/Call/Then.php
@@ -17,15 +17,15 @@ namespace Behat\Behat\Definition\Call;
  */
 final class Then extends RuntimeDefinition
 {
+    public const KEYWORD = 'Then';
+
     /**
      * Initializes definition.
      *
-     * @param string      $pattern
-     * @param callable    $callable
-     * @param null|string $description
+     * @param array<object|string, string>|callable $callable
      */
-    public function __construct($pattern, $callable, $description = null)
+    public function __construct(string $pattern, $callable, ?string $description = null)
     {
-        parent::__construct('Then', $pattern, $callable, $description);
+        parent::__construct(self::KEYWORD, $pattern, $callable, $description);
     }
 }

--- a/src/Behat/Behat/Definition/Call/When.php
+++ b/src/Behat/Behat/Definition/Call/When.php
@@ -17,15 +17,15 @@ namespace Behat\Behat\Definition\Call;
  */
 final class When extends RuntimeDefinition
 {
+    public const KEYWORD = 'When';
+
     /**
      * Initializes definition.
      *
-     * @param string      $pattern
-     * @param callable    $callable
-     * @param null|string $description
+     * @param array<object|string, string>|callable $callable
      */
-    public function __construct($pattern, $callable, $description = null)
+    public function __construct(string $pattern, $callable, ?string $description = null)
     {
-        parent::__construct('When', $pattern, $callable, $description);
+        parent::__construct(self::KEYWORD, $pattern, $callable, $description);
     }
 }

--- a/src/Behat/Behat/Snippet/AggregateSnippet.php
+++ b/src/Behat/Behat/Snippet/AggregateSnippet.php
@@ -23,7 +23,7 @@ final class AggregateSnippet
     /**
      * @var Snippet[]
      */
-    private $snippets;
+    private array $snippets;
 
     /**
      * Initializes snippet.
@@ -37,30 +37,24 @@ final class AggregateSnippet
 
     /**
      * Returns snippet type.
-     *
-     * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return current($this->snippets)->getType();
     }
 
     /**
      * Returns snippet unique ID (step type independent).
-     *
-     * @return string
      */
-    public function getHash()
+    public function getHash(): string
     {
         return current($this->snippets)->getHash();
     }
 
     /**
      * Returns definition snippet text.
-     *
-     * @return string
      */
-    public function getSnippet()
+    public function getSnippet(): string
     {
         return current($this->snippets)->getSnippet();
     }
@@ -70,7 +64,7 @@ final class AggregateSnippet
      *
      * @return StepNode[]
      */
-    public function getSteps()
+    public function getSteps(): array
     {
         return array_unique(
             array_map(
@@ -88,7 +82,7 @@ final class AggregateSnippet
      *
      * @return string[]
      */
-    public function getTargets()
+    public function getTargets(): array
     {
         return array_unique(
             array_map(
@@ -105,7 +99,7 @@ final class AggregateSnippet
      *
      * @return string[]
      */
-    public function getUsedClasses()
+    public function getUsedClasses(): array
     {
         if (empty($this->snippets)) {
             return array();

--- a/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
+++ b/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
@@ -27,18 +27,12 @@ interface SnippetGenerator
     /**
      * Checks if generator supports search query.
      *
-     * @param Environment $environment
-     * @param StepNode    $step
-     *
      * @return bool
      */
     public function supportsEnvironmentAndStep(Environment $environment, StepNode $step);
 
     /**
      * Generates snippet from search.
-     *
-     * @param Environment $environment
-     * @param StepNode    $step
      *
      * @return Snippet
      */

--- a/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
@@ -57,13 +57,20 @@ class ConsoleSnippetPrinter implements SnippetPrinter
      */
     public function printSnippets($targetName, array $snippets)
     {
-        $message = $this->translator->trans('snippet_proposal_title', array('%count%' => $targetName), 'output');
+        $message = $this->translator->trans('snippet_proposal_title', ['%count%' => $targetName], 'output');
 
         $this->output->writeln('--- ' . $message . PHP_EOL);
 
+        $usedClasses = [];
         foreach ($snippets as $snippet) {
+            foreach ($snippet->getUsedClasses() as $usedClass) {
+                $usedClasses[$usedClass] = true;
+            }
+
             $this->output->writeln(sprintf('<snippet_undefined>%s</snippet_undefined>', $snippet->getSnippet()) . PHP_EOL);
         }
+
+        $this->outputClassesUsesStatements(array_keys($usedClasses));
     }
 
     /**
@@ -83,5 +90,23 @@ class ConsoleSnippetPrinter implements SnippetPrinter
         }
 
         $this->output->writeln('');
+    }
+
+    /**
+     * @param array<string> $usedClasses
+     */
+    public function outputClassesUsesStatements(array $usedClasses): void
+    {
+        if ([] === $usedClasses) {
+            return;
+        }
+
+        $message = $this->translator->trans('snippet_proposal_use', ['%count%' => \count($usedClasses)], 'output');
+
+        $this->output->writeln('--- '.$message.PHP_EOL);
+
+        foreach ($usedClasses as $usedClass) {
+            $this->output->writeln(sprintf('    <snippet_undefined>use %s;</snippet_undefined>', $usedClass));
+        }
     }
 }


### PR DESCRIPTION
### Description
An old issue (cf. #1379) proposed to generate snippets with attributes in place of annotations.
I worked on it last days and finally came up with a working solution.

### Proposal
For now, I didn't switch all annotations to attributes.
I add a new CLI option to use attributes if we want, and an associated config key also.

So you can now do:

`behat -f progress --no-colors --snippets-for=FeatureContext --snippets-use-attributes` for example.

or add the new config key in `behat.yml` to use attributes by default:
```yaml
default:
  contexts:
    snippets:
      use_attributes: true
``` 

Although attributes are now widely supported, I think it's better to act in two phases: first, this PR, to implement attributes as an option. And later to invert and use attributes by default.