### PR TITLE
chore: remove mentions to php 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,10 +85,6 @@ jobs:
       - name: Run tests (Behat)
         run: ./bin/behat -fprogress --strict
 
-      - name: Run tests (Behat for PHP 8.0)
-        if: matrix.php >= 8.0
-        run: ./bin/behat -fprogress --strict --tags=@php8
-
   static-analysis:
     name: Static analysis
     runs-on: ubuntu-latest

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,4 +1,1 @@
 default:
-  gherkin:
-    filters:
-      tags: ~@php8

--- a/features/attributes.feature
+++ b/features/attributes.feature
@@ -1,10 +1,9 @@
 Feature: attributes
   In order to keep annotations shorter and faster to parse
   As a tester
-  I need to be able to use PHP8 Attributes
+  I need to be able to use PHP Attributes
 
-  @php8
-  Scenario: PHP 8 Step Attributes
+  Scenario: Step Attributes
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
@@ -65,8 +64,7 @@ Feature: attributes
       6 steps (6 passed)
       """
 
-  @php8
-  Scenario: PHP 8 Hook Feature Hook Attributes
+  Scenario: Hook Feature Hook Attributes
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
@@ -170,8 +168,7 @@ Feature: attributes
       6 steps (6 passed)
       """
 
-  @php8
-  Scenario: PHP 8 Hook Scenario Hook Attributes
+  Scenario: Hook Scenario Hook Attributes
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
@@ -283,8 +280,8 @@ Feature: attributes
       6 steps (6 passed)
       """
 
-  @php8 @suite-hooks
-  Scenario: PHP 8 Hook Suite Hook Attributes
+  @suite-hooks
+  Scenario: Hook Suite Hook Attributes
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
@@ -385,8 +382,7 @@ Feature: attributes
       3 steps (3 passed)
       """
 
-  @php8
-  Scenario: PHP 8 Hook Step Hook Attributes
+  Scenario: Hook Step Hook Attributes
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php

--- a/features/autowire.feature
+++ b/features/autowire.feature
@@ -247,7 +247,6 @@ Feature: Helper services autowire
     When I run "behat --no-colors -f progress features/autowire.feature"
     Then it should pass
 
-  @php8
   Scenario: Union constructor arguments
     Given a file named "features/autowire.feature" with:
       """

--- a/features/definitions_transformations.feature
+++ b/features/definitions_transformations.feature
@@ -642,7 +642,6 @@ Feature: Step Arguments Transformations
       8 steps (8 passed)
       """
 
-  @php8
   Scenario: By-type transformations don't trigger from union types
     Given a file named "features/union-transforms.feature" with:
       """

--- a/tests/Behat/Tests/Config/ConfigTest.php
+++ b/tests/Behat/Tests/Config/ConfigTest.php
@@ -20,7 +20,7 @@ final class ConfigTest extends TestCase
             'default' => [
                 'gherkin' => [
                     'filters' => [
-                        'tags' => '~@php8'
+                        'tags' => '~@test'
                     ],
                 ],
             ],


### PR DESCRIPTION
There were some places in our code where we were taking specific actions for PHP 8. This is not needed any longer as we don't support a lower version any more. This PR removes those special cases