### PR TITLE
dx: add composer scripts for testing tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,11 @@ You can read detailed guidance on what BC means in [Symfony2 BC guide](http://sy
 ## Running tests
 
 Make sure that you don't break anything with your changes by running the test
-suite with your locale set to english:
+suite with this command:
 
 ```bash
-$> LANG=C bin/behat --format=progress
+composer all-tests
 ```
+
+This will run all the Behat tests, all the PHPUnit tests and Psalm. If the tests find any issues,
+you can run these tools individually by running `composer behat`, `composer phpunit` or `composer psalm`.

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
             "@phpunit",
             "@psalm"
         ],
-        "behat": "LANG=C bin/behat",
+        "behat": "LANG=C bin/behat  --rerun",
         "behat-progress": "LANG=C bin/behat --format=progress",
         "phpunit": "phpunit",
         "psalm": "psalm"

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         "behat/gherkin": "^4.10.0",
         "behat/transliterator": "^1.5",
         "composer-runtime-api": "^2.2",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
+        "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
+        "symfony/console": "^5.4 || ^6.4 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
         "symfony/translation": "^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0",
-        "psr/container": "^1.0 || ^2.0"
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0"
     },
 
     "require-dev": {
@@ -62,6 +62,18 @@
         "branch-alias": {
             "dev-master": "3.x-dev"
         }
+    },
+
+    "scripts": {
+        "all-tests": [
+            "@behat-progress",
+            "@phpunit",
+            "@psalm"
+        ],
+        "behat": "LANG=C bin/behat",
+        "behat-progress": "LANG=C bin/behat --format=progress",
+        "phpunit": "phpunit",
+        "psalm": "psalm"
     },
 
     "bin": ["bin/behat"]


### PR DESCRIPTION
While developing for Behat I found myself running the commands that run the tests quite often. To make this easier this PR introduces some composer scripts, including one that will run all your tests. The script that runs all the tests runs behat in progress mode, while the one that runs it individually runs it in pretty mode