### PR TITLE
PHP Config - suite filters

### DIFF
--- a/features/suite.feature
+++ b/features/suite.feature
@@ -330,18 +330,29 @@ Feature: Suites
           When I ate 10 apple
           Then I should have 5 apples
       """
-    And a file named "behat.yml" with:
+    And a file named "behat.php" with:
       """
-      default:
-        suites:
-          little_kid:
-            contexts: [ LittleKidContext ]
-            filters:
-              role:   little kid
-          big_brother:
-            contexts: [ BigBrotherContext ]
-            filters:
-              role:   big brother
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
+      use Behat\Config\Suite;
+      use Behat\Config\Filter\RoleFilter;
+
+      $profile = (new Profile('default'))
+        ->withSuite(
+          (new Suite('little_kid'))
+            ->withContexts(LittleKidContext::class)
+            ->withFilter(new RoleFilter('little kid'))
+        )
+        ->withSuite(
+          (new Suite('big_brother'))
+            ->withContexts(BigBrotherContext::class)
+            ->withFilter(new RoleFilter('big brother'))
+        )
+      ;
+
+      return (new Config())->withProfile($profile);
       """
     When I run "behat --no-colors -fpretty --format-settings='{\"paths\": true}' features"
     Then it should pass with:
@@ -427,18 +438,29 @@ Feature: Suites
           When I ate 10 apple
           Then I should have 5 apples
       """
-    And a file named "behat.yml" with:
+    And a file named "behat.php" with:
       """
-      default:
-        suites:
-          little_kid:
-            contexts: [ LittleKidContext ]
-            filters:
-              narrative: '/As a little kid/'
-          big_brother:
-            contexts: [ BigBrotherContext ]
-            filters:
-              narrative: '/As a big brother/'
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
+      use Behat\Config\Suite;
+      use Behat\Config\Filter\NarrativeFilter;
+
+      $profile = (new Profile('default'))
+        ->withSuite(
+          (new Suite('little_kid'))
+            ->withContexts(LittleKidContext::class)
+            ->withFilter(new NarrativeFilter('/As a little kid/'))
+        )
+        ->withSuite(
+          (new Suite('big_brother'))
+            ->withContexts(BigBrotherContext::class)
+            ->withFilter(new NarrativeFilter('/As a big brother/'))
+        )
+      ;
+
+      return (new Config())->withProfile($profile);
       """
     When I run "behat --no-colors -fpretty --format-settings='{\"paths\": true}' features"
     Then it should pass with:
@@ -524,18 +546,29 @@ Feature: Suites
           When I ate 10 apple
           Then I should have 5 apples
       """
-    And a file named "behat.yml" with:
+    And a file named "behat.php" with:
       """
-      default:
-        suites:
-          little_kid:
-            contexts: [ LittleKidContext ]
-            filters:
-              role:   little kid
-          big_brother:
-            contexts: [ BigBrotherContext ]
-            filters:
-              role:   big brother
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
+      use Behat\Config\Suite;
+      use Behat\Config\Filter\RoleFilter;
+
+      $profile = (new Profile('default'))
+        ->withSuite(
+          (new Suite('little_kid'))
+            ->withContexts(LittleKidContext::class)
+            ->withFilter(new RoleFilter('little kid'))
+        )
+        ->withSuite(
+          (new Suite('big_brother'))
+            ->withContexts(BigBrotherContext::class)
+            ->withFilter(new RoleFilter('big brother'))
+        )
+      ;
+
+      return (new Config())->withProfile($profile);
       """
     When I run "behat --no-colors -s big_brother -fpretty --format-settings='{\"paths\": true}' features"
     Then it should pass with:

--- a/src/Behat/Config/Suite.php
+++ b/src/Behat/Config/Suite.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Behat\Config;
 
+use Behat\Config\Filter\FilterInterface;
+use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
+
 final class Suite
 {
     public function __construct(
@@ -37,6 +40,17 @@ final class Suite
         foreach ($paths as $path) {
             $this->settings['paths'][] = $path;
         }
+
+        return $this;
+    }
+
+    public function withFilter(FilterInterface $filter): self
+    {
+        if (array_key_exists($filter->name(), $this->settings['filters'] ?? [])) {
+            throw new ConfigurationLoadingException(sprintf('The filter "%s" already exists.', $filter->name()));
+        }
+
+        $this->settings['filters'][$filter->name()] = $filter->value();
 
         return $this;
     }

--- a/tests/Behat/Tests/Config/ExtensionTest.php
+++ b/tests/Behat/Tests/Config/ExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Behat\Tests\Config;
 
 use Behat\Config\Config;

--- a/tests/Behat/Tests/Config/SuiteTest.php
+++ b/tests/Behat/Tests/Config/SuiteTest.php
@@ -7,6 +7,7 @@ namespace Behat\Tests\Config;
 use Behat\Config\Filter\NameFilter;
 use Behat\Config\Filter\TagFilter;
 use Behat\Config\Suite;
+use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use PHPUnit\Framework\TestCase;
 
 final class SuiteTest extends TestCase
@@ -78,5 +79,17 @@ final class SuiteTest extends TestCase
                 'name' => 'name1',
             ]
         ], $config->toArray());
+    }
+
+    public function testItThrowsAnExceptionWhenAddingExistingFilter(): void
+    {
+        $suite = new Suite('first');
+
+        $suite->withFilter(new TagFilter('tag1'));
+
+        $this->expectException(ConfigurationLoadingException::class);
+        $this->expectExceptionMessage('The filter "tags" already exists.');
+
+        $suite->withFilter(new TagFilter('tag1'));
     }
 }

--- a/tests/Behat/Tests/Config/SuiteTest.php
+++ b/tests/Behat/Tests/Config/SuiteTest.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Behat\Tests\Config;
 
+use Behat\Config\Filter\NameFilter;
+use Behat\Config\Filter\TagFilter;
 use Behat\Config\Suite;
 use PHPUnit\Framework\TestCase;
 
@@ -58,6 +62,20 @@ final class SuiteTest extends TestCase
                 'features/admin/first',
                 'features/front/first',
                 'features/api/first',
+            ]
+        ], $config->toArray());
+    }
+
+    public function testAddingFilters(): void
+    {
+        $config = new Suite('first');
+        $config->withFilter(new TagFilter('tag1'));
+        $config->withFilter(new NameFilter('name1'));
+
+        $this->assertEquals([
+            'filters' => [
+                'tags' => 'tag1',
+                'name' => 'name1',
             ]
         ], $config->toArray());
     }


### PR DESCRIPTION
I'm wondering if we should implement `withFilters(FilterInterface ...$filters) `instead.
But for now, we have implemented them like this on Profile.

```php
use Behat\Config\Config;
use Behat\Config\Profile;
use Behat\Config\Suite;
use Behat\Config\Filter\RoleFilter;

$profile = (new Profile('default'))
    ->withSuite(
        (new Suite('little_kid'))
            ->withContexts(LittleKidContext::class)
            ->withFilter(new RoleFilter('little kid'))
        )
    ->withSuite(
        (new Suite('big_brother'))
            ->withContexts(BigBrotherContext::class)
            ->withFilter(new RoleFilter('big brother'))
        )
;

return (new Config())->withProfile($profile);
```