### PR TITLE
fix: allow using the narrative filter on the command line

### DIFF
--- a/features/narrative_filters.feature
+++ b/features/narrative_filters.feature
@@ -1,0 +1,63 @@
+Feature: Narrative filters
+  In order to run only needed features
+  As a Behat user
+  I need Behat to support features filtering based on a regex filter on the narrative
+
+  Scenario: Brothers
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /** @Given I have :count apple(s) */
+          public function iHaveApples($count) { }
+
+          /** @When I ate :count apple(s) */
+          public function iAteApples($count) { }
+
+          /** @Then I should have :count apple(s) */
+          public function iShouldHaveApples($count) { }
+      }
+      """
+    And a file named "features/little_kid.feature" with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry
+          Given I have 3 apples
+          When I ate 1 apple
+          Then I should have 2 apples
+      """
+    And a file named "features/big_brother.feature" with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a big brother
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry
+          Given I have 15 apples
+          When I ate 10 apple
+          Then I should have 5 apples
+      """
+    When I run "behat --no-colors -f pretty --narrative '/As a (little|big) kid/'"
+    Then it should pass with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry   # features/little_kid.feature:6
+          Given I have 3 apples       # FeatureContext::iHaveApples()
+          When I ate 1 apple          # FeatureContext::iAteApples()
+          Then I should have 2 apples # FeatureContext::iShouldHaveApples()
+
+      1 scenario (1 passed)
+      3 steps (3 passed)
+      """

--- a/features/role_filters.feature
+++ b/features/role_filters.feature
@@ -1,0 +1,63 @@
+Feature: Role filters
+  In order to run only needed features
+  As a Behat user
+  I need Behat to support features filtering based on role
+
+  Scenario: Brothers
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+      use Behat\Behat\Context\Context;
+
+      class FeatureContext implements Context
+      {
+          /** @Given I have :count apple(s) */
+          public function iHaveApples($count) { }
+
+          /** @When I ate :count apple(s) */
+          public function iAteApples($count) { }
+
+          /** @Then I should have :count apple(s) */
+          public function iShouldHaveApples($count) { }
+      }
+      """
+    And a file named "features/little_kid.feature" with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry
+          Given I have 3 apples
+          When I ate 1 apple
+          Then I should have 2 apples
+      """
+    And a file named "features/big_brother.feature" with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a big brother
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry
+          Given I have 15 apples
+          When I ate 10 apple
+          Then I should have 5 apples
+      """
+    When I run "behat --no-colors -f pretty --role 'little kid'"
+    Then it should pass with:
+      """
+      Feature: Apples story
+        In order to eat apple
+        As a little kid
+        I need to have an apple in my pocket
+
+        Scenario: I'm little hungry   # features/little_kid.feature:6
+          Given I have 3 apples       # FeatureContext::iHaveApples()
+          When I ate 1 apple          # FeatureContext::iAteApples()
+          Then I should have 2 apples # FeatureContext::iShouldHaveApples()
+
+      1 scenario (1 passed)
+      3 steps (3 passed)
+      """

--- a/src/Behat/Behat/Gherkin/Cli/FilterController.php
+++ b/src/Behat/Behat/Gherkin/Cli/FilterController.php
@@ -11,6 +11,7 @@
 namespace Behat\Behat\Gherkin\Cli;
 
 use Behat\Gherkin\Filter\NameFilter;
+use Behat\Gherkin\Filter\NarrativeFilter;
 use Behat\Gherkin\Filter\RoleFilter;
 use Behat\Gherkin\Filter\TagFilter;
 use Behat\Gherkin\Gherkin;
@@ -52,19 +53,25 @@ final class FilterController implements Controller
         $command
             ->addOption(
                 '--name', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-                "Only executeCall the feature elements which match part" . PHP_EOL .
+                "Only execute the feature elements which match part" . PHP_EOL .
                 "of the given name or regex."
             )
             ->addOption(
                 '--tags', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-                "Only executeCall the features or scenarios with tags" . PHP_EOL .
+                "Only execute the features or scenarios with tags" . PHP_EOL .
                 "matching tag filter expression."
             )
             ->addOption(
                 '--role', null, InputOption::VALUE_REQUIRED,
-                "Only executeCall the features with actor role matching" . PHP_EOL .
+                "Only execute the features with actor role matching" . PHP_EOL .
                 "a wildcard."
-            );
+            )
+            ->addOption(
+                '--narrative', null, InputOption::VALUE_REQUIRED,
+                "Only execute the features with actor description" . PHP_EOL .
+                "matching a regex."
+            )
+        ;
     }
 
     /**
@@ -89,6 +96,10 @@ final class FilterController implements Controller
 
         if ($role = $input->getOption('role')) {
             $filters[] = new RoleFilter($role);
+        }
+
+        if ($narrative = $input->getOption('narrative')) {
+            $filters[] = new NarrativeFilter($narrative);
         }
 
         if (count($filters)) {

--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -176,7 +176,7 @@ final class LazyFeatureIterator implements SpecificationIterator
             '`%s` filter is not supported by the `%s` suite. Supported types are `%s`.',
             $type,
             $suite->getName(),
-            implode('`, `', array('role', 'name', 'tags'))
+            implode('`, `', array('narrative', 'role', 'name', 'tags'))
         ), $suite->getName());
     }
 


### PR DESCRIPTION
When looking at the PR that added the filters to the PHP config I noticed that the narrative filter had not been added as the filters that could be run from the command line. It was also missing from one error message. 
I also found that there was no test for running the role filter from the command line

This PR addresses all these issues