### PR TITLE
DX: disable Xdebug by default and provide a CLI option to activate it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "behat/gherkin": "^4.10.0",
         "behat/transliterator": "^1.5",
         "composer-runtime-api": "^2.2",
+        "composer/xdebug-handler": "^3.0",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -14,6 +14,7 @@ use Behat\Testwork\ServiceContainer\Configuration\ConfigurationLoader;
 use Behat\Testwork\ServiceContainer\ContainerLoader;
 use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Composer\XdebugHandler\XdebugHandler;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -84,6 +85,7 @@ final class Application extends BaseApplication
                 'guessed based on your platform and the output if not specified.'
             ),
             new InputOption('--no-colors', null, InputOption::VALUE_NONE, 'Force no ANSI color in the output.'),
+            new InputOption('--xdebug', null, InputOption::VALUE_NONE, 'Allow Xdebug to run.'),
         ));
     }
 
@@ -97,6 +99,14 @@ final class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
+        $isXdebugAllowed = $input->hasParameterOption('--xdebug');
+        if (!$isXdebugAllowed) {
+            $xdebugHandler = new XdebugHandler('behat');
+            $xdebugHandler->setPersistent();
+            $xdebugHandler->check();
+            unset($xdebugHandler);
+        }
+
         // xdebug's default nesting level of 100 is not enough
         if (extension_loaded('xdebug')
             && false === strpos(ini_get('disable_functions'), 'ini_set')


### PR DESCRIPTION
If you have been debugging your code with Xdebug and forget to turn it off, when running Behat it can be 2-3 times slower, even if you don't set any breakpoints or actually use Xdebug. Following what other tools like PHPStan or Rector do, with this PR by default we disable Xdebug when running Behat. We add a new `--xdebug` command line option that allows you to run Behat without disabling Xdebug. 

This uses the https://github.com/composer/xdebug-handler library, also used by PHPStan and Rector to provide this same functionality