### PR TITLE
fix: Inherit step definition attributes on methods extended from parent Context

### DIFF
--- a/features/definitions_override_attributes.feature
+++ b/features/definitions_override_attributes.feature
@@ -1,20 +1,19 @@
-Feature: Step Definitions Override
+Feature: Step Definitions Override Attributes
   In order to fine-tune definitions defined in parent classes
   As a step definitions developer
-  I need to be able to override definition methods using annotations
+  I need to be able to override definition methods using step definition attributes
 
-  Scenario: Overridden method without own annotation will inherit parent pattern
+  Scenario: Overridden method without own attribute will inherit parent pattern
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
       use Behat\Behat\Context\Context;
+      use Behat\Step\Then;
 
       class ParentContext
       {
-          /**
-           * @Then :token should be :value
-           */
+          #[Then(':token should be :value')]
           public function shouldBe($token, $value) {}
       }
 
@@ -38,18 +37,53 @@ Feature: Step Definitions Override
       1 step (1 passed)
       """
 
-  Scenario: Overridden method with different annotation will have both patterns
+  Scenario: Overridden method with different attribute will have both patterns
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """
       <?php
 
       use Behat\Behat\Context\Context;
+      use Behat\Step\Then;
 
       class ParentContext
       {
-          /**
-           * @Then :token should be :value
-           */
+          #[Then(':token should be :value')]
+          public function shouldBe($token, $value) {}
+      }
+
+      class FeatureContext extends ParentContext implements Context
+      {
+          #[Then(':token should be equal to :value')]
+          public function shouldBe($token, $value) {}
+      }
+      """
+    And a file named "features/step_patterns.feature" with:
+      """
+      Feature: Step Pattern
+        Scenario:
+          Then 5 should be equal to 10
+          Then 5 should be 10
+      """
+    When I run "behat -f progress --no-colors"
+    Then it should pass with:
+      """
+      ..
+
+      1 scenario (1 passed)
+      2 steps (2 passed)
+      """
+
+  Scenario: Overridden method with parent attribute and child annotation
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+      use Behat\Step\Then;
+
+      class ParentContext
+      {
+          #[Then(':token should be :value')]
           public function shouldBe($token, $value) {}
       }
 


### PR DESCRIPTION
As mentioned by @stof here: https://github.com/Behat/Behat/issues/1565#issuecomment-2535430466, `AttributeContextReader` was incomplete compared to its annotation equivalent.

We add here the missing code to retrieve parent callees, like annotations do.

Closes #1565