### PR TITLE
chore: Fix typo in return type annotation

### DIFF
--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -278,7 +278,7 @@ TPL;
     /**
      * Returns already proposed method names.
      *
-     * @return array<string, array<string, string>
+     * @return array<string, string>
      */
     private function getAlreadyProposedMethods(string $contextClass): array
     {


### PR DESCRIPTION
Fixes a typo that slipped in with #1549 as per https://github.com/Behat/Behat/pull/1549#discussion_r1875747963