### PR TITLE
DX: initial install of PHPStan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Run Psalm
         run: ./vendor/bin/psalm --output-format=github --php-version=${{ matrix.php }}
 
+      - name: Run PHPStan
+        run: ./vendor/bin/phpstan
+
   build-phar:
     name: Build PHAR file
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 
     "require-dev": {
         "herrera-io/box": "~1.6.1",
+        "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^9.6",
         "sebastian/diff": "^4.0",
         "symfony/polyfill-php84": "^1.31",
@@ -69,10 +70,12 @@
         "all-tests": [
             "@behat-progress",
             "@phpunit",
-            "@psalm"
+            "@psalm",
+            "@phpstan"
         ],
         "behat": "LANG=C bin/behat  --rerun",
         "behat-progress": "LANG=C bin/behat --format=progress",
+        "phpstan": "phpstan",
         "phpunit": "phpunit",
         "psalm": "psalm"
     },

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,16 @@
+parameters:
+    level: 1
+    paths:
+        - src
+    excludePaths:
+        - src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfonyLegacy.php
+        - src/Behat/Testwork/EventDispatcher/TestworkEventDispatcherSymfony5.php
+    ignoreErrors:
+        -
+            identifier: class.notFound
+            paths:
+                - src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
+        -
+            identifier: constructor.unusedParameter
+            paths:
+                - src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -106,7 +106,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
      * Prints scenario title (first line of long title).
      *
      * @param OutputPrinter $printer
-     * @param string        $longTitle
+     * @param string|null   $longTitle
      */
     private function printTitle(OutputPrinter $printer, $longTitle)
     {
@@ -122,7 +122,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
      * Prints scenario description (other lines of long title).
      *
      * @param OutputPrinter $printer
-     * @param string        $longTitle
+     * @param string|null   $longTitle
      */
     private function printDescription(OutputPrinter $printer, $longTitle)
     {

--- a/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
+++ b/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
@@ -33,6 +33,7 @@ class FormatterNotFoundException extends InvalidArgumentException implements Out
     public function __construct($message, $name)
     {
         parent::__construct($message);
+        $this->name = $name;
     }
 
     /**


### PR DESCRIPTION
We aim to replace Psalm with PHPStan as the static analysis tool of choice for this repository. This PR adds this new tool and adds the changes needed to reach level 1.

For now we keep Psalm, we don't want to remove it until we have reached at least PHPStan level 3, which could be the equivalent of the current level 6 in Psalm