### PR TITLE
Add generic types for the specification type for SpecificationIterator

### DIFF
--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
@@ -14,6 +14,7 @@ use Behat\Behat\EventDispatcher\Event\AfterFeatureSetup;
 use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
 use Behat\Behat\EventDispatcher\Event\BeforeFeatureTeardown;
 use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
+use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Tester\Result\TestResult;
@@ -24,11 +25,13 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * Feature tester dispatching BEFORE/AFTER events during tests.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @implements SpecificationTester<FeatureNode>
  */
 final class EventDispatchingFeatureTester implements SpecificationTester
 {
     /**
-     * @var SpecificationTester
+     * @var SpecificationTester<FeatureNode>
      */
     private $baseTester;
     /**
@@ -39,8 +42,8 @@ final class EventDispatchingFeatureTester implements SpecificationTester
     /**
      * Initializes tester.
      *
-     * @param SpecificationTester      $baseTester
-     * @param EventDispatcherInterface $eventDispatcher
+     * @param SpecificationTester<FeatureNode> $baseTester
+     * @param EventDispatcherInterface         $eventDispatcher
      */
     public function __construct(SpecificationTester $baseTester, EventDispatcherInterface $eventDispatcher)
     {

--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -25,6 +25,8 @@ use Behat\Testwork\Suite\Suite;
  * Lazily iterates (parses one-by-one) over features.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @implements SpecificationIterator<FeatureNode>
  */
 final class LazyFeatureIterator implements SpecificationIterator
 {

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -13,6 +13,7 @@ namespace Behat\Behat\Gherkin\Specification\Locator;
 use Behat\Behat\Gherkin\Specification\LazyFeatureIterator;
 use Behat\Gherkin\Filter\PathsFilter;
 use Behat\Gherkin\Gherkin;
+use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Specification\Locator\SpecificationLocator;
 use Behat\Testwork\Specification\NoSpecificationsIterator;
 use Behat\Testwork\Suite\Exception\SuiteConfigurationException;
@@ -25,6 +26,8 @@ use RegexIterator;
  * Loads gherkin features from the filesystem using gherkin parser.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @implements SpecificationLocator<FeatureNode>
  */
 final class FilesystemFeatureLocator implements SpecificationLocator
 {

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemRerunScenariosListLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemRerunScenariosListLocator.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Gherkin\Specification\Locator;
 
 use Behat\Behat\Gherkin\Specification\LazyFeatureIterator;
 use Behat\Gherkin\Gherkin;
+use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Specification\Locator\SpecificationLocator;
 use Behat\Testwork\Specification\NoSpecificationsIterator;
 use Behat\Testwork\Suite\Suite;
@@ -20,6 +21,8 @@ use Behat\Testwork\Suite\Suite;
  * Loads gherkin features using a file with the list of scenarios.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @implements SpecificationLocator<FeatureNode>
  */
 final class FilesystemRerunScenariosListLocator implements SpecificationLocator
 {

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemScenariosListLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemScenariosListLocator.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Gherkin\Specification\Locator;
 
 use Behat\Behat\Gherkin\Specification\LazyFeatureIterator;
 use Behat\Gherkin\Gherkin;
+use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Specification\Locator\SpecificationLocator;
 use Behat\Testwork\Specification\NoSpecificationsIterator;
 use Behat\Testwork\Suite\Suite;
@@ -20,6 +21,8 @@ use Behat\Testwork\Suite\Suite;
  * Loads gherkin features using a file with the list of scenarios.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @implements SpecificationLocator<FeatureNode>
  */
 final class FilesystemScenariosListLocator implements SpecificationLocator
 {

--- a/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Hook\Tester;
 
 use Behat\Behat\Hook\Scope\AfterFeatureScope;
 use Behat\Behat\Hook\Scope\BeforeFeatureScope;
+use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Hook\HookDispatcher;
 use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
@@ -23,11 +24,13 @@ use Behat\Testwork\Tester\SpecificationTester;
  * Feature tester which dispatches hooks during its execution.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @implements SpecificationTester<FeatureNode>
  */
 final class HookableFeatureTester implements SpecificationTester
 {
     /**
-     * @var SpecificationTester
+     * @var SpecificationTester<FeatureNode>
      */
     private $baseTester;
     /**
@@ -38,8 +41,8 @@ final class HookableFeatureTester implements SpecificationTester
     /**
      * Initializes tester.
      *
-     * @param SpecificationTester $baseTester
-     * @param HookDispatcher      $hookDispatcher
+     * @param SpecificationTester<FeatureNode> $baseTester
+     * @param HookDispatcher                   $hookDispatcher
      */
     public function __construct(SpecificationTester $baseTester, HookDispatcher $hookDispatcher)
     {

--- a/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Tester\Runtime;
 
 use Behat\Behat\Tester\OutlineTester;
 use Behat\Behat\Tester\ScenarioTester;
+use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Environment\EnvironmentManager;
@@ -27,6 +28,8 @@ use Behat\Testwork\Tester\SpecificationTester;
  * Tester executing feature tests in the runtime.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @implements SpecificationTester<FeatureNode>
  */
 final class RuntimeFeatureTester implements SpecificationTester
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseCompleted.php
@@ -22,7 +22,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
 final class AfterExerciseCompleted extends ExerciseCompleted implements AfterTested
 {
     /**
-     * @var SpecificationIterator[]
+     * @var SpecificationIterator<mixed>[]
      */
     private $specificationIterators;
     /**
@@ -37,7 +37,7 @@ final class AfterExerciseCompleted extends ExerciseCompleted implements AfterTes
     /**
      * Initializes event.
      *
-     * @param SpecificationIterator[] $specificationIterators
+     * @param SpecificationIterator<mixed>[] $specificationIterators
      * @param TestResult              $result
      * @param Teardown                $teardown
      */
@@ -48,11 +48,6 @@ final class AfterExerciseCompleted extends ExerciseCompleted implements AfterTes
         $this->teardown = $teardown;
     }
 
-    /**
-     * Returns specification iterators.
-     *
-     * @return SpecificationIterator[]
-     */
     public function getSpecificationIterators()
     {
         return $this->specificationIterators;

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseSetup.php
@@ -21,7 +21,7 @@ use Behat\Testwork\Tester\Setup\Setup;
 final class AfterExerciseSetup extends ExerciseCompleted implements AfterSetup
 {
     /**
-     * @var SpecificationIterator[]
+     * @var SpecificationIterator<mixed>[]
      */
     private $specificationIterators;
     /**
@@ -32,7 +32,7 @@ final class AfterExerciseSetup extends ExerciseCompleted implements AfterSetup
     /**
      * Initializes event.
      *
-     * @param SpecificationIterator[] $specificationIterators
+     * @param SpecificationIterator<mixed>[] $specificationIterators
      * @param Setup                   $setup
      */
     public function __construct(array $specificationIterators, Setup $setup)
@@ -41,11 +41,6 @@ final class AfterExerciseSetup extends ExerciseCompleted implements AfterSetup
         $this->setup = $setup;
     }
 
-    /**
-     * Returns specification iterators.
-     *
-     * @return SpecificationIterator[]
-     */
     public function getSpecificationIterators()
     {
         return $this->specificationIterators;

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteSetup.php
@@ -22,7 +22,7 @@ use Behat\Testwork\Tester\Setup\Setup;
 final class AfterSuiteSetup extends SuiteTested implements AfterSetup
 {
     /**
-     * @var SpecificationIterator
+     * @var SpecificationIterator<mixed>
      */
     private $iterator;
     /**
@@ -34,7 +34,7 @@ final class AfterSuiteSetup extends SuiteTested implements AfterSetup
      * Initializes event.
      *
      * @param Environment           $env
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<mixed> $iterator
      * @param Setup                 $setup
      */
     public function __construct(Environment $env, SpecificationIterator $iterator, Setup $setup)
@@ -45,11 +45,6 @@ final class AfterSuiteSetup extends SuiteTested implements AfterSetup
         $this->setup = $setup;
     }
 
-    /**
-     * Returns specification iterator.
-     *
-     * @return SpecificationIterator
-     */
     public function getSpecificationIterator()
     {
         return $this->iterator;

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteTested.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
 final class AfterSuiteTested extends SuiteTested implements AfterTested
 {
     /**
-     * @var SpecificationIterator
+     * @var SpecificationIterator<mixed>
      */
     private $iterator;
     /**
@@ -39,7 +39,7 @@ final class AfterSuiteTested extends SuiteTested implements AfterTested
      * Initializes event.
      *
      * @param Environment           $env
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<mixed> $iterator
      * @param TestResult            $result
      * @param Teardown              $teardown
      */
@@ -56,11 +56,6 @@ final class AfterSuiteTested extends SuiteTested implements AfterTested
         $this->teardown = $teardown;
     }
 
-    /**
-     * Returns specification iterator.
-     *
-     * @return SpecificationIterator
-     */
     public function getSpecificationIterator()
     {
         return $this->iterator;

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseCompleted.php
@@ -20,25 +20,20 @@ use Behat\Testwork\Specification\SpecificationIterator;
 final class BeforeExerciseCompleted extends ExerciseCompleted implements BeforeTested
 {
     /**
-     * @var SpecificationIterator[]
+     * @var SpecificationIterator<mixed>[]
      */
     private $specificationIterators;
 
     /**
      * Initializes event.
      *
-     * @param SpecificationIterator[] $specificationIterators
+     * @param SpecificationIterator<mixed>[] $specificationIterators
      */
     public function __construct(array $specificationIterators)
     {
         $this->specificationIterators = $specificationIterators;
     }
 
-    /**
-     * Returns specification iterators.
-     *
-     * @return SpecificationIterator[]
-     */
     public function getSpecificationIterators()
     {
         return $this->specificationIterators;

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseTeardown.php
@@ -21,7 +21,7 @@ use Behat\Testwork\Tester\Result\TestResult;
 final class BeforeExerciseTeardown extends ExerciseCompleted implements BeforeTeardown
 {
     /**
-     * @var SpecificationIterator[]
+     * @var SpecificationIterator<mixed>[]
      */
     private $specificationIterators;
     /**
@@ -32,7 +32,7 @@ final class BeforeExerciseTeardown extends ExerciseCompleted implements BeforeTe
     /**
      * Initializes event.
      *
-     * @param SpecificationIterator[] $specificationIterators
+     * @param SpecificationIterator<mixed>[] $specificationIterators
      * @param TestResult              $result
      */
     public function __construct(array $specificationIterators, TestResult $result)
@@ -41,11 +41,6 @@ final class BeforeExerciseTeardown extends ExerciseCompleted implements BeforeTe
         $this->result = $result;
     }
 
-    /**
-     * Returns specification iterators.
-     *
-     * @return SpecificationIterator[]
-     */
     public function getSpecificationIterators()
     {
         return $this->specificationIterators;

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTeardown.php
@@ -22,7 +22,7 @@ use Behat\Testwork\Tester\Result\TestResult;
 final class BeforeSuiteTeardown extends SuiteTested implements BeforeTeardown
 {
     /**
-     * @var SpecificationIterator
+     * @var SpecificationIterator<mixed>
      */
     private $iterator;
     /**
@@ -34,7 +34,7 @@ final class BeforeSuiteTeardown extends SuiteTested implements BeforeTeardown
      * Initializes event.
      *
      * @param Environment           $env
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<mixed> $iterator
      * @param TestResult            $result
      */
     public function __construct(Environment $env, SpecificationIterator $iterator, TestResult $result)
@@ -45,11 +45,6 @@ final class BeforeSuiteTeardown extends SuiteTested implements BeforeTeardown
         $this->result = $result;
     }
 
-    /**
-     * Returns specification iterator.
-     *
-     * @return SpecificationIterator
-     */
     public function getSpecificationIterator()
     {
         return $this->iterator;

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTested.php
@@ -21,7 +21,7 @@ use Behat\Testwork\Specification\SpecificationIterator;
 final class BeforeSuiteTested extends SuiteTested implements BeforeTested
 {
     /**
-     * @var SpecificationIterator
+     * @var SpecificationIterator<mixed>
      */
     private $iterator;
 
@@ -29,7 +29,7 @@ final class BeforeSuiteTested extends SuiteTested implements BeforeTested
      * Initializes event.
      *
      * @param Environment           $env
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<mixed> $iterator
      */
     public function __construct(Environment $env, SpecificationIterator $iterator)
     {
@@ -38,11 +38,6 @@ final class BeforeSuiteTested extends SuiteTested implements BeforeTested
         $this->iterator = $iterator;
     }
 
-    /**
-     * Returns specification iterator.
-     *
-     * @return SpecificationIterator
-     */
     public function getSpecificationIterator()
     {
         return $this->iterator;

--- a/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
@@ -29,7 +29,7 @@ abstract class ExerciseCompleted extends Event
     /**
      * Returns specification iterators.
      *
-     * @return SpecificationIterator[]
+     * @return SpecificationIterator<mixed>[]
      */
     abstract public function getSpecificationIterators();
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
@@ -27,7 +27,7 @@ abstract class SuiteTested extends LifecycleEvent
     /**
      * Returns specification iterator.
      *
-     * @return SpecificationIterator
+     * @return SpecificationIterator<mixed>
      */
     abstract public function getSpecificationIterator();
 }

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
@@ -23,11 +23,14 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * Exercise dispatching BEFORE/AFTER events during its execution.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template TSpec
+ * @implements Exercise<TSpec>
  */
 final class EventDispatchingExercise implements Exercise
 {
     /**
-     * @var Exercise
+     * @var Exercise<TSpec>
      */
     private $baseExercise;
     /**
@@ -38,7 +41,7 @@ final class EventDispatchingExercise implements Exercise
     /**
      * Initializes exercise.
      *
-     * @param Exercise                 $baseExercise
+     * @param Exercise<TSpec>          $baseExercise
      * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(Exercise $baseExercise, EventDispatcherInterface $eventDispatcher)

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
@@ -25,11 +25,14 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * Suite tester dispatching BEFORE/AFTER events during testing.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template TSpec
+ * @implements SuiteTester<TSpec>
  */
 final class EventDispatchingSuiteTester implements SuiteTester
 {
     /**
-     * @var SuiteTester
+     * @var SuiteTester<TSpec>
      */
     private $baseTester;
     /**
@@ -40,7 +43,7 @@ final class EventDispatchingSuiteTester implements SuiteTester
     /**
      * Initializes tester.
      *
-     * @param SuiteTester              $baseTester
+     * @param SuiteTester<TSpec>       $baseTester
      * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(SuiteTester $baseTester, EventDispatcherInterface $eventDispatcher)
@@ -49,9 +52,6 @@ final class EventDispatchingSuiteTester implements SuiteTester
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setUp(Environment $env, SpecificationIterator $iterator, $skip)
     {
         $event = new BeforeSuiteTested($env, $iterator);
@@ -67,17 +67,11 @@ final class EventDispatchingSuiteTester implements SuiteTester
         return $setup;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function test(Environment $env, SpecificationIterator $iterator, $skip = false)
     {
         return $this->baseTester->test($env, $iterator, $skip);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
     {
         $event = new BeforeSuiteTeardown($env, $iterator, $result);

--- a/src/Behat/Testwork/Hook/Scope/AfterSuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/AfterSuiteScope.php
@@ -26,7 +26,7 @@ final class AfterSuiteScope implements SuiteScope, AfterTestScope
      */
     private $environment;
     /**
-     * @var SpecificationIterator
+     * @var SpecificationIterator<mixed>
      */
     private $iterator;
     /**
@@ -38,7 +38,7 @@ final class AfterSuiteScope implements SuiteScope, AfterTestScope
      * Initializes scope.
      *
      * @param Environment           $environment
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<mixed> $iterator
      * @param TestResult            $result
      */
     public function __construct(Environment $environment, SpecificationIterator $iterator, TestResult $result)

--- a/src/Behat/Testwork/Hook/Scope/BeforeSuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/BeforeSuiteScope.php
@@ -25,7 +25,7 @@ final class BeforeSuiteScope implements SuiteScope
      */
     private $environment;
     /**
-     * @var SpecificationIterator
+     * @var SpecificationIterator<mixed>
      */
     private $iterator;
 
@@ -33,7 +33,7 @@ final class BeforeSuiteScope implements SuiteScope
      * Initializes scope.
      *
      * @param Environment           $env
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<mixed> $iterator
      */
     public function __construct(Environment $env, SpecificationIterator $iterator)
     {
@@ -65,9 +65,6 @@ final class BeforeSuiteScope implements SuiteScope
         return $this->environment;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getSpecificationIterator()
     {
         return $this->iterator;

--- a/src/Behat/Testwork/Hook/Scope/SuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/SuiteScope.php
@@ -25,7 +25,7 @@ interface SuiteScope extends HookScope
     /**
      * Returns specification iterator.
      *
-     * @return SpecificationIterator
+     * @return SpecificationIterator<mixed>
      */
     public function getSpecificationIterator();
 }

--- a/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
+++ b/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
@@ -24,11 +24,14 @@ use Behat\Testwork\Tester\SuiteTester;
  * Suite tester which dispatches hooks during its execution.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template TSpec
+ * @implements SuiteTester<TSpec>
  */
 final class HookableSuiteTester implements SuiteTester
 {
     /**
-     * @var SuiteTester
+     * @var SuiteTester<TSpec>
      */
     private $baseTester;
     /**
@@ -39,7 +42,7 @@ final class HookableSuiteTester implements SuiteTester
     /**
      * Initializes tester.
      *
-     * @param SuiteTester    $baseTester
+     * @param SuiteTester<TSpec> $baseTester
      * @param HookDispatcher $hookDispatcher
      */
     public function __construct(SuiteTester $baseTester, HookDispatcher $hookDispatcher)
@@ -48,9 +51,6 @@ final class HookableSuiteTester implements SuiteTester
         $this->hookDispatcher = $hookDispatcher;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setUp(Environment $env, SpecificationIterator $iterator, $skip)
     {
         $setup = $this->baseTester->setUp($env, $iterator, $skip);
@@ -65,17 +65,11 @@ final class HookableSuiteTester implements SuiteTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function test(Environment $env, SpecificationIterator $iterator, $skip)
     {
         return $this->baseTester->test($env, $iterator, $skip);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
     {
         $teardown = $this->baseTester->tearDown($env, $iterator, $skip, $result);

--- a/src/Behat/Testwork/Ordering/OrderedExercise.php
+++ b/src/Behat/Testwork/Ordering/OrderedExercise.php
@@ -22,6 +22,9 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Exercise that is ordered according to a specified algorithm
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
+ *
+ * @template TSpec
+ * @implements Exercise<TSpec>
  */
 final class OrderedExercise implements Exercise
 {
@@ -31,22 +34,22 @@ final class OrderedExercise implements Exercise
     private $orderer;
 
     /**
-     * @var SpecificationIterator[]
+     * @var SpecificationIterator<TSpec>[]|null
      */
     private $unordered;
 
     /**
-     * @var SpecificationIterator[]
+     * @var SpecificationIterator<TSpec>[]|null
      */
     private $ordered;
 
     /**
-     * @var Exercise
+     * @var Exercise<TSpec>
      */
     private $decoratedExercise;
 
     /**
-     * @param Exercise $decoratedExercise
+     * @param Exercise<TSpec> $decoratedExercise
      */
     public function __construct(Exercise $decoratedExercise)
     {
@@ -54,41 +57,16 @@ final class OrderedExercise implements Exercise
         $this->decoratedExercise = $decoratedExercise;
     }
 
-    /**
-     * Sets up exercise for a test.
-     *
-     * @param SpecificationIterator[] $iterators
-     * @param bool $skip
-     *
-     * @return Setup
-     */
     public function setUp(array $iterators, $skip)
     {
         return $this->decoratedExercise->setUp($this->order($iterators), $skip);
     }
 
-    /**
-     * Tests suites specifications.
-     *
-     * @param SpecificationIterator[] $iterators
-     * @param bool $skip
-     *
-     * @return TestResult
-     */
     public function test(array $iterators, $skip)
     {
         return $this->decoratedExercise->test($this->order($iterators), $skip);
     }
 
-    /**
-     * Tears down exercise after a test.
-     *
-     * @param SpecificationIterator[] $iterators
-     * @param bool $skip
-     * @param TestResult $result
-     *
-     * @return Teardown
-     */
     public function tearDown(array $iterators, $skip, TestResult $result)
     {
         return $this->decoratedExercise->tearDown($this->order($iterators), $skip, $result);
@@ -105,8 +83,8 @@ final class OrderedExercise implements Exercise
     }
 
     /**
-     * @param SpecificationIterator[] $iterators
-     * @return SpecificationIterator[]
+     * @param SpecificationIterator<TSpec>[] $iterators
+     * @return SpecificationIterator<TSpec>[]
      */
     private function order(array $iterators)
     {

--- a/src/Behat/Testwork/Ordering/Orderer/NoopOrderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/NoopOrderer.php
@@ -10,8 +10,6 @@
 
 namespace Behat\Testwork\Ordering\Orderer;
 
-use Behat\Testwork\Specification\SpecificationIterator;
-
 /**
  * Null implementation of Orderer that does no ordering
  *
@@ -19,11 +17,6 @@ use Behat\Testwork\Specification\SpecificationIterator;
  */
 final class NoopOrderer implements Orderer
 {
-
-    /**
-     * @param SpecificationIterator[] $scenarioIterators
-     * @return SpecificationIterator[]
-     */
     public function order(array $scenarioIterators)
     {
         return $scenarioIterators;

--- a/src/Behat/Testwork/Ordering/Orderer/Orderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/Orderer.php
@@ -20,8 +20,10 @@ use Behat\Testwork\Specification\SpecificationIterator;
 interface Orderer
 {
     /**
-     * @param SpecificationIterator[] $scenarioIterators
-     * @return SpecificationIterator[]
+     * @template T
+     *
+     * @param SpecificationIterator<T>[] $scenarioIterators
+     * @return SpecificationIterator<T>[]
      */
     public function order(array $scenarioIterators);
 

--- a/src/Behat/Testwork/Ordering/Orderer/RandomOrderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/RandomOrderer.php
@@ -20,10 +20,6 @@ use Behat\Testwork\Specification\SpecificationIterator;
  */
 final class RandomOrderer implements Orderer
 {
-    /**
-     * @param SpecificationIterator[] $scenarioIterators
-     * @return SpecificationIterator[]
-     */
     public function order(array $scenarioIterators)
     {
         $orderedFeatures = $this->orderFeatures($scenarioIterators);
@@ -33,8 +29,9 @@ final class RandomOrderer implements Orderer
     }
 
     /**
-     * @param array $scenarioIterators
-     * @return array
+     * @template T
+     * @param SpecificationIterator<T>[] $scenarioIterators
+     * @return SpecificationIterator<T>[]
      */
     private function orderFeatures(array $scenarioIterators)
     {

--- a/src/Behat/Testwork/Ordering/Orderer/ReverseOrderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/ReverseOrderer.php
@@ -20,10 +20,6 @@ use Behat\Testwork\Specification\SpecificationIterator;
  */
 final class ReverseOrderer implements Orderer
 {
-    /**
-     * @param SpecificationIterator[] $scenarioIterators
-     * @return SpecificationIterator[]
-     */
     public function order(array $scenarioIterators)
     {
         $orderedFeatures = $this->orderFeatures($scenarioIterators);
@@ -33,8 +29,9 @@ final class ReverseOrderer implements Orderer
     }
 
     /**
-     * @param array $scenarioIterators
-     * @return array
+     * @template T
+     * @param SpecificationIterator<T>[] $scenarioIterators
+     * @return SpecificationIterator<T>[]
      */
     private function orderFeatures(array $scenarioIterators)
     {
@@ -52,8 +49,9 @@ final class ReverseOrderer implements Orderer
     }
 
     /**
-     * @param $orderedSuites
-     * @return array
+     * @template T
+     * @param SpecificationIterator<T>[] $orderedSuites
+     * @return SpecificationIterator<T>[]
      */
     private function orderSuites($orderedSuites)
     {

--- a/src/Behat/Testwork/Specification/GroupedSpecificationIterator.php
+++ b/src/Behat/Testwork/Specification/GroupedSpecificationIterator.php
@@ -16,6 +16,9 @@ use Behat\Testwork\Suite\Suite;
  * Iterates over specification iterators grouped by their suite.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template T
+ * @implements SpecificationIterator<T>
  */
 final class GroupedSpecificationIterator implements SpecificationIterator
 {
@@ -35,8 +38,8 @@ final class GroupedSpecificationIterator implements SpecificationIterator
     /**
      * Initializes iterator.
      *
-     * @param Suite                   $suite
-     * @param SpecificationIterator[] $specificationIterators
+     * @param Suite                          $suite
+     * @param list<SpecificationIterator<T>> $specificationIterators
      */
     public function __construct(Suite $suite, array $specificationIterators)
     {
@@ -47,9 +50,11 @@ final class GroupedSpecificationIterator implements SpecificationIterator
     /**
      * Groups specifications by their suite.
      *
-     * @param SpecificationIterator[] $specificationIterators
+     * @template TSpec
      *
-     * @return GroupedSpecificationIterator[]
+     * @param SpecificationIterator<TSpec>[] $specificationIterators
+     *
+     * @return array<string, GroupedSpecificationIterator<TSpec>>
      */
     public static function group(array $specificationIterators)
     {

--- a/src/Behat/Testwork/Specification/Locator/SpecificationLocator.php
+++ b/src/Behat/Testwork/Specification/Locator/SpecificationLocator.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Suite\Suite;
  * @see SpecificationFinder
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template-covariant T
  */
 interface SpecificationLocator
 {
@@ -36,7 +38,7 @@ interface SpecificationLocator
      * @param Suite  $suite
      * @param string $locator
      *
-     * @return SpecificationIterator
+     * @return SpecificationIterator<T>
      */
     public function locateSpecifications(Suite $suite, $locator);
 }

--- a/src/Behat/Testwork/Specification/NoSpecificationsIterator.php
+++ b/src/Behat/Testwork/Specification/NoSpecificationsIterator.php
@@ -19,6 +19,8 @@ use EmptyIterator;
  * Return an instance of this class from locator if no specifications are found.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @implements SpecificationIterator<never>
  */
 final class NoSpecificationsIterator extends EmptyIterator implements SpecificationIterator
 {

--- a/src/Behat/Testwork/Specification/SpecificationArrayIterator.php
+++ b/src/Behat/Testwork/Specification/SpecificationArrayIterator.php
@@ -19,7 +19,9 @@ use Behat\Testwork\Suite\Suite;
  * Return instance of this class from locator if specifications cannot be searched lazily.
  *
  * @author Christophe Coevoet <stof@notk.org>
- * @extends ArrayIterator<int, mixed>
+ * @template T
+ * @implements SpecificationIterator<T>
+ * @extends ArrayIterator<int, T>
  */
 final class SpecificationArrayIterator extends ArrayIterator implements SpecificationIterator
 {
@@ -31,8 +33,8 @@ final class SpecificationArrayIterator extends ArrayIterator implements Specific
     /**
      * Initializes iterator.
      *
-     * @param Suite   $suite
-     * @param mixed[] $specifications
+     * @param Suite         $suite
+     * @param array<int, T> $specifications
      */
     public function __construct(Suite $suite, $specifications = array())
     {

--- a/src/Behat/Testwork/Specification/SpecificationFinder.php
+++ b/src/Behat/Testwork/Specification/SpecificationFinder.php
@@ -17,18 +17,20 @@ use Behat\Testwork\Suite\Suite;
  * Finds test specifications for provided suites using registered locators.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template T
  */
 final class SpecificationFinder
 {
     /**
-     * @var SpecificationLocator[]
+     * @var SpecificationLocator<T>[]
      */
     private $specificationLocators = array();
 
     /**
      * Registers specification locator.
      *
-     * @param SpecificationLocator $locator
+     * @param SpecificationLocator<T> $locator
      */
     public function registerSpecificationLocator(SpecificationLocator $locator)
     {
@@ -56,7 +58,7 @@ final class SpecificationFinder
      * @param Suite[]     $suites
      * @param null|string $locator
      *
-     * @return SpecificationIterator[]
+     * @return list<SpecificationIterator<T>>
      */
     public function findSuitesSpecifications(array $suites, $locator = null)
     {
@@ -74,7 +76,7 @@ final class SpecificationFinder
      * @param Suite       $suite
      * @param null|string $locator
      *
-     * @return SpecificationIterator[]
+     * @return list<SpecificationIterator<T>>
      */
     private function findSuiteSpecifications(Suite $suite, $locator = null)
     {

--- a/src/Behat/Testwork/Specification/SpecificationIterator.php
+++ b/src/Behat/Testwork/Specification/SpecificationIterator.php
@@ -18,7 +18,8 @@ use Iterator;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @extends Iterator<int, Suite>
+ * @template-covariant T
+ * @extends Iterator<int, T>
  */
 interface SpecificationIterator extends Iterator
 {

--- a/src/Behat/Testwork/Tester/Exercise.php
+++ b/src/Behat/Testwork/Tester/Exercise.php
@@ -19,13 +19,15 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Prepares and tests provided exercise specifications.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template TSpec
  */
 interface Exercise
 {
     /**
      * Sets up exercise for a test.
      *
-     * @param SpecificationIterator[] $iterators
+     * @param SpecificationIterator<TSpec>[] $iterators
      * @param bool                 $skip
      *
      * @return Setup
@@ -35,7 +37,7 @@ interface Exercise
     /**
      * Tests suites specifications.
      *
-     * @param SpecificationIterator[] $iterators
+     * @param SpecificationIterator<TSpec>[] $iterators
      * @param bool                 $skip
      *
      * @return TestResult
@@ -45,7 +47,7 @@ interface Exercise
     /**
      * Tears down exercise after a test.
      *
-     * @param SpecificationIterator[] $iterators
+     * @param SpecificationIterator<TSpec>[] $iterators
      * @param bool                 $skip
      * @param TestResult              $result
      *

--- a/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php
+++ b/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php
@@ -25,6 +25,9 @@ use Behat\Testwork\Tester\SuiteTester;
  * Tester executing exercises in the runtime.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template TSpec
+ * @implements Exercise<TSpec>
  */
 final class RuntimeExercise implements Exercise
 {
@@ -33,7 +36,7 @@ final class RuntimeExercise implements Exercise
      */
     private $envManager;
     /**
-     * @var SuiteTester
+     * @var SuiteTester<TSpec>
      */
     private $suiteTester;
 
@@ -41,7 +44,7 @@ final class RuntimeExercise implements Exercise
      * Initializes tester.
      *
      * @param EnvironmentManager $envManager
-     * @param SuiteTester        $suiteTester
+     * @param SuiteTester<TSpec> $suiteTester
      */
     public function __construct(EnvironmentManager $envManager, SuiteTester $suiteTester)
     {

--- a/src/Behat/Testwork/Tester/Runtime/RuntimeSuiteTester.php
+++ b/src/Behat/Testwork/Tester/Runtime/RuntimeSuiteTester.php
@@ -25,35 +25,32 @@ use Behat\Testwork\Tester\SuiteTester;
  * Tester executing suite tests in the runtime.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template TSpec
+ * @implements SuiteTester<TSpec>
  */
 final class RuntimeSuiteTester implements SuiteTester
 {
     /**
-     * @var SpecificationTester
+     * @var SpecificationTester<TSpec>
      */
     private $specTester;
 
     /**
      * Initializes tester.
      *
-     * @param SpecificationTester $specTester
+     * @param SpecificationTester<TSpec> $specTester
      */
     public function __construct(SpecificationTester $specTester)
     {
         $this->specTester = $specTester;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setUp(Environment $env, SpecificationIterator $iterator, $skip)
     {
         return new SuccessfulSetup();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function test(Environment $env, SpecificationIterator $iterator, $skip = false)
     {
         $results = array();
@@ -70,9 +67,6 @@ final class RuntimeSuiteTester implements SuiteTester
         return new TestResults($results);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
     {
         return new SuccessfulTeardown();

--- a/src/Behat/Testwork/Tester/SpecificationTester.php
+++ b/src/Behat/Testwork/Tester/SpecificationTester.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Prepares and tests provided specification against provided environment.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template TSpec
  */
 interface SpecificationTester
 {
@@ -26,7 +28,7 @@ interface SpecificationTester
      * Sets up specification for a test.
      *
      * @param Environment $env
-     * @param mixed       $spec
+     * @param TSpec       $spec
      * @param bool     $skip
      *
      * @return Setup
@@ -37,7 +39,7 @@ interface SpecificationTester
      * Tests provided specification.
      *
      * @param Environment $env
-     * @param mixed       $spec
+     * @param TSpec       $spec
      * @param bool     $skip
      *
      * @return TestResult
@@ -48,7 +50,7 @@ interface SpecificationTester
      * Tears down specification after a test.
      *
      * @param Environment $env
-     * @param mixed       $spec
+     * @param TSpec       $spec
      * @param bool     $skip
      * @param TestResult  $result
      *

--- a/src/Behat/Testwork/Tester/SuiteTester.php
+++ b/src/Behat/Testwork/Tester/SuiteTester.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Prepares and tests provided suite specifications against provided environment.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template TSpec
  */
 interface SuiteTester
 {
@@ -27,7 +29,7 @@ interface SuiteTester
      * Sets up suite for a test.
      *
      * @param Environment           $env
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<TSpec> $iterator
      * @param bool               $skip
      *
      * @return Setup
@@ -38,7 +40,7 @@ interface SuiteTester
      * Tests provided suite specifications.
      *
      * @param Environment           $env
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<TSpec> $iterator
      * @param bool               $skip
      *
      * @return TestResult
@@ -49,7 +51,7 @@ interface SuiteTester
      * Tears down suite after a test.
      *
      * @param Environment           $env
-     * @param SpecificationIterator $iterator
+     * @param SpecificationIterator<TSpec> $iterator
      * @param bool               $skip
      * @param TestResult            $result
      *


### PR DESCRIPTION
in hook and event objects, I decided to use `SpecificationIterator<mixed>` as type instead of making event classes generic, to avoid projects using hooks or events to have to specify that they work with a `BeforeSuiteHook<FeatureNode>` in Behat.
I expect the `getSpecificationIterator` or `getSpecificationIterators` methods of those objects to be used only for rare use cases, so the additional type safety for those rare use cases is not worth annoying everyone for the simple use cases.