### PR TITLE
feat: adds a formatter option that allows you to set if you want stdout displayed as part of the formatter output

### DIFF
--- a/features/show_output.feature
+++ b/features/show_output.feature
@@ -196,9 +196,10 @@ Feature: Show output
       use Behat\Config\Config;
       use Behat\Config\Profile;
       use Behat\Config\Formatter\ProgressFormatter;
+      use Behat\Config\Formatter\ShowOutputOption;
 
       $profile = (new Profile('default'))
-        ->withFormatter(new ProgressFormatter(showOutput: 'no'))
+        ->withFormatter(new ProgressFormatter(showOutput: ShowOutputOption::No))
       ;
 
       return (new Config())->withProfile($profile);

--- a/features/show_output.feature
+++ b/features/show_output.feature
@@ -1,0 +1,220 @@
+Feature: Show output
+  In order to see the stdout output of the code being tested
+  As a feature developer
+  I need to be able to set if this output will be shown or not
+
+  Background:
+    Given a file named "features/bootstrap/FeatureContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+      use Behat\Step\When;
+
+      class FeatureContext implements Context
+      {
+          #[When('I have a step that has no output and passes')]
+          public function passingWithoutOutput() {
+          }
+
+          #[When('I have a step that shows some output and passes')]
+          public function passingWithOutput() {
+              echo "This step has some output";
+          }
+
+          #[When('I have a step that shows some output and fails')]
+          public function failingWithOutput() {
+              echo "This step also has output";
+              throw new Exception("step failed as supposed");
+          }
+      }
+      """
+    And a file named "features/show_output.feature" with:
+      """
+      Feature: Steps with output
+        In order to test the show output feature
+        As a behat developer
+        I need to have some steps that have some output
+
+        Scenario: Some steps with output
+          When I have a step that has no output and passes
+          And I have a step that shows some output and passes
+          And I have a step that shows some output and fails
+      """
+
+  Scenario: Pretty printer prints all output by default
+    When I run "behat --no-colors --format=pretty --format-settings='{\"paths\": false}'"
+    Then it should fail with:
+      """
+      Feature: Steps with output
+        In order to test the show output feature
+        As a behat developer
+        I need to have some steps that have some output
+
+        Scenario: Some steps with output
+          When I have a step that has no output and passes
+          And I have a step that shows some output and passes
+            │ This step has some output
+          And I have a step that shows some output and fails
+            │ This step also has output
+            step failed as supposed (Exception)
+
+      --- Failed scenarios:
+
+          features/show_output.feature:6
+
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
+      """
+
+  Scenario: Pretty printer does not print any output if option set to "no"
+    When I run "behat --no-colors --format=pretty --format-settings='{\"paths\": false, \"show_output\": \"no\" }'"
+    Then it should fail with:
+      """
+      Feature: Steps with output
+        In order to test the show output feature
+        As a behat developer
+        I need to have some steps that have some output
+
+        Scenario: Some steps with output
+          When I have a step that has no output and passes
+          And I have a step that shows some output and passes
+          And I have a step that shows some output and fails
+            step failed as supposed (Exception)
+
+      --- Failed scenarios:
+
+          features/show_output.feature:6
+
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
+      """
+
+  Scenario: Pretty printer only prints output on failed steps if option set to "on-fail"
+    When I run "behat --no-colors --format=pretty --format-settings='{\"paths\": false, \"show_output\": \"on-fail\" }'"
+    Then it should fail with:
+      """
+      Feature: Steps with output
+        In order to test the show output feature
+        As a behat developer
+        I need to have some steps that have some output
+
+        Scenario: Some steps with output
+          When I have a step that has no output and passes
+          And I have a step that shows some output and passes
+          And I have a step that shows some output and fails
+            │ This step also has output
+            step failed as supposed (Exception)
+
+      --- Failed scenarios:
+
+          features/show_output.feature:6
+
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
+      """
+
+  Scenario: Progress printer only prints output in summary by default
+    When I run "behat --no-colors --format=progress"
+    Then it should fail with:
+      """
+      ..F
+
+      --- Failed steps:
+
+      001 Scenario: Some steps with output                     # features/show_output.feature:6
+            And I have a step that shows some output and fails # features/show_output.feature:9
+              │ This step also has output
+              step failed as supposed (Exception)
+
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
+      """
+
+  Scenario: Progress printer does not print any output if option set to "no"
+    When I run "behat --no-colors --format=progress --format-settings='{\"show_output\": \"no\" }'"
+    Then it should fail with:
+      """
+      ..F
+
+      --- Failed steps:
+
+      001 Scenario: Some steps with output                     # features/show_output.feature:6
+            And I have a step that shows some output and fails # features/show_output.feature:9
+              step failed as supposed (Exception)
+
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
+      """
+
+  Scenario: Progress printer prints all output if option set to "yes"
+    When I run "behat --no-colors --format=progress --format-settings='{\"show_output\": \"yes\" }'"
+    Then it should fail with:
+      """
+      ..
+      FeatureContext::passingWithOutput():
+        | This step has some output
+      F
+      FeatureContext::failingWithOutput():
+        | This step also has output
+
+      --- Failed steps:
+
+      001 Scenario: Some steps with output                     # features/show_output.feature:6
+            And I have a step that shows some output and fails # features/show_output.feature:9
+              │ This step also has output
+              step failed as supposed (Exception)
+
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
+      """
+
+  Scenario: Progress printer only prints output on fail if option set to "on-fail"
+    When I run "behat --no-colors --format=progress --format-settings='{\"show_output\": \"on-fail\" }'"
+    Then it should fail with:
+      """
+      ..F
+      FeatureContext::failingWithOutput():
+        | This step also has output
+
+      --- Failed steps:
+
+      001 Scenario: Some steps with output                     # features/show_output.feature:6
+            And I have a step that shows some output and fails # features/show_output.feature:9
+              │ This step also has output
+              step failed as supposed (Exception)
+
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
+      """
+
+  Scenario: Check that this option can be set using the config file
+    Given a file named "behat.php" with:
+      """
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
+      use Behat\Config\Formatter\ProgressFormatter;
+
+      $profile = (new Profile('default'))
+        ->withFormatter(new ProgressFormatter(showOutput: 'no'))
+      ;
+
+      return (new Config())->withProfile($profile);
+
+      """
+    When I run "behat --no-colors --format=progress"
+    Then it should fail with:
+      """
+      ..F
+
+      --- Failed steps:
+
+      001 Scenario: Some steps with output                     # features/show_output.feature:6
+            And I have a step that shows some output and fails # features/show_output.feature:9
+              step failed as supposed (Exception)
+
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
+      """

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -102,13 +102,17 @@ final class ListPrinter
     /**
      * Prints step list.
      *
-     * @param OutputPrinter $printer
      * @param string        $intro
      * @param integer       $resultCode
      * @param StepStat[]    $stepStats
      */
-    public function printStepList(OutputPrinter $printer, $intro, $resultCode, array $stepStats)
-    {
+    public function printStepList(
+        OutputPrinter $printer,
+        $intro,
+        $resultCode,
+        array $stepStats,
+        string $showOutput = "in-summary"
+    ) {
         if (!count($stepStats)) {
             return;
         }
@@ -120,9 +124,17 @@ final class ListPrinter
 
         foreach ($stepStats as $num => $stepStat) {
             if ($stepStat instanceof StepStatV2) {
-                $this->printStepStat($printer, $num + 1, $stepStat, $style);
+                $this->printStepStat($printer, $num + 1, $stepStat, $style, $showOutput);
             } elseif ($stepStat instanceof StepStat) {
-                $this->printStat($printer, $stepStat->getText(), $stepStat->getPath(), $style, $stepStat->getStdOut(), $stepStat->getError());
+                $this->printStat(
+                    $printer,
+                    $stepStat->getText(),
+                    $stepStat->getPath(),
+                    $style,
+                    $stepStat->getStdOut(),
+                    $stepStat->getError(),
+                    $showOutput
+                );
             }
         }
     }
@@ -157,7 +169,6 @@ final class ListPrinter
     /**
      * Prints hook stat.
      *
-     * @param OutputPrinter $printer
      * @param string        $name
      * @param string        $path
      * @param string        $style
@@ -166,14 +177,21 @@ final class ListPrinter
      *
      * @deprecated Remove in 4.0
      */
-    private function printStat(OutputPrinter $printer, $name, $path, $style, $stdOut, $error)
-    {
+    private function printStat(
+        OutputPrinter $printer,
+        string $name,
+        string $path,
+        string $style,
+        ?string $stdOut,
+        ?string $error,
+        string $showOutput
+    ) {
         $path = $this->relativizePaths($path);
         $printer->writeln(sprintf('    {+%s}%s{-%s} {+comment}# %s{-comment}', $style, $name, $style, $path));
 
         $pad = function ($line) { return '      ' . $line; };
 
-        if (null !== $stdOut) {
+        if (null !== $stdOut && $showOutput !== 'no') {
             $padText = function ($line) { return '      │ ' . $line; };
             $stdOutString = array_map($padText, explode("\n", $stdOut));
             $printer->writeln(implode("\n", $stdOutString));
@@ -222,16 +240,13 @@ final class ListPrinter
         $printer->writeln();
     }
 
-    /**
-     * Prints hook stat.
-     *
-     * @param OutputPrinter $printer
-     * @param integer       $number
-     * @param StepStatV2    $stat
-     * @param string        $style
-     */
-    private function printStepStat(OutputPrinter $printer, $number, StepStatV2 $stat, $style)
-    {
+    private function printStepStat(
+        OutputPrinter $printer,
+        int $number,
+        StepStatV2 $stat,
+        string $style,
+        string $showOutput
+    ) {
         $maxLength = max(mb_strlen($stat->getScenarioText(), 'utf8'), mb_strlen($stat->getStepText(), 'utf8') + 2) + 1;
 
         $printer->writeln(
@@ -257,7 +272,7 @@ final class ListPrinter
 
         $pad = function ($line) { return '        ' . $line; };
 
-        if (null !== $stat->getStdOut()) {
+        if (null !== $stat->getStdOut() && $showOutput !== 'no') {
             $padText = function ($line) { return '        │ ' . $line; };
             $stdOutString = array_map($padText, explode("\n", $stat->getStdOut()));
             $printer->writeln(implode("\n", $stdOutString));

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -22,6 +22,7 @@ use Behat\Behat\Output\Statistics\HookStat;
 use Behat\Behat\Output\Statistics\ScenarioStat;
 use Behat\Behat\Output\Statistics\StepStatV2;
 use Behat\Behat\Output\Statistics\StepStat;
+use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Testwork\Exception\ExceptionPresenter;
 use Behat\Testwork\Hook\Scope\AfterSuiteScope;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
@@ -111,7 +112,7 @@ final class ListPrinter
         $intro,
         $resultCode,
         array $stepStats,
-        string $showOutput = "in-summary"
+        ShowOutputOption $showOutput = ShowOutputOption::InSummary
     ) {
         if (!count($stepStats)) {
             return;
@@ -184,14 +185,14 @@ final class ListPrinter
         string $style,
         ?string $stdOut,
         ?string $error,
-        string $showOutput
+        ShowOutputOption $showOutput
     ) {
         $path = $this->relativizePaths($path);
         $printer->writeln(sprintf('    {+%s}%s{-%s} {+comment}# %s{-comment}', $style, $name, $style, $path));
 
         $pad = function ($line) { return '      ' . $line; };
 
-        if (null !== $stdOut && $showOutput !== 'no') {
+        if (null !== $stdOut && $showOutput !== ShowOutputOption::No) {
             $padText = function ($line) { return '      │ ' . $line; };
             $stdOutString = array_map($padText, explode("\n", $stdOut));
             $printer->writeln(implode("\n", $stdOutString));
@@ -245,7 +246,7 @@ final class ListPrinter
         int $number,
         StepStatV2 $stat,
         string $style,
-        string $showOutput
+        ShowOutputOption $showOutput
     ) {
         $maxLength = max(mb_strlen($stat->getScenarioText(), 'utf8'), mb_strlen($stat->getStepText(), 'utf8') + 2) + 1;
 
@@ -272,7 +273,7 @@ final class ListPrinter
 
         $pad = function ($line) { return '        ' . $line; };
 
-        if (null !== $stat->getStdOut() && $showOutput !== 'no') {
+        if (null !== $stat->getStdOut() && $showOutput !== ShowOutputOption::No) {
             $padText = function ($line) { return '        │ ' . $line; };
             $stdOutString = array_map($padText, explode("\n", $stat->getStdOut()));
             $printer->writeln(implode("\n", $stdOutString));

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -92,7 +92,10 @@ final class PrettyStepPrinter implements StepPrinter
         $this->printText($formatter->getOutputPrinter(), $step->getKeyword(), $step->getText(), $result);
         $this->pathPrinter->printStepPath($formatter, $scenario, $step, $result, mb_strlen($this->indentText, 'utf8'));
         $this->printArguments($formatter, $step->getArguments(), $result);
-        $this->printStdOut($formatter->getOutputPrinter(), $result);
+        $showOutput = $formatter->getParameter('show_output');
+        if ($showOutput === 'yes' || ($showOutput === 'on-fail' && !$result->isPassed())) {
+            $this->printStdOut($formatter->getOutputPrinter(), $result);
+        }
         $this->printException($formatter->getOutputPrinter(), $result);
     }
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -16,6 +16,7 @@ use Behat\Behat\Output\Node\Printer\StepPrinter;
 use Behat\Behat\Tester\Result\DefinedStepResult;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Behat\Tester\Result\StepResult;
+use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Gherkin\Node\ArgumentInterface;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\ScenarioLikeInterface as Scenario;
@@ -92,8 +93,9 @@ final class PrettyStepPrinter implements StepPrinter
         $this->printText($formatter->getOutputPrinter(), $step->getKeyword(), $step->getText(), $result);
         $this->pathPrinter->printStepPath($formatter, $scenario, $step, $result, mb_strlen($this->indentText, 'utf8'));
         $this->printArguments($formatter, $step->getArguments(), $result);
-        $showOutput = $formatter->getParameter('show_output');
-        if ($showOutput === 'yes' || ($showOutput === 'on-fail' && !$result->isPassed())) {
+        $showOutput = $formatter->getParameter(ShowOutputOption::OPTION_NAME);
+        if ($showOutput === ShowOutputOption::Yes ||
+            ($showOutput === ShowOutputOption::OnFail && !$result->isPassed())) {
             $this->printStdOut($formatter->getOutputPrinter(), $result);
         }
         $this->printException($formatter->getOutputPrinter(), $result);

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
@@ -58,11 +58,12 @@ final class ProgressStatisticsPrinter implements StatisticsPrinter
         $hookStats = $statistics->getFailedHookStats();
         $this->listPrinter->printFailedHooksList($printer, 'failed_hooks_title', $hookStats);
 
+        $showOutput = $formatter->getParameter('show_output');
         $stepStats = $statistics->getFailedSteps();
-        $this->listPrinter->printStepList($printer, 'failed_steps_title', TestResult::FAILED, $stepStats);
+        $this->listPrinter->printStepList($printer, 'failed_steps_title', TestResult::FAILED, $stepStats, $showOutput);
 
         $stepStats = $statistics->getPendingSteps();
-        $this->listPrinter->printStepList($printer, 'pending_steps_title', TestResult::PENDING, $stepStats);
+        $this->listPrinter->printStepList($printer, 'pending_steps_title', TestResult::PENDING, $stepStats, $showOutput);
 
         $this->counterPrinter->printCounters($printer, 'scenarios_count', $statistics->getScenarioStatCounts());
         $this->counterPrinter->printCounters($printer, 'steps_count', $statistics->getStepStatCounts());

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
@@ -14,6 +14,7 @@ use Behat\Behat\Output\Node\Printer\CounterPrinter;
 use Behat\Behat\Output\Node\Printer\ListPrinter;
 use Behat\Behat\Output\Node\Printer\StatisticsPrinter;
 use Behat\Behat\Output\Statistics\Statistics;
+use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Tester\Result\TestResult;
 
@@ -58,7 +59,7 @@ final class ProgressStatisticsPrinter implements StatisticsPrinter
         $hookStats = $statistics->getFailedHookStats();
         $this->listPrinter->printFailedHooksList($printer, 'failed_hooks_title', $hookStats);
 
-        $showOutput = $formatter->getParameter('show_output');
+        $showOutput = $formatter->getParameter(ShowOutputOption::OPTION_NAME);
         $stepStats = $statistics->getFailedSteps();
         $this->listPrinter->printStepList($printer, 'failed_steps_title', TestResult::FAILED, $stepStats, $showOutput);
 

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
@@ -14,6 +14,7 @@ use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
 use Behat\Behat\Output\Node\Printer\StepPrinter;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Behat\Tester\Result\StepResult;
+use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Gherkin\Node\ScenarioLikeInterface as Scenario;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\Output\Formatter;
@@ -56,8 +57,11 @@ final class ProgressStepPrinter implements StepPrinter
         $printer = $formatter->getOutputPrinter();
         $style = $this->resultConverter->convertResultToString($result);
 
+        // After printing any output, we need to print a new line before continuing
+        // to print the "dots" of the progress
         if ($this->hasPrintedOutput) {
             $printer->writeln('');
+            $this->hasPrintedOutput = false;
         }
 
         switch ($result->getResultCode()) {
@@ -78,8 +82,9 @@ final class ProgressStepPrinter implements StepPrinter
                 break;
         }
 
-        $showOutput = $formatter->getParameter('show_output');
-        if ($showOutput === 'yes' || ($showOutput === 'on-fail' && !$result->isPassed())) {
+        $showOutput = $formatter->getParameter(ShowOutputOption::OPTION_NAME);
+        if ($showOutput === ShowOutputOption::Yes ||
+            ($showOutput === ShowOutputOption::OnFail && !$result->isPassed())) {
             $this->printStdOut($formatter->getOutputPrinter(), $result);
         }
 

--- a/src/Behat/Config/Formatter/PrettyFormatter.php
+++ b/src/Behat/Config/Formatter/PrettyFormatter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Behat\Config\Formatter;
 
+use UnexpectedValueException;
+
 final class PrettyFormatter extends Formatter
 {
     public const NAME = 'pretty';
@@ -14,21 +16,27 @@ final class PrettyFormatter extends Formatter
      * @param bool $paths display the file path and line number for each scenario
      *                    and the context file and method for each step
      * @param bool $multiline print out PyStrings and TableNodes in full
-     * @param string $showOutput show the test stdout output as part of the formatter output (yes, no, on-fail)
+     * @param ShowOutputOption $showOutput show the test stdout output as part of the
+     *                                     formatter output (yes, no, on-fail)
      */
     public function __construct(
-        bool $timer = true,
-        bool $expand = false,
-        bool $paths = true,
-        bool $multiline = true,
-        string $showOutput = 'yes',
+        bool             $timer = true,
+        bool             $expand = false,
+        bool             $paths = true,
+        bool             $multiline = true,
+        ShowOutputOption $showOutput = ShowOutputOption::Yes,
     ) {
+        if ($showOutput === ShowOutputOption::InSummary) {
+            throw new UnexpectedValueException(
+                'The pretty formatter does not support the "in-summary" show output option'
+            );
+        }
         parent::__construct(name: self::NAME, settings: [
             'timer' => $timer,
             'expand' => $expand,
             'paths' => $paths,
             'multiline' => $multiline,
-            'show_output' => $showOutput
+            ShowOutputOption::OPTION_NAME => $showOutput->value
         ]);
     }
 

--- a/src/Behat/Config/Formatter/PrettyFormatter.php
+++ b/src/Behat/Config/Formatter/PrettyFormatter.php
@@ -14,18 +14,21 @@ final class PrettyFormatter extends Formatter
      * @param bool $paths display the file path and line number for each scenario
      *                    and the context file and method for each step
      * @param bool $multiline print out PyStrings and TableNodes in full
+     * @param string $showOutput show the test stdout output as part of the formatter output (yes, no, on-fail)
      */
     public function __construct(
         bool $timer = true,
         bool $expand = false,
         bool $paths = true,
         bool $multiline = true,
+        string $showOutput = 'yes',
     ) {
         parent::__construct(name: self::NAME, settings: [
             'timer' => $timer,
             'expand' => $expand,
             'paths' => $paths,
             'multiline' => $multiline,
+            'show_output' => $showOutput
         ]);
     }
 

--- a/src/Behat/Config/Formatter/ProgressFormatter.php
+++ b/src/Behat/Config/Formatter/ProgressFormatter.php
@@ -10,15 +10,16 @@ final class ProgressFormatter extends Formatter
 
     /**
      * @param bool $timer show time and memory usage at the end of the test run
-     * @param string $showOutput show the test stdout output as part of the formatter output (yes, no, on-fail, in-summary)
+     * @param ShowOutputOption $showOutput show the test stdout output as part of the
+     *                                     formatter output (yes, no, on-fail, in-summary)
      */
     public function __construct(
-        bool $timer = true,
-        string $showOutput = 'in-summary',
+        bool             $timer = true,
+        ShowOutputOption $showOutput = ShowOutputOption::InSummary,
     ) {
         parent::__construct(name: self::NAME, settings: [
             'timer' => $timer,
-            'show_output' => $showOutput
+            ShowOutputOption::OPTION_NAME => $showOutput->value
         ]);
     }
 

--- a/src/Behat/Config/Formatter/ProgressFormatter.php
+++ b/src/Behat/Config/Formatter/ProgressFormatter.php
@@ -10,12 +10,15 @@ final class ProgressFormatter extends Formatter
 
     /**
      * @param bool $timer show time and memory usage at the end of the test run
+     * @param string $showOutput show the test stdout output as part of the formatter output (yes, no, on-fail, in-summary)
      */
     public function __construct(
         bool $timer = true,
+        string $showOutput = 'in-summary',
     ) {
         parent::__construct(name: self::NAME, settings: [
             'timer' => $timer,
+            'show_output' => $showOutput
         ]);
     }
 

--- a/src/Behat/Config/Formatter/ShowOutputOption.php
+++ b/src/Behat/Config/Formatter/ShowOutputOption.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Behat\Config\Formatter;
+
+enum ShowOutputOption: string
+{
+    public const OPTION_NAME = 'show_output';
+
+    case Yes = 'yes';
+    case No = 'no';
+    case OnFail = 'on-fail';
+    case InSummary = 'in-summary';
+}

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\Output;
 
+use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Testwork\Event\Event;
 use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Testwork\Output\Node\EventListener\EventListener;
@@ -127,6 +128,10 @@ final class NodeEventListeningFormatter implements Formatter
      */
     public function getParameter($name)
     {
-        return $this->parameters[$name] ?? null;
+        $value = $this->parameters[$name] ?? null;
+        if ($value !== null && $name === ShowOutputOption::OPTION_NAME) {
+            return ShowOutputOption::from($value);
+        }
+        return $value;
     }
 }

--- a/tests/Behat/Tests/Config/ProfileTest.php
+++ b/tests/Behat/Tests/Config/ProfileTest.php
@@ -10,11 +10,13 @@ use Behat\Config\Filter\TagFilter;
 use Behat\Config\Formatter\JUnitFormatter;
 use Behat\Config\Formatter\PrettyFormatter;
 use Behat\Config\Formatter\ProgressFormatter;
+use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Config\Profile;
 use Behat\Config\Suite;
 use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 final class ProfileTest extends TestCase
 {
@@ -170,5 +172,34 @@ final class ProfileTest extends TestCase
                 'junit' => false,
             ],
         ], $profile->toArray());
+    }
+
+    public function testSettingShowOutputOption(): void
+    {
+        $profile = new Profile('default');
+
+        $profile->disableFormatter(PrettyFormatter::NAME);
+        $profile->disableFormatter(JUnitFormatter::NAME);
+        $profile->withFormatter(new ProgressFormatter(showOutput: ShowOutputOption::Yes));
+
+        $this->assertEquals([
+            'formatters' => [
+                'pretty' => false,
+                'progress' => [
+                    'timer' => true,
+                    'show_output' => 'yes'
+                ],
+                'junit' => false,
+            ],
+        ], $profile->toArray());
+    }
+
+    public function testSettingInvalidShowOutputOption(): void
+    {
+        $profile = new Profile('default');
+
+        $this->expectException(UnexpectedValueException::class);
+
+        $profile->withFormatter(new PrettyFormatter(showOutput: ShowOutputOption::InSummary));
     }
 }

--- a/tests/Behat/Tests/Config/ProfileTest.php
+++ b/tests/Behat/Tests/Config/ProfileTest.php
@@ -144,9 +144,11 @@ final class ProfileTest extends TestCase
                     'paths' => false,
                     'multiline' => true,
                     'output_verbosity' => 2,
+                    'show_output' => 'yes'
                 ],
                 'progress' => [
                     'timer' => false,
+                    'show_output' => 'in-summary'
                 ],
                 'junit' => [],
             ],


### PR DESCRIPTION
When running your tests, the stdout output from the tests will not be printed as part of the formatter output if you use the progress formatter and will be printed if you use the pretty formatter. These are sensible defaults but in some cases you may want to see the test output as part of the progress output or not see the output as part of the pretty output.

This PR adds a new `show_output` option to the formatters options which can be used to enable or disable stdout for any formatter (only applies to pretty and progress formatters, not the junit formatter where it does not make sense to include the output)

This option can be set to `yes`, `no` or `on-fail` for the pretty formatter. It defaults to `yes`
This option can be set to `yes`, `no`, `on-fail` or `in-summary` for the progress formatter. It defaults to `in-summary`. This option will show the test output in the summary at the end of the test run if there are any failed steps
