### PR TITLE
chore: Remove composer dev dependency on legacy herrera-io/box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     },
 
     "require-dev": {
-        "herrera-io/box": "~1.6.1",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^9.6",
         "sebastian/diff": "^4.0",


### PR DESCRIPTION
This has not actually been used since #1462 which switched to installing box-project/box
[directly in github actions](
https://github.com/Behat/Behat/pull/1462/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R135).