### PR TITLE
Do not disable xdebug if there is an active debugging connection

### DIFF
--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -99,7 +99,9 @@ final class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        $isXdebugAllowed = $input->hasParameterOption('--xdebug');
+        $isXdebugAllowed = $input->hasParameterOption('--xdebug') ||
+            (extension_loaded('xdebug') && xdebug_is_debugger_active());
+
         if (!$isXdebugAllowed) {
             $xdebugHandler = new XdebugHandler('behat');
             $xdebugHandler->setPersistent();


### PR DESCRIPTION
Following @stof 's suggestion in https://github.com/Behat/Behat/issues/1577 in this PR we check if there is an active Xdebug session, and if there is, we don't disable it, even if no `--xdebug` flag has been passed
