### PR TITLE
Fix types for InitializedContextEnvironment

### DIFF
--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -24,8 +24,6 @@ use Psr\Container\ContainerInterface;
  * @see ContextEnvironmentHandler
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @template T of Context
  */
 final class InitializedContextEnvironment implements ContextEnvironment, ServiceContainerEnvironment
 {
@@ -37,7 +35,9 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
     private ?ContainerInterface $serviceContainer = null;
 
     /**
-     * @var array<class-string<T>, T>
+     * @var array<class-string<Context>, Context>
+     *
+     * TODO use a class-string-map type to have an accurate type once https://github.com/phpstan/phpstan/issues/9521 is implemented
      */
     private $contexts = array();
 
@@ -113,6 +113,8 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
 
     /**
      * Returns registered context by its class name.
+     *
+     * @template T of Context
      *
      * @param class-string<T> $class
      *


### PR DESCRIPTION
This class has no reason to become generic. And its `getContext` method must keep using a method-level generic type.

This fixes my comments from https://github.com/Behat/Behat/pull/1590
There is no errors to ignore for phpstan due to the missing support for the `class-string-map` type because of the level we use right now. This error does exists (see the `phpstan.return` error reported in https://phpstan.org/r/a8603171-7f14-42b8-90af-e83e409b2650) but it belongs to level 7.