### PR TITLE
feature: Add option to print unused definitions

### DIFF
--- a/features/unused_definitions.feature
+++ b/features/unused_definitions.feature
@@ -1,0 +1,41 @@
+Feature: Unused definitions
+  In order to remove unused code
+  As a feature developer
+  I need to be able to generate a list of unused definitions
+
+  Background:
+    Given I set the working directory to the "UnusedDefinitions" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option                     | value    |
+      | --no-colors                |          |
+      | --format                   | progress |
+
+  Scenario: Print unused definitions for a single suite
+    When I run behat with the following additional options:
+      | option                     | value       |
+      | --suite                    | first_suite |
+      | --print-unused-definitions |             |
+    Then it should pass with:
+      """
+      --- 2 unused definitions:
+
+      [Then|*] I call a step used in the second feature
+      `FeatureContext::stepUsedInSecondFeature()`
+
+      [Then|*] I call a step not used in any feature
+      This is a step that is never used and should be removed
+      `FeatureContext::stepNotUsedInAnyFeature()`
+      """
+
+  Scenario: Print unused definitions for two suites
+    When I run behat with the following additional options:
+      | option                     | value       |
+      | --print-unused-definitions |             |
+    Then it should pass with:
+      """
+      --- 1 unused definition:
+
+      [Then|*] I call a step not used in any feature
+      This is a step that is never used and should be removed
+      `FeatureContext::stepNotUsedInAnyFeature()`
+      """

--- a/features/unused_definitions.feature
+++ b/features/unused_definitions.feature
@@ -39,3 +39,29 @@ Feature: Unused definitions
       This is a step that is never used and should be removed
       `FeatureContext::stepNotUsedInAnyFeature()`
       """
+
+  Scenario: Print unused definitions from yaml config
+    When I run behat with the following additional options:
+      | option   | value                   |
+      | --config | unused_definitions.yaml |
+    Then it should pass with:
+      """
+      --- 1 unused definition:
+
+      [Then|*] I call a step not used in any feature
+      This is a step that is never used and should be removed
+      `FeatureContext::stepNotUsedInAnyFeature()`
+      """
+
+  Scenario: Print unused definitions from PHP config
+    When I run behat with the following additional options:
+      | option    | value              |
+      | --profile | unused_definitions |
+    Then it should pass with:
+      """
+      --- 1 unused definition:
+
+      [Then|*] I call a step not used in any feature
+      This is a step that is never used and should be removed
+      `FeatureContext::stepNotUsedInAnyFeature()`
+      """

--- a/i18n.php
+++ b/i18n.php
@@ -17,6 +17,7 @@
         'pending_count'           => '[1,Inf] %count% pending',
         'undefined_count'         => '[1,Inf] %count% undefined',
         'skipped_count'           => '[1,Inf] %count% skipped',
+        'unused_definitions'      => '{0} No unused definitions|{1} 1 unused definition:|]1,Inf] %count% unused definitions:',
     ),
     'bg'    => array(
         'snippet_context_choice'  => 'В сет <snippet_undefined><snippet_keyword>%count%</snippet_keyword> има недекларирани стъпки. Изберете в кой Context да бъдат създадени:</snippet_undefined>',
@@ -36,6 +37,7 @@
         'pending_count'           => '[1,Inf] %count% изчакващи',
         'undefined_count'         => '[1,Inf] %count% неопределени',
         'skipped_count'           => '[1,Inf] %count% пропуснати',
+        'unused_definitions'      => '{0} Няма неизползвани дефиниции|{1} 1 неизползвана дефиниция:|]1,Inf] %count% неизползвани дефиниции:',
     ),
     'cs'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> obsahuje chybné kroky. Definujte je za použití následujícího kódu:</snippet_undefined>',
@@ -53,6 +55,7 @@
         'pending_count'          => '{1} %count% čeká|{2,3,4} %count% čekají|]4,Inf] %count% čeká',
         'undefined_count'        => '{1} %count% nedefinován|{2,3,4} %count% nedefinovány|]4,Inf] %count% nedefinováno',
         'skipped_count'          => '{1} %count% přeskočen|{2,3,4} %count% přeskočeny|]4,Inf] %count% přeskočeno',
+        'unused_definitions'     => '{0} Žádné nepoužité definice|{1} 1 nepoužitá definice:|]1,Inf] %count% nepoužitých definic:',
     ),
     'de'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> hat fehlende Schritte. Definiere diese mit den folgenden Snippets:</snippet_undefined>',
@@ -70,6 +73,7 @@
         'pending_count'          => '[1,Inf] %count% ausstehend',
         'undefined_count'        => '[1,Inf] %count% nicht definiert',
         'skipped_count'          => '[1,Inf] %count% übersprungen',
+        'unused_definitions'     => '{0} Keine unbenutzten Definitionen|{1} 1 unbenutzte Definition:|]1,Inf] %count% unbenutzte Definitionen:',
     ),
     'es'    => array(
         'snippet_proposal_title' => '<snippet_undefined>A <snippet_keyword>%count%</snippet_keyword> le faltan pasos. Defínelos con estos pasos:</snippet_undefined>',
@@ -87,6 +91,7 @@
         'pending_count'          => '[1,Inf] %count% pendientes',
         'undefined_count'        => '[1,Inf] %count% por definir',
         'skipped_count'          => '[1,Inf] %count% saltadas',
+        'unused_definitions'     => '{0} No hay definiciones sin usar|{1} 1 definición sin usar:|]1,Inf] %count% definiciones sin usar:',
     ),
     'fr'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> a des étapes manquantes. Définissez-les avec les modèles suivants :</snippet_undefined>',
@@ -104,6 +109,7 @@
         'pending_count'          => '[1,Inf] %count% en attente',
         'undefined_count'        => '[1,Inf] %count% indéfinis',
         'skipped_count'          => '[1,Inf] %count% ignorés',
+        'unused_definitions'     => '{0} Aucune définition inutilisée|{1} 1 définition inutilisée:|]1,Inf] %count% définitions inutilisées:',
     ),
     'hu'    => array(
         'snippet_context_choice'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> sorozat meghatározatlan lépéseket tartalmaz. Válaszd ki a környezetet kódrészlet készítéséhez:</snippet_undefined>',
@@ -123,6 +129,7 @@
         'pending_count'           => '[1,Inf] %count% elintézendő',
         'undefined_count'         => '[1,Inf] %count% meghatározatlan',
         'skipped_count'           => '[1,Inf] %count% kihagyott',
+        'unused_definitions'      => '{0} Nincsenek nem használt definíciók|{1} nem használt definíció:|]1,Inf] %count% nem használt definíciók:',
     ),
     'it'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> ha dei passaggi mancanti. Definiscili con questi snippet:</snippet_undefined>',
@@ -140,6 +147,7 @@
         'pending_count'          => '[1,Inf] %count% in sospeso',
         'undefined_count'        => '{1} 1 non definito|]1,Inf] %count% non definiti',
         'skipped_count'          => '{1} 1 ignorato|]1,Inf] %count% ignorati',
+        'unused_definitions'     => '{0} Nessuna definizione inutilizzata|{1} 1 definizione inutilizzata:|]1,Inf] %count% definizioni inutilizzate:',
     ),
     'ja'    => array(
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> のステップが見つかりません。 次のスニペットで定義できます:</snippet_undefined>',
@@ -158,6 +166,7 @@
         'pending_count'           => '[1,Inf] %count% 個保留',
         'undefined_count'         => '[1,Inf] %count% 個未定義',
         'skipped_count'           => '[1,Inf] %count% 個スキップ',
+        'unused_definitions'      => '{0} 未使用の定義はありません|{1} 未使用の定義が1つあります:|]1,Inf] 未使用の定義が %count% 個あります:',
     ),
     'ko'    => array(
         'snippet_proposal_title'  => '<snippet_keyword>%count%</snippet_keyword> <snippet_undefined> 정의가 되지 않았습니다. 스니펫을 생성할 컨텍스트를 선택하십시오:</snippet_undefined>',
@@ -176,6 +185,7 @@
         'pending_count'           => '[1,Inf] %count% 준비중',
         'undefined_count'         => '[1,Inf] %count% 정의되지 않았습니다.',
         'skipped_count'           => '[1,Inf] %count% 건너뜀',
+        'unused_definitions'      => '{0} 사용하지 않은 정의가 없습니다|{1} 사용하지 않은 정의가 1개 있습니다:|]1,Inf] 사용하지 않은 정의가 %count%개 있습니다:',
     ),
     'nl'    => array(
         'snippet_proposal_title' => '<snippet_undefined>Ontbrekende stappen in <snippet_keyword>%count%</snippet_keyword>. Definieer ze met de volgende fragmenten:</snippet_undefined>',
@@ -193,6 +203,7 @@
         'pending_count'          => '[1,Inf] %count% wachtende',
         'undefined_count'        => '[1,Inf] %count% niet gedefinieerd',
         'skipped_count'          => '[1,Inf] %count% overgeslagen',
+        'unused_definitions'     => '{0} Geen ongebruikte definities|{1} 1 ongebruikte definitie:|]1,Inf] %count% ongebruikte definities:',
     ),
     'no'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> mangler steg. Definer dem med disse snuttene:</snippet_undefined>',
@@ -210,6 +221,7 @@
         'pending_count'          => '[1,Inf] %count% ikke implementert',
         'undefined_count'        => '[1,Inf] %count% ikke definert',
         'skipped_count'          => '[1,Inf] %count% hoppet over',
+        'unused_definitions'     => '{0} Ingen ubrukte definisjoner|{1} 1 ubrukt definisjon:|]1,Inf] %count% ubrukte definisjoner:',
     ),
     'pl'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> zawiera brakujące kroki. Utwórz je korzystając z tych fragmentów kodu:</snippet_undefined>',
@@ -227,6 +239,7 @@
         'pending_count'          => '{1} %count% oczekujący|{2,3,4,22,23,24,32,33,34,42,43,44} %count% oczekujące|]4,Inf] %count% oczekujących',
         'undefined_count'        => '{1} %count% niezdefiniowany|{2,3,4,22,23,24,32,33,34,42,43,44} %count% niezdefiniowane|]4,Inf] %count% niezdefiniowanych',
         'skipped_count'          => '{1} %count% pominięty|{2,3,4,22,23,24,32,33,34,42,43,44} %count% pominięte|]4,Inf] %count% pominiętych',
+        'unused_definitions'     => '{0} Brak nieużytych definicji|{1} 1 nieużyta definicja:|]1,Inf] %count% nieużytych definicji:',
     ),
     'pt'    => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> contém definições em falta. Defina-as com estes exemplos:</snippet_undefined>',
@@ -244,6 +257,7 @@
         'pending_count'          => '[1,Inf] %count% por definir',
         'undefined_count'        => '{1} indefinido|]1,Inf] %count% indefinidos',
         'skipped_count'          => '{1} omitido|]1,Inf] %count% omitidos',
+        'unused_definitions'     => '{0} Nenhuma definição não utilizada|{1} 1 definição não utilizada:|]1,Inf] %count% definições não utilizadas:',
     ),
     'pt-BR' => array(
         'snippet_proposal_title' => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> possue etapas faltando. Defina elas com esse(s) trecho(s) de código:</snippet_undefined>',
@@ -261,6 +275,7 @@
         'pending_count'          => '[1,Inf] %count% pendente',
         'undefined_count'        => '[1,Inf] %count% indefinido',
         'skipped_count'          => '[1,Inf] %count% pulado',
+        'unused_definitions'     => '{0} Nenhuma definição não utilizada|{1} 1 definição não utilizada:|]1,Inf] %count% definições não utilizadas:',
     ),
     'ro'    => array(
         'snippet_proposal_title'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> are pași lipsa. Puteți implementa pașii cu ajutorul acestor fragmente de cod:</snippet_undefined>',
@@ -279,6 +294,7 @@
         'pending_count'           => '[1,Inf] %count% in așteptare',
         'undefined_count'         => '[1,Inf] %count% fara implementare',
         'skipped_count'           => '{1} %count% omis|]1,Inf] %count% omiși',
+        'unused_definitions'      => '{0} Nu există definiții neutilizate|{1} 1 definiție neutilizată:|]1,Inf] %count% definiții neutilizate:',
     ),
     'ru'    => array(
         'snippet_proposal_title'  => '<snippet_keyword>%count%</snippet_keyword> <snippet_undefined>не содержит необходимых определений. Вы можете добавить их используя шаблоны:</snippet_undefined>',
@@ -297,6 +313,7 @@
         'pending_count'           => '[1,Inf] %count% в ожидании',
         'undefined_count'         => '{1,21,31} %count% не определен|]1,Inf] %count% не определено',
         'skipped_count'           => '{1,21,31} %count% пропущен|]1,Inf] %count% пропущено',
+        'unused_definitions'      => '{0} Нет неиспользованных определений|{1} 1 неиспользованное определение:|]1,Inf] %count% неиспользованных определений:',
     ),
     'zh'    => array(
         'snippet_context_choice'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> 有新的场景步骤， 请选择要生成代码片段的ContextClass:</snippet_undefined>',
@@ -315,5 +332,6 @@
         'pending_count'           => '[1,Inf] %count% 个待实现方法',
         'undefined_count'         => '[1,Inf] %count% 个未定义',
         'skipped_count'           => '[1,Inf] %count% 个跳过',
+        'unused_definitions'      => '{0} 没有未使用的定义|{1} 1 个未使用的定义:|]1,Inf] %count% 个未使用的定义:',
     ),
 );

--- a/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
+++ b/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
@@ -29,6 +29,8 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Definition
      */
     private $pattern;
 
+    private bool $used = false;
+
     /**
      * Initializes definition.
      *
@@ -67,5 +69,15 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Definition
     public function __toString()
     {
         return $this->getType() . ' ' . $this->getPattern();
+    }
+
+    public function markAsUsed(): void
+    {
+        $this->used = true;
+    }
+
+    public function hasBeenUsed(): bool
+    {
+        return $this->used;
     }
 }

--- a/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
+++ b/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
@@ -39,6 +39,7 @@ final class UnusedDefinitionsController implements Controller
         private DefinitionRepository $definitionRepository,
         private EventDispatcherInterface $eventDispatcher,
         private ConsoleDefinitionInformationPrinter $printer,
+        private bool $printUnusedDefinitions
     ) {
     }
 
@@ -57,6 +58,9 @@ final class UnusedDefinitionsController implements Controller
     public function execute(InputInterface $input, OutputInterface $output): ?int
     {
         if ($input->getOption('print-unused-definitions')) {
+            $this->printUnusedDefinitions = true;
+        }
+        if ($this->printUnusedDefinitions) {
             $this->eventDispatcher->addListener(SuiteTested::AFTER, array($this, 'registerDefinitionUsages'), -999);
             $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'printUnusedDefinitions'), -999);
         }

--- a/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
+++ b/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
@@ -46,7 +46,9 @@ final class UnusedDefinitionsController implements Controller
     {
         $command
             ->addOption(
-                '--print-unused-definitions', null, InputOption::VALUE_NONE,
+                '--print-unused-definitions',
+                null,
+                InputOption::VALUE_NONE,
                 "Reports definitions that were never used."
             )
         ;

--- a/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
+++ b/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Definition\Cli;
+
+use Behat\Behat\Definition\Call\RuntimeDefinition;
+use Behat\Behat\Definition\DefinitionRepository;
+use Behat\Behat\Definition\Printer\ConsoleDefinitionInformationPrinter;
+use Behat\Testwork\Cli\Controller;
+use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
+use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
+use Behat\Testwork\EventDispatcher\Event\SuiteTested;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Prints unused definitions
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class UnusedDefinitionsController implements Controller
+{
+    /**
+     * @var array <string, array{definition: RuntimeDefinition, used: bool}>
+     */
+    private array $definitionUsage = [];
+
+    public function __construct(
+        private DefinitionRepository $definitionRepository,
+        private EventDispatcherInterface $eventDispatcher,
+        private ConsoleDefinitionInformationPrinter $printer,
+    ) {
+    }
+
+    public function configure(Command $command): void
+    {
+        $command
+            ->addOption(
+                '--print-unused-definitions', null, InputOption::VALUE_NONE,
+                "Reports definitions that were never used."
+            )
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        if ($input->getOption('print-unused-definitions')) {
+            $this->eventDispatcher->addListener(SuiteTested::AFTER, array($this, 'registerDefinitionUsages'), -999);
+            $this->eventDispatcher->addListener(ExerciseCompleted::AFTER, array($this, 'printUnusedDefinitions'), -999);
+        }
+        return null;
+    }
+
+    public function registerDefinitionUsages(AfterSuiteTested $event): void
+    {
+        $environmentDefinitions = $this->definitionRepository->getEnvironmentDefinitions($event->getEnvironment());
+        foreach ($environmentDefinitions as $definition) {
+            if ($definition instanceof RuntimeDefinition) {
+                $path = $definition->getPath();
+                if (!isset($this->definitionUsage[$path])) {
+                    $this->definitionUsage[$path] = [
+                        'definition' => $definition,
+                        'used' => $definition->hasBeenUsed(),
+                    ];
+                } elseif ($definition->hasBeenUsed()) {
+                    $this->definitionUsage[$path]['used'] = true;
+                }
+            }
+        }
+    }
+
+    public function printUnusedDefinitions(): void
+    {
+        $unusedDefinitions = array_filter($this->definitionUsage, function ($definition) {
+            return $definition['used'] === false;
+        });
+        $unusedDefinitions = array_column($unusedDefinitions, 'definition');
+
+        $this->printer->printUnusedDefinitions($unusedDefinitions);
+    }
+}

--- a/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
+++ b/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
@@ -81,9 +81,7 @@ final class UnusedDefinitionsController implements Controller
 
     public function printUnusedDefinitions(): void
     {
-        $unusedDefinitions = array_filter($this->definitionUsage, function ($definition) {
-            return $definition['used'] === false;
-        });
+        $unusedDefinitions = array_filter($this->definitionUsage, fn ($definition) => $definition['used'] === false);
         $unusedDefinitions = array_column($unusedDefinitions, 'definition');
 
         $this->printer->printUnusedDefinitions($unusedDefinitions);

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
@@ -67,8 +67,11 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
      *
      * @param string $text
      */
-    final protected function write($text)
+    final protected function write($text, bool $addEmptyLine = false)
     {
+        if ($addEmptyLine) {
+            $this->output->writeln('');
+        }
         $this->output->writeln($text);
         $this->output->writeln('');
     }
@@ -99,6 +102,11 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
     final protected function translateDefinition(Suite $suite, Definition $definition)
     {
         return $this->translator->translateDefinition($suite, $definition);
+    }
+
+    final protected function translateInfoText(string $infoText, array $parameters): string
+    {
+        return $this->translator->translateInfoText($infoText, $parameters);
     }
 
     /**

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
@@ -67,9 +67,9 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
      *
      * @param string $text
      */
-    final protected function write($text, bool $addEmptyLine = false)
+    final protected function write($text, bool $lineBreakBefore = false)
     {
-        if ($addEmptyLine) {
+        if ($lineBreakBefore) {
             $this->output->writeln('');
         }
         $this->output->writeln($text);

--- a/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
+++ b/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
@@ -15,6 +15,7 @@ use Behat\Testwork\Argument\ServiceContainer\ArgumentExtension;
 use Behat\Behat\Gherkin\ServiceContainer\GherkinExtension;
 use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\Environment\ServiceContainer\EnvironmentExtension;
+use Behat\Testwork\EventDispatcher\ServiceContainer\EventDispatcherExtension;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Behat\Testwork\ServiceContainer\ServiceProcessor;
@@ -100,7 +101,7 @@ final class DefinitionExtension implements Extension
         $this->loadAnnotationReader($container);
         $this->loadAttributeReader($container);
         $this->loadDefinitionPrinters($container);
-        $this->loadController($container);
+        $this->loadControllers($container);
         $this->loadDocblockHelper($container);
     }
 
@@ -258,12 +259,7 @@ final class DefinitionExtension implements Extension
         $container->setDefinition($this->getListPrinterId(), $definition);
     }
 
-    /**
-     * Loads definition controller.
-     *
-     * @param ContainerBuilder $container
-     */
-    private function loadController(ContainerBuilder $container)
+    private function loadControllers(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Behat\Definition\Cli\AvailableDefinitionsController', array(
             new Reference(SuiteExtension::REGISTRY_ID),
@@ -273,6 +269,14 @@ final class DefinitionExtension implements Extension
         ));
         $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 500));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.available_definitions', $definition);
+
+        $definition = new Definition('Behat\Behat\Definition\Cli\UnusedDefinitionsController', array(
+            new Reference(self::REPOSITORY_ID),
+            new Reference(EventDispatcherExtension::DISPATCHER_ID),
+            new Reference($this->getInformationPrinterId())
+        ));
+        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 300));
+        $container->setDefinition(CliExtension::CONTROLLER_TAG . '.unused_definitions', $definition);
     }
 
     /**

--- a/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
+++ b/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
@@ -84,6 +84,12 @@ final class DefinitionExtension implements Extension
      */
     public function configure(ArrayNodeDefinition $builder)
     {
+        $builder
+            ->addDefaultsIfNotSet()
+            ->children()
+            ->scalarNode('print_unused_definitions')
+            ->defaultFalse()
+        ;
     }
 
     /**
@@ -101,7 +107,7 @@ final class DefinitionExtension implements Extension
         $this->loadAnnotationReader($container);
         $this->loadAttributeReader($container);
         $this->loadDefinitionPrinters($container);
-        $this->loadControllers($container);
+        $this->loadControllers($container, $config['print_unused_definitions']);
         $this->loadDocblockHelper($container);
     }
 
@@ -259,7 +265,7 @@ final class DefinitionExtension implements Extension
         $container->setDefinition($this->getListPrinterId(), $definition);
     }
 
-    private function loadControllers(ContainerBuilder $container)
+    private function loadControllers(ContainerBuilder $container, bool $printUnusedDefinitions): void
     {
         $definition = new Definition('Behat\Behat\Definition\Cli\AvailableDefinitionsController', array(
             new Reference(SuiteExtension::REGISTRY_ID),
@@ -273,7 +279,8 @@ final class DefinitionExtension implements Extension
         $definition = new Definition('Behat\Behat\Definition\Cli\UnusedDefinitionsController', array(
             new Reference(self::REPOSITORY_ID),
             new Reference(EventDispatcherExtension::DISPATCHER_ID),
-            new Reference($this->getInformationPrinterId())
+            new Reference($this->getInformationPrinterId()),
+            $printUnusedDefinitions
         ));
         $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 300));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.unused_definitions', $definition);

--- a/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
+++ b/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
@@ -57,6 +57,11 @@ final class DefinitionTranslator
         return $definition;
     }
 
+    public function translateInfoText(string $infoText, array $parameters): string
+    {
+        return $this->translator->trans($infoText, $parameters, 'output');
+    }
+
     public function getLocale()
     {
         return $this->translator->getLocale();

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -11,6 +11,7 @@
 namespace Behat\Behat\Tester\Runtime;
 
 use Behat\Behat\Definition\Call\DefinitionCall;
+use Behat\Behat\Definition\Call\RuntimeDefinition;
 use Behat\Behat\Definition\DefinitionFinder;
 use Behat\Behat\Definition\Exception\SearchException;
 use Behat\Behat\Definition\SearchResult;
@@ -115,6 +116,11 @@ final class RuntimeStepTester implements StepTester
     {
         if (!$search->hasMatch()) {
             return new UndefinedStepResult();
+        }
+
+        $definition = $search->getMatchedDefinition();
+        if ($definition instanceof RuntimeDefinition) {
+            $definition->markAsUsed();
         }
 
         if ($skip) {

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -118,6 +118,8 @@ final class RuntimeStepTester implements StepTester
             return new UndefinedStepResult();
         }
 
+        // If a definition has been found, we mark it as used even if it may be skipped,
+        // as we want to count skipped definitions as used
         $definition = $search->getMatchedDefinition();
         if ($definition instanceof RuntimeDefinition) {
             $definition->markAsUsed();

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -68,6 +68,13 @@ final class Profile
         return $this;
     }
 
+    public function withPrintUnusedDefinitions(bool $printUnusedDefinitions = true): self
+    {
+        $this->settings['definitions']['print_unused_definitions'] = $printUnusedDefinitions;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->settings;

--- a/tests/Fixtures/UnusedDefinitions/behat.php
+++ b/tests/Fixtures/UnusedDefinitions/behat.php
@@ -5,13 +5,16 @@ use Behat\Config\Profile;
 use Behat\Config\Suite;
 
 return (new Config())
-    ->withProfile((new Profile('default'))
-        ->withSuite((new Suite('first_suite'))
+    ->withProfile(
+        (new Profile('default'))
+        ->withSuite(
+            (new Suite('first_suite'))
             ->withPaths(
                 'features/first_feature.feature'
             )
         )
-        ->withSuite((new Suite('second_suite'))
+        ->withSuite(
+            (new Suite('second_suite'))
             ->withPaths(
                 'features/second_feature.feature',
             )

--- a/tests/Fixtures/UnusedDefinitions/behat.php
+++ b/tests/Fixtures/UnusedDefinitions/behat.php
@@ -1,0 +1,19 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+return (new Config())
+    ->withProfile((new Profile('default'))
+        ->withSuite((new Suite('first_suite'))
+            ->withPaths(
+                'features/first_feature.feature'
+            )
+        )
+        ->withSuite((new Suite('second_suite'))
+            ->withPaths(
+                'features/second_feature.feature',
+            )
+        )
+    );

--- a/tests/Fixtures/UnusedDefinitions/behat.php
+++ b/tests/Fixtures/UnusedDefinitions/behat.php
@@ -19,4 +19,11 @@ return (new Config())
                 'features/second_feature.feature',
             )
         )
-    );
+    )
+    ->withProfile(
+        (new Profile('unused_definitions'))
+        ->withPrintUnusedDefinitions()
+    )
+;
+
+;

--- a/tests/Fixtures/UnusedDefinitions/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/UnusedDefinitions/features/bootstrap/FeatureContext.php
@@ -10,30 +10,36 @@ class FeatureContext implements Context
 {
 
     #[Given('I call a step used in the first feature')]
-    public function stepUsedInFirstFeature(): void {
+    public function stepUsedInFirstFeature(): void
+    {
     }
 
     #[When('I call a step used in both features')]
-    public function stepUsedInBothFeatures(): void {
+    public function stepUsedInBothFeatures(): void
+    {
     }
 
     #[When('I call a pending step')]
-    public function pendingStep(): void {
+    public function pendingStep(): void
+    {
         throw new PendingException();
     }
 
     #[When('I call a skipped step')]
-    public function skippedStep(): void {
+    public function skippedStep(): void
+    {
     }
 
     #[Then('I call a step used in the second feature')]
-    public function stepUsedInSecondFeature(): void {
+    public function stepUsedInSecondFeature(): void
+    {
     }
 
     /**
      * This is a step that is never used and should be removed
      */
     #[Then('I call a step not used in any feature')]
-    public function stepNotUsedInAnyFeature(): void {
+    public function stepNotUsedInAnyFeature(): void
+    {
     }
 }

--- a/tests/Fixtures/UnusedDefinitions/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/UnusedDefinitions/features/bootstrap/FeatureContext.php
@@ -1,0 +1,39 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+
+class FeatureContext implements Context
+{
+
+    #[Given('I call a step used in the first feature')]
+    public function stepUsedInFirstFeature(): void {
+    }
+
+    #[When('I call a step used in both features')]
+    public function stepUsedInBothFeatures(): void {
+    }
+
+    #[When('I call a pending step')]
+    public function pendingStep(): void {
+        throw new PendingException();
+    }
+
+    #[When('I call a skipped step')]
+    public function skippedStep(): void {
+    }
+
+    #[Then('I call a step used in the second feature')]
+    public function stepUsedInSecondFeature(): void {
+    }
+
+    /**
+     * This is a step that is never used and should be removed
+     */
+    #[Then('I call a step not used in any feature')]
+    public function stepNotUsedInAnyFeature(): void {
+    }
+}

--- a/tests/Fixtures/UnusedDefinitions/features/first_feature.feature
+++ b/tests/Fixtures/UnusedDefinitions/features/first_feature.feature
@@ -1,0 +1,8 @@
+Feature:
+
+  Scenario:
+    Given I call a step used in the first feature
+    When I call a step used in both features
+    And I call a pending step
+    And I call a skipped step
+    And I call an undefined step

--- a/tests/Fixtures/UnusedDefinitions/features/second_feature.feature
+++ b/tests/Fixtures/UnusedDefinitions/features/second_feature.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Scenario:
+    When I call a step used in both features
+    Then I call a step used in the second feature

--- a/tests/Fixtures/UnusedDefinitions/unused_definitions.yaml
+++ b/tests/Fixtures/UnusedDefinitions/unused_definitions.yaml
@@ -1,0 +1,3 @@
+default:
+    definitions:
+        print_unused_definitions: true


### PR DESCRIPTION
In large codebases, step definitions can become obsolete and we can end up with a number of unused definitions and we would probably want to get rid of them in order to remove dead code. This PR adds a new `--print-unused-definitions` option to the Behat runner which will print a list of unused definitions at the end of the run.