### PR TITLE
Fix incorrect getLibPath() method in GherkinExtension.php after Gherkin package restructuring

### DIFF
--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -155,7 +155,7 @@ final class GherkinExtension implements Extension
     private function getLibPath()
     {
         $reflection = new ReflectionClass('Behat\Gherkin\Gherkin');
-        $libPath = rtrim(dirname($reflection->getFilename()) . '/../../../', DIRECTORY_SEPARATOR);
+        $libPath = rtrim(dirname($reflection->getFilename()) . '/../', DIRECTORY_SEPARATOR);
 
         return $libPath;
     }


### PR DESCRIPTION
This PR fixes an issue in Behat\Behat\Gherkin\ServiceContainer\GherkinExtension::getLibPath(), where the method incorrectly assumes the path to the Gherkin library using '/../../../'.

After [Behat/Gherkin#288](https://github.com/Behat/Gherkin/pull/288), the CachedArrayKeywords.php file was relocated, making the hardcoded path incorrect. This caused issues with loading Gherkin keyword data, leading to errors like:
```
PHP Fatal error:  Uncaught TypeError: Behat\Gherkin\Keywords\ArrayKeywords::__construct(): 
Argument #1 ($keywords) must be of type array, false given...
```
Changes:

- Updated getLibPath() to use '/../' instead of '/../../../' to correctly resolve the library path.

Impact:

- Fixes Behat execution errors caused by the incorrect path resolution.
- Ensures compatibility with the latest Behat/Gherkin restructuring.