### PR TITLE
Remove dependency on file location in Gherkin package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "8.1.* || 8.2.* || 8.3.* || 8.4.* ",
         "ext-mbstring": "*",
-        "behat/gherkin": "^4.10.0",
+        "behat/gherkin": "^4.12.0",
         "behat/transliterator": "^1.5",
         "composer-runtime-api": "^2.2",
         "composer/xdebug-handler": "^3.0",

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Gherkin\ServiceContainer;
 
+use Behat\Gherkin\Keywords\CachedArrayKeywords;
 use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\Filesystem\ServiceContainer\FilesystemExtension;
 use Behat\Testwork\ServiceContainer\Exception\ExtensionException;
@@ -136,8 +137,6 @@ final class GherkinExtension implements Extension
      */
     private function loadParameters(ContainerBuilder $container)
     {
-        $container->setParameter('gherkin.paths.lib', $this->getLibPath());
-        $container->setParameter('gherkin.paths.i18n', '%gherkin.paths.lib%/i18n.php');
         $container->setParameter(
             'suite.generic.default_settings',
             array(
@@ -145,19 +144,6 @@ final class GherkinExtension implements Extension
                 'contexts' => array('FeatureContext')
             )
         );
-    }
-
-    /**
-     * Returns gherkin library path.
-     *
-     * @return string
-     */
-    private function getLibPath()
-    {
-        $reflection = new ReflectionClass('Behat\Gherkin\Gherkin');
-        $libPath = rtrim(dirname($reflection->getFilename()) . '/../../../', DIRECTORY_SEPARATOR);
-
-        return $libPath;
     }
 
     /**
@@ -178,9 +164,8 @@ final class GherkinExtension implements Extension
      */
     private function loadKeywords(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Gherkin\Keywords\CachedArrayKeywords', array(
-            '%gherkin.paths.i18n%'
-        ));
+        $definition = new Definition(CachedArrayKeywords::class);
+        $definition->setFactory([CachedArrayKeywords::class, 'withDefaultKeywords']);
         $container->setDefinition(self::KEYWORDS_ID, $definition);
 
         $definition = new Definition('Behat\Gherkin\Keywords\KeywordsDumper', array(


### PR DESCRIPTION
Fixes the issue described in https://github.com/Behat/Behat/pull/1602 by using the new named constructor for `CachedArrayKeywords` instead of relying on the specific location of a file within the Gherkin package