### PR TITLE
Add step line in JUnit formatter

### DIFF
--- a/features/bootstrap/schema/junit.xsd
+++ b/features/bootstrap/schema/junit.xsd
@@ -49,6 +49,7 @@
             <xs:attribute name="classname" type="xs:string" use="optional"/>
             <xs:attribute name="status" type="xs:string" use="optional"/>
             <xs:attribute name="file" type="xs:string" use="optional"/>
+            <xs:attribute name="line" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/features/hooks_failures_junit_annotations.feature
+++ b/features/hooks_failures_junit_annotations.feature
@@ -55,13 +55,13 @@ Feature: Display hook failures location in junit printer using annotations
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="2" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="BeforeSuite: Error in beforeSuite hook (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="1" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -99,11 +99,11 @@ Feature: Display hook failures location in junit printer using annotations
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature">
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4">
             <failure message="AfterSuite: Error in afterSuite hook (Exception)" type="teardown"></failure>
           </testcase>
         </testsuite>
@@ -148,13 +148,13 @@ Feature: Display hook failures location in junit printer using annotations
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="2" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="BeforeFeature: Error in beforeFeature hook (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -197,13 +197,13 @@ Feature: Display hook failures location in junit printer using annotations
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8">
             <failure message="AfterFeature: Error in afterFeature hook (Exception)" type="teardown"></failure>
           </testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -246,13 +246,13 @@ Feature: Display hook failures location in junit printer using annotations
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="1" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="BeforeScenario: Error in beforeScenario hook (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -295,13 +295,13 @@ Feature: Display hook failures location in junit printer using annotations
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="AfterScenario: Error in afterScenario hook (Exception)" type="teardown"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -344,13 +344,13 @@ Feature: Display hook failures location in junit printer using annotations
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="BeforeStep: When I have a simple step: Error in beforeStep hook (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -393,13 +393,13 @@ Feature: Display hook failures location in junit printer using annotations
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="AfterStep: When I have a simple step: Error in afterStep hook (Exception)" type="teardown"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """

--- a/features/hooks_failures_junit_attributes.feature
+++ b/features/hooks_failures_junit_attributes.feature
@@ -53,13 +53,13 @@ Feature: Display hook failures location in junit printer using attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="2" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="BeforeSuite: Error in beforeSuite hook (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="1" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -95,11 +95,11 @@ Feature: Display hook failures location in junit printer using attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature">
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4">
             <failure message="AfterSuite: Error in afterSuite hook (Exception)" type="teardown"></failure>
           </testcase>
         </testsuite>
@@ -142,13 +142,13 @@ Feature: Display hook failures location in junit printer using attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="2" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="BeforeFeature: Error in beforeFeature hook (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -189,13 +189,13 @@ Feature: Display hook failures location in junit printer using attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8">
             <failure message="AfterFeature: Error in afterFeature hook (Exception)" type="teardown"></failure>
           </testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -236,13 +236,13 @@ Feature: Display hook failures location in junit printer using attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="1" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="BeforeScenario: Error in beforeScenario hook (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -283,13 +283,13 @@ Feature: Display hook failures location in junit printer using attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="AfterScenario: Error in afterScenario hook (Exception)" type="teardown"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -330,13 +330,13 @@ Feature: Display hook failures location in junit printer using attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="BeforeStep: When I have a simple step: Error in beforeStep hook (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -377,13 +377,13 @@ Feature: Display hook failures location in junit printer using attributes
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="default">
         <testsuite name="First feature" tests="2" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="First feature" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature">
+          <testcase name="First scenario" classname="First feature" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="5">
             <failure message="AfterStep: When I have a simple step: Error in afterStep hook (Exception)" type="teardown"></failure>
           </testcase>
-          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature"></testcase>
+          <testcase name="Second scenario" classname="First feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-one.feature" line="8"></testcase>
         </testsuite>
         <testsuite name="Second feature" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature"></testcase>
+          <testcase name="First scenario" classname="Second feature" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-two.feature" line="4"></testcase>
         </testsuite>
       </testsuites>
       """

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -32,25 +32,25 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="single_feature">
         <testsuite name="Adding numbers" tests="9" skipped="0" failures="3" errors="2" time="-IGNORE-VALUE-">
-          <testcase name="Passed" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature"></testcase>
-          <testcase name="Undefined" classname="Adding numbers" status="undefined" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
+          <testcase name="Passed" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="11"></testcase>
+          <testcase name="Undefined" classname="Adding numbers" status="undefined" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="16">
             <error message="And Something new" type="undefined"/>
           </testcase>
-          <testcase name="Pending" classname="Adding numbers" status="pending" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
+          <testcase name="Pending" classname="Adding numbers" status="pending" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="21">
             <error message="And Something not done yet: TODO: write pending definition" type="pending"/>
           </testcase>
-          <testcase name="Failed" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
+          <testcase name="Failed" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="25">
             <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #1" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
+          <testcase name="Passed &amp; Failed #1" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29">
             <failure message="Then I must have 16: Failed asserting that 15 matches expected '16'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature"/>
-          <testcase name="Passed &amp; Failed #3" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature">
+          <testcase name="Passed &amp; Failed #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29"/>
+          <testcase name="Passed &amp; Failed #3" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29">
             <failure message="Then I must have 32: Failed asserting that 33 matches expected '32'."/>
           </testcase>
-          <testcase name="Another Outline #1" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature"/>
-          <testcase name="Another Outline #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature"/>
+          <testcase name="Another Outline #1" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="39"/>
+          <testcase name="Another Outline #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="39"/>
         </testsuite>
       </testsuites>
       """
@@ -66,10 +66,10 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="multiple_features">
         <testsuite name="Adding Feature 1" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding 4 to 10" classname="Adding Feature 1" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_features_1.feature"></testcase>
+          <testcase name="Adding 4 to 10" classname="Adding Feature 1" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_features_1.feature" line="9"></testcase>
         </testsuite>
         <testsuite name="Adding Feature 2" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding 8 to 10" classname="Adding Feature 2" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_features_2.feature"></testcase>
+          <testcase name="Adding 8 to 10" classname="Adding Feature 2" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_features_2.feature" line="9"></testcase>
         </testsuite>
       </testsuites>
       """
@@ -85,8 +85,8 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="multiline_titles">
         <testsuite name="Use multiline titles" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Adding some interesting value" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature"/>
-          <testcase name="Adding another value" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature"/>
+          <testcase name="Adding some interesting value" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature" line="13"/>
+          <testcase name="Adding another value" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature" line="20"/>
         </testsuite>
       </testsuites>
       """
@@ -102,7 +102,7 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="small_kid">
         <testsuite name="Adding easy numbers" tests="1" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Easy sum" classname="Adding easy numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_suites_1.feature"/>
+          <testcase name="Easy sum" classname="Adding easy numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_suites_1.feature" line="11"/>
         </testsuite>
       </testsuites>
       """
@@ -112,7 +112,7 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="old_man">
         <testsuite name="Adding difficult numbers" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Difficult sum" classname="Adding difficult numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_suites_2.feature">
+          <testcase name="Difficult sum" classname="Adding difficult numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_suites_2.feature" line="11">
             <failure message="Then I must have 477: Failed asserting that 378 matches expected '477'."/>
           </testcase>
         </testsuite>
@@ -130,10 +130,10 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="skipped_test_cases">
         <testsuite name="Skipped test cases" tests="2" skipped="2" failures="0" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Skipped" classname="Skipped test cases" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-skipped_test_cases.feature">
+          <testcase name="Skipped" classname="Skipped test cases" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-skipped_test_cases.feature" line="11">
             <failure message="BeforeScenario: This scenario has a failed setup (Exception)" type="setup"></failure>
           </testcase>
-          <testcase name="Another skipped" classname="Skipped test cases" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-skipped_test_cases.feature">
+          <testcase name="Another skipped" classname="Skipped test cases" status="skipped" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-skipped_test_cases.feature" line="15">
             <failure message="BeforeScenario: This scenario has a failed setup (Exception)" type="setup"></failure>
           </testcase>
         </testsuite>
@@ -151,7 +151,7 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="stop_on_failure">
         <testsuite name="Stop on failure" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
-          <testcase name="Failed" classname="Stop on failure" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-stop_on_failure.feature">
+          <testcase name="Failed" classname="Stop on failure" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-stop_on_failure.feature" line="11">
             <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
           </testcase>
         </testsuite>

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
@@ -54,6 +54,8 @@ class JUnitStepPrinter implements StepPrinter
 
         $attributes = ['message' => $message];
 
+        $outputPrinter->addCurrentTestCaseAttributes(['line' => $step->getLine()]);
+
         switch ($result->getResultCode()) {
             case TestResult::FAILED:
                 $outputPrinter->addTestcaseChild('failure', $attributes);

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -99,8 +99,6 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
 
     /**
      * Adds attributes to the current <testcase> node.
-     *
-     * @param array $testcaseAttributes
      */
     public function addCurrentTestCaseAttributes(array $testcaseAttributes)
     {

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -98,6 +98,16 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
     }
 
     /**
+     * Adds attributes to the current <testcase> node.
+     *
+     * @param array $testcaseAttributes
+     */
+    public function addCurrentTestCaseAttributes(array $testcaseAttributes)
+    {
+        $this->addAttributesToNode($this->currentTestcase, $testcaseAttributes);
+    }
+
+    /**
      * Add a testcase child element.
      *
      * @param string $nodeName


### PR DESCRIPTION
Hi,

From https://github.com/testmoapp/junitxml, I've seen that the `<testcase>` tag can support a line number. It can helps pinpointing a failing test quickly. 

Thanks ! 