### PR TITLE
Throw an exception if a given parameter is a PyStringNode or a TableNode, but this argument is not expected in the context

### DIFF
--- a/features/arguments.feature
+++ b/features/arguments.feature
@@ -33,8 +33,18 @@ Feature: Step Arguments
               $this->input = $string;
           }
 
+          #[Given('/^an untyped pystring:$/')]
+          public function anUntypedPystring(PyStringNode $string) {
+              $this->input = $string;
+          }
+
           #[Given('/^a table:$/')]
           public function aTable(TableNode $table) {
+              $this->input = $table;
+          }
+
+          #[Given('/^an untyped table:$/')]
+          public function anUntypedTable($table) {
               $this->input = $table;
           }
 
@@ -52,6 +62,10 @@ Feature: Step Arguments
           public function iHaveNumberAndNumber($number1, $number2) {
               \PHPUnit\Framework\Assert::assertEquals(13, intval($number1));
               \PHPUnit\Framework\Assert::assertEquals(243, intval($number2));
+          }
+
+          #[Given('/^a step with no argument$/')]
+          public function aStepWithNoArgument(): void {
           }
       }
       """
@@ -153,6 +167,72 @@ Feature: Step Arguments
       1 scenario (1 passed)
       2 steps (2 passed)
       """
+
+  Scenario: given TableNode argument that is not defined in context
+    Given a file named "features/knowned-argument-exception.feature" with:
+      """
+      Feature: Tables
+        Scenario:
+          Given a step with no argument
+            | item1 | item2 | item3 |
+            | super | mega  | extra |
+            | hyper | mini  | XXL   |
+      """
+    When I run "behat --no-colors -f progress features/knowned-argument-exception.feature"
+    Then it should fail with:
+      """
+      You have passed a TableNode or PystringNode as an argument, but it was not used in the function. This is probably an error in your feature file.
+      """
+      
+    Given a file named "features/knowned-argument-exception.feature" with:
+      """
+      Feature: Tables
+        Scenario:
+          Given an untyped table:
+            | item1 | item2 | item3 |
+            | super | mega  | extra |
+            | hyper | mini  | XXL   |
+      """
+    When I run "behat --no-colors -f progress features/knowned-argument-exception.feature"
+    Then it should pass
+
+  Scenario: given PyStringNode argument that is not defined in context
+    Given a file named "features/knowned-argument-exception.feature" with:
+      """
+      Feature: PystringNodes
+        Scenario:
+          Given a step with no argument
+            '''
+            <word1>
+              w
+               o
+          r
+           <word2>
+               d
+            '''
+      """
+    When I run "behat --no-colors -f progress features/knowned-argument-exception.feature"
+    Then it should fail with:
+      """
+      You have passed a TableNode or PystringNode as an argument, but it was not used in the function. This is probably an error in your feature file.
+      """
+      
+    Given a file named "features/knowned-argument-exception.feature" with:
+      """
+      Feature: PystringNodes
+        Scenario:
+          Given an untyped pystring:
+            '''
+            <word1>
+              w
+               o
+          r
+           <word2>
+               d
+            '''
+      """
+    When I run "behat --no-colors -f progress features/knowned-argument-exception.feature"
+    Then it should pass
 
   Scenario: Named arguments
     Given a file named "features/named_args.feature" with:

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -10,6 +10,8 @@
 
 namespace Behat\Testwork\Argument;
 
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
 use ReflectionFunctionAbstract;
 use ReflectionClass;
 use ReflectionNamedType;
@@ -53,13 +55,38 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
 
         list($named, $typehinted, $numbered) = $this->splitArguments($parameters, $arguments);
 
+        $someArgumentsAreKnowned = $this->hasKnownedArgument($numbered);
+
         $arguments =
             $this->prepareNamedArguments($parameters, $named) +
             $this->prepareTypehintedArguments($parameters, $typehinted) +
             $this->prepareNumberedArguments($parameters, $numbered) +
             $this->prepareDefaultArguments($parameters);
 
+        // If a parameter was a TableNode or a PystringNode, but has been throwned out of the arguments,
+        // then it's an error in the feature file.
+        if ($someArgumentsAreKnowned && !$this->hasKnownedArgument($arguments)) {
+            throw new \InvalidArgumentException(
+                'You have passed a TableNode or PystringNode as an argument, but it was not used in the function. This is probably an error in your feature file.'
+            );
+        }
+
         return $this->reorderArguments($parameters, $arguments);
+    }
+
+    /**
+     * return true if the arguments array contain a TableNode or PyStringNode
+     * @param array<mixed> $arguments
+     */
+    private function hasKnownedArgument(array $arguments): bool
+    {
+        foreach ($arguments as $argument) {
+            if ($argument instanceof TableNode || $argument instanceof PyStringNode) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Fixes #1609 according to [@acoulton comment](https://github.com/Behat/Behat/issues/1609#issuecomment-2769851124)