### PR TITLE
Display line number of failing test in pretty mode

### DIFF
--- a/features/catch_throwable.feature
+++ b/features/catch_throwable.feature
@@ -53,7 +53,7 @@ Feature: Support PHP 7 Throwable
 
       --- Failed scenarios:
 
-          features/fatal_errors.feature:6
+          features/fatal_errors.feature:6 (on line 7)
 
       1 scenario (1 failed)
       2 steps (1 failed, 1 skipped)

--- a/i18n.php
+++ b/i18n.php
@@ -20,6 +20,7 @@ return [
         'undefined_count'         => '[1,Inf] %count% undefined',
         'skipped_count'           => '[1,Inf] %count% skipped',
         'unused_definitions'      => '{0} No unused definitions|{1} 1 unused definition:|]1,Inf] %count% unused definitions:',
+        'on_line_number'          => 'on line %line%',
     ],
     'bg'    => [
         'snippet_context_choice'  => 'В сет <snippet_undefined><snippet_keyword>%count%</snippet_keyword> има недекларирани стъпки. Изберете в кой Context да бъдат създадени:</snippet_undefined>',
@@ -112,6 +113,7 @@ return [
         'undefined_count'        => '[1,Inf] %count% indéfinis',
         'skipped_count'          => '[1,Inf] %count% ignorés',
         'unused_definitions'     => '{0} Aucune définition inutilisée|{1} 1 définition inutilisée:|]1,Inf] %count% définitions inutilisées:',
+        'on_line_number'          => 'à la ligne %line%',
     ],
     'hu'    => [
         'snippet_context_choice'  => '<snippet_undefined><snippet_keyword>%count%</snippet_keyword> sorozat meghatározatlan lépéseket tartalmaz. Válaszd ki a környezetet kódrészlet készítéséhez:</snippet_undefined>',

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -73,7 +73,7 @@ final class ListPrinter
      * @param integer        $resultCode
      * @param ScenarioStat[] $scenarioStats
      */
-    public function printScenariosList(OutputPrinter $printer, $intro, $resultCode, array $scenarioStats)
+    public function printScenariosList(OutputPrinter $printer, $intro, $resultCode, array $scenarioStats, ?array $stepStats = null)
     {
         if (!count($scenarioStats)) {
             return;
@@ -83,9 +83,21 @@ final class ListPrinter
         $intro = $this->translator->trans($intro, [], 'output');
 
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
-        foreach ($scenarioStats as $stat) {
+        foreach ($scenarioStats as $key => $stat) {
             $path = $this->relativizePaths((string) $stat);
-            $printer->writeln(sprintf('    {+%s}%s{-%s}', $style, $path, $style));
+
+            $stepStat = isset($stepStats[$key]) ? $stepStats[$key] : null;
+            $stepLine = $stepStat ? $this->extractLineNumber((string) $stepStat) : null;
+
+            if ($stepLine !== null) {
+                $lineNumber = $this->translator->trans('on_line_number', ['%line%' => $stepLine], 'output');
+                
+                $lineHelper = ' (' . $lineNumber . ')';
+            } else {
+                $lineHelper = '';
+            }
+
+            $printer->writeln(sprintf('    {+%s}%s%s{-%s}', $style, $path, $lineHelper, $style));
         }
 
         $printer->writeln();
@@ -295,6 +307,12 @@ final class ListPrinter
         }
 
         return str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $path);
+    }
+
+    
+    private function extractLineNumber(string $path): ?string
+    {
+        return explode(':', $path)[1] ?? null;
     }
 
     private function getLocationFromScope(?HookScope $scope): ?string

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStatisticsPrinter.php
@@ -59,7 +59,8 @@ final class PrettyStatisticsPrinter implements StatisticsPrinter
         $this->listPrinter->printScenariosList($printer, 'skipped_scenarios_title', TestResult::SKIPPED, $scenarioStats);
 
         $scenarioStats = $statistics->getFailedScenarios();
-        $this->listPrinter->printScenariosList($printer, 'failed_scenarios_title', TestResult::FAILED, $scenarioStats);
+        $failedStepStats = $statistics->getFailedSteps();
+        $this->listPrinter->printScenariosList($printer, 'failed_scenarios_title', TestResult::FAILED, $scenarioStats, $failedStepStats);
 
         $this->counterPrinter->printCounters($printer, 'scenarios_count', $statistics->getScenarioStatCounts());
         $this->counterPrinter->printCounters($printer, 'steps_count', $statistics->getStepStatCounts());


### PR DESCRIPTION
Fixes #1612 

### Other possible unused option

I hesitated to use the `printStepList` used in the Progress printer, but it would have display two time the same informations.

### Implementation

I am not really fan of my implementation, because the failing scenario is not linked to the failing steps.
I did assume that, as the rest of the steps in the scenario are just skipped, there would be a match between the `failingScenariosStats` and the `failingStepsStats`, but I would have been far more confident if I could do something like `$failingStep->getScenario()` to find the failing step(s?) of a scenario.

### I18n

I do not know what are the translation process, so I did only translate in english and in french, but it will probably display something wrong in other languages (unless there is a fallback on english ?)