### PR TITLE
Fix & improve conversion of Context and Extension YAML configs

### DIFF
--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -403,6 +403,7 @@ Feature: Convert config
   Scenario: Full configuration
     When I copy the "full_configuration.yaml" file to the temp folder
     And I copy the "imported.yaml" file to the temp folder
+    And the "MY_SECRET_PASSWORD" environment variable is set to "sesame"
     When I run behat with the following additional options:
       | option   | value                                    |
       | --config | {SYSTEM_TMP_DIR}/full_configuration.yaml |
@@ -437,7 +438,12 @@ Feature: Convert config
               ->withPrintUnusedDefinitions(true)
               ->withExtension(new Extension('custom_extension.php'))
               ->withSuite((new Suite('my_suite'))
-                  ->withContexts('MyContext')
+                  ->addContext(
+                      'MyContext',
+                      [
+                          'password' => '%env(MY_SECRET_PASSWORD)%',
+                      ]
+                  )
                   ->withPaths('one.feature')
                   ->withFilter(new TagFilter('@run'))))
           ->withProfile((new Profile('other'))

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -182,6 +182,41 @@ Feature: Convert config
       """
     And the temp "suite_contexts.yaml" file should have been removed
 
+  Scenario: Suite contexts with arguments
+    When I copy the "suite_contexts_with_args.yaml" file to the temp folder
+    When I run behat with the following additional options:
+      | option   | value                                          |
+      | --config | {SYSTEM_TMP_DIR}/suite_contexts_with_args.yaml |
+    Then the temp "suite_contexts_with_args.php" file should be like:
+      """
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
+      use Behat\Config\Suite;
+
+      return (new Config())
+          ->withProfile((new Profile('default'))
+              ->withSuite((new Suite('my_suite'))
+                  ->addContext('MyContext')
+                  ->addContext(
+                      'App\AContextWithPositionalArgs',
+                      [
+                          'First Arg',
+                          'Second Arg',
+                      ]
+                  )
+                  ->addContext(
+                      'App\AContextWithNamedArgs',
+                      [
+                          'param1' => 'Something',
+                          'param2' => 'Else',
+                      ]
+                  )
+                  ->addContext('App\AnotherContext')));
+      """
+    And the temp "suite_contexts.yaml" file should have been removed
+
   Scenario: Suite paths
     When I copy the "suite_paths.yaml" file to the temp folder
     When I run behat with the following additional options:
@@ -378,4 +413,3 @@ Feature: Convert config
       """
     And the temp "full_configuration.yaml" file should have been removed
     And the temp "imported.yaml" file should have been removed
-

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -303,6 +303,7 @@ Feature: Convert config
       use Behat\Config\Suite;
       use MyContext;
       use Some\Behat\Extension\ExplicitlyReferencedExtension;
+      use Some\ShorthandExtension\ServiceContainer\ShorthandExtension;
       use test\MyApp\Contexts\MyFirstContext;
       use test\MyApp\Contexts\MySecondContext;
 
@@ -310,7 +311,7 @@ Feature: Convert config
           ->withProfile((new Profile('default'))
               ->withExtension(new Extension('class_references_loader.php'))
               ->withExtension(new Extension(ExplicitlyReferencedExtension::class))
-              ->withExtension(new Extension('Some\ShorthandExtension'))
+              ->withExtension(new Extension(ShorthandExtension::class))
               ->withSuite((new Suite('named_contexts'))
                   ->withContexts(
                       'UnknownContext',

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -288,6 +288,48 @@ Feature: Convert config
       """
     And the temp "extensions.yaml" file should have been removed
 
+  Scenario: Class references for known extensions and contexts
+    Given I copy the "class_references.yaml" file to the temp folder
+    When  I run behat with the following additional options:
+      | option   | value                                  |
+      | --config | {SYSTEM_TMP_DIR}/class_references.yaml |
+    Then the temp "class_references.php" file should be like:
+      """
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Extension;
+      use Behat\Config\Profile;
+      use Behat\Config\Suite;
+      use MyContext;
+      use Some\Behat\Extension\ExplicitlyReferencedExtension;
+      use test\MyApp\Contexts\MyFirstContext;
+      use test\MyApp\Contexts\MySecondContext;
+
+      return (new Config())
+          ->withProfile((new Profile('default'))
+              ->withExtension(new Extension('class_references_loader.php'))
+              ->withExtension(new Extension(ExplicitlyReferencedExtension::class))
+              ->withExtension(new Extension('Some\ShorthandExtension'))
+              ->withSuite((new Suite('named_contexts'))
+                  ->withContexts(
+                      'UnknownContext',
+                      MyContext::class,
+                      MyFirstContext::class,
+                      MySecondContext::class
+                  ))
+              ->withSuite((new Suite('contexts_with_args'))
+                  ->addContext('UnknownContext')
+                  ->addContext(
+                      MyFirstContext::class,
+                      [
+                          'param1',
+                      ]
+                  )
+                  ->addContext(MySecondContext::class)));
+      """
+    And the temp "class_references.yaml" file should have been removed
+
   Scenario: Profile filters
     When I copy the "profile_filters.yaml" file to the temp folder
     When I run behat with the following additional options:

--- a/src/Behat/Config/Converter/ConfigConverterTools.php
+++ b/src/Behat/Config/Converter/ConfigConverterTools.php
@@ -17,7 +17,7 @@ class ConfigConverterTools
     public static function addMethodCall(string $methodName, array $arguments, Expr $expr): Expr
     {
         $builderFactory = self::getBuilderFactory();
-        $args = $builderFactory->args($arguments);
+        $args = $builderFactory->args(self::replaceClassReferences($arguments));
         return $builderFactory->methodCall($expr, $methodName, $args);
     }
 
@@ -30,7 +30,7 @@ class ConfigConverterTools
     public static function addArgumentsToConstructor(array $arguments, New_ $expr)
     {
         $builderFactory = self::getBuilderFactory();
-        $expr->args = $builderFactory->args($arguments);
+        $expr->args = $builderFactory->args(self::replaceClassReferences($arguments));
     }
 
     public static function createUseStatement(string $className): Use_
@@ -45,5 +45,19 @@ class ConfigConverterTools
             self::$builderFactory = new BuilderFactory();
         }
         return self::$builderFactory;
+    }
+
+    private static function replaceClassReferences(array $arguments): array
+    {
+        return array_map(
+            static fn ($arg) => is_string($arg) && class_exists($arg) ? self::getClassReference($arg) : $arg,
+            $arguments,
+        );
+    }
+
+    private static function getClassReference(string $className): Expr
+    {
+        $builderFactory = self::getBuilderFactory();
+        return $builderFactory->classConstFetch($className, 'class');
     }
 }

--- a/src/Behat/Config/Converter/UsedClassesCollector.php
+++ b/src/Behat/Config/Converter/UsedClassesCollector.php
@@ -14,9 +14,24 @@ class UsedClassesCollector extends NodeVisitorAbstract
 
     public function enterNode(Node $node): ?Node
     {
-        if (!$node instanceof Node\Name\FullyQualified) {
-            return null;
+        if ($node instanceof Node\Name\FullyQualified) {
+            return $this->importClass($node);
         }
+
+        if ($node instanceof Node\Expr\ClassConstFetch && $node->class instanceof Node\Name) {
+            // E.g. a `MyClass::class` argument
+            return new Node\Expr\ClassConstFetch(
+                $this->importClass($node->class),
+                $node->name,
+                $node->getAttributes(),
+            );
+        }
+
+        return null;
+    }
+
+    private function importClass(Node\Name $node): Node\Name
+    {
         $className = $node->toString();
         $shortName = $node->getLast();
 

--- a/src/Behat/Config/Extension.php
+++ b/src/Behat/Config/Extension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Behat\Config;
 
 use Behat\Config\Converter\ConfigConverterTools;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
 use PhpParser\Node\Expr;
 
 final class Extension implements ExtensionConfigInterface
@@ -29,10 +30,19 @@ final class Extension implements ExtensionConfigInterface
     {
         $extensionObject =  ConfigConverterTools::createObject(self::class);
 
+        $name = $this->name;
+        if (!class_exists($name)) {
+            // It might be a shorthand reference to the extension - attempt to convert to an FQCN
+            $fullName = ExtensionManager::guessFullExtensionClassName($name);
+            if (class_exists($fullName)) {
+                $name = $fullName;
+            }
+        }
+
         if ($this->settings === []) {
-            $arguments = [$this->name];
+            $arguments = [$name];
         } else {
-            $arguments = [$this->name, $this->settings];
+            $arguments = [$name, $this->settings];
         }
         ConfigConverterTools::addArgumentsToConstructor($arguments, $extensionObject);
 

--- a/src/Behat/Config/Suite.php
+++ b/src/Behat/Config/Suite.php
@@ -19,7 +19,8 @@ final class Suite implements ConfigConverterInterface
     private const PATHS_SETTING = 'paths';
     private const FILTERS_SETTING = 'filters';
 
-    private const CONTEXTS_FUNCTION = 'withContexts';
+    private const WITH_CONTEXTS_FUNCTION = 'withContexts';
+    private const ADD_CONTEXT_FUNCTION = 'addContext';
     private const PATHS_FUNCTION = 'withPaths';
     private const FILTER_FUNCTION = 'withFilter';
 
@@ -104,13 +105,35 @@ final class Suite implements ConfigConverterInterface
 
     private function addContextsToExpr(Expr &$expr): void
     {
-        if (isset($this->settings[self::CONTEXTS_SETTING])) {
-            $expr = ConfigConverterTools::addMethodCall(
-                self::CONTEXTS_FUNCTION,
-                $this->settings[self::CONTEXTS_SETTING],
-                $expr
-            );
-            unset($this->settings[self::CONTEXTS_SETTING]);
+        if (!isset($this->settings[self::CONTEXTS_SETTING])) {
+            return;
+        }
+
+        $contexts = $this->settings[self::CONTEXTS_SETTING];
+        unset($this->settings[self::CONTEXTS_SETTING]);
+
+        // Contexts can be configured with or without constructor arguments.
+        $hasAnyWithArguments = (bool) array_filter($contexts, fn ($c) => is_array($c));
+
+        if (!$hasAnyWithArguments) {
+            // All the contexts are just class names, we can add them as a single `->withContexts` call
+            $expr = ConfigConverterTools::addMethodCall(self::WITH_CONTEXTS_FUNCTION, $contexts, $expr);
+            return;
+        }
+
+        // One or more contexts has constructor arguments. We need to preserve the existing order, in case any are
+        // registering hooks. Therefore, we need to add each one individually.
+        foreach ($contexts as $contextConfig) {
+            if (is_array($contextConfig)) {
+                // The structure is [$context => $constructorArgs]
+                $args = [
+                    array_key_first($contextConfig),
+                    array_shift($contextConfig),
+                ];
+            } else {
+                $args = [$contextConfig];
+            }
+            $expr = ConfigConverterTools::addMethodCall(self::ADD_CONTEXT_FUNCTION, $args, $expr);
         }
     }
 

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -131,11 +131,9 @@ final class ExtensionManager
     /**
      * Attempts to guess full extension class from relative.
      *
-     * @param string $locator
-     *
-     * @return string
+     * @internal
      */
-    private function getFullExtensionClass($locator)
+    public static function guessFullExtensionClassName(string $locator): string
     {
         $parts = explode('\\', $locator);
         $name = preg_replace('/Extension$/', '', end($parts)) . 'Extension';
@@ -171,7 +169,7 @@ final class ExtensionManager
             return new $class();
         }
 
-        if (class_exists($class = $this->getFullExtensionClass($locator))) {
+        if (class_exists($class = self::guessFullExtensionClassName($locator))) {
             return new $class();
         }
 

--- a/tests/Fixtures/ConvertConfig/class_references.yaml
+++ b/tests/Fixtures/ConvertConfig/class_references.yaml
@@ -4,8 +4,8 @@ default:
         class_references_loader.php: ~
         # Is referenced exactly by its class name, and the class is defined, so will be imported & referenced
         Some\Behat\Extension\ExplicitlyReferencedExtension: ~
-        # Uses the "automagic" Some\ShorthandExtension => Some\ShorthandExtension\ServiceContainer\ShorthandExtension
-        # Is not converted to a class reference
+        # Uses the "automagic" Some\ShorthandExtension
+        # Will be converted to the actual Some\ShorthandExtension\ServiceContainer\ShorthandExtension class reference
         Some\ShorthandExtension: ~
     suites:
         named_contexts:

--- a/tests/Fixtures/ConvertConfig/class_references.yaml
+++ b/tests/Fixtures/ConvertConfig/class_references.yaml
@@ -1,0 +1,25 @@
+default:
+    extensions:
+        # Loads the custom classes we need for this feature
+        class_references_loader.php: ~
+        # Is referenced exactly by its class name, and the class is defined, so will be imported & referenced
+        Some\Behat\Extension\ExplicitlyReferencedExtension: ~
+        # Uses the "automagic" Some\ShorthandExtension => Some\ShorthandExtension\ServiceContainer\ShorthandExtension
+        # Is not converted to a class reference
+        Some\ShorthandExtension: ~
+    suites:
+        named_contexts:
+            contexts:
+                # Undefined class (could be a service locator), left as a string
+                - UnknownContext
+                # These classes are all defined and will be imported
+                - MyContext
+                - test\MyApp\Contexts\MyFirstContext
+                - test\MyApp\Contexts\MySecondContext
+
+        contexts_with_args:
+            contexts:
+                - UnknownContext
+                - test\MyApp\Contexts\MyFirstContext:
+                      - param1
+                - test\MyApp\Contexts\MySecondContext

--- a/tests/Fixtures/ConvertConfig/class_references_loader.php
+++ b/tests/Fixtures/ConvertConfig/class_references_loader.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Used by the `class_references.yaml` file to define the class names that will be converted to PHP class references.
+ */
+use Behat\Behat\Context\Context;
+use Behat\Testwork\ServiceContainer\Extension;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class CreateClassNamesExtension implements Extension
+{
+    public function process(ContainerBuilder $container)
+    {
+    }
+
+    public function getConfigKey()
+    {
+        return 'anything';
+    }
+
+    public function initialize(ExtensionManager $extensionManager)
+    {
+    }
+
+    public function configure(ArrayNodeDefinition $builder)
+    {
+    }
+
+    public function load(ContainerBuilder $container, array $config)
+    {
+    }
+
+}
+
+// These are the classes that are referenced from the class_references YAML.
+//
+// They need to be actually defined for the reference to pass the `class_exists()` check we
+// use to identify PHP classes from other strings.
+//
+// Avoid the verbosity that would be required to define them all separately (especially considering they
+// are all in different namespaces) by defining them with class_alias.
+//
+// The other complication is that because the feature runs with the YAML copied to a temp directory,
+// it is tricky to configure the Behat autoloader to find these classes in the "fixtures" directory.
+// Hence using an ugly extension file to run this code.
+class_alias(CreateClassNamesExtension::class, 'Some\Behat\Extension\ExplicitlyReferencedExtension');
+class_alias(CreateClassNamesExtension::class, 'Some\ShorthandExtension\ServiceContainer\ShorthandExtension');
+$context = new class implements Context {
+};
+class_alias($context::class, 'MyContext');
+class_alias($context::class, 'test\MyApp\Contexts\MyFirstContext');
+class_alias($context::class, 'test\MyApp\Contexts\MySecondContext');
+
+return new CreateClassNamesExtension();

--- a/tests/Fixtures/ConvertConfig/full_configuration.yaml
+++ b/tests/Fixtures/ConvertConfig/full_configuration.yaml
@@ -14,7 +14,8 @@ default:
     suites:
         my_suite:
             contexts:
-                - MyContext
+                - MyContext:
+                    password: '%env(MY_SECRET_PASSWORD)%'
             paths:
                 - "one.feature"
             filters:

--- a/tests/Fixtures/ConvertConfig/suite_contexts_with_args.yaml
+++ b/tests/Fixtures/ConvertConfig/suite_contexts_with_args.yaml
@@ -1,0 +1,12 @@
+default:
+    suites:
+        my_suite:
+            contexts:
+                - MyContext
+                - App\AContextWithPositionalArgs:
+                    - First Arg
+                    - Second Arg
+                - App\AContextWithNamedArgs:
+                      param1: Something
+                      param2: Else
+                - App\AnotherContext


### PR DESCRIPTION
This fixes a bug when converting YAML configuration that contains Contexts with constructor arguments. 

It also adds features to reference Contexts and Extensions as `Context::class` rather than `'Context'` in the generated PHP.

I have combined into one PR as they are quite related, but can split the bugfix from the features if you'd prefer.