### PR TITLE
Add option to print all paths as absolute paths

### DIFF
--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -416,6 +416,24 @@ Feature: Convert config
       """
     And the temp "formatters.yaml" file should have been removed
 
+  Scenario: path options
+    When I copy the "path_options.yaml" file to the temp folder
+    When I run behat with the following additional options:
+      | option   | value                                    |
+      | --config | {SYSTEM_TMP_DIR}/path_options.yaml |
+    Then the temp "path_options.php" file should be like:
+      """
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
+
+      return (new Config())
+          ->withProfile((new Profile('default'))
+              ->withPathOptions(printAbsolutePaths: true));
+      """
+    And the temp "path_options.yaml" file should have been removed
+
   Scenario: Full configuration
     When I copy the "full_configuration.yaml" file to the temp folder
     And I copy the "imported.yaml" file to the temp folder
@@ -453,6 +471,7 @@ Feature: Convert config
               ->withFilter(new NameFilter('john'))
               ->withFilter(new RoleFilter('admin'))
               ->withPrintUnusedDefinitions(true)
+              ->withPathOptions(printAbsolutePaths: true)
               ->withExtension(new Extension('custom_extension.php'))
               ->withSuite((new Suite('my_suite'))
                   ->addContext(

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -142,6 +142,6 @@ Feature: Error Reporting
           When an exception is thrown # features/exception_in_scenario.feature:7
             Exception: Exception is thrown in features/bootstrap/FeatureContext.php:50
             Stack trace:
-            #0 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(110): FeatureContext->anExceptionIsThrown()
-            #1 src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(
+            #0 {BASE_PATH}src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(110): FeatureContext->anExceptionIsThrown()
+            #1 {BASE_PATH}src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(64): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(
     """

--- a/features/print_absolute_paths.feature
+++ b/features/print_absolute_paths.feature
@@ -1,0 +1,58 @@
+Feature: Print absolute paths
+  In order to be able to find the right paths to files
+  As a developer
+  I need to be able to ask Behat to print the full absolute path for files
+
+  Background:
+    Given I set the working directory to the "PrintAbsolutePaths" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option          | value            |
+      | --no-colors     |                  |
+
+  Scenario: Add option in command line
+    When I run behat with the following additional options:
+      | option                 | value |
+      | --print-absolute-paths |       |
+    Then the output with absolute paths should contain:
+      """
+        Scenario:                                    # BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
+
+      --- Failed scenarios:
+
+          BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+      """
+
+  Scenario: Add option in config file
+    When I run behat with the following additional options:
+      | option    | value                |
+      | --profile | absolute_paths       |
+    Then the output with absolute paths should contain:
+      """
+        Scenario:                                    # BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
+
+      --- Failed scenarios:
+
+          BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+      """
+
+  Scenario: Add option in yaml config file
+    When I run behat with the following additional options:
+      | option    | value               |
+      | --config  | absolute_paths.yaml |
+    Then the output with absolute paths should contain:
+      """
+        Scenario:                                    # BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
+
+      --- Failed scenarios:
+
+          BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+      """

--- a/features/print_absolute_paths.feature
+++ b/features/print_absolute_paths.feature
@@ -13,46 +13,30 @@ Feature: Print absolute paths
     When I run behat with the following additional options:
       | option                 | value |
       | --print-absolute-paths |       |
-    Then the output with absolute paths should contain:
+    Then the output should contain:
       """
-        Scenario:                                    # BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+        Scenario:                                    # {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
+            Warning: Undefined variable $b in {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
 
       --- Failed scenarios:
 
-          BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+          {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
       """
 
   Scenario: Add option in config file
     When I run behat with the following additional options:
       | option    | value                |
       | --profile | absolute_paths       |
-    Then the output with absolute paths should contain:
+    Then the output should contain:
       """
-        Scenario:                                    # BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+        Scenario:                                    # {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
+            Warning: Undefined variable $b in {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
 
       --- Failed scenarios:
 
-          BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
-      """
-
-  Scenario: Add option in yaml config file
-    When I run behat with the following additional options:
-      | option    | value               |
-      | --config  | absolute_paths.yaml |
-    Then the output with absolute paths should contain:
-      """
-        Scenario:                                    # BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
-          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
-          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
-
-      --- Failed scenarios:
-
-          BASE_PATH/tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+          {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
       """

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -13,6 +13,8 @@ parameters:
                 - src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
                 - src/Behat/Behat/EventDispatcher/Cli/StopOnFailureController.php
                 - src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+                - src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
                 - src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
                 - src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+                - src/Behat/Testwork/Exception/ExceptionPresenter.php
                 - src/Behat/Testwork/Ordering/Cli/OrderController.php

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -13,8 +13,6 @@ parameters:
                 - src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
                 - src/Behat/Behat/EventDispatcher/Cli/StopOnFailureController.php
                 - src/Behat/Behat/Output/Node/Printer/ListPrinter.php
-                - src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
                 - src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
                 - src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
-                - src/Behat/Testwork/Exception/ExceptionPresenter.php
                 - src/Behat/Testwork/Ordering/Cli/OrderController.php

--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -34,6 +34,7 @@ use Behat\Testwork\Filesystem\ServiceContainer\FilesystemExtension;
 use Behat\Testwork\Ordering\ServiceContainer\OrderingExtension;
 use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
 use Behat\Testwork\Output\ServiceContainer\OutputExtension;
+use Behat\Testwork\PathOptions\ServiceContainer\PathOptionsExtension;
 use Behat\Testwork\ServiceContainer\ServiceProcessor;
 use Behat\Testwork\Specification\ServiceContainer\SpecificationExtension;
 use Behat\Testwork\Suite\ServiceContainer\SuiteExtension;
@@ -83,6 +84,7 @@ final class ApplicationFactory extends BaseFactory
             new AutoloaderExtension(['' => '%paths.base%/features/bootstrap']),
             new SuiteExtension($processor),
             new OutputExtension('pretty', $this->getDefaultFormatterFactories($processor), $processor),
+            new PathOptionsExtension(),
             new ExceptionExtension($processor),
             new GherkinExtension($processor),
             new CallExtension($processor),

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -51,21 +51,18 @@ final class ListPrinter
 
     /**
      * @param ExceptionPresenter $exceptionPresenter deprecated , will be removed in the next major version
-     * @param string $basePath deprecated , will be removed in the next major version
+     * @param string $basePath
      */
     public function __construct(
         ResultToStringConverter $resultConverter,
         ExceptionPresenter $exceptionPresenter,
         TranslatorInterface $translator,
         string $basePath,
+        ?ConfigurablePathPrinter $configurablePathPrinter = null,
     ) {
         $this->resultConverter = $resultConverter;
         $this->translator = $translator;
-    }
-
-    public function setConfigurablePathPrinter(ConfigurablePathPrinter $configurablePathPrinter)
-    {
-        $this->configurablePathPrinter = $configurablePathPrinter;
+        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath, printAbsolutePaths: false);
     }
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
@@ -38,16 +38,15 @@ final class PrettyPathPrinter
      * Initializes printer.
      *
      * @param WidthCalculator $widthCalculator
-     * @param string          $basePath deprecated, will be removed in next major version
+     * @param string          $basePath
      */
-    public function __construct(WidthCalculator $widthCalculator, string $basePath)
-    {
+    public function __construct(
+        WidthCalculator $widthCalculator,
+        string $basePath,
+        ?ConfigurablePathPrinter $configurablePathPrinter = null,
+    ) {
         $this->widthCalculator = $widthCalculator;
-    }
-
-    public function setConfigurablePathPrinter(ConfigurablePathPrinter $configurablePathPrinter)
-    {
-        $this->configurablePathPrinter = $configurablePathPrinter;
+        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath, printAbsolutePaths: false);
     }
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
@@ -18,6 +18,7 @@ use Behat\Gherkin\Node\ScenarioLikeInterface as Scenario;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\OutputPrinter;
+use Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter;
 
 /**
  * Prints paths for scenarios, examples, backgrounds and steps.
@@ -30,21 +31,23 @@ final class PrettyPathPrinter
      * @var WidthCalculator
      */
     private $widthCalculator;
-    /**
-     * @var string
-     */
-    private $basePath;
+
+    private ConfigurablePathPrinter $configurablePathPrinter;
 
     /**
      * Initializes printer.
      *
      * @param WidthCalculator $widthCalculator
-     * @param string          $basePath
+     * @param string          $basePath deprecated, will be removed in next major version
      */
-    public function __construct(WidthCalculator $widthCalculator, $basePath)
+    public function __construct(WidthCalculator $widthCalculator, string $basePath)
     {
         $this->widthCalculator = $widthCalculator;
-        $this->basePath = $basePath;
+    }
+
+    public function setConfigurablePathPrinter(ConfigurablePathPrinter $configurablePathPrinter)
+    {
+        $this->configurablePathPrinter = $configurablePathPrinter;
     }
 
     /**
@@ -65,7 +68,7 @@ final class PrettyPathPrinter
             return;
         }
 
-        $fileAndLine = sprintf('%s:%s', $this->relativizePaths($feature->getFile()), $scenario->getLine());
+        $fileAndLine = sprintf('%s:%s', $this->configurablePathPrinter->processPathsInText($feature->getFile()), $scenario->getLine());
         $headerWidth = $this->widthCalculator->calculateScenarioHeaderWidth($scenario, $indentation);
         $scenarioWidth = $this->widthCalculator->calculateScenarioWidth($scenario, $indentation, 2);
         $spacing = str_repeat(' ', max(0, $scenarioWidth - $headerWidth));
@@ -117,21 +120,5 @@ final class PrettyPathPrinter
         $spacing = str_repeat(' ', max(0, $scenarioWidth - $stepWidth));
 
         $printer->writeln(sprintf('%s {+comment}# %s{-comment}', $spacing, $path));
-    }
-
-    /**
-     * Transforms path to relative.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    private function relativizePaths($path)
-    {
-        if (!$this->basePath) {
-            return $path;
-        }
-
-        return str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $path);
     }
 }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -18,6 +18,7 @@ use Behat\Config\Formatter\PrettyFormatter;
 use Behat\Testwork\Exception\ServiceContainer\ExceptionExtension;
 use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
 use Behat\Testwork\Output\ServiceContainer\OutputExtension;
+use Behat\Testwork\PathOptions\ServiceContainer\PathOptionsExtension;
 use Behat\Testwork\ServiceContainer\ServiceProcessor;
 use Behat\Testwork\Translator\ServiceContainer\TranslatorExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -219,8 +220,8 @@ class PrettyFormatterFactory implements FormatterFactory
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyPathPrinter', [
             new Reference('output.node.printer.pretty.width_calculator'),
             '%paths.base%',
+            new Reference(PathOptionsExtension::CONFIGURABLE_PATH_PRINTER_ID),
         ]);
-        $definition->addMethodCall(('setConfigurablePathPrinter'), [new Reference('configurable.path.printer')]);
         $container->setDefinition('output.node.printer.pretty.path', $definition);
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyScenarioPrinter', [
@@ -367,8 +368,8 @@ class PrettyFormatterFactory implements FormatterFactory
             new Reference(ExceptionExtension::PRESENTER_ID),
             new Reference(TranslatorExtension::TRANSLATOR_ID),
             '%paths.base%',
+            new Reference(PathOptionsExtension::CONFIGURABLE_PATH_PRINTER_ID),
         ]);
-        $definition->addMethodCall(('setConfigurablePathPrinter'), [new Reference('configurable.path.printer')]);
         $container->setDefinition('output.node.printer.list', $definition);
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyStatisticsPrinter', [

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -220,6 +220,7 @@ class PrettyFormatterFactory implements FormatterFactory
             new Reference('output.node.printer.pretty.width_calculator'),
             '%paths.base%',
         ]);
+        $definition->addMethodCall(('setConfigurablePathPrinter'), [new Reference('configurable.path.printer')]);
         $container->setDefinition('output.node.printer.pretty.path', $definition);
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyScenarioPrinter', [
@@ -367,6 +368,7 @@ class PrettyFormatterFactory implements FormatterFactory
             new Reference(TranslatorExtension::TRANSLATOR_ID),
             '%paths.base%',
         ]);
+        $definition->addMethodCall(('setConfigurablePathPrinter'), [new Reference('configurable.path.printer')]);
         $container->setDefinition('output.node.printer.list', $definition);
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Pretty\PrettyStatisticsPrinter', [

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -14,6 +14,7 @@ use Behat\Config\Formatter\ProgressFormatter;
 use Behat\Testwork\Exception\ServiceContainer\ExceptionExtension;
 use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
 use Behat\Testwork\Output\ServiceContainer\OutputExtension;
+use Behat\Testwork\PathOptions\ServiceContainer\PathOptionsExtension;
 use Behat\Testwork\ServiceContainer\ServiceProcessor;
 use Behat\Testwork\Translator\ServiceContainer\TranslatorExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -103,8 +104,8 @@ class ProgressFormatterFactory implements FormatterFactory
             new Reference(ExceptionExtension::PRESENTER_ID),
             new Reference(TranslatorExtension::TRANSLATOR_ID),
             '%paths.base%',
+            new Reference(PathOptionsExtension::CONFIGURABLE_PATH_PRINTER_ID),
         ]);
-        $definition->addMethodCall(('setConfigurablePathPrinter'), [new Reference('configurable.path.printer')]);
         $container->setDefinition('output.node.printer.list', $definition);
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Progress\ProgressStepPrinter', [

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -104,6 +104,7 @@ class ProgressFormatterFactory implements FormatterFactory
             new Reference(TranslatorExtension::TRANSLATOR_ID),
             '%paths.base%',
         ]);
+        $definition->addMethodCall(('setConfigurablePathPrinter'), [new Reference('configurable.path.printer')]);
         $container->setDefinition('output.node.printer.list', $definition);
 
         $definition = new Definition('Behat\Behat\Output\Node\Printer\Progress\ProgressStepPrinter', [

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -29,6 +29,8 @@ final class Profile implements ConfigConverterInterface
     private const FORMATTERS_SETTING = 'formatters';
     private const DEFINITIONS_SETTING = 'definitions';
     private const PRINT_UNUSED_DEFINITIONS_SETTING = 'print_unused_definitions';
+    private const PATH_OPTIONS_SETTING = 'path_options';
+    private const PRINT_ABSOLUTE_PATHS_SETTING = 'print_absolute_paths';
 
     private const DISABLE_FORMATTER_FUNCTION = 'disableFormatter';
     private const FORMATTER_FUNCTION = 'withFormatter';
@@ -36,6 +38,8 @@ final class Profile implements ConfigConverterInterface
     private const UNUSED_DEFINITIONS_FUNCTION = 'withPrintUnusedDefinitions';
     private const EXTENSION_FUNCTION = 'withExtension';
     private const SUITE_FUNCTION = 'withSuite';
+    private const PATH_OPTIONS_FUNCTION = 'withPathOptions';
+    private const PRINT_ABSOLUTE_PATHS_PARAMETER = 'printAbsolutePaths';
 
     public function __construct(
         private string $name,
@@ -102,6 +106,13 @@ final class Profile implements ConfigConverterInterface
         return $this;
     }
 
+    public function withPathOptions(bool $printAbsolutePaths): self
+    {
+        $this->settings[self::PATH_OPTIONS_SETTING][self::PRINT_ABSOLUTE_PATHS_SETTING] = $printAbsolutePaths;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->settings;
@@ -118,6 +129,7 @@ final class Profile implements ConfigConverterInterface
         $this->addFormattersToExpr($expr);
         $this->addFiltersToExpr($expr);
         $this->addUnusedDefinitionsToExpr($expr);
+        $this->addPathOptionsToExpr($expr);
         $this->addExtensionsToExpr($expr);
         $this->addSuitesToExpr($expr);
 
@@ -212,6 +224,22 @@ final class Profile implements ConfigConverterInterface
         unset($this->settings[self::DEFINITIONS_SETTING][self::PRINT_UNUSED_DEFINITIONS_SETTING]);
         if ($this->settings[self::DEFINITIONS_SETTING] === []) {
             unset($this->settings[self::DEFINITIONS_SETTING]);
+        }
+    }
+
+    private function addPathOptionsToExpr(Expr &$expr): void
+    {
+        if (!isset($this->settings[self::PATH_OPTIONS_SETTING][self::PRINT_ABSOLUTE_PATHS_SETTING])) {
+            return;
+        }
+        $expr = ConfigConverterTools::addMethodCall(
+            self::PATH_OPTIONS_FUNCTION,
+            [self::PRINT_ABSOLUTE_PATHS_PARAMETER => $this->settings[self::PATH_OPTIONS_SETTING][self::PRINT_ABSOLUTE_PATHS_SETTING]],
+            $expr
+        );
+        unset($this->settings[self::PATH_OPTIONS_SETTING][self::PRINT_ABSOLUTE_PATHS_SETTING]);
+        if ($this->settings[self::PATH_OPTIONS_SETTING] === []) {
+            unset($this->settings[self::PATH_OPTIONS_SETTING]);
         }
     }
 

--- a/src/Behat/Testwork/Exception/ExceptionPresenter.php
+++ b/src/Behat/Testwork/Exception/ExceptionPresenter.php
@@ -41,13 +41,9 @@ final class ExceptionPresenter
     public function __construct(
         ?string $basePath = null,
         private int $defaultVerbosity = OutputPrinter::VERBOSITY_NORMAL,
+        ?ConfigurablePathPrinter $configurablePathPrinter = null,
     ) {
-        $this->defaultVerbosity = $defaultVerbosity;
-    }
-
-    public function setConfigurablePathPrinter(ConfigurablePathPrinter $configurablePathPrinter)
-    {
-        $this->configurablePathPrinter = $configurablePathPrinter;
+        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath, printAbsolutePaths: false);
     }
 
     /**

--- a/src/Behat/Testwork/Exception/ExceptionPresenter.php
+++ b/src/Behat/Testwork/Exception/ExceptionPresenter.php
@@ -13,6 +13,7 @@ namespace Behat\Testwork\Exception;
 use Behat\Testwork\Call\Exception\FatalThrowableError;
 use Behat\Testwork\Exception\Stringer\ExceptionStringer;
 use Behat\Testwork\Output\Printer\OutputPrinter;
+use Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter;
 use Exception;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
@@ -25,37 +26,28 @@ use Throwable;
 final class ExceptionPresenter
 {
     /**
-     * @var string
-     */
-    private $basePath;
-
-    /**
      * @var ExceptionStringer[]
      */
     private $stringers = [];
-    /**
-     * @var integer
-     */
-    private $defaultVerbosity = OutputPrinter::VERBOSITY_NORMAL;
+
+    private ConfigurablePathPrinter $configurablePathPrinter;
 
     /**
      * Initializes presenter.
      *
-     * @param string  $basePath
+     * @param string  $basePath deprecated, will be removed in next major version
      * @param integer $defaultVerbosity
      */
-    public function __construct($basePath = null, $defaultVerbosity = OutputPrinter::VERBOSITY_NORMAL)
-    {
-        if (null !== $basePath) {
-            $realBasePath = realpath($basePath);
-
-            if ($realBasePath) {
-                $basePath = $realBasePath;
-            }
-        }
-
-        $this->basePath = $basePath;
+    public function __construct(
+        ?string $basePath = null,
+        private int $defaultVerbosity = OutputPrinter::VERBOSITY_NORMAL,
+    ) {
         $this->defaultVerbosity = $defaultVerbosity;
+    }
+
+    public function setConfigurablePathPrinter(ConfigurablePathPrinter $configurablePathPrinter)
+    {
+        $this->configurablePathPrinter = $configurablePathPrinter;
     }
 
     /**
@@ -91,7 +83,7 @@ final class ExceptionPresenter
 
         foreach ($this->stringers as $stringer) {
             if ($stringer->supportsException($exception)) {
-                return $this->relativizePaths($stringer->stringException($exception, $verbosity));
+                return $this->configurablePathPrinter->processPathsInText($stringer->stringException($exception, $verbosity));
             }
         }
 
@@ -100,10 +92,10 @@ final class ExceptionPresenter
                 $exception = $this->removeBehatCallsFromTrace($exception);
             }
 
-            return $this->relativizePaths(trim($exception));
+            return $this->configurablePathPrinter->processPathsInText(trim($exception));
         }
 
-        return trim($this->relativizePaths($exception->getMessage()) . ' (' . get_class($exception) . ')');
+        return trim($this->configurablePathPrinter->processPathsInText($exception->getMessage()) . ' (' . get_class($exception) . ')');
     }
 
     private function removeBehatCallsFromTrace(Exception $exception)
@@ -132,21 +124,5 @@ final class ExceptionPresenter
             PHP_EOL,
             $traceOutput
         );
-    }
-
-    /**
-     * Relativizes absolute paths in the text.
-     *
-     * @param string $text
-     *
-     * @return string
-     */
-    private function relativizePaths($text)
-    {
-        if (!$this->basePath) {
-            return $text;
-        }
-
-        return str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $text);
     }
 }

--- a/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
+++ b/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
@@ -12,6 +12,7 @@ namespace Behat\Testwork\Exception\ServiceContainer;
 
 use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\Output\Printer\OutputPrinter;
+use Behat\Testwork\PathOptions\ServiceContainer\PathOptionsExtension;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Behat\Testwork\ServiceContainer\ServiceProcessor;
@@ -117,8 +118,8 @@ final class ExceptionExtension implements Extension
         $definition = new Definition('Behat\Testwork\Exception\ExceptionPresenter', [
             '%paths.base%',
             $verbosity,
+            new Reference(PathOptionsExtension::CONFIGURABLE_PATH_PRINTER_ID),
         ]);
-        $definition->addMethodCall(('setConfigurablePathPrinter'), [new Reference('configurable.path.printer')]);
         $container->setDefinition(self::PRESENTER_ID, $definition);
     }
 

--- a/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
+++ b/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
@@ -118,6 +118,7 @@ final class ExceptionExtension implements Extension
             '%paths.base%',
             $verbosity,
         ]);
+        $definition->addMethodCall(('setConfigurablePathPrinter'), [new Reference('configurable.path.printer')]);
         $container->setDefinition(self::PRESENTER_ID, $definition);
     }
 

--- a/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
+++ b/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\PathOptions\Cli;
+
+use Behat\Testwork\Cli\Controller;
+use Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Configures the printing of paths in the output
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+class PathOptionsController implements Controller
+{
+    public function __construct(
+        private ConfigurablePathPrinter $configurablePathPrinter,
+    ) {
+    }
+
+    public function configure(Command $command)
+    {
+        $command
+            ->addOption(
+                '--print-absolute-paths', null, InputOption::VALUE_NONE,
+                'Print absolute paths in output'
+            )
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $printAbsolutePaths = $input->getOption('print-absolute-paths');
+
+        $this->configurePrintPaths($printAbsolutePaths);
+        return null;
+    }
+
+    private function configurePrintPaths(bool $printAbsolutePaths): void
+    {
+        if ($printAbsolutePaths) {
+            $this->configurablePathPrinter->setPrintAbsolutePaths($printAbsolutePaths);
+        }
+    }
+}

--- a/src/Behat/Testwork/PathOptions/Printer/ConfigurablePathPrinter.php
+++ b/src/Behat/Testwork/PathOptions/Printer/ConfigurablePathPrinter.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\PathOptions\Printer;
+
+final class ConfigurablePathPrinter
+{
+    private string $basePath;
+
+    public function __construct(
+        string $basePath,
+        private bool $printAbsolutePaths,
+    ) {
+        $realBasePath = realpath($basePath);
+
+        if ($realBasePath) {
+            $basePath = $realBasePath;
+        }
+
+        $this->basePath = $basePath;
+    }
+
+    public function setPrintAbsolutePaths(bool $printAbsolutePaths): void
+    {
+        $this->printAbsolutePaths = $printAbsolutePaths;
+    }
+
+    /**
+     * Conditionally transforms paths to relative.
+     */
+    public function processPathsInText(string $text): string
+    {
+        if ($this->printAbsolutePaths === true) {
+            return $text;
+        }
+
+        return str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $text);
+    }
+}

--- a/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
+++ b/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\PathOptions\ServiceContainer;
+
+use Behat\Testwork\Cli\ServiceContainer\CliExtension;
+use Behat\Testwork\ServiceContainer\Extension;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Provides management of paths in the output.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class PathOptionsExtension implements Extension
+{
+    public function getConfigKey()
+    {
+        return 'path_options';
+    }
+
+    public function initialize(ExtensionManager $extensionManager)
+    {
+    }
+
+    public function configure(ArrayNodeDefinition $builder)
+    {
+        $builder
+            ->addDefaultsIfNotSet()
+            ->children()
+            ->scalarNode('print_absolute_paths')
+            ->defaultFalse()
+        ;
+    }
+
+    public function load(ContainerBuilder $container, array $config)
+    {
+        $this->loadConfigurablePathPrinter($container, $config['print_absolute_paths']);
+        $this->loadPathOptionsController($container);
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+    }
+
+    private function loadConfigurablePathPrinter(ContainerBuilder $container, bool $printAbsolutePaths): void
+    {
+        $definition = new Definition('Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter', [
+            '%paths.base%',
+            $printAbsolutePaths,
+        ]);
+        $container->setDefinition('configurable.path.printer', $definition);
+    }
+
+    private function loadPathOptionsController(ContainerBuilder $container)
+    {
+        $definition = new Definition('Behat\Testwork\PathOptions\Cli\PathOptionsController', [
+            new Reference('configurable.path.printer'),
+        ]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 1000]);
+        $container->setDefinition(CliExtension::CONTROLLER_TAG . '.path', $definition);
+    }
+
+}

--- a/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
+++ b/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
@@ -25,6 +25,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class PathOptionsExtension implements Extension
 {
+    public const CONFIGURABLE_PATH_PRINTER_ID = 'configurable.path.printer';
+
     public function getConfigKey()
     {
         return 'path_options';
@@ -60,13 +62,13 @@ final class PathOptionsExtension implements Extension
             '%paths.base%',
             $printAbsolutePaths,
         ]);
-        $container->setDefinition('configurable.path.printer', $definition);
+        $container->setDefinition(self::CONFIGURABLE_PATH_PRINTER_ID, $definition);
     }
 
     private function loadPathOptionsController(ContainerBuilder $container)
     {
         $definition = new Definition('Behat\Testwork\PathOptions\Cli\PathOptionsController', [
-            new Reference('configurable.path.printer'),
+            new Reference(self::CONFIGURABLE_PATH_PRINTER_ID),
         ]);
         $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 1000]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.path', $definition);

--- a/tests/Fixtures/ConvertConfig/full_configuration.yaml
+++ b/tests/Fixtures/ConvertConfig/full_configuration.yaml
@@ -26,6 +26,8 @@ default:
             role: "admin"
     definitions:
         print_unused_definitions: true
+    path_options:
+        print_absolute_paths: true
     extensions:
         custom_extension.php: ~
 

--- a/tests/Fixtures/ConvertConfig/path_options.yaml
+++ b/tests/Fixtures/ConvertConfig/path_options.yaml
@@ -1,0 +1,3 @@
+default:
+    path_options:
+        print_absolute_paths: true

--- a/tests/Fixtures/PrintAbsolutePaths/absolute_paths.yaml
+++ b/tests/Fixtures/PrintAbsolutePaths/absolute_paths.yaml
@@ -1,0 +1,3 @@
+default:
+    path_options:
+        print_absolute_paths: true

--- a/tests/Fixtures/PrintAbsolutePaths/absolute_paths.yaml
+++ b/tests/Fixtures/PrintAbsolutePaths/absolute_paths.yaml
@@ -1,3 +1,0 @@
-default:
-    path_options:
-        print_absolute_paths: true

--- a/tests/Fixtures/PrintAbsolutePaths/behat.php
+++ b/tests/Fixtures/PrintAbsolutePaths/behat.php
@@ -1,0 +1,10 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+
+return (new Config())
+    ->withProfile((new Profile('default')))
+    ->withProfile((new Profile('absolute_paths'))
+        ->withPathOptions(printAbsolutePaths: true)
+    );

--- a/tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php
@@ -1,0 +1,18 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Step\Given;
+
+class FeatureContext implements Context
+{
+    #[Given('I have a passing step')]
+    public function iHaveAPassingStep()
+    {
+    }
+
+    #[Given('I have a step that throws an exception')]
+    public function iHaveAFailingStep()
+    {
+        $a = $b;
+    }
+}

--- a/tests/Fixtures/PrintAbsolutePaths/features/test.feature
+++ b/tests/Fixtures/PrintAbsolutePaths/features/test.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Scenario:
+    Given I have a passing step
+    And I have a step that throws an exception


### PR DESCRIPTION
Currently we have several places in our code where we handle paths to relativize them. This PR replaces them with a single service that can print paths and which is configurable. And we add a new option which can be used to tell Behat to print all paths as absolute instead of relative paths. This option is available on the command line and also in the Php and Yaml configs