### PR TITLE
bug: Keep options for JUnit formatter when converting config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "behat/transliterator": "^1.5",
         "composer-runtime-api": "^2.2",
         "composer/xdebug-handler": "^3.0",
-        "nikic/php-parser": "^5.0",
+        "nikic/php-parser": "^5.2",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -382,6 +382,7 @@ Feature: Convert config
       use Behat\Config\Config;
       use Behat\Config\Extension;
       use Behat\Config\Formatter\Formatter;
+      use Behat\Config\Formatter\JUnitFormatter;
       use Behat\Config\Formatter\PrettyFormatter;
       use Behat\Config\Formatter\ProgressFormatter;
       use Behat\Config\Profile;
@@ -396,7 +397,10 @@ Feature: Convert config
                   'other_property' => 'value',
               ]))
                   ->withOutputVerbosity(2))
-              ->withExtension(new Extension('custom_extension.php')));
+              ->withExtension(new Extension('custom_extension.php')))
+          ->withProfile((new Profile('with_junit'))
+              ->withFormatter((new JUnitFormatter())
+                  ->withOutputPath('build/logs/junit')));
       """
     And the temp "formatters.yaml" file should have been removed
 

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -385,6 +385,7 @@ Feature: Convert config
       use Behat\Config\Formatter\JUnitFormatter;
       use Behat\Config\Formatter\PrettyFormatter;
       use Behat\Config\Formatter\ProgressFormatter;
+      use Behat\Config\Formatter\ShowOutputOption;
       use Behat\Config\Profile;
 
       return (new Config())
@@ -398,9 +399,11 @@ Feature: Convert config
               ]))
                   ->withOutputVerbosity(2))
               ->withExtension(new Extension('custom_extension.php')))
-          ->withProfile((new Profile('with_junit'))
+          ->withProfile((new Profile('with_options'))
               ->withFormatter((new JUnitFormatter())
-                  ->withOutputPath('build/logs/junit')));
+                  ->withOutputPath('build/logs/junit'))
+              ->withFormatter(new ProgressFormatter(showOutput: ShowOutputOption::OnFail))
+              ->withFormatter(new PrettyFormatter(expand: true, showOutput: ShowOutputOption::No)));
       """
     And the temp "formatters.yaml" file should have been removed
 

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -402,8 +402,16 @@ Feature: Convert config
           ->withProfile((new Profile('with_options'))
               ->withFormatter((new JUnitFormatter())
                   ->withOutputPath('build/logs/junit'))
-              ->withFormatter(new ProgressFormatter(showOutput: ShowOutputOption::OnFail))
-              ->withFormatter(new PrettyFormatter(expand: true, showOutput: ShowOutputOption::No)));
+              ->withFormatter((new ProgressFormatter(showOutput: ShowOutputOption::OnFail))
+                  ->withOutputVerbosity(3))
+              ->withFormatter((new PrettyFormatter(expand: true, showOutput: ShowOutputOption::No))
+                  ->withOutputStyles([
+                      'failed' => [
+                          'white',
+                          'red',
+                          'blink',
+                      ],
+                  ])));
       """
     And the temp "formatters.yaml" file should have been removed
 

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -156,7 +156,7 @@ final class Profile implements ConfigConverterInterface
                 $formatter = match ($name) {
                     PrettyFormatter::NAME => $formatterSettings === true ? new PrettyFormatter() : new PrettyFormatter(...$formatterSettings),
                     ProgressFormatter::NAME => $formatterSettings === true ? new ProgressFormatter() : new ProgressFormatter(...$formatterSettings),
-                    JUnitFormatter::NAME => new JUnitFormatter(),
+                    JUnitFormatter::NAME => $formatterSettings === true ? new JUnitFormatter() : new JUnitFormatter(...$formatterSettings),
                     default => $formatterSettings === true ? new Formatter($name) : new Formatter($name, $formatterSettings),
                 };
                 $expr = ConfigConverterTools::addMethodCall(

--- a/tests/Fixtures/ConvertConfig/custom_extension.php
+++ b/tests/Fixtures/ConvertConfig/custom_extension.php
@@ -53,6 +53,7 @@ class CustomFormatter implements Formatter
 
     public static function getSubscribedEvents()
     {
+        return [];
     }
 
     public function getName()

--- a/tests/Fixtures/ConvertConfig/formatters.yaml
+++ b/tests/Fixtures/ConvertConfig/formatters.yaml
@@ -10,3 +10,8 @@ default:
             other_property: value
     extensions:
         custom_extension.php: ~
+
+with_junit:
+    formatters:
+        junit:
+            output_path: build/logs/junit

--- a/tests/Fixtures/ConvertConfig/formatters.yaml
+++ b/tests/Fixtures/ConvertConfig/formatters.yaml
@@ -11,7 +11,13 @@ default:
     extensions:
         custom_extension.php: ~
 
-with_junit:
+with_options:
     formatters:
         junit:
             output_path: build/logs/junit
+        progress:
+            timer: true
+            show_output: on-fail
+        pretty:
+            expand: true
+            show_output: no

--- a/tests/Fixtures/ConvertConfig/formatters.yaml
+++ b/tests/Fixtures/ConvertConfig/formatters.yaml
@@ -18,6 +18,9 @@ with_options:
         progress:
             timer: true
             show_output: on-fail
+            output_verbosity: 3
         pretty:
             expand: true
             show_output: no
+            output_styles:
+                failed: [ white, red, blink ]


### PR DESCRIPTION
Although the JUnit formatter has no options of its own, it does support the standard (output_path, etc) options. 

These were being lost when converting config from YAML to PHP.