### PR TITLE
feature: Convert `output_verbosity` values to constants in PHP config

### DIFF
--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -387,6 +387,7 @@ Feature: Convert config
       use Behat\Config\Formatter\ProgressFormatter;
       use Behat\Config\Formatter\ShowOutputOption;
       use Behat\Config\Profile;
+      use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 
       return (new Config())
           ->withProfile((new Profile('default'))
@@ -397,13 +398,13 @@ Feature: Convert config
               ->withFormatter((new Formatter('custom_formatter', [
                   'other_property' => 'value',
               ]))
-                  ->withOutputVerbosity(2))
+                  ->withOutputVerbosity(OutputFactory::VERBOSITY_VERBOSE))
               ->withExtension(new Extension('custom_extension.php')))
           ->withProfile((new Profile('with_options'))
               ->withFormatter((new JUnitFormatter())
                   ->withOutputPath('build/logs/junit'))
               ->withFormatter((new ProgressFormatter(showOutput: ShowOutputOption::OnFail))
-                  ->withOutputVerbosity(3))
+                  ->withOutputVerbosity(OutputFactory::VERBOSITY_VERY_VERBOSE))
               ->withFormatter((new PrettyFormatter(expand: true, showOutput: ShowOutputOption::No))
                   ->withOutputStyles([
                       'failed' => [
@@ -436,6 +437,7 @@ Feature: Convert config
       use Behat\Config\Formatter\ProgressFormatter;
       use Behat\Config\Profile;
       use Behat\Config\Suite;
+      use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 
       return (new Config())
           ->import('imported.php')
@@ -447,7 +449,7 @@ Feature: Convert config
               ->withFormatter((new Formatter('custom_formatter', [
                   'other_property' => 'value',
               ]))
-                  ->withOutputVerbosity(2))
+                  ->withOutputVerbosity(OutputFactory::VERBOSITY_VERBOSE))
               ->withFilter(new NameFilter('john'))
               ->withFilter(new RoleFilter('admin'))
               ->withPrintUnusedDefinitions(true)

--- a/src/Behat/Config/Converter/ConfigConverterTools.php
+++ b/src/Behat/Config/Converter/ConfigConverterTools.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Behat\Config\Converter;
 
+use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 use PhpParser\BuilderFactory;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Use_;
+use ReflectionClass;
+use ReflectionClassConstant;
 
 class ConfigConverterTools
 {
@@ -50,14 +53,28 @@ class ConfigConverterTools
     private static function replaceClassReferences(array $arguments): array
     {
         return array_map(
-            static fn ($arg) => is_string($arg) && class_exists($arg) ? self::getClassReference($arg) : $arg,
+            static fn ($arg) => is_string($arg) && class_exists($arg)
+                ? self::getClassConstReference($arg, 'class')
+                : $arg,
             $arguments,
         );
     }
 
-    private static function getClassReference(string $className): Expr
+    private static function getClassConstReference(string $className, string $constantName): Expr
     {
         $builderFactory = self::getBuilderFactory();
-        return $builderFactory->classConstFetch($className, 'class');
+        return $builderFactory->classConstFetch($className, $constantName);
+    }
+
+    public static function findReferenceToClassConstant(string $className, mixed $settingValue): mixed
+    {
+        $consts = (new ReflectionClass($className))->getConstants(ReflectionClassConstant::IS_PUBLIC);
+        foreach ($consts as $constantName => $constantValue) {
+            if ($settingValue === $constantValue) {
+                return ConfigConverterTools::getClassConstReference($className, $constantName);
+            }
+        }
+        // Can't find a constant for it, just return the original value
+        return $settingValue;
     }
 }

--- a/src/Behat/Config/Formatter/Formatter.php
+++ b/src/Behat/Config/Formatter/Formatter.php
@@ -6,7 +6,10 @@ namespace Behat\Config\Formatter;
 
 use Behat\Config\ConfigConverterInterface;
 use Behat\Config\Converter\ConfigConverterTools;
+use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 use PhpParser\Node\Expr;
+use ReflectionClass;
+use ReflectionClassConstant;
 
 class Formatter implements FormatterConfigInterface, ConfigConverterInterface
 {
@@ -132,6 +135,9 @@ class Formatter implements FormatterConfigInterface, ConfigConverterInterface
         foreach ($this->settings as $settingName => $setting) {
             $functionName = Formatter::FORMATTER_FUNCTION_NAMES_PER_SETTING[$settingName] ?? null;
             if ($functionName !== null) {
+                if ($settingName === self::OUTPUT_VERBOSITY_SETTING) {
+                    $setting = ConfigConverterTools::findReferenceToClassConstant(OutputFactory::class, $setting);
+                }
                 $expr = ConfigConverterTools::addMethodCall(
                     $functionName,
                     [$setting],


### PR DESCRIPTION
The `->withOutputVerbosity` formatter config method in PHP is expected to take an `OutputVerbosity::VERBOSITY_*` constant value (as per the phpdoc for that method).

If the user's YAML config contains one of the valid values as an integer we can convert it to a constant reference. This will make the PHP file clearer without e.g. needing a separate comment as might have been present in the YAML.

If we don't recognise the value (it may be invalid, or e.g. an env var) then we just convert it as the original scalar value.