### PR TITLE
Support (and convert) PHP config for tester options

### DIFF
--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -451,7 +451,7 @@ Feature: Convert config
           ->withProfile(new Profile('default'))
           ->withProfile((new Profile('ignore-errors'))
               ->withTesterOptions((new TesterOptions())
-                  ->withErrorReporting(22527)))
+                  ->withErrorReporting(E_ALL & ~E_DEPRECATED)))
           ->withProfile((new Profile('not-strict'))
               ->withTesterOptions((new TesterOptions())
                   ->withStrictResultInterpretation(false)))
@@ -460,7 +460,7 @@ Feature: Convert config
                   ->withStrictResultInterpretation()
                   ->withStopOnFailure(false)
                   ->withSkipAllTests()
-                  ->withErrorReporting(24565)));
+                  ->withErrorReporting(E_ALL & ~(E_WARNING | E_NOTICE | E_DEPRECATED))));
       """
     And the temp "tester_options.yaml" file should have been removed
 
@@ -518,7 +518,7 @@ Feature: Convert config
           ->withProfile((new Profile('other'))
               ->disableFormatter('pretty')
               ->withTesterOptions((new TesterOptions())
-                  ->withErrorReporting(1)))
+                  ->withErrorReporting(E_ERROR)))
           ->withPreferredProfile('other');
       """
     And the temp "imported.php" file should be like:

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -366,7 +366,7 @@ Feature: Convert config
 
       return (new Config())
           ->withProfile((new Profile('default'))
-              ->withPrintUnusedDefinitions(true));
+              ->withPrintUnusedDefinitions());
       """
     And the temp "unused_definitions.yaml" file should have been removed
 
@@ -457,9 +457,9 @@ Feature: Convert config
                   ->withStrictResultInterpretation(false)))
           ->withProfile((new Profile('complete'))
               ->withTesterOptions((new TesterOptions())
-                  ->withStrictResultInterpretation(true)
+                  ->withStrictResultInterpretation()
                   ->withStopOnFailure(false)
-                  ->withSkipAllTests(true)
+                  ->withSkipAllTests()
                   ->withErrorReporting(24565)));
       """
     And the temp "tester_options.yaml" file should have been removed
@@ -501,10 +501,10 @@ Feature: Convert config
                   ->withOutputVerbosity(OutputFactory::VERBOSITY_VERBOSE))
               ->withFilter(new NameFilter('john'))
               ->withFilter(new RoleFilter('admin'))
-              ->withPrintUnusedDefinitions(true)
+              ->withPrintUnusedDefinitions()
               ->withPathOptions(printAbsolutePaths: true)
               ->withTesterOptions((new TesterOptions())
-                  ->withStrictResultInterpretation(true))
+                  ->withStrictResultInterpretation())
               ->withExtension(new Extension('custom_extension.php'))
               ->withSuite((new Suite('my_suite'))
                   ->addContext(

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -434,6 +434,36 @@ Feature: Convert config
       """
     And the temp "path_options.yaml" file should have been removed
 
+  Scenario: Tester options
+    Given I copy the "tester_options.yaml" file to the temp folder
+    When I run behat with the following additional options:
+      | option   | value                                    |
+      | --config | {SYSTEM_TMP_DIR}/tester_options.yaml |
+    Then the temp "tester_options.php" file should be like:
+      """
+      <?php
+
+      use Behat\Config\Config;
+      use Behat\Config\Profile;
+      use Behat\Config\TesterOptions;
+
+      return (new Config())
+          ->withProfile(new Profile('default'))
+          ->withProfile((new Profile('ignore-errors'))
+              ->withTesterOptions((new TesterOptions())
+                  ->withErrorReporting(22527)))
+          ->withProfile((new Profile('not-strict'))
+              ->withTesterOptions((new TesterOptions())
+                  ->withStrictResultInterpretation(false)))
+          ->withProfile((new Profile('complete'))
+              ->withTesterOptions((new TesterOptions())
+                  ->withStrictResultInterpretation(true)
+                  ->withStopOnFailure(false)
+                  ->withSkipAllTests(true)
+                  ->withErrorReporting(24565)));
+      """
+    And the temp "tester_options.yaml" file should have been removed
+
   Scenario: Full configuration
     When I copy the "full_configuration.yaml" file to the temp folder
     And I copy the "imported.yaml" file to the temp folder
@@ -455,6 +485,7 @@ Feature: Convert config
       use Behat\Config\Formatter\ProgressFormatter;
       use Behat\Config\Profile;
       use Behat\Config\Suite;
+      use Behat\Config\TesterOptions;
       use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 
       return (new Config())
@@ -472,6 +503,8 @@ Feature: Convert config
               ->withFilter(new RoleFilter('admin'))
               ->withPrintUnusedDefinitions(true)
               ->withPathOptions(printAbsolutePaths: true)
+              ->withTesterOptions((new TesterOptions())
+                  ->withStrictResultInterpretation(true))
               ->withExtension(new Extension('custom_extension.php'))
               ->withSuite((new Suite('my_suite'))
                   ->addContext(
@@ -483,7 +516,9 @@ Feature: Convert config
                   ->withPaths('one.feature')
                   ->withFilter(new TagFilter('@run'))))
           ->withProfile((new Profile('other'))
-              ->disableFormatter('pretty'))
+              ->disableFormatter('pretty')
+              ->withTesterOptions((new TesterOptions())
+                  ->withErrorReporting(1)))
           ->withPreferredProfile('other');
       """
     And the temp "imported.php" file should be like:

--- a/src/Behat/Config/Config.php
+++ b/src/Behat/Config/Config.php
@@ -71,6 +71,7 @@ final class Config implements ConfigInterface, ConfigConverterInterface
         foreach ($this->settings as $settingsName => $settings) {
             if ($settingsName === self::PREFERRED_PROFILE_NAME_SETTING) {
                 $expr = ConfigConverterTools::addMethodCall(
+                    self::class,
                     self::PREFERRED_PROFILE_FUNCTION,
                     [$settings],
                     $expr
@@ -82,6 +83,7 @@ final class Config implements ConfigInterface, ConfigConverterInterface
                     $arguments = [$settings];
                 }
                 $expr = ConfigConverterTools::addMethodCall(
+                    self::class,
                     self::IMPORT_FUNCTION,
                     $arguments,
                     $expr
@@ -89,6 +91,7 @@ final class Config implements ConfigInterface, ConfigConverterInterface
             } else {
                 $profile = new Profile($settingsName, $settings ?? []);
                 $expr = ConfigConverterTools::addMethodCall(
+                    self::class,
                     self::PROFILE_FUNCTION,
                     [$profile->toPhpExpr()],
                     $expr

--- a/src/Behat/Config/Converter/ConfigConverterTools.php
+++ b/src/Behat/Config/Converter/ConfigConverterTools.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Behat\Config\Converter;
 
-use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 use PhpParser\BuilderFactory;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\New_;
@@ -12,16 +11,72 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Use_;
 use ReflectionClass;
 use ReflectionClassConstant;
+use ReflectionMethod;
 
 class ConfigConverterTools
 {
     private static ?BuilderFactory $builderFactory = null;
 
-    public static function addMethodCall(string $methodName, array $arguments, Expr $expr): Expr
+    public static function addMethodCall(string $class, string $methodName, array $arguments, Expr $expr): Expr
     {
         $builderFactory = self::getBuilderFactory();
+        $arguments = self::removeDefaultArguments((new ReflectionClass($class))->getMethod($methodName), $arguments);
         $args = $builderFactory->args(self::replaceClassReferences($arguments));
         return $builderFactory->methodCall($expr, $methodName, $args);
+    }
+
+    private static function removeDefaultArguments(ReflectionMethod $method, array $arguments): array
+    {
+        $hasRemovedAny = false;
+        $result = [];
+        foreach ($method->getParameters() as $index => $parameter) {
+            if ($parameter->isVariadic()) {
+                // We can't do anything useful (easily) for methods with variadics, just return the originals
+                return $arguments;
+            }
+
+            // Config objects can export their method arguments as positional or named arguments.
+            $argKey = array_key_exists($parameter->getName(), $arguments) ? $parameter->getName() : $index;
+
+            // The Config object must provide a value for every argument (defaults are stripped here). If we are
+            // missing arguments, that implies the ->toPhpExpr implementation is out of sync with the method definition.
+            assert(
+                array_key_exists($argKey, $arguments),
+                sprintf(
+                    'Missing argument #%d (%s) for %s::%s',
+                    $index,
+                    $parameter->getName(),
+                    $method->getDeclaringClass()->getName(),
+                    $method->getName(),
+                ),
+            );
+
+            $argValue = $arguments[$argKey];
+            if ($parameter->isDefaultValueAvailable() && $parameter->getDefaultValue() === $argValue) {
+                // We can skip this, it has the default value. That means we'll need to specify any following arguments
+                // by name even if we were given them as positional.
+                $hasRemovedAny = true;
+            } else {
+                $result[($hasRemovedAny ? $parameter->getName() : $argKey)] = $argValue;
+            }
+
+            // Record that this argument has been used
+            unset($arguments[$argKey]);
+        }
+
+        // We should have applied all arguments that were provided. If not, that implies the ->toPhpExpr implementation
+        // is out of sync with the method definition.
+        assert(
+            $arguments === [],
+            sprintf(
+                'Too many arguments provided for %s::%s (%s)',
+                $method->getDeclaringClass()->getName(),
+                $method->getName(),
+                implode(', ', array_keys($arguments)),
+            ),
+        );
+
+        return $result;
     }
 
     public static function createObject(string $className): New_

--- a/src/Behat/Config/Formatter/Formatter.php
+++ b/src/Behat/Config/Formatter/Formatter.php
@@ -139,6 +139,7 @@ class Formatter implements FormatterConfigInterface, ConfigConverterInterface
                     $setting = ConfigConverterTools::findReferenceToClassConstant(OutputFactory::class, $setting);
                 }
                 $expr = ConfigConverterTools::addMethodCall(
+                    self::class,
                     $functionName,
                     [$setting],
                     $expr

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -163,6 +163,7 @@ final class Profile implements ConfigConverterInterface
         foreach ($this->settings[self::FORMATTERS_SETTING] as $name => $formatterSettings) {
             if ($formatterSettings === false) {
                 $expr = ConfigConverterTools::addMethodCall(
+                    self::class,
                     self::DISABLE_FORMATTER_FUNCTION,
                     [$name],
                     $expr
@@ -184,6 +185,7 @@ final class Profile implements ConfigConverterInterface
                     default => $formatterSettings === true ? new Formatter($name) : new Formatter($name, $formatterSettings),
                 };
                 $expr = ConfigConverterTools::addMethodCall(
+                    self::class,
                     self::FORMATTER_FUNCTION,
                     [$formatter->toPhpExpr()],
                     $expr
@@ -208,6 +210,7 @@ final class Profile implements ConfigConverterInterface
             };
             if ($filter !== null) {
                 $expr = ConfigConverterTools::addMethodCall(
+                    self::class,
                     self::FILTER_FUNCTION,
                     [$filter->toPhpExpr()],
                     $expr
@@ -229,6 +232,7 @@ final class Profile implements ConfigConverterInterface
             return;
         }
         $expr = ConfigConverterTools::addMethodCall(
+            self::class,
             self::UNUSED_DEFINITIONS_FUNCTION,
             [$this->settings[self::DEFINITIONS_SETTING][self::PRINT_UNUSED_DEFINITIONS_SETTING]],
             $expr
@@ -245,6 +249,7 @@ final class Profile implements ConfigConverterInterface
             return;
         }
         $expr = ConfigConverterTools::addMethodCall(
+            self::class,
             self::PATH_OPTIONS_FUNCTION,
             [self::PRINT_ABSOLUTE_PATHS_PARAMETER => $this->settings[self::PATH_OPTIONS_SETTING][self::PRINT_ABSOLUTE_PATHS_SETTING]],
             $expr
@@ -263,6 +268,7 @@ final class Profile implements ConfigConverterInterface
         }
 
         $expr = ConfigConverterTools::addMethodCall(
+            self::class,
             self::TESTER_OPTIONS_FUNCTION,
             [$optionsObject->toPhpExpr()],
             $expr,
@@ -278,6 +284,7 @@ final class Profile implements ConfigConverterInterface
             $extensionObject = new Extension($name, $extensionSettings ?? []);
 
             $expr = ConfigConverterTools::addMethodCall(
+                self::class,
                 self::EXTENSION_FUNCTION,
                 [$extensionObject->toPhpExpr()],
                 $expr
@@ -294,6 +301,7 @@ final class Profile implements ConfigConverterInterface
         foreach ($this->settings[self::SUITES_SETTING] as $name => $suiteSettings) {
             $suiteObject = new Suite($name, $suiteSettings ?? []);
             $expr = ConfigConverterTools::addMethodCall(
+                self::class,
                 self::SUITE_FUNCTION,
                 [$suiteObject->toPhpExpr()],
                 $expr

--- a/src/Behat/Config/Suite.php
+++ b/src/Behat/Config/Suite.php
@@ -117,7 +117,7 @@ final class Suite implements ConfigConverterInterface
 
         if (!$hasAnyWithArguments) {
             // All the contexts are just class names, we can add them as a single `->withContexts` call
-            $expr = ConfigConverterTools::addMethodCall(self::WITH_CONTEXTS_FUNCTION, $contexts, $expr);
+            $expr = ConfigConverterTools::addMethodCall(self::class, self::WITH_CONTEXTS_FUNCTION, $contexts, $expr);
             return;
         }
 
@@ -131,9 +131,9 @@ final class Suite implements ConfigConverterInterface
                     array_shift($contextConfig),
                 ];
             } else {
-                $args = [$contextConfig];
+                $args = [$contextConfig, []];
             }
-            $expr = ConfigConverterTools::addMethodCall(self::ADD_CONTEXT_FUNCTION, $args, $expr);
+            $expr = ConfigConverterTools::addMethodCall(self::class, self::ADD_CONTEXT_FUNCTION, $args, $expr);
         }
     }
 
@@ -141,6 +141,7 @@ final class Suite implements ConfigConverterInterface
     {
         if (isset($this->settings[self::PATHS_SETTING])) {
             $expr = ConfigConverterTools::addMethodCall(
+                self::class,
                 self::PATHS_FUNCTION,
                 $this->settings[self::PATHS_SETTING],
                 $expr
@@ -162,6 +163,7 @@ final class Suite implements ConfigConverterInterface
                 };
                 if ($filter !== null) {
                     $expr = ConfigConverterTools::addMethodCall(
+                        self::class,
                         self::FILTER_FUNCTION,
                         [$filter->toPhpExpr()],
                         $expr

--- a/src/Behat/Config/TesterOptions.php
+++ b/src/Behat/Config/TesterOptions.php
@@ -118,6 +118,9 @@ final class TesterOptions implements ConfigConverterInterface
         foreach ($this->settings as $group => $groupSettings) {
             foreach ($groupSettings as $settingName => $setting) {
                 $functionName = self::FUNCTION_NAMES_PER_SETTING[$group][$settingName] ?? null;
+                if ($settingName === self::ERROR_REPORTING_SETTING) {
+                    $setting = ConfigConverterTools::errorReportingToConstants($setting);
+                }
                 if ($functionName) {
                     $expr = ConfigConverterTools::addMethodCall(
                         self::class,

--- a/src/Behat/Config/TesterOptions.php
+++ b/src/Behat/Config/TesterOptions.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Behat\Config;
+
+use Behat\Config\Converter\ConfigConverterTools;
+use PhpParser\Node\Expr;
+
+final class TesterOptions implements ConfigConverterInterface
+{
+    private const TESTERS_SETTINGS_GROUP = 'testers';
+
+    private const CALLS_SETTINGS_GROUP = 'calls';
+
+    private const STRICT_SETTING = 'strict';
+
+    private const STOP_ON_FAILURE_SETTING = 'stop_on_failure';
+
+    private const SKIP_SETTING = 'skip';
+
+    private const ERROR_REPORTING_SETTING = 'error_reporting';
+
+    private const FUNCTION_NAMES_PER_SETTING = [
+        self::CALLS_SETTINGS_GROUP => [
+            self::ERROR_REPORTING_SETTING => 'withErrorReporting',
+        ],
+        self::TESTERS_SETTINGS_GROUP => [
+            self::STOP_ON_FAILURE_SETTING => 'withStopOnFailure',
+            self::SKIP_SETTING => 'withSkipAllTests',
+            self::STRICT_SETTING => 'withStrictResultInterpretation',
+        ],
+    ];
+
+    /**
+     * Used when converting config to PHP, to move relevant Profile settings into this object
+     *
+     * @internal
+     */
+    public static function consumeSettingsFromProfile(&$profileSettings): ?self
+    {
+        // These settings live under multiple array keys. We don't want to expose/couple these details to the Profile,
+        // but we need the Profile to be able to detect whether there *are* any TesterOptions to convert.
+
+        // Build an array of relevant settings groups. Remove any that are found from the settings array in the Profile
+        // object, so that the config converter recognises they have been handled.
+        $settings = [];
+        foreach ([self::TESTERS_SETTINGS_GROUP, self::CALLS_SETTINGS_GROUP] as $group) {
+            if (isset($profileSettings[$group])) {
+                $settings[$group] = $profileSettings[$group];
+                unset($profileSettings[$group]);
+            }
+        }
+
+        if ($settings === []) {
+            // There are no relevant settings, so the config does not need to call ->withTesterOptions on the Profile
+            return null;
+        }
+
+        return new self($settings);
+    }
+
+    public function __construct(
+        private array $settings = [],
+    ) {
+
+    }
+
+    public function toArray(): array
+    {
+        return $this->settings;
+    }
+
+    /**
+     * Behat will convert PHP warnings / errors during steps to exceptions if they match this error_reporting level
+     */
+    public function withErrorReporting(int $errorReporting): self
+    {
+        $this->settings[self::CALLS_SETTINGS_GROUP][self::ERROR_REPORTING_SETTING] = $errorReporting;
+
+        return $this;
+    }
+
+
+    /**
+     * Control whether Behat should fail on undefined or pending steps (equivalent to the `--strict` CLI flag)
+     */
+    public function withStrictResultInterpretation(bool $strict = true): self
+    {
+        $this->settings[self::TESTERS_SETTINGS_GROUP][self::STRICT_SETTING] = $strict;
+
+        return $this;
+    }
+
+    /**
+     * Control whether Behat should actually execute steps (equivalent to the `--dry-run` CLI flag)
+     */
+    public function withSkipAllTests(bool $skip = true): self
+    {
+        $this->settings[self::TESTERS_SETTINGS_GROUP][self::SKIP_SETTING] = $skip;
+
+        return $this;
+    }
+
+    /**
+     * Control whether Behat should stop after the first failing scenario (equivalent to `--stop-on-failure` on CLI)
+     */
+    public function withStopOnFailure(bool $stopOnFailure = true): self
+    {
+        $this->settings[self::TESTERS_SETTINGS_GROUP][self::STOP_ON_FAILURE_SETTING] = $stopOnFailure;
+
+        return $this;
+    }
+
+    public function toPhpExpr(): Expr
+    {
+        $expr = $optionsObject = ConfigConverterTools::createObject(self::class);
+
+        // Convert recognised settings to their setter functions
+        foreach ($this->settings as $group => $groupSettings) {
+            foreach ($groupSettings as $settingName => $setting) {
+                $functionName = self::FUNCTION_NAMES_PER_SETTING[$group][$settingName] ?? null;
+                if ($functionName) {
+                    $expr = ConfigConverterTools::addMethodCall(
+                        $functionName,
+                        [$setting],
+                        $expr,
+                    );
+                    unset($this->settings[$group][$settingName]);
+                }
+            }
+        }
+
+        // Remove any now-empty groups (e.g. 'testers' => []) from the settings array
+        // Then if necessary provide any remaining settings to the object constructor. These are likely not used by
+        // Behat, but we want them in the generated config for the user to review.
+        $this->settings = array_filter($this->settings, static fn ($g) => $g !== []);
+        if ($this->settings !== []) {
+            ConfigConverterTools::addArgumentsToConstructor([$this->settings], $optionsObject);
+        }
+
+        return $expr;
+    }
+
+
+}

--- a/src/Behat/Config/TesterOptions.php
+++ b/src/Behat/Config/TesterOptions.php
@@ -120,6 +120,7 @@ final class TesterOptions implements ConfigConverterInterface
                 $functionName = self::FUNCTION_NAMES_PER_SETTING[$group][$settingName] ?? null;
                 if ($functionName) {
                     $expr = ConfigConverterTools::addMethodCall(
+                        self::class,
                         $functionName,
                         [$setting],
                         $expr,

--- a/tests/Behat/Tests/Config/Converter/ConfigConverterToolsTest.php
+++ b/tests/Behat/Tests/Config/Converter/ConfigConverterToolsTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Tests\Config\Converter;
+
+use Behat\Config\Converter\ConfigConverterTools;
+use PhpParser\PrettyPrinter\Standard;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigConverterToolsTest extends TestCase
+{
+    public static function providerRemoveDefaultArguments(): array
+    {
+        $object = new class {
+            public function takesNoArgs(): void
+            {
+
+            }
+
+            public function withSomething(bool $something): void
+            {
+
+            }
+
+            public function withSingleDefault(bool $value = true): void
+            {
+
+            }
+
+            public function withVariadic(string ...$args): void
+            {
+
+            }
+
+            public function withMultipleArgs(string $first, string $second = 'b', string $third = 'c'): void
+            {
+
+            }
+        };
+
+        return [
+            'no args, nothing removed' => [
+                $object::class,
+                'takesNoArgs',
+                [],
+                '(new %CLASS%())->takesNoArgs()',
+            ],
+            'no default, value set false' => [
+                $object::class,
+                'withSomething',
+                [false],
+                '(new %CLASS%())->withSomething(false)',
+            ],
+            'no default, value set true' => [
+                $object::class,
+                'withSomething',
+                [true],
+                '(new %CLASS%())->withSomething(true)',
+            ],
+            'has single default, non-default value' => [
+                $object::class,
+                'withSingleDefault',
+                [false],
+                '(new %CLASS%())->withSingleDefault(false)',
+            ],
+            'has single default, default value' => [
+                $object::class,
+                'withSingleDefault',
+                [true],
+                '(new %CLASS%())->withSingleDefault()',
+            ],
+            'variadic is unchanged' => [
+                $object::class,
+                'withVariadic',
+                ['a', 'b', 'c'],
+                "(new %CLASS%())->withVariadic('a', 'b', 'c')",
+            ],
+            'multiple args, all non-default' => [
+                $object::class,
+                'withMultipleArgs',
+                ['1', '2', '3'],
+                "(new %CLASS%())->withMultipleArgs('1', '2', '3')",
+            ],
+            'multiple args, all are default' => [
+                $object::class,
+                'withMultipleArgs',
+                ['1', 'b', 'c'],
+                "(new %CLASS%())->withMultipleArgs('1')",
+            ],
+            'multiple args, last is default' => [
+                $object::class,
+                'withMultipleArgs',
+                ['1', '2', 'c'],
+                "(new %CLASS%())->withMultipleArgs('1', '2')",
+            ],
+            'multiple args, middle is default (change to named)' => [
+                $object::class,
+                'withMultipleArgs',
+                ['1', 'b', '3'],
+                "(new %CLASS%())->withMultipleArgs('1', third: '3')",
+            ],
+            'provided as named params' => [
+                $object::class,
+                'withSomething',
+                ['something' => true],
+                "(new %CLASS%())->withSomething(something: true)",
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerRemoveDefaultArguments
+     */
+    public function testCanRemoveDefaultArgumentsFromMethodCalls(string $class, string $method, array $args, string $expect): void
+    {
+        $expr = ConfigConverterTools::createObject($class);
+        $expr = ConfigConverterTools::addMethodCall($class, $method, $args, $expr);
+        $printer = new Standard();
+        $code = str_replace('\\' . $class, '%CLASS%', $printer->prettyPrintExpr($expr));
+        $this->assertSame($expect, $code);
+    }
+
+    public static function providerValidateMethodCallInput(): array
+    {
+        $obj = new class {
+            public function withThings(string $one, string $two): void
+            {
+
+            }
+        };
+        return [
+            'undefined class' => [
+                'This\Is\Not\A\Class',
+                'whatever',
+                [],
+                'Class "This\Is\Not\A\Class" does not exist',
+            ],
+            'undefined method' => [
+                $obj::class,
+                'withNothing',
+                [],
+                'Method class@anonymous::withNothing() does not exist',
+            ],
+            'not enough params' => [
+                $obj::class,
+                'withThings',
+                ['one'],
+                'Missing argument #1 (two)',
+            ],
+            'too many params' => [
+                $obj::class,
+                'withThings',
+                ['one', 'two', 'three'],
+                'Too many arguments provided for',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerValidateMethodCallInput
+     */
+    public function testAddMethodCallValidatesInput(string $class, string $method, array $args, string $expect): void
+    {
+        $expr = ConfigConverterTools::createObject($class);
+        $this->expectExceptionMessage($expect);
+        ConfigConverterTools::addMethodCall($class, $method, $args, $expr);
+    }
+}

--- a/tests/Fixtures/ConfigStrictTesters/behat.php
+++ b/tests/Fixtures/ConfigStrictTesters/behat.php
@@ -1,0 +1,14 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\TesterOptions;
+
+return (new Config())
+    ->withProfile(new Profile('default'))
+    ->withProfile((new Profile('with-strict'))
+        ->withTesterOptions((new TesterOptions())
+            ->withStrictResultInterpretation(true)))
+    ->withProfile((new Profile('not-strict'))
+        ->withTesterOptions((new TesterOptions())
+            ->withStrictResultInterpretation(false)));

--- a/tests/Fixtures/ConfigStrictTesters/behat.php
+++ b/tests/Fixtures/ConfigStrictTesters/behat.php
@@ -8,7 +8,7 @@ return (new Config())
     ->withProfile(new Profile('default'))
     ->withProfile((new Profile('with-strict'))
         ->withTesterOptions((new TesterOptions())
-            ->withStrictResultInterpretation(true)))
+            ->withStrictResultInterpretation()))
     ->withProfile((new Profile('not-strict'))
         ->withTesterOptions((new TesterOptions())
             ->withStrictResultInterpretation(false)));

--- a/tests/Fixtures/ConfigStrictTesters/behat.yaml
+++ b/tests/Fixtures/ConfigStrictTesters/behat.yaml
@@ -1,9 +1,0 @@
-default: ~
-
-with-strict:
-  testers:
-    strict: true
-
-not-strict:
-  testers:
-    strict: false

--- a/tests/Fixtures/ConvertConfig/full_configuration.yaml
+++ b/tests/Fixtures/ConvertConfig/full_configuration.yaml
@@ -2,6 +2,8 @@ imports:
     - imported.yaml
 
 default:
+    testers:
+        strict: true
     formatters:
         pretty:
             paths:    false
@@ -32,6 +34,8 @@ default:
         custom_extension.php: ~
 
 other:
+    calls:
+        error_reporting: 1
     formatters:
         pretty: false
 

--- a/tests/Fixtures/ConvertConfig/tester_options.yaml
+++ b/tests/Fixtures/ConvertConfig/tester_options.yaml
@@ -1,0 +1,17 @@
+default: ~
+
+ignore-errors:
+    calls:
+        error_reporting: 22527
+
+not-strict:
+    testers:
+        strict: false
+
+complete:
+    calls:
+        error_reporting: 24565
+    testers:
+        strict: true
+        stop_on_failure: false
+        skip: true

--- a/tests/Fixtures/ErrorReporting/behat.php
+++ b/tests/Fixtures/ErrorReporting/behat.php
@@ -1,0 +1,14 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\TesterOptions;
+
+return (new Config())
+    ->withProfile(new Profile('default'))
+    ->withProfile((new Profile('ignore-all-but-error'))
+        ->withTesterOptions((new TesterOptions())
+            ->withErrorReporting(24565)))
+    ->withProfile((new Profile('ignore-deprecations'))
+        ->withTesterOptions((new TesterOptions())
+            ->withErrorReporting(22527)));

--- a/tests/Fixtures/ErrorReporting/behat.php
+++ b/tests/Fixtures/ErrorReporting/behat.php
@@ -8,7 +8,7 @@ return (new Config())
     ->withProfile(new Profile('default'))
     ->withProfile((new Profile('ignore-all-but-error'))
         ->withTesterOptions((new TesterOptions())
-            ->withErrorReporting(24565)))
+            ->withErrorReporting(E_ALL & ~(E_WARNING | E_NOTICE | E_DEPRECATED))))
     ->withProfile((new Profile('ignore-deprecations'))
         ->withTesterOptions((new TesterOptions())
-            ->withErrorReporting(22527)));
+            ->withErrorReporting(E_ALL & ~E_DEPRECATED)));

--- a/tests/Fixtures/ErrorReporting/behat.yaml
+++ b/tests/Fixtures/ErrorReporting/behat.yaml
@@ -1,9 +1,0 @@
-default: ~
-
-ignore-all-but-error:
-    calls:
-        error_reporting: 24565
-
-ignore-deprecations:
-    calls:
-        error_reporting: 22527

--- a/tests/Fixtures/StopOnFailure/behat.php
+++ b/tests/Fixtures/StopOnFailure/behat.php
@@ -8,7 +8,7 @@ return (new Config())
     ->withProfile(new Profile('default'))
     ->withProfile((new Profile('stop-on-failure'))
         ->withTesterOptions((new TesterOptions())
-            ->withStopOnFailure(true)))
+            ->withStopOnFailure()))
     ->withProfile((new Profile('no-stop-on-failure'))
         ->withTesterOptions((new TesterOptions())
             ->withStopOnFailure(false)));

--- a/tests/Fixtures/StopOnFailure/behat.php
+++ b/tests/Fixtures/StopOnFailure/behat.php
@@ -1,0 +1,14 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\TesterOptions;
+
+return (new Config())
+    ->withProfile(new Profile('default'))
+    ->withProfile((new Profile('stop-on-failure'))
+        ->withTesterOptions((new TesterOptions())
+            ->withStopOnFailure(true)))
+    ->withProfile((new Profile('no-stop-on-failure'))
+        ->withTesterOptions((new TesterOptions())
+            ->withStopOnFailure(false)));

--- a/tests/Fixtures/StopOnFailure/behat.yaml
+++ b/tests/Fixtures/StopOnFailure/behat.yaml
@@ -1,9 +1,0 @@
-default: ~
-
-stop-on-failure:
-    testers:
-        stop_on_failure: true
-
-no-stop-on-failure:
-    testers:
-        stop_on_failure: false


### PR DESCRIPTION
This branch is based on #1625 so that should be reviewed and merged first.

Adds support for configuring the tester and error_reporting options through PHP, and for converting those configs from YAML.

This includes automatically removing default arguments when generating PHP config methods from YAML so that you get e.g. `->withStopOnFailure()` rather than `->withStopOnFailure(true)`. That change also applies to a couple of existing methods - as shown in the updated convert_config feature file - and as a byproduct means that the config conversion process is now stricter internally about making sure that called methods exist and have been provided with the correct argument list.


Fixes #1624