### PR TITLE
fix: ExceptionPresenter was causing a TypeError with null $basePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.21.1] - 2025-04-22
+
+### Fixed
+
+* ExceptionPresenter was causing a TypeError when constructed with a null $basePath by @acoulton in [#1631](https://github.com/Behat/Behat/pull/1631)
+
 ## [3.21.0] - 2025-04-18
 
 ### Fixed
@@ -1241,6 +1247,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
   * Initial release
 
+[3.21.1]: https://github.com/Behat/Behat/compare/v3.21.0...v3.21.1
+[3.21.0]: https://github.com/Behat/Behat/compare/v3.20.0...v3.21.0
 [3.20.0]: https://github.com/Behat/Behat/compare/v3.19.0...v3.20.0
 [3.19.0]: https://github.com/Behat/Behat/compare/v3.18.1...v3.19.0
 [3.18.1]: https://github.com/Behat/Behat/compare/v3.18.0...v3.18.1

--- a/src/Behat/Testwork/Exception/ExceptionPresenter.php
+++ b/src/Behat/Testwork/Exception/ExceptionPresenter.php
@@ -35,7 +35,7 @@ final class ExceptionPresenter
     /**
      * Initializes presenter.
      *
-     * @param string  $basePath deprecated, will be removed in next major version
+     * @param ?string  $basePath deprecated, will be removed in next major version
      * @param integer $defaultVerbosity
      */
     public function __construct(
@@ -43,7 +43,12 @@ final class ExceptionPresenter
         private int $defaultVerbosity = OutputPrinter::VERBOSITY_NORMAL,
         ?ConfigurablePathPrinter $configurablePathPrinter = null,
     ) {
-        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath, printAbsolutePaths: false);
+        // Historically, this class accepted a null (or not present) value for basePath. This was never passed by Behat,
+        // but was used by third parties to force the class to render exception traces with absolute file paths.
+        // The ConfigurablePathPrinter requires a value, but it is not used if printAbsolutePaths is true.
+        // Therefore, if the user provided null we can safely cast to '' (the working directory) and tell the printer
+        // to show absolute paths.
+        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath ?? '', printAbsolutePaths: $basePath === null);
     }
 
     /**


### PR DESCRIPTION
As reported in #1630 and #1629, we missed that the ExceptionPresenter can be validly created with a null $basePath but it is not valid to pass this to the new ConfigurablePathPrinter. Although Behat never does this, third-parties do.

The old behaviour in that case was that the ExceptionPresenter would just print absolute paths.

We can achieve the same thing by setting the correct value for printAbsolutePaths when we create the ConfigurablePathPrinter. We can then just cast the $basePath to an empty string as this will be ignored if we're printing absolute paths.

fixes #1630 
fixes #1629 