### PR TITLE
Backport the fix for Behat/Gherkin file paths to a 3.16.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.16.1] - 2025-05-07
+
+### Changed
+
+* Remove dependency on file location in Gherkin package. The (internal) service container parameters gherkin.paths.lib
+  and gherkin.paths.i18n are no longer defined or used. Minimum behat/gherkin version is now ^4.12.0.
+  By @carlos-granados in #1604, backported from 3.20.0 to fix errors for users stuck on 3.16.0 due to
+  dependency conflicts.
+
 ## [3.16.0] - 2024-11-08
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "8.1.* || 8.2.* || 8.3.* || 8.4.* ",
         "ext-mbstring": "*",
-        "behat/gherkin": "^4.10.0",
+        "behat/gherkin": "^4.12.0",
         "behat/transliterator": "^1.5",
         "composer-runtime-api": "^2.2",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Gherkin\ServiceContainer;
 
+use Behat\Gherkin\Keywords\CachedArrayKeywords;
 use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\Filesystem\ServiceContainer\FilesystemExtension;
 use Behat\Testwork\ServiceContainer\Exception\ExtensionException;
@@ -135,8 +136,6 @@ final class GherkinExtension implements Extension
      */
     private function loadParameters(ContainerBuilder $container)
     {
-        $container->setParameter('gherkin.paths.lib', $this->getLibPath());
-        $container->setParameter('gherkin.paths.i18n', '%gherkin.paths.lib%/i18n.php');
         $container->setParameter(
             'suite.generic.default_settings',
             array(
@@ -144,19 +143,6 @@ final class GherkinExtension implements Extension
                 'contexts' => array('FeatureContext')
             )
         );
-    }
-
-    /**
-     * Returns gherkin library path.
-     *
-     * @return string
-     */
-    private function getLibPath()
-    {
-        $reflection = new ReflectionClass('Behat\Gherkin\Gherkin');
-        $libPath = rtrim(dirname($reflection->getFilename()) . '/../../../', DIRECTORY_SEPARATOR);
-
-        return $libPath;
     }
 
     /**
@@ -177,9 +163,8 @@ final class GherkinExtension implements Extension
      */
     private function loadKeywords(ContainerBuilder $container)
     {
-        $definition = new Definition('Behat\Gherkin\Keywords\CachedArrayKeywords', array(
-            '%gherkin.paths.i18n%'
-        ));
+        $definition = new Definition(CachedArrayKeywords::class);
+        $definition->setFactory([CachedArrayKeywords::class, 'withDefaultKeywords']);
         $container->setDefinition(self::KEYWORDS_ID, $definition);
 
         $definition = new Definition('Behat\Gherkin\Keywords\KeywordsDumper', array(


### PR DESCRIPTION
A number of users have been affected by the change to file paths in Behat/Gherkin v4.13.0 (released yesterday).

This is because:

* Behat/Gherkin has no dependencies, so can happily bump to 4.13.0 on any system running PHP >= 8.1
* Behat/Behat v3.17.0 introduced a dependency on composer/xdebug-handler:v3
* Behat/Behat v3.20.0 introduced a dependency on nikic/php-parser@v5
* We only released #1604 (which is required to support Behat/Gherkin >= 4.13.0) in v3.20.0

Therefore there are projects on PHP >= 8.1 (so still officially supported by us) who will get Behat/Gherkin v4.13.0 but may not be able to get Behat/Behat v3.20.0 due to having other dependencies that are holding them to earlier versions of composer/xdebug-handler or nikic/php-parser.

I propose we do a 3.16.1 release with the fix backported to solve the immediate issue (anyone running PHP 8.1 should be able to get to 3.16.0, and if they are not on 8.1 they won't get the problematic Gherkin version).