### PR TITLE
feat: implement editor url

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -500,7 +500,16 @@ EOL;
 
             // texts with absolute paths
             $text = preg_replace_callback(
-                '/\{BASE_PATH\}[^\n "]+/',
+                '/\{BASE_PATH\}[^\n \<"]+/',
+                function ($matches) {
+                    return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
+                },
+                $text
+            );
+
+            // texts in editor URLs
+            $text = preg_replace_callback(
+                '/open\?file[^\<"]+/',
                 function ($matches) {
                     return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
                 },

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -430,7 +430,9 @@ Feature: Convert config
 
       return (new Config())
           ->withProfile((new Profile('default'))
-              ->withPathOptions(printAbsolutePaths: true));
+              ->withPathOptions(printAbsolutePaths: true))
+          ->withProfile((new Profile('with_editor_url'))
+              ->withPathOptions(editorUrl: 'phpstorm://open?file={relPath}&line={line}'));
       """
     And the temp "path_options.yaml" file should have been removed
 
@@ -502,7 +504,10 @@ Feature: Convert config
               ->withFilter(new NameFilter('john'))
               ->withFilter(new RoleFilter('admin'))
               ->withPrintUnusedDefinitions()
-              ->withPathOptions(printAbsolutePaths: true)
+              ->withPathOptions(
+                  printAbsolutePaths: true,
+                  editorUrl: 'phpstorm://open?file={relPath}&line={line}'
+              )
               ->withTesterOptions((new TesterOptions())
                   ->withStrictResultInterpretation())
               ->withExtension(new Extension('custom_extension.php'))

--- a/features/editor_url.feature
+++ b/features/editor_url.feature
@@ -1,0 +1,76 @@
+Feature: Editor URL
+  In order to be able to open files directly in my editor
+  As a developer
+  I need to be able to ask Behat to add editor links to file paths in the output
+
+  Background:
+    Given I set the working directory to the "EditorUrl" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option          | value            |
+      | --no-colors     |                  |
+
+  Scenario: Add option in command line
+    When I run behat with the following additional options:
+      | option       | value                                        |
+      | --editor-url | 'phpstorm://open?file={relPath}&line={line}' |
+    Then the output should contain:
+      """
+        Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>features/test.feature:3</>
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>features/bootstrap/FeatureContext.php line 16</>
+
+      --- Failed scenarios:
+
+          <href=phpstorm://open?file=features/test.feature&line=3>features/test.feature:3</>
+      """
+
+  Scenario: Add option in config file
+    When I run behat with the following additional options:
+      | option    | value      |
+      | --profile | editor_url |
+    Then the output should contain:
+      """
+        Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>features/test.feature:3</>
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>features/bootstrap/FeatureContext.php line 16</>
+
+      --- Failed scenarios:
+
+          <href=phpstorm://open?file=features/test.feature&line=3>features/test.feature:3</>
+      """
+
+  Scenario: Use absolute paths in editor URL
+    When I run behat with the following additional options:
+      | option       | value                                        |
+      | --editor-url | 'phpstorm://open?file={absPath}&line={line}' |
+    Then the output should contain:
+      """
+        Scenario:                                    # <href=phpstorm://open?file={BASE_PATH}tests/Fixtures/EditorUrl/features/test.feature&line=3>features/test.feature:3</>
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in <href=phpstorm://open?file={BASE_PATH}tests/Fixtures/EditorUrl/features/bootstrap/FeatureContext.php&line=16>features/bootstrap/FeatureContext.php line 16</>
+
+      --- Failed scenarios:
+
+          <href=phpstorm://open?file={BASE_PATH}tests/Fixtures/EditorUrl/features/test.feature&line=3>features/test.feature:3</>
+      """
+
+  Scenario: Use relative paths in url but absolute paths in visible text
+    When I run behat with the following additional options:
+      | option                 | value                                        |
+      | --print-absolute-paths |                                              |
+      | --editor-url           | 'phpstorm://open?file={relPath}&line={line}' |
+    Then the output should contain:
+      """
+        Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>{BASE_PATH}tests/Fixtures/EditorUrl/features/test.feature:3</>
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>{BASE_PATH}tests/Fixtures/EditorUrl/features/bootstrap/FeatureContext.php line 16</>
+
+      --- Failed scenarios:
+
+          <href=phpstorm://open?file=features/test.feature&line=3>{BASE_PATH}tests/Fixtures/EditorUrl/features/test.feature:3</>
+      """
+

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -61,7 +61,7 @@ final class ListPrinter
     ) {
         $this->resultConverter = $resultConverter;
         $this->translator = $translator;
-        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath, printAbsolutePaths: false);
+        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath, printAbsolutePaths: false, editorUrl: null);
     }
 
     /**
@@ -285,12 +285,12 @@ final class ListPrinter
                 ),
                 $scope instanceof BeforeScenarioScope,
                 $scope instanceof AfterScenarioScope => $this->configurablePathPrinter->processPathsInText(
-                    $scope->getFeature()->getFile()
-                ) . ':' . $scope->getScenario()->getLine(),
+                    $scope->getFeature()->getFile() . ':' . $scope->getScenario()->getLine()
+                ),
                 $scope instanceof BeforeStepScope,
                 $scope instanceof AfterStepScope => $this->configurablePathPrinter->processPathsInText(
-                    $scope->getFeature()->getFile()
-                ) . ':' . $scope->getStep()->getLine(),
+                    $scope->getFeature()->getFile() . ':' . $scope->getStep()->getLine()
+                ),
                 default => null,
             };
         }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
@@ -43,7 +43,7 @@ final class PrettyPathPrinter
         ?ConfigurablePathPrinter $configurablePathPrinter = null,
     ) {
         $this->widthCalculator = $widthCalculator;
-        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath, printAbsolutePaths: false);
+        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath, printAbsolutePaths: false, editorUrl: null);
     }
 
     /**
@@ -61,7 +61,7 @@ final class PrettyPathPrinter
             return;
         }
 
-        $fileAndLine = sprintf('%s:%s', $this->configurablePathPrinter->processPathsInText($feature->getFile()), $scenario->getLine());
+        $fileAndLine = $this->configurablePathPrinter->processPathsInText(sprintf('%s:%s', $feature->getFile(), $scenario->getLine()));
         $headerWidth = $this->widthCalculator->calculateScenarioHeaderWidth($scenario, $indentation);
         $scenarioWidth = $this->widthCalculator->calculateScenarioWidth($scenario, $indentation, 2);
         $spacing = str_repeat(' ', max(0, $scenarioWidth - $headerWidth));

--- a/src/Behat/Testwork/Exception/ExceptionPresenter.php
+++ b/src/Behat/Testwork/Exception/ExceptionPresenter.php
@@ -47,7 +47,7 @@ final class ExceptionPresenter
         // The ConfigurablePathPrinter requires a value, but it is not used if printAbsolutePaths is true.
         // Therefore, if the user provided null we can safely cast to '' (the working directory) and tell the printer
         // to show absolute paths.
-        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath ?? '', printAbsolutePaths: $basePath === null);
+        $this->configurablePathPrinter = $configurablePathPrinter ?? new ConfigurablePathPrinter($basePath ?? '', printAbsolutePaths: $basePath === null, editorUrl: null);
     }
 
     /**

--- a/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
+++ b/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
@@ -36,22 +36,31 @@ class PathOptionsController implements Controller
                 '--print-absolute-paths', null, InputOption::VALUE_NONE,
                 'Print absolute paths in output'
             )
+            ->addOption(
+                '--editor-url', null, InputOption::VALUE_REQUIRED,
+                'URL template for opening files in an editor'
+            )
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $printAbsolutePaths = $input->getOption('print-absolute-paths');
+        $editorUrl = $input->getOption('editor-url');
 
-        $this->configurePrintPaths($printAbsolutePaths);
+        $this->configurePrintPaths($printAbsolutePaths, $editorUrl);
 
         return null;
     }
 
-    private function configurePrintPaths(bool $printAbsolutePaths): void
+    private function configurePrintPaths(bool $printAbsolutePaths, ?string $editorUrl): void
     {
         if ($printAbsolutePaths) {
             $this->configurablePathPrinter->setPrintAbsolutePaths($printAbsolutePaths);
+        }
+
+        if ($editorUrl !== null) {
+            $this->configurablePathPrinter->setEditorUrl($editorUrl);
         }
     }
 }

--- a/src/Behat/Testwork/PathOptions/Printer/ConfigurablePathPrinter.php
+++ b/src/Behat/Testwork/PathOptions/Printer/ConfigurablePathPrinter.php
@@ -10,6 +10,8 @@
 
 namespace Behat\Testwork\PathOptions\Printer;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
 final class ConfigurablePathPrinter
 {
     private string $basePath;
@@ -17,6 +19,7 @@ final class ConfigurablePathPrinter
     public function __construct(
         string $basePath,
         private bool $printAbsolutePaths,
+        private ?string $editorUrl = null,
     ) {
         $realBasePath = realpath($basePath);
 
@@ -32,15 +35,55 @@ final class ConfigurablePathPrinter
         $this->printAbsolutePaths = $printAbsolutePaths;
     }
 
+    public function setEditorUrl(?string $editorUrl): void
+    {
+        $this->editorUrl = $editorUrl;
+    }
+
     /**
-     * Conditionally transforms paths to relative.
+     * Conditionally transforms paths to relative and adds editor links if configured.
      */
     public function processPathsInText(string $text): string
     {
-        if ($this->printAbsolutePaths === true) {
-            return $text;
+        // If no editor URL is set, use the original behavior
+        if ($this->editorUrl === null) {
+            if ($this->printAbsolutePaths === true) {
+                return $text;
+            }
+
+            return str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $text);
         }
 
-        return str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $text);
+        // Search for paths in the text
+        $basePathPattern = preg_quote($this->basePath . DIRECTORY_SEPARATOR, '/');
+        $pattern = '/(' . $basePathPattern . '[^:\s]+)((:|\s+line\s+)(\d+))?/';
+
+        return preg_replace_callback($pattern, function (array $matches): string {
+            $filePath = $matches[1];
+            $line = $matches[4] ?? null;
+
+            // Calculate absolute and relative paths
+            $absPath = $filePath;
+            $relPath = str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $filePath);
+
+            // Format the path according to printAbsolutePaths setting
+            $displayPath = $this->printAbsolutePaths ? $absPath : $relPath;
+
+            // If no line number is present, use empty string
+            if ($line === null) {
+                $line = '';
+            }
+
+            // Replace placeholders in the editor URL
+            $editorUrl = str_replace(
+                ['{absPath}', '{relPath}', '{line}'],
+                [$absPath, $relPath, $line],
+                $this->editorUrl
+            );
+
+            // Create a link with the path
+            // $matches[2] represents the line number with its prefix (`:LINE` or ` line LINE`)
+            return '<href=' . OutputFormatter::escape($editorUrl) . '>' . $displayPath . ($matches[2] ?? '') . '</>';
+        }, $text);
     }
 }

--- a/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
+++ b/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
@@ -14,6 +14,7 @@ use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -38,17 +39,22 @@ final class PathOptionsExtension implements Extension
 
     public function configure(ArrayNodeDefinition $builder)
     {
-        $builder
+        $builder = $builder
             ->addDefaultsIfNotSet()
             ->children()
             ->scalarNode('print_absolute_paths')
             ->defaultFalse()
+            ->end();
+        assert($builder instanceof NodeBuilder);
+        $builder
+            ->scalarNode('editor_url')
+            ->defaultNull()
         ;
     }
 
     public function load(ContainerBuilder $container, array $config)
     {
-        $this->loadConfigurablePathPrinter($container, $config['print_absolute_paths']);
+        $this->loadConfigurablePathPrinter($container, $config['print_absolute_paths'], $config['editor_url'] ?? null);
         $this->loadPathOptionsController($container);
     }
 
@@ -56,11 +62,12 @@ final class PathOptionsExtension implements Extension
     {
     }
 
-    private function loadConfigurablePathPrinter(ContainerBuilder $container, bool $printAbsolutePaths): void
+    private function loadConfigurablePathPrinter(ContainerBuilder $container, bool $printAbsolutePaths, ?string $editorUrl): void
     {
         $definition = new Definition('Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter', [
             '%paths.base%',
             $printAbsolutePaths,
+            $editorUrl,
         ]);
         $container->setDefinition(self::CONFIGURABLE_PATH_PRINTER_ID, $definition);
     }

--- a/tests/Fixtures/ConvertConfig/full_configuration.yaml
+++ b/tests/Fixtures/ConvertConfig/full_configuration.yaml
@@ -30,6 +30,7 @@ default:
         print_unused_definitions: true
     path_options:
         print_absolute_paths: true
+        editor_url: phpstorm://open?file={relPath}&line={line}
     extensions:
         custom_extension.php: ~
 

--- a/tests/Fixtures/ConvertConfig/path_options.yaml
+++ b/tests/Fixtures/ConvertConfig/path_options.yaml
@@ -1,3 +1,6 @@
 default:
     path_options:
         print_absolute_paths: true
+with_editor_url:
+    path_options:
+        editor_url: phpstorm://open?file={relPath}&line={line}

--- a/tests/Fixtures/EditorUrl/behat.php
+++ b/tests/Fixtures/EditorUrl/behat.php
@@ -1,0 +1,10 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+
+return (new Config())
+    ->withProfile(new Profile('default'))
+    ->withProfile((new Profile('editor_url'))
+        ->withPathOptions(editorUrl: 'phpstorm://open?file={relPath}&line={line}')
+    );

--- a/tests/Fixtures/EditorUrl/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/EditorUrl/features/bootstrap/FeatureContext.php
@@ -1,0 +1,18 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Step\Given;
+
+class FeatureContext implements Context
+{
+    #[Given('I have a passing step')]
+    public function iHaveAPassingStep()
+    {
+    }
+
+    #[Given('I have a step that throws an exception')]
+    public function iHaveAFailingStep()
+    {
+        $a = $b;
+    }
+}

--- a/tests/Fixtures/EditorUrl/features/test.feature
+++ b/tests/Fixtures/EditorUrl/features/test.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Scenario:
+    Given I have a passing step
+    And I have a step that throws an exception


### PR DESCRIPTION
In the same way that PHPStan or Rector do, allow setting an editorURL template that will be used to add links to paths when printing them on the terminal.

The editorURL can be any URL that any IDE recognises to open that specific file, One example is PhpStorm which accepts URLs like this one:

`phpstorm://open?file={path}&line={line}`

The template can use three different placeholders:

{absPath} : absolute path of the file
{relPath}: relative path of the file
{line}: line number in the file

Fixes https://github.com/Behat/Behat/issues/1596

Once this is merged I will add the corresponding documentation in Behat docs