### PR TITLE
dx: add option that allows you to remove prefixes in printed paths

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -468,7 +468,7 @@ EOL;
         // windows path fix
         if ('/' !== DIRECTORY_SEPARATOR) {
             $text = preg_replace_callback(
-                '/[ "]features\/[^\n "]+/',
+                '/[ "](features|tests)\/[^\n "]+/',
                 function ($matches) {
                     return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
                 },
@@ -674,7 +674,14 @@ EOL;
                 if (str_starts_with($value, '{SYSTEM_TMP_DIR}')) {
                     $value = $this->tempDir . substr($value, strlen('{SYSTEM_TMP_DIR}'));
                 }
+                if (str_starts_with($value, '{BASE_PATH}')) {
+                    $basePath = realpath(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR;
+                    $value = $basePath . substr($value, strlen('{BASE_PATH}'));
+                }
 
+                if ($option === '--remove-prefix' && DIRECTORY_SEPARATOR !== '/') {
+                    $value = str_replace('/', DIRECTORY_SEPARATOR, $value);
+                }
                 $option .= '=' . $value;
             }
             $this->options .= ' ' . $option;

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -432,7 +432,12 @@ Feature: Convert config
           ->withProfile((new Profile('default'))
               ->withPathOptions(printAbsolutePaths: true))
           ->withProfile((new Profile('with_editor_url'))
-              ->withPathOptions(editorUrl: 'phpstorm://open?file={relPath}&line={line}'));
+              ->withPathOptions(editorUrl: 'phpstorm://open?file={relPath}&line={line}'))
+          ->withProfile((new Profile('with_remove_prefix'))
+              ->withPathOptions(removePrefix: [
+                  'features/bootstrap/',
+                  'features/',
+              ]));
       """
     And the temp "path_options.yaml" file should have been removed
 
@@ -506,7 +511,11 @@ Feature: Convert config
               ->withPrintUnusedDefinitions()
               ->withPathOptions(
                   printAbsolutePaths: true,
-                  editorUrl: 'phpstorm://open?file={relPath}&line={line}'
+                  editorUrl: 'phpstorm://open?file={relPath}&line={line}',
+                  removePrefix: [
+                      'features/bootstrap/',
+                      'features/',
+                  ]
               )
               ->withTesterOptions((new TesterOptions())
                   ->withStrictResultInterpretation())

--- a/features/remove_prefix.feature
+++ b/features/remove_prefix.feature
@@ -1,0 +1,76 @@
+Feature: Remove prefix
+  In order to have cleaner output with shorter paths
+  As a developer
+  I need to be able to ask Behat to remove specific prefixes from paths in the output
+
+  Background:
+    Given I set the working directory to the "RemovePrefix" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option      | value |
+      | --no-colors |       |
+
+  Scenario: Add option in command line
+    When I run behat with the following additional options:
+      | option          | value                         |
+      | --remove-prefix | features/bootstrap/,features/ |
+    Then the output should contain:
+      """
+        Scenario:                                    # test.feature:3
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in FeatureContext.php line 16
+
+      --- Failed scenarios:
+
+          test.feature:3
+      """
+
+  Scenario: Add option in config file
+    When I run behat with the following additional options:
+      | option    | value         |
+      | --profile | remove_prefix |
+    Then the output should contain:
+      """
+        Scenario:                                    # test.feature:3
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in FeatureContext.php line 16
+
+      --- Failed scenarios:
+
+          test.feature:3
+      """
+
+  Scenario: Use remove prefix with editor URL
+    When I run behat with the following additional options:
+      | option          | value                                        |
+      | --editor-url    | 'phpstorm://open?file={relPath}&line={line}' |
+      | --remove-prefix | features/bootstrap/,features/                |
+    Then the output should contain:
+      """
+        Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>test.feature:3</>
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>FeatureContext.php line 16</>
+
+      --- Failed scenarios:
+
+          <href=phpstorm://open?file=features/test.feature&line=3>test.feature:3</>
+      """
+
+  Scenario: Use remove prefix with absolute paths
+    When I run behat with the following additional options:
+      | option                 | value       |
+      | --print-absolute-paths |             |
+      | --remove-prefix        | {BASE_PATH} |
+    Then the output should contain:
+      """
+        Scenario:                                    # tests/Fixtures/RemovePrefix/features/test.feature:3
+          Given I have a passing step                # FeatureContext::iHaveAPassingStep()
+          And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
+            Warning: Undefined variable $b in tests/Fixtures/RemovePrefix/features/bootstrap/FeatureContext.php line 16
+
+      --- Failed scenarios:
+
+          tests/Fixtures/RemovePrefix/features/test.feature:3
+      """

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -31,6 +31,7 @@ final class Profile implements ConfigConverterInterface
     private const PATH_OPTIONS_SETTING = 'path_options';
     private const PRINT_ABSOLUTE_PATHS_SETTING = 'print_absolute_paths';
     private const EDITOR_URL_SETTING = 'editor_url';
+    private const REMOVE_PREFIX_SETTING = 'remove_prefix';
 
     private const DISABLE_FORMATTER_FUNCTION = 'disableFormatter';
     private const FORMATTER_FUNCTION = 'withFormatter';
@@ -39,9 +40,11 @@ final class Profile implements ConfigConverterInterface
     private const EXTENSION_FUNCTION = 'withExtension';
     private const SUITE_FUNCTION = 'withSuite';
     private const PATH_OPTIONS_FUNCTION = 'withPathOptions';
+    private const TESTER_OPTIONS_FUNCTION = 'withTesterOptions';
+
     private const PRINT_ABSOLUTE_PATHS_PARAMETER = 'printAbsolutePaths';
     private const EDITOR_URL_PARAMETER = 'editorUrl';
-    private const TESTER_OPTIONS_FUNCTION = 'withTesterOptions';
+    private const REMOVE_PREFIX_PARAMETER = 'removePrefix';
 
     public function __construct(
         private string $name,
@@ -108,12 +111,22 @@ final class Profile implements ConfigConverterInterface
         return $this;
     }
 
-    public function withPathOptions(bool $printAbsolutePaths = false, ?string $editorUrl = null): self
-    {
+    /**
+     * @param string[] $removePrefix
+     */
+    public function withPathOptions(
+        bool $printAbsolutePaths = false,
+        ?string $editorUrl = null,
+        array $removePrefix = [],
+    ): self {
         $this->settings[self::PATH_OPTIONS_SETTING][self::PRINT_ABSOLUTE_PATHS_SETTING] = $printAbsolutePaths;
 
         if ($editorUrl !== null) {
             $this->settings[self::PATH_OPTIONS_SETTING][self::EDITOR_URL_SETTING] = $editorUrl;
+        }
+
+        if (!empty($removePrefix)) {
+            $this->settings[self::PATH_OPTIONS_SETTING][self::REMOVE_PREFIX_SETTING] = $removePrefix;
         }
 
         return $this;
@@ -253,10 +266,12 @@ final class Profile implements ConfigConverterInterface
         $args = [
             self::PRINT_ABSOLUTE_PATHS_PARAMETER => false,
             self::EDITOR_URL_PARAMETER => null,
+            self::REMOVE_PREFIX_PARAMETER => [],
         ];
         $settingsPerParameter = [
             self::PRINT_ABSOLUTE_PATHS_PARAMETER => self::PRINT_ABSOLUTE_PATHS_SETTING,
             self::EDITOR_URL_PARAMETER => self::EDITOR_URL_SETTING,
+            self::REMOVE_PREFIX_PARAMETER => self::REMOVE_PREFIX_SETTING,
         ];
         $settingFound = false;
         foreach ($settingsPerParameter as $parameter => $setting) {

--- a/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
+++ b/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
@@ -40,6 +40,10 @@ class PathOptionsController implements Controller
                 '--editor-url', null, InputOption::VALUE_REQUIRED,
                 'URL template for opening files in an editor'
             )
+            ->addOption(
+                '--remove-prefix', null, InputOption::VALUE_REQUIRED,
+                'Comma-separated list of prefixes to remove from paths'
+            )
         ;
     }
 
@@ -47,13 +51,23 @@ class PathOptionsController implements Controller
     {
         $printAbsolutePaths = $input->getOption('print-absolute-paths');
         $editorUrl = $input->getOption('editor-url');
+        $removePrefix = $input->getOption('remove-prefix');
 
-        $this->configurePrintPaths($printAbsolutePaths, $editorUrl);
+        // Parse comma-separated list into an array
+        $removePrefixArray = [];
+        if ($removePrefix !== null) {
+            $removePrefixArray = explode(',', $removePrefix);
+        }
+
+        $this->configurePrintPaths($printAbsolutePaths, $editorUrl, $removePrefixArray);
 
         return null;
     }
 
-    private function configurePrintPaths(bool $printAbsolutePaths, ?string $editorUrl): void
+    /**
+     * @param string[] $removePrefix
+     */
+    private function configurePrintPaths(bool $printAbsolutePaths, ?string $editorUrl, array $removePrefix = []): void
     {
         if ($printAbsolutePaths) {
             $this->configurablePathPrinter->setPrintAbsolutePaths($printAbsolutePaths);
@@ -61,6 +75,10 @@ class PathOptionsController implements Controller
 
         if ($editorUrl !== null) {
             $this->configurablePathPrinter->setEditorUrl($editorUrl);
+        }
+
+        if (!empty($removePrefix)) {
+            $this->configurablePathPrinter->setRemovePrefix($removePrefix);
         }
     }
 }

--- a/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
+++ b/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
@@ -49,12 +49,24 @@ final class PathOptionsExtension implements Extension
         $builder
             ->scalarNode('editor_url')
             ->defaultNull()
+            ->end()
+        ;
+        $builder
+            ->arrayNode('remove_prefix')
+            ->scalarPrototype()
+            ->defaultValue([])
+            ->end()
         ;
     }
 
     public function load(ContainerBuilder $container, array $config)
     {
-        $this->loadConfigurablePathPrinter($container, $config['print_absolute_paths'], $config['editor_url'] ?? null);
+        $this->loadConfigurablePathPrinter(
+            $container,
+            $config['print_absolute_paths'],
+            $config['editor_url'] ?? null,
+            $config['remove_prefix']
+        );
         $this->loadPathOptionsController($container);
     }
 
@@ -62,12 +74,20 @@ final class PathOptionsExtension implements Extension
     {
     }
 
-    private function loadConfigurablePathPrinter(ContainerBuilder $container, bool $printAbsolutePaths, ?string $editorUrl): void
-    {
+    /**
+     * @param string[] $removePrefix
+     */
+    private function loadConfigurablePathPrinter(
+        ContainerBuilder $container,
+        bool $printAbsolutePaths,
+        ?string $editorUrl,
+        array $removePrefix = [],
+    ): void {
         $definition = new Definition('Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter', [
             '%paths.base%',
             $printAbsolutePaths,
             $editorUrl,
+            $removePrefix,
         ]);
         $container->setDefinition(self::CONFIGURABLE_PATH_PRINTER_ID, $definition);
     }

--- a/tests/Fixtures/ConvertConfig/full_configuration.yaml
+++ b/tests/Fixtures/ConvertConfig/full_configuration.yaml
@@ -31,6 +31,9 @@ default:
     path_options:
         print_absolute_paths: true
         editor_url: phpstorm://open?file={relPath}&line={line}
+        remove_prefix:
+            - features/bootstrap/
+            - features/
     extensions:
         custom_extension.php: ~
 

--- a/tests/Fixtures/ConvertConfig/path_options.yaml
+++ b/tests/Fixtures/ConvertConfig/path_options.yaml
@@ -4,3 +4,8 @@ default:
 with_editor_url:
     path_options:
         editor_url: phpstorm://open?file={relPath}&line={line}
+with_remove_prefix:
+    path_options:
+        remove_prefix:
+            - features/bootstrap/
+            - features/

--- a/tests/Fixtures/RemovePrefix/behat.php
+++ b/tests/Fixtures/RemovePrefix/behat.php
@@ -1,0 +1,13 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+
+return (new Config())
+    ->withProfile(new Profile('default'))
+    ->withProfile((new Profile('remove_prefix'))
+        ->withPathOptions(removePrefix: [
+            'features' . DIRECTORY_SEPARATOR . 'bootstrap' . DIRECTORY_SEPARATOR,
+            'features' . DIRECTORY_SEPARATOR,
+        ])
+    );

--- a/tests/Fixtures/RemovePrefix/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/RemovePrefix/features/bootstrap/FeatureContext.php
@@ -1,0 +1,18 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Step\Given;
+
+class FeatureContext implements Context
+{
+    #[Given('I have a passing step')]
+    public function iHaveAPassingStep()
+    {
+    }
+
+    #[Given('I have a step that throws an exception')]
+    public function iHaveAFailingStep()
+    {
+        $a = $b;
+    }
+}

--- a/tests/Fixtures/RemovePrefix/features/test.feature
+++ b/tests/Fixtures/RemovePrefix/features/test.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Scenario:
+    Given I have a passing step
+    And I have a step that throws an exception


### PR DESCRIPTION
If your feature or context files are located in some subfolders, for example `tests/behat/features` and `src/behat`, it is not very informative if these folders are always printed when printing paths and you may prefer to remove them, so that for example instead of

```
Scenario: # tests/behat/features/users/login.feature:3
```

you see
```
Scenario: # users/login.feature:3
```

This PR adds a new `removePrefix` option to the configurable path printer that allows you to define a list of prefixes that need to be removed from paths when printing them. This affects only the visible paths, not the ones used in the editorUrl. This option is available in the command line (where the prefixes need to be comma separated), the yaml config and the php config

These prefixes are removed in the order in which they are defined, so you need to list more specific prefixes first

