### PR TITLE
chore: Relax constraint on composer/xdebug-handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-mbstring": "*",
         "behat/gherkin": "^4.12.0",
         "composer-runtime-api": "^2.2",
-        "composer/xdebug-handler": "^3.0",
+        "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
         "nikic/php-parser": "^5.2",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",


### PR DESCRIPTION
These will allow users to upgrade to newer Behat versions even
if they have a dependency that is holding back their 
composer/xdebug-handler version.

* 1.4.0 adds support for PHP 8 and is therefore the minimum we can allow
* 2.x has API changes, but none that affect the methods we are calling
* 3.x only drops support for old PHP and adds strict types

Therefore, it should be safe to accept all of these versions.

Refs #1637

### Testing

We do not currently have any feature / test coverage for the "disable xdebug" feature.

I structured a feature that could prove it was working as expected, and have run that manually / locally with the latest 1.4.x, 2.x and 3.x versions.

For testing in CI we have two issues:

First, our dev dependency on `friends-of-php/php-cs-fixer` requires `composer/xdebug-handler:^3.0.3`. This makes it a bit complex to set up matrix jobs that can install the 1.4.x or 2.x versions.

Second, our main Behat process automatically disables xdebug. This setting is persisted to child processes by xdebug-handler (which writes temporary .ini files, then modifies the env vars to read them). Therefore there's no way to prove whether the `--xdebug` command line argument does anything, because the child Behat processes we run will *always* start with xdebug disabled.

I don't think we want to enable xdebug for all of our features, so the only thing I can think of would be to run a totally separate Behat process (e.g. as a new step in the job) just to prove the xdebug behaviour - but that again feels quite complex for what this is?