### PR TITLE
chore: Support 4.19.x versions of nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "behat/gherkin": "^4.12.0",
         "composer-runtime-api": "^2.2",
         "composer/xdebug-handler": "^3.0",
-        "nikic/php-parser": "^5.2",
+        "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -177,7 +177,7 @@ Feature: Convert config
               ->withSuite((new Suite('my_suite'))
                   ->withContexts(
                       'MyContext',
-                      'App\AnotherContext'
+                      'AnotherContext'
                   )));
       """
     And the temp "suite_contexts.yaml" file should have been removed
@@ -200,20 +200,20 @@ Feature: Convert config
               ->withSuite((new Suite('my_suite'))
                   ->addContext('MyContext')
                   ->addContext(
-                      'App\AContextWithPositionalArgs',
+                      'AContextWithPositionalArgs',
                       [
                           'First Arg',
                           'Second Arg',
                       ]
                   )
                   ->addContext(
-                      'App\AContextWithNamedArgs',
+                      'AContextWithNamedArgs',
                       [
                           'param1' => 'Something',
                           'param2' => 'Else',
                       ]
                   )
-                  ->addContext('App\AnotherContext')));
+                  ->addContext('AnotherContext')));
       """
     And the temp "suite_contexts.yaml" file should have been removed
 

--- a/tests/Fixtures/ConvertConfig/suite_contexts.yaml
+++ b/tests/Fixtures/ConvertConfig/suite_contexts.yaml
@@ -3,4 +3,4 @@ default:
         my_suite:
             contexts:
                 - MyContext
-                - App\AnotherContext
+                - AnotherContext

--- a/tests/Fixtures/ConvertConfig/suite_contexts_with_args.yaml
+++ b/tests/Fixtures/ConvertConfig/suite_contexts_with_args.yaml
@@ -3,10 +3,10 @@ default:
         my_suite:
             contexts:
                 - MyContext
-                - App\AContextWithPositionalArgs:
+                - AContextWithPositionalArgs:
                     - First Arg
                     - Second Arg
-                - App\AContextWithNamedArgs:
+                - AContextWithNamedArgs:
                       param1: Something
                       param2: Else
-                - App\AnotherContext
+                - AnotherContext


### PR DESCRIPTION
Requiring ^5.2 was causing dependency conflicts that were preventing end-users from upgrading to newer Behat versions.

We only actually *require* nikic/php-parser for running the convert-config command to generate PHP config from the old YAML files. I therefore explored making it a suggested dependency that was only used to run that command.

The problem is that it is also required indirectly by many of our dev dependencies (including PHPUnit, which we use to run our assertions). This means we can't configure a CI run where it is **not** installed, so would not have confidence that Behat does indeed work as expected without it.

The best compromise is to relax the constraint to ^4.19.2 (this version introduced enum support, which we need). That should resolve the conflict for the majority of users.

Refs #1637 