### PR TITLE
test: Run fixture-based scenarios in isolated directories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "rector/rector": "2.1.4",
         "sebastian/diff": "^4.0",
         "symfony/polyfill-php84": "^1.31",
-        "symfony/process": "^5.4 || ^6.4 || ^7.0"
+        "symfony/process": "^5.4 || ^6.4 || ^7.0",
+        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0"
     },
 
     "suggest": {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -370,6 +370,21 @@ EOL;
         Assert::assertEquals($this->getExpectedOutput($text), $fileContent);
     }
 
+    #[Then(':path file should contain exactly:')]
+    public function fileShouldContainExactly(string $path, PyStringNode $text): void
+    {
+        $path = $this->workingDir.'/'.$path;
+        Assert::assertFileExists($path);
+
+        $fileContent = trim(file_get_contents($path));
+        // Normalize the line endings in the output
+        if ("\n" !== PHP_EOL) {
+            $fileContent = str_replace(PHP_EOL, "\n", $fileContent);
+        }
+
+        Assert::assertEquals($text, $fileContent);
+    }
+
     /**
      * Checks whether specified content and structure of the xml is correct without worrying about layout.
      *

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -639,7 +639,7 @@ EOL;
                     $value = $this->tempDir . substr($value, strlen('{SYSTEM_TMP_DIR}'));
                 }
                 if (str_starts_with($value, '{BASE_PATH}')) {
-                    $basePath = $this->workingDir . DIRECTORY_SEPARATOR;
+                    $basePath = realpath($this->workingDir) . DIRECTORY_SEPARATOR;
                     $value = $basePath . substr($value, strlen('{BASE_PATH}'));
                 }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -40,10 +40,7 @@ class FeatureContext implements Context
      * @var string
      */
     private $workingDir;
-    /**
-     * @var string
-     */
-    private $tempDir;
+
     /**
      * @var string
      */
@@ -91,7 +88,6 @@ class FeatureContext implements Context
             throw new RuntimeException('Unable to find the PHP executable.');
         }
         $this->workingDir = $dir;
-        $this->tempDir = $dir;
         $this->phpBin = $php;
     }
 
@@ -406,15 +402,6 @@ EOL;
         Assert::assertFileDoesNotExist($path);
     }
 
-    /**
-     * @Then the temp :path file xml should be like:
-     */
-    public function theTempFileFileXmlShouldBeLike($path, PyStringNode $text): void
-    {
-        $path = $this->tempDir . '/' . $path;
-        $this->checkXmlFileContents($path, $text);
-    }
-
     private function checkXmlFileContents($path, PyStringNode $text)
     {
         Assert::assertFileExists($path);
@@ -549,15 +536,6 @@ EOL;
         $this->checkXmlIsValid($path, $schemaPath);
     }
 
-    /**
-     * @Then the temp file :xmlFile should be a valid document according to :schemaPath
-     */
-    public function theTempFileShouldBeAValidDocumentAccordingTo($xmlFile, $schemaPath): void
-    {
-        $path = $this->tempDir . '/' . $xmlFile;
-        $this->checkXmlIsValid($path, $schemaPath);
-    }
-
     private function checkXmlIsValid(string $xmlFile, string $schemaPath): void
     {
         $dom = new DOMDocument();
@@ -635,9 +613,6 @@ EOL;
             $option = $row['option'];
             $value = $row['value'];
             if ($value !== '') {
-                if (str_starts_with($value, '{SYSTEM_TMP_DIR}')) {
-                    $value = $this->tempDir . substr($value, strlen('{SYSTEM_TMP_DIR}'));
-                }
                 if (str_starts_with($value, '{BASE_PATH}')) {
                     $basePath = realpath($this->workingDir) . DIRECTORY_SEPARATOR;
                     $value = $basePath . substr($value, strlen('{BASE_PATH}'));

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -54,6 +54,11 @@ class FeatureContext implements Context
      */
     private $answerString;
 
+    public function __construct(
+        private readonly Filesystem $filesystem = new Filesystem(),
+    ) {
+    }
+
     /**
      * Cleans test folders in the temporary directory.
      *
@@ -64,11 +69,6 @@ class FeatureContext implements Context
     public static function cleanTestFolders()
     {
         (new Filesystem())->remove(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat');
-    }
-
-    public function __construct(
-        private readonly Filesystem $filesystem = new Filesystem(),
-    ) {
     }
 
     /**

--- a/features/config_strict_testers.feature
+++ b/features/config_strict_testers.feature
@@ -4,7 +4,7 @@ Feature: Strict result interpretation defined in configuration file
   I need to be able to configure "strict" option in the configuration file
 
   Background:
-    Given I set the working directory to the "ConfigStrictTesters" fixtures folder
+    Given I initialise the working directory from the "ConfigStrictTesters" fixtures folder
     And I provide the following options for all behat invocations:
       | option      | value    |
       | --no-colors |          |

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -425,7 +425,7 @@ Feature: Convert config
       | option   | value             |
       | --config | path_options.yaml |
     Then it should pass
-    And "path_options.php" file should contain:
+    And "path_options.php" file should contain exactly:
       """
       <?php
 
@@ -481,7 +481,7 @@ Feature: Convert config
       | option   | value                   |
       | --config | full_configuration.yaml |
     Then it should pass
-    And "full_configuration.php" file should contain:
+    And "full_configuration.php" file should contain exactly:
       """
       <?php
 

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -140,7 +140,7 @@ Feature: Convert config
       return (new Config())
           ->withProfile(new Profile('other'));
       """
-    And the temp "imports.yaml" file should have been removed
+    And the temp "multiple_imports.yaml" file should have been removed
     And the temp "imported.yaml" file should have been removed
     And the temp "other_imported.yaml" file should have been removed
 
@@ -223,7 +223,7 @@ Feature: Convert config
                   )
                   ->addContext('AnotherContext')));
       """
-    And the temp "suite_contexts.yaml" file should have been removed
+    And the temp "suite_contexts_with_args.yaml" file should have been removed
 
   Scenario: Suite paths
     When I copy the "suite_paths.yaml" file to the temp folder

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -101,8 +101,8 @@ Feature: Convert config
       """
       Starting conversion
       Converting configuration file: multiple_imports.yaml
-      Converting configuration file: ./imported.yaml
-      Converting configuration file: ./other_imported.yaml
+      Converting configuration file: .%%DS%%imported.yaml
+      Converting configuration file: .%%DS%%other_imported.yaml
       Conversion finished
       """
     And "multiple_imports.php" file should contain:

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -4,7 +4,7 @@ Feature: Convert config
   I need to be able to convert this configuration to the new PHP format
 
   Background:
-    Given I set the working directory to the "ConvertConfig" fixtures folder
+    Given I initialise the working directory from the "ConvertConfig" fixtures folder
     And I clear the default behat options
     And I provide the following options for all behat invocations:
       | option           | value |
@@ -12,12 +12,11 @@ Feature: Convert config
       | --convert-config |       |
 
   Scenario: Convert empty file
-    When I copy the "empty.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                       |
-      | --config | {SYSTEM_TMP_DIR}/empty.yaml |
+      | option   | value      |
+      | --config | empty.yaml |
     Then it should pass
-    And the temp "empty.php" file should be like:
+    And "empty.php" file should contain:
       """
       <?php
 
@@ -25,15 +24,14 @@ Feature: Convert config
 
       return new Config();
       """
-    And the temp "empty.yaml" file should have been removed
+    And the "empty.yaml" file should have been removed from the working directory
 
   Scenario: Convert profiles
-    When I copy the "profiles.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                          |
-      | --config | {SYSTEM_TMP_DIR}/profiles.yaml |
+      | option   | value         |
+      | --config | profiles.yaml |
     Then it should pass
-    And the temp "profiles.php" file should be like:
+    And "profiles.php" file should contain:
       """
       <?php
 
@@ -44,15 +42,14 @@ Feature: Convert config
           ->withProfile(new Profile('default'))
           ->withProfile(new Profile('another'));
       """
-    And the temp "profiles.yaml" file should have been removed
+    And the "profiles.yaml" file should have been removed from the working directory
 
   Scenario: Preferred profile
-    When I copy the "preferred_profile.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                                   |
-      | --config | {SYSTEM_TMP_DIR}/preferred_profile.yaml |
+      | option   | value                  |
+      | --config | preferred_profile.yaml |
     Then it should pass
-    And the temp "preferred_profile.php" file should be like:
+    And "preferred_profile.php" file should contain:
       """
       <?php
 
@@ -65,16 +62,14 @@ Feature: Convert config
               ->disableFormatter('pretty'))
           ->withPreferredProfile('another');
       """
-    And the temp "preferred_profile.yaml" file should have been removed
+    And the "preferred_profile.yaml" file should have been removed from the working directory
 
   Scenario: Imports
-    When I copy the "imports.yaml" file to the temp folder
-    And I copy the "imported.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                         |
-      | --config | {SYSTEM_TMP_DIR}/imports.yaml |
+      | option   | value        |
+      | --config | imports.yaml |
     Then it should pass
-    And the temp "imports.php" file should be like:
+    And "imports.php" file should contain:
       """
       <?php
 
@@ -85,7 +80,7 @@ Feature: Convert config
           ->import('imported.php')
           ->withProfile(new Profile('default'));
     """
-    And the temp "imported.php" file should be like:
+    And "imported.php" file should contain:
       """
       <?php
 
@@ -95,18 +90,22 @@ Feature: Convert config
       return (new Config())
           ->withProfile(new Profile('another'));
       """
-    And the temp "imports.yaml" file should have been removed
-    And the temp "imported.yaml" file should have been removed
+    And the "imports.yaml" file should have been removed from the working directory
+    And the "imported.yaml" file should have been removed from the working directory
 
   Scenario: Multiple Imports
-    When I copy the "multiple_imports.yaml" file to the temp folder
-    And I copy the "imported.yaml" file to the temp folder
-    And I copy the "other_imported.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                                  |
-      | --config | {SYSTEM_TMP_DIR}/multiple_imports.yaml |
-    Then it should pass
-    And the temp "multiple_imports.php" file should be like:
+      | option   | value                 |
+      | --config | multiple_imports.yaml |
+    Then it should pass with:
+      """
+      Starting conversion
+      Converting configuration file: multiple_imports.yaml
+      Converting configuration file: ./imported.yaml
+      Converting configuration file: ./other_imported.yaml
+      Conversion finished
+      """
+    And "multiple_imports.php" file should contain:
       """
       <?php
 
@@ -119,8 +118,8 @@ Feature: Convert config
               'other_imported.php',
           ])
           ->withProfile(new Profile('default'));
-    """
-    And the temp "imported.php" file should be like:
+      """
+    And "imported.php" file should contain:
       """
       <?php
 
@@ -130,7 +129,7 @@ Feature: Convert config
       return (new Config())
           ->withProfile(new Profile('another'));
       """
-    And the temp "other_imported.php" file should be like:
+    And "other_imported.php" file should contain:
       """
       <?php
 
@@ -140,17 +139,16 @@ Feature: Convert config
       return (new Config())
           ->withProfile(new Profile('other'));
       """
-    And the temp "multiple_imports.yaml" file should have been removed
-    And the temp "imported.yaml" file should have been removed
-    And the temp "other_imported.yaml" file should have been removed
+    And the "multiple_imports.yaml" file should have been removed from the working directory
+    And the "imported.yaml" file should have been removed from the working directory
+    And the "other_imported.yaml" file should have been removed from the working directory
 
   Scenario: Suites
-    When I copy the "suites.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                        |
-      | --config | {SYSTEM_TMP_DIR}/suites.yaml |
+      | option   | value       |
+      | --config | suites.yaml |
     Then it should pass
-    And the temp "suites.php" file should be like:
+    And "suites.php" file should contain:
       """
       <?php
 
@@ -163,15 +161,14 @@ Feature: Convert config
               ->withSuite(new Suite('one_suite'))
               ->withSuite(new Suite('another_suite')));
       """
-    And the temp "suites.yaml" file should have been removed
+    And the "suites.yaml" file should have been removed from the working directory
 
   Scenario: Suite contexts
-    When I copy the "suite_contexts.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                                |
-      | --config | {SYSTEM_TMP_DIR}/suite_contexts.yaml |
+      | option   | value               |
+      | --config | suite_contexts.yaml |
     Then it should pass
-    And the temp "suite_contexts.php" file should be like:
+    And "suite_contexts.php" file should contain:
       """
       <?php
 
@@ -187,15 +184,14 @@ Feature: Convert config
                       'AnotherContext'
                   )));
       """
-    And the temp "suite_contexts.yaml" file should have been removed
+    And the "suite_contexts.yaml" file should have been removed from the working directory
 
   Scenario: Suite contexts with arguments
-    When I copy the "suite_contexts_with_args.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                                          |
-      | --config | {SYSTEM_TMP_DIR}/suite_contexts_with_args.yaml |
+      | option   | value                         |
+      | --config | suite_contexts_with_args.yaml |
     Then it should pass
-    And the temp "suite_contexts_with_args.php" file should be like:
+    And "suite_contexts_with_args.php" file should contain:
       """
       <?php
 
@@ -223,15 +219,14 @@ Feature: Convert config
                   )
                   ->addContext('AnotherContext')));
       """
-    And the temp "suite_contexts_with_args.yaml" file should have been removed
+    And the "suite_contexts_with_args.yaml" file should have been removed from the working directory
 
   Scenario: Suite paths
-    When I copy the "suite_paths.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                             |
-      | --config | {SYSTEM_TMP_DIR}/suite_paths.yaml |
+      | option   | value            |
+      | --config | suite_paths.yaml |
     Then it should pass
-    And the temp "suite_paths.php" file should be like:
+    And "suite_paths.php" file should contain:
       """
       <?php
 
@@ -247,15 +242,14 @@ Feature: Convert config
                       'other.feature'
                   )));
       """
-    And the temp "suite_paths.yaml" file should have been removed
+    And the "suite_paths.yaml" file should have been removed from the working directory
 
   Scenario: Suite filters
-    When I copy the "suite_filters.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                               |
-      | --config | {SYSTEM_TMP_DIR}/suite_filters.yaml |
+      | option   | value              |
+      | --config | suite_filters.yaml |
     Then it should pass
-    And the temp "suite_filters.php" file should be like:
+    And "suite_filters.php" file should contain:
       """
       <?php
 
@@ -269,15 +263,14 @@ Feature: Convert config
               ->withSuite((new Suite('my_suite'))
                   ->withFilter(new TagFilter('@run'))));
       """
-    And the temp "suite_filters.yaml" file should have been removed
+    And the "suite_filters.yaml" file should have been removed from the working directory
 
   Scenario: Extensions
-    When I copy the "extensions.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                            |
-      | --config | {SYSTEM_TMP_DIR}/extensions.yaml |
+      | option   | value           |
+      | --config | extensions.yaml |
     Then it should pass
-    And the temp "extensions.php" file should be like:
+    And "extensions.php" file should contain:
       """
       <?php
 
@@ -297,15 +290,14 @@ Feature: Convert config
                   ],
               ])));
       """
-    And the temp "extensions.yaml" file should have been removed
+    And the "extensions.yaml" file should have been removed from the working directory
 
   Scenario: Class references for known extensions and contexts
-    Given I copy the "class_references.yaml" file to the temp folder
     When  I run behat with the following additional options:
-      | option   | value                                  |
-      | --config | {SYSTEM_TMP_DIR}/class_references.yaml |
+      | option   | value                 |
+      | --config | class_references.yaml |
     Then it should pass
-    And the temp "class_references.php" file should be like:
+    And "class_references.php" file should contain:
       """
       <?php
 
@@ -341,15 +333,14 @@ Feature: Convert config
                   )
                   ->addContext(MySecondContext::class)));
       """
-    And the temp "class_references.yaml" file should have been removed
+    And the "class_references.yaml" file should have been removed from the working directory
 
   Scenario: Profile filters
-    When I copy the "profile_filters.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                                 |
-      | --config | {SYSTEM_TMP_DIR}/profile_filters.yaml |
+      | option   | value                |
+      | --config | profile_filters.yaml |
     Then it should pass
-    And the temp "profile_filters.php" file should be like:
+    And "profile_filters.php" file should contain:
       """
       <?php
 
@@ -363,15 +354,14 @@ Feature: Convert config
               ->withFilter(new NameFilter('john'))
               ->withFilter(new RoleFilter('admin')));
       """
-    And the temp "profile_filters.yaml" file should have been removed
+    And the "profile_filters.yaml" file should have been removed from the working directory
 
   Scenario: Unused definitions
-    When I copy the "unused_definitions.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                                    |
-      | --config | {SYSTEM_TMP_DIR}/unused_definitions.yaml |
+      | option   | value                   |
+      | --config | unused_definitions.yaml |
     Then it should pass
-    And the temp "unused_definitions.php" file should be like:
+    And "unused_definitions.php" file should contain:
       """
       <?php
 
@@ -382,15 +372,14 @@ Feature: Convert config
           ->withProfile((new Profile('default'))
               ->withPrintUnusedDefinitions());
       """
-    And the temp "unused_definitions.yaml" file should have been removed
+    And the "unused_definitions.yaml" file should have been removed from the working directory
 
   Scenario: Formatters
-    When I copy the "formatters.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                            |
-      | --config | {SYSTEM_TMP_DIR}/formatters.yaml |
+      | option   | value           |
+      | --config | formatters.yaml |
     Then it should pass
-    And the temp "formatters.php" file should be like:
+    And "formatters.php" file should contain:
       """
       <?php
 
@@ -429,15 +418,14 @@ Feature: Convert config
                       ],
                   ])));
       """
-    And the temp "formatters.yaml" file should have been removed
+    And the "formatters.yaml" file should have been removed from the working directory
 
   Scenario: path options
-    When I copy the "path_options.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                                    |
-      | --config | {SYSTEM_TMP_DIR}/path_options.yaml |
+      | option   | value             |
+      | --config | path_options.yaml |
     Then it should pass
-    And the temp "path_options.php" file should be like:
+    And "path_options.php" file should contain:
       """
       <?php
 
@@ -455,15 +443,14 @@ Feature: Convert config
                   'features/',
               ]));
       """
-    And the temp "path_options.yaml" file should have been removed
+    And the "path_options.yaml" file should have been removed from the working directory
 
   Scenario: Tester options
-    Given I copy the "tester_options.yaml" file to the temp folder
     When I run behat with the following additional options:
-      | option   | value                                    |
-      | --config | {SYSTEM_TMP_DIR}/tester_options.yaml |
+      | option   | value               |
+      | --config | tester_options.yaml |
     Then it should pass
-    And the temp "tester_options.php" file should be like:
+    And "tester_options.php" file should contain:
       """
       <?php
 
@@ -486,17 +473,15 @@ Feature: Convert config
                   ->withSkipAllTests()
                   ->withErrorReporting(E_ALL & ~(E_WARNING | E_NOTICE | E_DEPRECATED))));
       """
-    And the temp "tester_options.yaml" file should have been removed
+    And the "tester_options.yaml" file should have been removed from the working directory
 
   Scenario: Full configuration
-    When I copy the "full_configuration.yaml" file to the temp folder
-    And I copy the "imported.yaml" file to the temp folder
     And the "MY_SECRET_PASSWORD" environment variable is set to "sesame"
     When I run behat with the following additional options:
-      | option   | value                                    |
-      | --config | {SYSTEM_TMP_DIR}/full_configuration.yaml |
+      | option   | value                   |
+      | --config | full_configuration.yaml |
     Then it should pass
-    And the temp "full_configuration.php" file should be like:
+    And "full_configuration.php" file should contain:
       """
       <?php
 
@@ -553,7 +538,7 @@ Feature: Convert config
                   ->withErrorReporting(E_ERROR)))
           ->withPreferredProfile('other');
       """
-    And the temp "imported.php" file should be like:
+    And "imported.php" file should contain:
       """
       <?php
 
@@ -563,5 +548,5 @@ Feature: Convert config
       return (new Config())
           ->withProfile(new Profile('another'));
       """
-    And the temp "full_configuration.yaml" file should have been removed
-    And the temp "imported.yaml" file should have been removed
+    And the "full_configuration.yaml" file should have been removed from the working directory
+    And the "imported.yaml" file should have been removed from the working directory

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -16,7 +16,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                       |
       | --config | {SYSTEM_TMP_DIR}/empty.yaml |
-    Then the temp "empty.php" file should be like:
+    Then it should pass
+    And the temp "empty.php" file should be like:
       """
       <?php
 
@@ -31,7 +32,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                          |
       | --config | {SYSTEM_TMP_DIR}/profiles.yaml |
-    Then the temp "profiles.php" file should be like:
+    Then it should pass
+    And the temp "profiles.php" file should be like:
       """
       <?php
 
@@ -49,7 +51,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                   |
       | --config | {SYSTEM_TMP_DIR}/preferred_profile.yaml |
-    Then the temp "preferred_profile.php" file should be like:
+    Then it should pass
+    And the temp "preferred_profile.php" file should be like:
       """
       <?php
 
@@ -70,7 +73,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                         |
       | --config | {SYSTEM_TMP_DIR}/imports.yaml |
-    Then the temp "imports.php" file should be like:
+    Then it should pass
+    And the temp "imports.php" file should be like:
       """
       <?php
 
@@ -101,7 +105,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                  |
       | --config | {SYSTEM_TMP_DIR}/multiple_imports.yaml |
-    Then the temp "multiple_imports.php" file should be like:
+    Then it should pass
+    And the temp "multiple_imports.php" file should be like:
       """
       <?php
 
@@ -144,7 +149,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                        |
       | --config | {SYSTEM_TMP_DIR}/suites.yaml |
-    Then the temp "suites.php" file should be like:
+    Then it should pass
+    And the temp "suites.php" file should be like:
       """
       <?php
 
@@ -164,7 +170,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                |
       | --config | {SYSTEM_TMP_DIR}/suite_contexts.yaml |
-    Then the temp "suite_contexts.php" file should be like:
+    Then it should pass
+    And the temp "suite_contexts.php" file should be like:
       """
       <?php
 
@@ -187,7 +194,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                          |
       | --config | {SYSTEM_TMP_DIR}/suite_contexts_with_args.yaml |
-    Then the temp "suite_contexts_with_args.php" file should be like:
+    Then it should pass
+    And the temp "suite_contexts_with_args.php" file should be like:
       """
       <?php
 
@@ -222,7 +230,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                             |
       | --config | {SYSTEM_TMP_DIR}/suite_paths.yaml |
-    Then the temp "suite_paths.php" file should be like:
+    Then it should pass
+    And the temp "suite_paths.php" file should be like:
       """
       <?php
 
@@ -245,7 +254,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                               |
       | --config | {SYSTEM_TMP_DIR}/suite_filters.yaml |
-    Then the temp "suite_filters.php" file should be like:
+    Then it should pass
+    And the temp "suite_filters.php" file should be like:
       """
       <?php
 
@@ -266,7 +276,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                            |
       | --config | {SYSTEM_TMP_DIR}/extensions.yaml |
-    Then the temp "extensions.php" file should be like:
+    Then it should pass
+    And the temp "extensions.php" file should be like:
       """
       <?php
 
@@ -293,7 +304,8 @@ Feature: Convert config
     When  I run behat with the following additional options:
       | option   | value                                  |
       | --config | {SYSTEM_TMP_DIR}/class_references.yaml |
-    Then the temp "class_references.php" file should be like:
+    Then it should pass
+    And the temp "class_references.php" file should be like:
       """
       <?php
 
@@ -336,7 +348,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                 |
       | --config | {SYSTEM_TMP_DIR}/profile_filters.yaml |
-    Then the temp "profile_filters.php" file should be like:
+    Then it should pass
+    And the temp "profile_filters.php" file should be like:
       """
       <?php
 
@@ -357,7 +370,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                    |
       | --config | {SYSTEM_TMP_DIR}/unused_definitions.yaml |
-    Then the temp "unused_definitions.php" file should be like:
+    Then it should pass
+    And the temp "unused_definitions.php" file should be like:
       """
       <?php
 
@@ -375,7 +389,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                            |
       | --config | {SYSTEM_TMP_DIR}/formatters.yaml |
-    Then the temp "formatters.php" file should be like:
+    Then it should pass
+    And the temp "formatters.php" file should be like:
       """
       <?php
 
@@ -421,7 +436,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                    |
       | --config | {SYSTEM_TMP_DIR}/path_options.yaml |
-    Then the temp "path_options.php" file should be like:
+    Then it should pass
+    And the temp "path_options.php" file should be like:
       """
       <?php
 
@@ -446,7 +462,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                    |
       | --config | {SYSTEM_TMP_DIR}/tester_options.yaml |
-    Then the temp "tester_options.php" file should be like:
+    Then it should pass
+    And the temp "tester_options.php" file should be like:
       """
       <?php
 
@@ -478,7 +495,8 @@ Feature: Convert config
     When I run behat with the following additional options:
       | option   | value                                    |
       | --config | {SYSTEM_TMP_DIR}/full_configuration.yaml |
-    Then the temp "full_configuration.php" file should be like:
+    Then it should pass
+    And the temp "full_configuration.php" file should be like:
       """
       <?php
 

--- a/features/definitions_transformations_annotations.feature
+++ b/features/definitions_transformations_annotations.feature
@@ -4,7 +4,7 @@ Feature: Step Arguments Transformations Annotations
   I need to use transformation functions using annotations
 
   Background:
-    Given I set the working directory to the "Transformations" fixtures folder
+    Given I initialise the working directory from the "Transformations" fixtures folder
     And I provide the following options for all behat invocations:
       | option      | value       |
       | --no-colors |             |

--- a/features/definitions_transformations_attributes.feature
+++ b/features/definitions_transformations_attributes.feature
@@ -4,7 +4,7 @@ Feature: Step Arguments Transformations with Attributes
   I need to use transformation functions using PHP attributes
 
   Background:
-    Given I set the working directory to the "Transformations" fixtures folder
+    Given I initialise the working directory from the "Transformations" fixtures folder
     And I provide the following options for all behat invocations:
       | option      | value      |
       | --no-colors |            |
@@ -58,4 +58,3 @@ Feature: Step Arguments Transformations with Attributes
       4 scenarios (4 passed)
       11 steps (11 passed)
       """
-

--- a/features/editor_url.feature
+++ b/features/editor_url.feature
@@ -4,7 +4,7 @@ Feature: Editor URL
   I need to be able to ask Behat to add editor links to file paths in the output
 
   Background:
-    Given I set the working directory to the "EditorUrl" fixtures folder
+    Given I initialise the working directory from the "EditorUrl" fixtures folder
     And I provide the following options for all behat invocations:
       | option          | value            |
       | --no-colors     |                  |
@@ -47,14 +47,14 @@ Feature: Editor URL
       | --editor-url | 'phpstorm://open?file={absPath}&line={line}' |
     Then the output should contain:
       """
-        Scenario:                                    # <href=phpstorm://open?file={BASE_PATH}tests/Fixtures/EditorUrl/features/test.feature&line=3>features/test.feature:3</>
+        Scenario:                                    # <href=phpstorm://open?file=%%WORKING_DIR%%features/test.feature&line=3>features/test.feature:3</>
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in <href=phpstorm://open?file={BASE_PATH}tests/Fixtures/EditorUrl/features/bootstrap/FeatureContext.php&line=16>features/bootstrap/FeatureContext.php line 16</>
+            Warning: Undefined variable $b in <href=phpstorm://open?file=%%WORKING_DIR%%features/bootstrap/FeatureContext.php&line=16>features/bootstrap/FeatureContext.php line 16</>
 
       --- Failed scenarios:
 
-          <href=phpstorm://open?file={BASE_PATH}tests/Fixtures/EditorUrl/features/test.feature&line=3>features/test.feature:3</>
+          <href=phpstorm://open?file=%%WORKING_DIR%%features/test.feature&line=3>features/test.feature:3</>
       """
 
   Scenario: Use relative paths in url but absolute paths in visible text
@@ -64,13 +64,12 @@ Feature: Editor URL
       | --editor-url           | 'phpstorm://open?file={relPath}&line={line}' |
     Then the output should contain:
       """
-        Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>{BASE_PATH}tests/Fixtures/EditorUrl/features/test.feature:3</>
+        Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>%%WORKING_DIR%%features/test.feature:3</>
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>{BASE_PATH}tests/Fixtures/EditorUrl/features/bootstrap/FeatureContext.php line 16</>
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>%%WORKING_DIR%%features/bootstrap/FeatureContext.php line 16</>
 
       --- Failed scenarios:
 
-          <href=phpstorm://open?file=features/test.feature&line=3>{BASE_PATH}tests/Fixtures/EditorUrl/features/test.feature:3</>
+          <href=phpstorm://open?file=features/test.feature&line=3>%%WORKING_DIR%%features/test.feature:3</>
       """
-

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -4,7 +4,7 @@ Feature: Error Reporting
   I need to have an ability to set a custom error level for steps to be executed in
 
   Background:
-    Given I set the working directory to the "ErrorReporting" fixtures folder
+    Given I initialise the working directory from the "ErrorReporting" fixtures folder
     And I provide the following options for all behat invocations:
       | option      | value    |
       | --no-colors |          |

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -1,4 +1,4 @@
-  Feature: JUnit Formatter
+Feature: JUnit Formatter
   In order to integrate with other development tools
   As a developer
   I need to be able to generate a JUnit-compatible report
@@ -10,9 +10,9 @@
       | --no-colors     |                  |
       | --snippets-type | regex            |
       | --format        | junit            |
-      | --out           | {SYSTEM_TMP_DIR} |
+      | --out           | {BASE_PATH}/logs |
 
-    Scenario: Run a single feature
+  Scenario: Run a single feature
     When I run behat with the following additional options:
       | option         | value          |
       | --snippets-for | FeatureContext |
@@ -27,7 +27,7 @@
               throw new PendingException();
           }
       """
-    And the temp "single_feature.xml" file xml should be like:
+    And the "logs/single_feature.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="single_feature">
@@ -54,14 +54,14 @@
         </testsuite>
       </testsuites>
       """
-    And the temp file "single_feature.xml" should be a valid document according to "junit.xsd"
+    And the file "logs/single_feature.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Run multiple Features
     When I run behat with the following additional options:
       | option  | value             |
       | --suite | multiple_features |
     Then it should pass with no output
-    And the temp "multiple_features.xml" file xml should be like:
+    And the "logs/multiple_features.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="multiple_features">
@@ -73,14 +73,14 @@
         </testsuite>
       </testsuites>
       """
-    And the temp file "multiple_features.xml" should be a valid document according to "junit.xsd"
+    And the file "logs/multiple_features.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Confirm multiline scenario titles are printed correctly
     When I run behat with the following additional options:
       | option  | value            |
       | --suite | multiline_titles |
     Then it should pass with no output
-    And the temp "multiline_titles.xml" file xml should be like:
+    And the "logs/multiline_titles.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="multiline_titles">
@@ -90,14 +90,14 @@
         </testsuite>
       </testsuites>
       """
-    And the temp file "multiline_titles.xml" should be a valid document according to "junit.xsd"
+    And the file "logs/multiline_titles.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Multiple suites
     When I run behat with the following additional options:
       | option   | value          |
       | --config | two_suites.php |
     Then it should fail with no output
-    And the temp "small_kid.xml" file xml should be like:
+    And the "logs/small_kid.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="small_kid">
@@ -106,8 +106,8 @@
         </testsuite>
       </testsuites>
       """
-    And the temp file "small_kid.xml" should be a valid document according to "junit.xsd"
-    And the temp "old_man.xml" file xml should be like:
+    And the file "logs/small_kid.xml" should be a valid document according to "junit.xsd"
+    And the "logs/old_man.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="old_man">
@@ -118,14 +118,14 @@
         </testsuite>
       </testsuites>
       """
-    And the temp file "old_man.xml" should be a valid document according to "junit.xsd"
+    And the file "logs/old_man.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Report skipped testcases
     When I run behat with the following additional options:
       | option  | value              |
       | --suite | skipped_test_cases |
     Then it should fail with no output
-    And the temp "skipped_test_cases.xml" file xml should be like:
+    And the "logs/skipped_test_cases.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="skipped_test_cases">
@@ -139,14 +139,14 @@
         </testsuite>
       </testsuites>
       """
-    And the temp file "skipped_test_cases.xml" should be a valid document according to "junit.xsd"
+    And the file "logs/skipped_test_cases.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Stop on Failure
     When I run behat with the following additional options:
       | option  | value           |
       | --suite | stop_on_failure |
     Then it should fail with no output
-    And the temp "stop_on_failure.xml" file xml should be like:
+    And the "logs/stop_on_failure.xml" file xml should be like:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuites name="stop_on_failure">
@@ -157,7 +157,7 @@
         </testsuite>
       </testsuites>
       """
-    And the temp file "stop_on_failure.xml" should be a valid document according to "junit.xsd"
+    And the file "logs/stop_on_failure.xml" should be a valid document according to "junit.xsd"
 
   Scenario: Aborting due to PHP error
     When I run behat with the following additional options:
@@ -167,7 +167,7 @@
     """
     cannot extend interface Behat\Behat\Context\Context
     """
-    And the temp "abort_on_php_error.xml" file xml should be like:
+    And the "logs/abort_on_php_error.xml" file xml should be like:
     """
     <?xml version="1.0" encoding="UTF-8"?>
     <testsuites name="abort_on_php_error"/>

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -4,7 +4,7 @@
   I need to be able to generate a JUnit-compatible report
 
   Background:
-    Given I set the working directory to the "JunitFormat" fixtures folder
+    Given I initialise the working directory from the "JunitFormat" fixtures folder
     And I provide the following options for all behat invocations:
       | option          | value            |
       | --no-colors     |                  |

--- a/features/path_filters.feature
+++ b/features/path_filters.feature
@@ -4,7 +4,7 @@ Feature: Path filters
   I need Behat to support path(s) filtering
 
   Background:
-    Given I set the working directory to the "PathFilters" fixtures folder
+    Given I initialise the working directory from the "PathFilters" fixtures folder
     And I provide the following options for all behat invocations:
       | option      | value   |
       | --no-colors |         |

--- a/features/print_absolute_paths.feature
+++ b/features/print_absolute_paths.feature
@@ -4,7 +4,7 @@ Feature: Print absolute paths
   I need to be able to ask Behat to print the full absolute path for files
 
   Background:
-    Given I set the working directory to the "PrintAbsolutePaths" fixtures folder
+    Given I initialise the working directory from the "PrintAbsolutePaths" fixtures folder
     And I provide the following options for all behat invocations:
       | option          | value            |
       | --no-colors     |                  |
@@ -15,14 +15,14 @@ Feature: Print absolute paths
       | --print-absolute-paths |       |
     Then the output should contain:
       """
-        Scenario:                                    # {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+        Scenario:                                    # %%WORKING_DIR%%features/test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
+            Warning: Undefined variable $b in %%WORKING_DIR%%features/bootstrap/FeatureContext.php line 16
 
       --- Failed scenarios:
 
-          {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+          %%WORKING_DIR%%features/test.feature:3
       """
 
   Scenario: Add option in config file
@@ -31,12 +31,12 @@ Feature: Print absolute paths
       | --profile | absolute_paths       |
     Then the output should contain:
       """
-        Scenario:                                    # {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+        Scenario:                                    # %%WORKING_DIR%%features/test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/bootstrap/FeatureContext.php line 16
+            Warning: Undefined variable $b in %%WORKING_DIR%%features/bootstrap/FeatureContext.php line 16
 
       --- Failed scenarios:
 
-          {BASE_PATH}tests/Fixtures/PrintAbsolutePaths/features/test.feature:3
+          %%WORKING_DIR%%features/test.feature:3
       """

--- a/features/print_absolute_paths.feature
+++ b/features/print_absolute_paths.feature
@@ -15,14 +15,14 @@ Feature: Print absolute paths
       | --print-absolute-paths |       |
     Then the output should contain:
       """
-        Scenario:                                    # %%WORKING_DIR%%features/test.feature:3
+        Scenario:                                    # %%WORKING_DIR%%features%%DS%%test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in %%WORKING_DIR%%features/bootstrap/FeatureContext.php line 16
+            Warning: Undefined variable $b in %%WORKING_DIR%%features%%DS%%bootstrap%%DS%%FeatureContext.php line 16
 
       --- Failed scenarios:
 
-          %%WORKING_DIR%%features/test.feature:3
+          %%WORKING_DIR%%features%%DS%%test.feature:3
       """
 
   Scenario: Add option in config file
@@ -31,12 +31,12 @@ Feature: Print absolute paths
       | --profile | absolute_paths       |
     Then the output should contain:
       """
-        Scenario:                                    # %%WORKING_DIR%%features/test.feature:3
+        Scenario:                                    # %%WORKING_DIR%%features%%DS%%test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in %%WORKING_DIR%%features/bootstrap/FeatureContext.php line 16
+            Warning: Undefined variable $b in %%WORKING_DIR%%features%%DS%%bootstrap%%DS%%FeatureContext.php line 16
 
       --- Failed scenarios:
 
-          %%WORKING_DIR%%features/test.feature:3
+          %%WORKING_DIR%%features%%DS%%test.feature:3
       """

--- a/features/remove_prefix.feature
+++ b/features/remove_prefix.feature
@@ -4,7 +4,7 @@ Feature: Remove prefix
   I need to be able to ask Behat to remove specific prefixes from paths in the output
 
   Background:
-    Given I set the working directory to the "RemovePrefix" fixtures folder
+    Given I initialise the working directory from the "RemovePrefix" fixtures folder
     And I provide the following options for all behat invocations:
       | option      | value |
       | --no-colors |       |
@@ -65,12 +65,12 @@ Feature: Remove prefix
       | --remove-prefix        | {BASE_PATH} |
     Then the output should contain:
       """
-        Scenario:                                    # tests/Fixtures/RemovePrefix/features/test.feature:3
+        Scenario:                                    # features/test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in tests/Fixtures/RemovePrefix/features/bootstrap/FeatureContext.php line 16
+            Warning: Undefined variable $b in features/bootstrap/FeatureContext.php line 16
 
       --- Failed scenarios:
 
-          tests/Fixtures/RemovePrefix/features/test.feature:3
+          features/test.feature:3
       """

--- a/features/remove_prefix.feature
+++ b/features/remove_prefix.feature
@@ -65,12 +65,12 @@ Feature: Remove prefix
       | --remove-prefix        | {BASE_PATH} |
     Then the output should contain:
       """
-        Scenario:                                    # features/test.feature:3
+        Scenario:                                    # features%%DS%%test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in features/bootstrap/FeatureContext.php line 16
+            Warning: Undefined variable $b in features%%DS%%bootstrap%%DS%%FeatureContext.php line 16
 
       --- Failed scenarios:
 
-          features/test.feature:3
+          features%%DS%%test.feature:3
       """

--- a/features/stop_on_failure.feature
+++ b/features/stop_on_failure.feature
@@ -4,7 +4,7 @@ Feature: Stop on failure via config
   I need to have a stop-on-failure option on the CLI or in config
 
   Background:
-    Given I set the working directory to the "StopOnFailure" fixtures folder
+    Given I initialise the working directory from the "StopOnFailure" fixtures folder
     And I provide the following options for all behat invocations:
       | option            | value              |
       | --no-colors       |                    |

--- a/features/unused_definitions.feature
+++ b/features/unused_definitions.feature
@@ -4,7 +4,7 @@ Feature: Unused definitions
   I need to be able to generate a list of unused definitions
 
   Background:
-    Given I set the working directory to the "UnusedDefinitions" fixtures folder
+    Given I initialise the working directory from the "UnusedDefinitions" fixtures folder
     And I provide the following options for all behat invocations:
       | option                     | value    |
       | --no-colors                |          |
@@ -79,4 +79,3 @@ Feature: Unused definitions
       [Given|*] /^I have clicked "+"$/
       `TranslatedDefinitionsContext::iHaveClickedPlus()`
       """
-


### PR DESCRIPTION
Previously, we were running the scenario in the fixture directory itself (or explicitly copying individual files to a temporary directory). This risks Behat modifying fixture files during the scenario (potentially unexpectedly) and therefore affecting subsequent scenarios.

Instead, run every scenario in an isolated temporary working directory, and simply initialise this from the fixture at the beginning. This guarantees that every scenario runs in an isolated environment.

It also simplifies our step definitions, as we no longer need to provide for copying individual files to a temp dir or having separate steps to assert the content / presence of files in the temp dir.

Placeholders to some paths in features have changed because the paths are now relative to the %%WORKING_DIR%% placeholder (and are not nested under the fixture directory path) rather than to the project root.

This PR also adds some small refactors and enhancements to our features & FeatureContext - including fixing a bug that we were not cleaning up temporary directories created while running our features.