### PR TITLE
Fix editorUrl functionality

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -9,6 +9,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use Behat\Behat\Output\Printer\Formatter\ConsoleFormatter;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Step\Given;
@@ -498,6 +499,8 @@ EOL;
                 $text
             );
         }
+
+        $text = ConsoleFormatter::replaceHref($text);
 
         return $text;
     }

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -21,6 +21,8 @@ final class ConsoleFormatter extends BaseOutputFormatter
 {
     public const CUSTOM_PATTERN = '/{\+([a-z-_]+)}(.*?){\-\\1}/si';
 
+    public const HREF_PATTERN = '/<href=([^>]+)>(.*?)<\/>/';
+
     /**
      * Formats a message according to the given styles.
      *
@@ -30,8 +32,10 @@ final class ConsoleFormatter extends BaseOutputFormatter
      */
     public function format($message): string
     {
-        return preg_replace_callback(self::CUSTOM_PATTERN, [$this, 'replaceStyle'], $message) ??
+        $formattedMessage = preg_replace_callback(self::CUSTOM_PATTERN, [$this, 'replaceStyle'], $message) ??
             'Error formatting output: ' . preg_last_error_msg();
+
+        return self::replaceHref($formattedMessage);
     }
 
     /**
@@ -54,5 +58,22 @@ final class ConsoleFormatter extends BaseOutputFormatter
         }
 
         return $style->apply($match[2]);
+    }
+
+    /**
+     * @internal
+     */
+    public static function replaceHref(string $message): string
+    {
+        return preg_replace_callback(
+            self::HREF_PATTERN,
+            function ($matches) {
+                $url = $matches[1];
+                $text = $matches[2];
+
+                return "\033]8;;{$url}\033\\{$text}\033]8;;\033\\";
+            },
+            $message
+        );
     }
 }


### PR DESCRIPTION
Yesterday I tried to use the new "editor url" functionality in my main project, only to find that it does not really work as expected 😞 . Since our project uses the Symfony console component, the same that Rector and PHPStan use, I had assumed that `<href=` links would be transformed by the console component in the same way as in those tools, so that this would be converted to the proper escape codes that actually show a link in the console. But our project uses a custom console formatter which is much simpler than the standard Symfony formatter and this conversion is not done. So our href links end up being printed verbatim to the console instead of being converted to proper links.

I feel a bit stupid about this because I would have sworn that I had actually tested this output in the console, but obviously I didn't. And the tests themselves should have told me that this was not OK, as the test output that we checked included these links being printed verbatim without being converted 😬 

This PR adds this conversion from href links to escape characters to our console formatter. And this time I did properly check that this works as expected in the console