### PR TITLE
chore: remove PHP 8 error conversion

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -571,10 +571,6 @@ EOL;
         // Replace wrong warning message of HHVM
         $output = str_replace('Notice: Undefined index: ', 'Notice: Undefined offset: ', $output);
 
-        // replace error messages that changed in PHP8
-        $output = str_replace('Warning: Undefined array key', 'Notice: Undefined offset:', $output);
-        $output = preg_replace('/Class "([^"]+)" not found/', 'Class \'$1\' not found', $output);
-
         return trim(preg_replace('/ +$/m', '', $output));
     }
 

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -22,7 +22,7 @@ Feature: Error Reporting
 
     001 Scenario: Access undefined index # features/php_errors_in_scenario.feature:9
           When I access array index 0    # features/php_errors_in_scenario.feature:10
-            Notice: Undefined offset: 0 in features/bootstrap/FeatureContext.php line 23
+            Warning: Undefined array key 0 in features/bootstrap/FeatureContext.php line 23
 
     002 Scenario: Trigger PHP deprecation # features/php_errors_in_scenario.feature:18
           When I trim NULL                # features/php_errors_in_scenario.feature:19
@@ -56,7 +56,7 @@ Feature: Error Reporting
 
     001 Scenario: Access undefined index # features/php_errors_in_scenario.feature:9
           When I access array index 0    # features/php_errors_in_scenario.feature:10
-            Notice: Undefined offset: 0 in features/bootstrap/FeatureContext.php line 23
+            Warning: Undefined array key 0 in features/bootstrap/FeatureContext.php line 23
 
     3 scenarios (2 passed, 1 failed)
     9 steps (7 passed, 1 failed, 1 skipped)

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -218,7 +218,7 @@ Feature: Extensions
 
       001 Scenario:                  # features/extensions.feature:2
             Given non-existent class # features/extensions.feature:3
-              Fatal error: Class 'Non\Existent\Cls' not found (Behat\Testwork\Call\Exception\FatalThrowableError)
+              Fatal error: Class "Non\Existent\Cls" not found (Behat\Testwork\Call\Exception\FatalThrowableError)
 
       002 Scenario:                   # features/extensions.feature:4
             Given non-existent method # features/extensions.feature:5


### PR DESCRIPTION
We were converting some of the errors generated by PHP8 to match the values that were listed in the text of the tests. Now that we don't support versions lower than PHP8 we can remove this conversion and just update this text