### PR TITLE
fix: Provide more context when failing with unexpected multiline args

### DIFF
--- a/features/arguments.feature
+++ b/features/arguments.feature
@@ -4,89 +4,16 @@ Feature: Step Arguments
   I need an ability to specify Table & PyString arguments to steps
 
   Background:
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context;
-      use Behat\Gherkin\Node\PyStringNode,
-          Behat\Gherkin\Node\TableNode;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-
-      class FeatureContext implements Context
-      {
-          private $input;
-          private $strings = array();
-          private $tables = array();
-
-          public function __construct() {
-              $this->strings[1] = "hello,\n  w\n   o\nr\nl\n   d";
-              $this->tables[1]  = array(
-                array('item1' => 'super', 'item2' => 'mega', 'item3' => 'extra'),
-                array('item1' => 'hyper', 'item2' => 'mini', 'item3' => 'XXL'),
-              );
-          }
-
-          #[Given('/^a pystring:$/')]
-          public function aPystring(PyStringNode $string) {
-              $this->input = $string;
-          }
-
-          #[Given('/^an untyped pystring:$/')]
-          public function anUntypedPystring($string) {
-              $this->input = $string;
-          }
-
-          #[Given('/^a table:$/')]
-          public function aTable(TableNode $table) {
-              $this->input = $table;
-          }
-
-          #[Given('/^an untyped table:$/')]
-          public function anUntypedTable($table) {
-              $this->input = $table;
-          }
-
-          #[Then('/^it must be equals to string (\d+)$/')]
-          public function itMustBeEqualsToString($number) {
-              \PHPUnit\Framework\Assert::assertEquals($this->strings[intval($number)], (string) $this->input);
-          }
-
-          #[Then('/^it must be equals to table (\d+)$/')]
-          public function itMustBeEqualsToTable($number) {
-              \PHPUnit\Framework\Assert::assertEquals($this->tables[intval($number)], $this->input->getHash());
-          }
-
-          #[Given('/^I have number2 = (?P<number2>\d+) and number1 = (?P<number1>\d+)$/')]
-          public function iHaveNumberAndNumber($number1, $number2) {
-              \PHPUnit\Framework\Assert::assertEquals(13, intval($number1));
-              \PHPUnit\Framework\Assert::assertEquals(243, intval($number2));
-          }
-
-          #[Given('/^a step with no argument$/')]
-          public function aStepWithNoArgument(): void {
-          }
-      }
-      """
+    Given I initialise the working directory from the Arguments fixtures folder
+    And I provide the following options for all behat invocations:
+      | option      | value    |
+      | --no-colors |          |
+      | --format    | progress |
 
   Scenario: PyStrings
-    Given a file named "features/pystring.feature" with:
-      """
-      Feature: PyStrings
-        Scenario:
-          Given a pystring:
-            '''
-            hello,
-              w
-               o
-          r
-           l
-               d
-            '''
-          Then it must be equals to string 1
-      """
-    When I run "behat --no-colors -f progress features/pystring.feature"
+    When I run behat with the following additional options:
+      | option                    | value |
+      | features/pystring.feature |       |
     Then it should pass with:
       """
       ..
@@ -96,26 +23,9 @@ Feature: Step Arguments
       """
 
   Scenario: PyString tokens
-    Given a file named "features/pystring_tokens.feature" with:
-      """
-      Feature: PyStrings
-        Scenario Outline:
-          Given a pystring:
-            '''
-            <word1>
-              w
-               o
-          r
-           <word2>
-               d
-            '''
-          Then it must be equals to string 1
-
-          Examples:
-            | word1  | word2 |
-            | hello, | l     |
-      """
-    When I run "behat --no-colors -f progress features/pystring_tokens.feature"
+    When I run behat with the following additional options:
+      | option                           | value |
+      | features/pystring_tokens.feature |       |
     Then it should pass with:
       """
       ..
@@ -125,21 +35,9 @@ Feature: Step Arguments
       """
 
   Scenario: Table tokens
-    Given a file named "features/table_tokens.feature" with:
-      """
-      Feature: Tables
-        Scenario Outline:
-          Given a table:
-            | item1   | item2   | item3   |
-            | <word1> | <word3> | extra   |
-            | hyper   | mini    | <word2> |
-          Then it must be equals to table 1
-
-          Examples:
-            | word1 | word2 | word3 |
-            | super | XXL   | mega  |
-      """
-    When I run "behat --no-colors -f progress features/table_tokens.feature"
+    When I run behat with the following additional options:
+      | option                        | value |
+      | features/table_tokens.feature |       |
     Then it should pass with:
       """
       ..
@@ -149,17 +47,9 @@ Feature: Step Arguments
       """
 
   Scenario: Table
-    Given a file named "features/table.feature" with:
-      """
-      Feature: Tables
-        Scenario:
-          Given a table:
-            | item1 | item2 | item3 |
-            | super | mega  | extra |
-            | hyper | mini  | XXL   |
-          Then it must be equals to table 1
-      """
-    When I run "behat --no-colors -f progress features/table.feature"
+    When I run behat with the following additional options:
+      | option                 | value |
+      | features/table.feature |       |
     Then it should pass with:
       """
       ..
@@ -169,83 +59,51 @@ Feature: Step Arguments
       """
 
   Scenario: given TableNode argument that is not defined in context
-    Given a file named "features/known-argument-exception.feature" with:
-      """
-      Feature: Tables
-        Scenario:
-          Given a step with no argument
-            | item1 | item2 | item3 |
-            | super | mega  | extra |
-            | hyper | mini  | XXL   |
-      """
-    When I run "behat --no-colors -f progress features/known-argument-exception.feature"
+    When I run behat with the following additional options:
+      | option                                      | value |
+      | features/unexpected-table-exception.feature |       |
     Then it should fail with:
       """
       You have passed a TableNode or PystringNode as an argument, but it was not used in the function. This is probably an error in your feature file.
       """
-      
-    Given a file named "features/known-argument-exception.feature" with:
+
+  Scenario: given TableNode that could match an un-typed step argument
+    When I run behat with the following additional options:
+      | option                                   | value |
+      | features/step-with-untyped-table.feature |       |
+    Then it should pass with:
       """
-      Feature: Tables
-        Scenario:
-          Given an untyped table:
-            | item1 | item2 | item3 |
-            | super | mega  | extra |
-            | hyper | mini  | XXL   |
+      .
+
+      1 scenario (1 passed)
+      1 step (1 passed)
       """
-    When I run "behat --no-colors -f progress features/known-argument-exception.feature"
-    Then it should pass
 
   Scenario: given PyStringNode argument that is not defined in context
-    Given a file named "features/known-argument-exception.feature" with:
-      """
-      Feature: PystringNodes
-        Scenario:
-          Given a step with no argument
-            '''
-            <word1>
-              w
-               o
-          r
-           <word2>
-               d
-            '''
-      """
-    When I run "behat --no-colors -f progress features/known-argument-exception.feature"
+    When I run behat with the following additional options:
+      | option                                         | value |
+      | features/unexpected-pystring-exception.feature |       |
     Then it should fail with:
       """
       You have passed a TableNode or PystringNode as an argument, but it was not used in the function. This is probably an error in your feature file.
       """
-      
-    Given a file named "features/known-argument-exception.feature" with:
+
+  Scenario: given PyString that could match an un-typed step argument
+    When I run behat with the following additional options:
+      | option                                      | value |
+      | features/step-with-untyped-pystring.feature |       |
+    Then it should pass with:
       """
-      Feature: PystringNodes
-        Scenario:
-          Given an untyped pystring:
-            '''
-            <word1>
-              w
-               o
-          r
-           <word2>
-               d
-            '''
+      .
+
+      1 scenario (1 passed)
+      1 step (1 passed)
       """
-    When I run "behat --no-colors -f progress features/known-argument-exception.feature"
-    Then it should pass
 
   Scenario: Named arguments
-    Given a file named "features/named_args.feature" with:
-      """
-      Feature: Named arguments
-        In order to maintain i18n for steps
-        As a step developer
-        I need to be able to declare regex with named parameters
-
-        Scenario:
-          Given I have number2 = 243 and number1 = 13
-      """
-    When I run "behat --no-colors -f progress features/named_args.feature "
+    When I run behat with the following additional options:
+      | option                      | value |
+      | features/named_args.feature |       |
     Then it should pass with:
       """
       .

--- a/features/arguments.feature
+++ b/features/arguments.feature
@@ -64,7 +64,8 @@ Feature: Step Arguments
       | features/unexpected-table-exception.feature |       |
     Then it should fail with:
       """
-      You have passed a TableNode or PystringNode as an argument, but it was not used in the function. This is probably an error in your feature file.
+        You have passed a TableNode or PystringNode, but it was not used by FeatureContext::aStepWithNoArgument.
+        This is probably an error in your step implementation or in %%WORKING_DIR%%features%%DS%%unexpected-table-exception.feature:3
       """
 
   Scenario: given TableNode that could match an un-typed step argument
@@ -85,7 +86,8 @@ Feature: Step Arguments
       | features/unexpected-pystring-exception.feature |       |
     Then it should fail with:
       """
-      You have passed a TableNode or PystringNode as an argument, but it was not used in the function. This is probably an error in your feature file.
+        You have passed a TableNode or PystringNode, but it was not used by FeatureContext::aStepWithNoArgument.
+        This is probably an error in your step implementation or in %%WORKING_DIR%%features%%DS%%unexpected-pystring-exception.feature:3
       """
 
   Scenario: given PyString that could match an un-typed step argument

--- a/src/Behat/Testwork/Argument/Exception/UnexpectedMultilineArgumentException.php
+++ b/src/Behat/Testwork/Argument/Exception/UnexpectedMultilineArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Behat\Testwork\Argument\Exception;
+
+use InvalidArgumentException;
+
+class UnexpectedMultilineArgumentException extends InvalidArgumentException implements ArgumentException
+{
+}

--- a/tests/Fixtures/Arguments/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Arguments/features/bootstrap/FeatureContext.php
@@ -1,0 +1,71 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Step\Given;
+use Behat\Step\Then;
+
+class FeatureContext implements Context
+{
+    private $input;
+    private $strings = [];
+    private $tables = [];
+
+    public function __construct()
+    {
+        $this->strings[1] = "hello,\n  w\n   o\nr\nl\n   d";
+        $this->tables[1] = [
+            ['item1' => 'super', 'item2' => 'mega', 'item3' => 'extra'],
+            ['item1' => 'hyper', 'item2' => 'mini', 'item3' => 'XXL'],
+        ];
+    }
+
+    #[Given('/^a pystring:$/')]
+    public function aPystring(PyStringNode $string)
+    {
+        $this->input = $string;
+    }
+
+    #[Given('/^an untyped pystring:$/')]
+    public function anUntypedPystring($string)
+    {
+        $this->input = $string;
+    }
+
+    #[Given('/^a table:$/')]
+    public function aTable(TableNode $table)
+    {
+        $this->input = $table;
+    }
+
+    #[Given('/^an untyped table:$/')]
+    public function anUntypedTable($table)
+    {
+        $this->input = $table;
+    }
+
+    #[Then('/^it must be equals to string (\d+)$/')]
+    public function itMustBeEqualsToString($number)
+    {
+        PHPUnit\Framework\Assert::assertEquals($this->strings[intval($number)], (string) $this->input);
+    }
+
+    #[Then('/^it must be equals to table (\d+)$/')]
+    public function itMustBeEqualsToTable($number)
+    {
+        PHPUnit\Framework\Assert::assertEquals($this->tables[intval($number)], $this->input->getHash());
+    }
+
+    #[Given('/^I have number2 = (?P<number2>\d+) and number1 = (?P<number1>\d+)$/')]
+    public function iHaveNumberAndNumber($number1, $number2)
+    {
+        PHPUnit\Framework\Assert::assertEquals(13, intval($number1));
+        PHPUnit\Framework\Assert::assertEquals(243, intval($number2));
+    }
+
+    #[Given('/^a step with no argument$/')]
+    public function aStepWithNoArgument(): void
+    {
+    }
+}

--- a/tests/Fixtures/Arguments/features/named_args.feature
+++ b/tests/Fixtures/Arguments/features/named_args.feature
@@ -1,0 +1,7 @@
+Feature: Named arguments
+  In order to maintain i18n for steps
+  As a step developer
+  I need to be able to declare regex with named parameters
+
+  Scenario:
+    Given I have number2 = 243 and number1 = 13

--- a/tests/Fixtures/Arguments/features/pystring.feature
+++ b/tests/Fixtures/Arguments/features/pystring.feature
@@ -1,0 +1,12 @@
+Feature: PyStrings
+  Scenario:
+    Given a pystring:
+      """
+      hello,
+        w
+         o
+    r
+     l
+         d
+      """
+    Then it must be equals to string 1

--- a/tests/Fixtures/Arguments/features/pystring_tokens.feature
+++ b/tests/Fixtures/Arguments/features/pystring_tokens.feature
@@ -1,0 +1,16 @@
+Feature: PyStrings
+  Scenario Outline:
+    Given a pystring:
+      """
+      <word1>
+        w
+         o
+    r
+     <word2>
+         d
+      """
+    Then it must be equals to string 1
+
+    Examples:
+      | word1  | word2 |
+      | hello, | l     |

--- a/tests/Fixtures/Arguments/features/step-with-untyped-pystring.feature
+++ b/tests/Fixtures/Arguments/features/step-with-untyped-pystring.feature
@@ -1,0 +1,11 @@
+Feature: PystringNodes
+  Scenario:
+    Given an untyped pystring:
+      """
+      <word1>
+        w
+         o
+    r
+     <word2>
+         d
+      """

--- a/tests/Fixtures/Arguments/features/step-with-untyped-table.feature
+++ b/tests/Fixtures/Arguments/features/step-with-untyped-table.feature
@@ -1,0 +1,6 @@
+Feature: Tables
+  Scenario:
+    Given an untyped table:
+      | item1 | item2 | item3 |
+      | super | mega  | extra |
+      | hyper | mini  | XXL   |

--- a/tests/Fixtures/Arguments/features/table.feature
+++ b/tests/Fixtures/Arguments/features/table.feature
@@ -1,0 +1,7 @@
+Feature: Tables
+  Scenario:
+    Given a table:
+      | item1 | item2 | item3 |
+      | super | mega  | extra |
+      | hyper | mini  | XXL   |
+    Then it must be equals to table 1

--- a/tests/Fixtures/Arguments/features/table_tokens.feature
+++ b/tests/Fixtures/Arguments/features/table_tokens.feature
@@ -1,0 +1,11 @@
+Feature: Tables
+  Scenario Outline:
+    Given a table:
+      | item1   | item2   | item3   |
+      | <word1> | <word3> | extra   |
+      | hyper   | mini    | <word2> |
+    Then it must be equals to table 1
+
+    Examples:
+      | word1 | word2 | word3 |
+      | super | XXL   | mega  |

--- a/tests/Fixtures/Arguments/features/unexpected-pystring-exception.feature
+++ b/tests/Fixtures/Arguments/features/unexpected-pystring-exception.feature
@@ -1,0 +1,11 @@
+Feature: PystringNodes
+  Scenario:
+    Given a step with no argument
+      """
+      <word1>
+        w
+         o
+    r
+     <word2>
+         d
+      """

--- a/tests/Fixtures/Arguments/features/unexpected-table-exception.feature
+++ b/tests/Fixtures/Arguments/features/unexpected-table-exception.feature
@@ -1,0 +1,6 @@
+Feature: Tables
+  Scenario:
+    Given a step with no argument
+      | item1 | item2 | item3 |
+      | super | mega  | extra |
+      | hyper | mini  | XXL   |


### PR DESCRIPTION
Because of the stage where it is thrown, the exception is treated as an overall fatal error. This meant that Behat does not output any detail on the feature file / step it was parsing when it encountered the unexpected argument. As a result, users had no information on the cause of the error and would have to check their features / steps manually.

Instead, include the name of the function and (where possible) the feature and step within the exception message. This will still mean that users have to fix these one at a time (Behat will exit on the first such exception) but they should at least now be able to locate the issue.

As reported by @AlexSkrypnyk in https://github.com/Behat/Behat/pull/1614#issuecomment-3354127345