### PR TITLE
Use configurable path printer in JSON and JUnit formatters

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -428,6 +428,8 @@ EOL;
 
         // The placeholder is necessary because of different separators on Unix and Windows environments
         $text = str_replace('-DIRECTORY-SEPARATOR-', DIRECTORY_SEPARATOR, $text);
+        // used for absolute paths
+        $text = str_replace('%%WORKING_DIR%%', realpath($this->workingDir . DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR, $text);
 
         $dom = new DOMDocument();
         $dom->loadXML($text);
@@ -452,6 +454,12 @@ EOL;
             '-DIRECTORY-SEPARATOR-',
             // use the correct representation of directory separators in json for each OS
             trim(json_encode(DIRECTORY_SEPARATOR, JSON_UNESCAPED_SLASHES), '"'),
+            $text
+        );
+        // used for absolute paths
+        $text = str_replace(
+            '%%WORKING_DIR%%',
+            trim(json_encode(realpath($this->workingDir . DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR, JSON_UNESCAPED_SLASHES), '"'),
             $text
         );
 

--- a/features/editor_url.feature
+++ b/features/editor_url.feature
@@ -73,3 +73,76 @@ Feature: Editor URL
 
           <href=phpstorm://open?file=features/test.feature&line=3>%%WORKING_DIR%%features/test.feature:3</>
       """
+
+  Scenario: Editor URL does not affect JSON formatter paths
+    When I run behat with the following additional options:
+      | option    | value                                        |
+      | --profile | editor_url                                   |
+      | --format  | json                                         |
+      | --out     | report.json                                  |
+    Then the "report.json" file json should be like:
+      """
+      {
+          "tests": 1,
+          "skipped": 0,
+          "failed": 1,
+          "pending": 0,
+          "undefined": 0,
+          "time": -IGNORE-VALUE-,
+          "suites": [
+              {
+                  "name": "default",
+                  "tests": 1,
+                  "skipped": 0,
+                  "failed": 1,
+                  "pending": 0,
+                  "undefined": 0,
+                  "time": -IGNORE-VALUE-,
+                  "features": [
+                      {
+                          "name": "",
+                          "tests": 1,
+                          "skipped": 0,
+                          "failed": 1,
+                          "pending": 0,
+                          "undefined": 0,
+                          "time": -IGNORE-VALUE-,
+                          "scenarios": [
+                              {
+                                  "name": "",
+                                  "time": -IGNORE-VALUE-,
+                                  "status": "failed",
+                                  "file": "features-DIRECTORY-SEPARATOR-test.feature",
+                                  "line": 5,
+                                  "failures": [
+                                      {
+                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line 16",
+                                          "type": "failed"
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ]
+      }
+    """
+
+  Scenario: Editor URL does not affect JUnit formatter paths
+    When I run behat with the following additional options:
+      | option    | value                                      |
+      | --profile | editor_url                                 |
+      | --format  | junit                                      |
+      | --out     | report                                     |
+    Then the "report/default.xml" file xml should be like:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="default">
+        <testsuite name="" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="" classname="" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-test.feature" line="5">
+            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line 16"></failure>
+          </testcase>
+        </testsuite>
+      </testsuites>
+      """

--- a/features/print_absolute_paths.feature
+++ b/features/print_absolute_paths.feature
@@ -40,3 +40,76 @@ Feature: Print absolute paths
 
           %%WORKING_DIR%%features%%DS%%test.feature:3
       """
+
+  Scenario: Print absolute paths in JSON formatter
+    When I run behat with the following additional options:
+      | option    | value          |
+      | --profile | absolute_paths |
+      | --format  | json           |
+      | --out     | report.json    |
+    Then the "report.json" file json should be like:
+      """
+      {
+          "tests": 1,
+          "skipped": 0,
+          "failed": 1,
+          "pending": 0,
+          "undefined": 0,
+          "time": -IGNORE-VALUE-,
+          "suites": [
+              {
+                  "name": "default",
+                  "tests": 1,
+                  "skipped": 0,
+                  "failed": 1,
+                  "pending": 0,
+                  "undefined": 0,
+                  "time": -IGNORE-VALUE-,
+                  "features": [
+                      {
+                          "name": "",
+                          "tests": 1,
+                          "skipped": 0,
+                          "failed": 1,
+                          "pending": 0,
+                          "undefined": 0,
+                          "time": -IGNORE-VALUE-,
+                          "scenarios": [
+                              {
+                                  "name": "",
+                                  "time": -IGNORE-VALUE-,
+                                  "status": "failed",
+                                  "file": "%%WORKING_DIR%%features-DIRECTORY-SEPARATOR-test.feature",
+                                  "line": 5,
+                                  "failures": [
+                                      {
+                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in %%WORKING_DIR%%features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line 16",
+                                          "type": "failed"
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ]
+      }
+      """
+
+  Scenario: Print absolute paths in JUnit formatter
+    When I run behat with the following additional options:
+      | option    | value          |
+      | --profile | absolute_paths |
+      | --format  | junit          |
+      | --out     | report         |
+    Then the "report/default.xml" file xml should be like:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="default">
+        <testsuite name="" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="" classname="" status="failed" time="-IGNORE-VALUE-" file="%%WORKING_DIR%%features-DIRECTORY-SEPARATOR-test.feature" line="5">
+            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in %%WORKING_DIR%%features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line 16"></failure>
+          </testcase>
+        </testsuite>
+      </testsuites>
+      """

--- a/features/remove_prefix.feature
+++ b/features/remove_prefix.feature
@@ -74,3 +74,78 @@ Feature: Remove prefix
 
           features%%DS%%test.feature:3
       """
+
+  Scenario: Remove prefixes in JSON formatter
+    When I run behat with the following additional options:
+      | option    | value           |
+      | --profile | remove_prefix   |
+      | --suite   | default         |
+      | --format  | json            |
+      | --out     | report.json     |
+    Then the "report.json" file json should be like:
+      """
+      {
+          "tests": 1,
+          "skipped": 0,
+          "failed": 1,
+          "pending": 0,
+          "undefined": 0,
+          "time": -IGNORE-VALUE-,
+          "suites": [
+              {
+                  "name": "default",
+                  "tests": 1,
+                  "skipped": 0,
+                  "failed": 1,
+                  "pending": 0,
+                  "undefined": 0,
+                  "time": -IGNORE-VALUE-,
+                  "features": [
+                      {
+                          "name": "",
+                          "tests": 1,
+                          "skipped": 0,
+                          "failed": 1,
+                          "pending": 0,
+                          "undefined": 0,
+                          "time": -IGNORE-VALUE-,
+                          "scenarios": [
+                              {
+                                  "name": "",
+                                  "time": -IGNORE-VALUE-,
+                                  "status": "failed",
+                                  "file": "test.feature",
+                                  "line": 5,
+                                  "failures": [
+                                      {
+                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in FeatureContext.php line 16",
+                                          "type": "failed"
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ]
+      }
+      """
+
+  Scenario: Remove prefixes in JUnit formatter
+    When I run behat with the following additional options:
+      | option    | value           |
+      | --profile | remove_prefix   |
+      | --suite   | default         |
+      | --format  | junit           |
+      | --out     | report          |
+    Then the "report/default.xml" file xml should be like:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="default">
+        <testsuite name="" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="" classname="" status="failed" time="-IGNORE-VALUE-" file="test.feature" line="5">
+            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in FeatureContext.php line 16"></failure>
+          </testcase>
+        </testsuite>
+      </testsuites>
+      """

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONFeaturePrinter.php
@@ -47,7 +47,7 @@ final class JSONFeaturePrinter implements FeaturePrinter
         assert($outputPrinter instanceof JSONOutputPrinter);
 
         $outputPrinter->extendFeatureAttributes([
-            'name' => $this->currentFeature->getTitle(),
+            'name' => $this->currentFeature->getTitle() ?? '',
             'tests' => $totalCount,
             'skipped' => $stats[TestResult::SKIPPED],
             'failed' => $stats[TestResult::FAILED],

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONScenarioPrinter.php
@@ -18,6 +18,7 @@ use Behat\Gherkin\Node\NamedScenarioInterface;
 use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\JSONOutputPrinter;
+use Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter;
 use Behat\Testwork\Tester\Result\TestResult;
 
 final class JSONScenarioPrinter implements ScenarioPrinter
@@ -29,6 +30,7 @@ final class JSONScenarioPrinter implements ScenarioPrinter
     public function __construct(
         private readonly ResultToStringConverter $resultConverter,
         private readonly JSONDurationListener $durationListener,
+        private readonly ConfigurablePathPrinter $configurablePathPrinter,
     ) {
     }
 
@@ -58,10 +60,10 @@ final class JSONScenarioPrinter implements ScenarioPrinter
 
         $file = $this->currentFeature->getFile();
         if ($file) {
-            $cwd = realpath(getcwd());
-            $scenarioAttributes['file'] =
-                str_starts_with($file, $cwd) ?
-                    ltrim(substr($file, strlen($cwd)), DIRECTORY_SEPARATOR) : $file;
+            $scenarioAttributes['file'] = $this->configurablePathPrinter->processPathsInText(
+                $file,
+                applyEditorUrl: false,
+            );
         }
 
         $outputPrinter = $formatter->getOutputPrinter();

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONSetupPrinter.php
@@ -60,7 +60,10 @@ final class JSONSetupPrinter implements SetupPrinter
                 if ($scope instanceof StepScope) {
                     $message .= ': ' . $scope->getStep()->getKeyword() . ' ' . $scope->getStep()->getText();
                 }
-                $message .= ': ' . $this->exceptionPresenter->presentException($hookCallResult->getException());
+                $message .= ': ' . $this->exceptionPresenter->presentException(
+                    $hookCallResult->getException(),
+                    applyEditorUrl: false
+                );
 
                 $attributes = [
                     'message' => $message,

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONStepPrinter.php
@@ -39,7 +39,10 @@ final class JSONStepPrinter implements StepPrinter
         $message = $step->getKeyword() . ' ' . $step->getText();
 
         if ($result instanceof ExceptionResult && $result->hasException()) {
-            $message .= ': ' . $this->exceptionPresenter->presentException($result->getException());
+            $message .= ': ' . $this->exceptionPresenter->presentException(
+                $result->getException(),
+                applyEditorUrl: false
+            );
         }
 
         $attributes = ['message' => $message];

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
@@ -19,6 +19,7 @@ use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\JUnitOutputPrinter;
+use Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter;
 use Behat\Testwork\Tester\Result\TestResult;
 
 /**
@@ -42,6 +43,7 @@ final class JUnitScenarioPrinter
         private readonly ResultToStringConverter $resultConverter,
         private readonly JUnitOutlineStoreListener $outlineStoreListener,
         private readonly ?JUnitDurationListener $durationListener = null,
+        private readonly ?ConfigurablePathPrinter $configurablePathPrinter = null,
     ) {
     }
 
@@ -63,11 +65,11 @@ final class JUnitScenarioPrinter
             'time' => $this->durationListener instanceof JUnitDurationListener ? $this->durationListener->getDuration($scenario) : '',
         ];
 
-        if ($file) {
-            $cwd = realpath(getcwd());
-            $testCaseAttributes['file'] =
-                str_starts_with($file, $cwd) ?
-                    ltrim(substr($file, strlen($cwd)), DIRECTORY_SEPARATOR) : $file;
+        if ($file && $this->configurablePathPrinter instanceof ConfigurablePathPrinter) {
+            $testCaseAttributes['file'] = $this->configurablePathPrinter->processPathsInText(
+                $file,
+                applyEditorUrl: false,
+            );
         }
 
         $outputPrinter->addTestcase($testCaseAttributes);

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
@@ -51,7 +51,10 @@ class JUnitSetupPrinter implements SetupPrinter
                 if ($scope instanceof StepScope) {
                     $message .= ': ' . $scope->getStep()->getKeyword() . ' ' . $scope->getStep()->getText();
                 }
-                $message .= ': ' . $this->exceptionPresenter->presentException($hookCallResult->getException());
+                $message .= ': ' . $this->exceptionPresenter->presentException(
+                    $hookCallResult->getException(),
+                    applyEditorUrl: false
+                );
 
                 $attributes = [
                     'message' => $message,

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
@@ -44,7 +44,10 @@ class JUnitStepPrinter implements StepPrinter
         $message = $step->getKeyword() . ' ' . $step->getText();
 
         if ($result instanceof ExceptionResult && $result->hasException()) {
-            $message .= ': ' . $this->exceptionPresenter->presentException($result->getException());
+            $message .= ': ' . $this->exceptionPresenter->presentException(
+                $result->getException(),
+                applyEditorUrl: false
+            );
         }
 
         $attributes = ['message' => $message];

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/JSONFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/JSONFormatterFactory.php
@@ -31,6 +31,7 @@ use Behat\Testwork\Output\Printer\Factory\FileOutputFactory;
 use Behat\Testwork\Output\Printer\JSONOutputPrinter;
 use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
 use Behat\Testwork\Output\ServiceContainer\OutputExtension;
+use Behat\Testwork\PathOptions\ServiceContainer\PathOptionsExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -81,6 +82,7 @@ final class JSONFormatterFactory implements FormatterFactory
         $definition = new Definition(JSONScenarioPrinter::class, [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference('output.node.listener.json.duration'),
+            new Reference(PathOptionsExtension::CONFIGURABLE_PATH_PRINTER_ID),
         ]);
         $container->setDefinition('output.node.printer.json.scenario', $definition);
 

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/JUnitFormatterFactory.php
@@ -31,6 +31,7 @@ use Behat\Testwork\Output\Printer\Factory\FilesystemOutputFactory;
 use Behat\Testwork\Output\Printer\JUnitOutputPrinter;
 use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
 use Behat\Testwork\Output\ServiceContainer\OutputExtension;
+use Behat\Testwork\PathOptions\ServiceContainer\PathOptionsExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -89,6 +90,7 @@ final class JUnitFormatterFactory implements FormatterFactory
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference('output.node.listener.junit.outline'),
             new Reference('output.node.listener.junit.duration'),
+            new Reference(PathOptionsExtension::CONFIGURABLE_PATH_PRINTER_ID),
         ]);
         $container->setDefinition('output.node.printer.junit.scenario', $definition);
 

--- a/src/Behat/Testwork/Exception/ExceptionPresenter.php
+++ b/src/Behat/Testwork/Exception/ExceptionPresenter.php
@@ -71,8 +71,11 @@ final class ExceptionPresenter
     /**
      * Presents exception as a string.
      */
-    public function presentException(Throwable $exception, ?int $verbosity = null): string
-    {
+    public function presentException(
+        Throwable $exception,
+        ?int $verbosity = null,
+        $applyEditorUrl = true,
+    ): string {
         $verbosity = $verbosity ?: $this->defaultVerbosity;
 
         if (!$exception instanceof Exception) {
@@ -81,7 +84,10 @@ final class ExceptionPresenter
 
         foreach ($this->stringers as $stringer) {
             if ($stringer->supportsException($exception)) {
-                return $this->configurablePathPrinter->processPathsInText($stringer->stringException($exception, $verbosity));
+                return $this->configurablePathPrinter->processPathsInText(
+                    $stringer->stringException($exception, $verbosity),
+                    applyEditorUrl: $applyEditorUrl
+                );
             }
         }
 

--- a/src/Behat/Testwork/PathOptions/Printer/ConfigurablePathPrinter.php
+++ b/src/Behat/Testwork/PathOptions/Printer/ConfigurablePathPrinter.php
@@ -56,10 +56,10 @@ final class ConfigurablePathPrinter
     /**
      * Conditionally transforms paths to relative and adds editor links if configured.
      */
-    public function processPathsInText(string $text): string
+    public function processPathsInText(string $text, bool $applyEditorUrl = true): string
     {
-        // If no editor URL is set, use the original behavior
-        if ($this->editorUrl === null) {
+        // If no editor URL is set or the caller opts out, use the original behavior
+        if ($this->editorUrl === null || $applyEditorUrl === false) {
             $processedText = $this->printAbsolutePaths ? $text : str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $text);
             // Apply removePrefix if configured
             if ($this->removePrefix !== []) {


### PR DESCRIPTION
The JSON and JUnit formatters were using a very simple management of the printed file paths. This PR replaces this with the ConfigurablePathPrinter that the other formatter use. This brings a couple of advantages:
- It uses the `%paths.base%` to calculate relative paths, this is more correct than using cwd as those formatters were doing
- It allows us to use the options offered by that printer

The editorUrl option of that printer is not appropriate for these formatters, which cannot use the link added to the paths, so I added a flag to mark if this option needs to be applied or not

Adds tests that check the correct working of the printer options in these formatters