### PR TITLE
Fix php version constraint in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
 
     "require": {
-        "php": "8.1.* || 8.2.* || 8.3.* || 8.4.* ",
+        "php": ">=8.1 <8.5",
         "ext-mbstring": "*",
         "behat/gherkin": "^4.12.0",
         "composer-runtime-api": "^2.2",


### PR DESCRIPTION
The latest version of php-cs-fixer showed a warning saying
"Unable to determine minimum supported PHP version from composer.json: Invalid version string "8.1.*""

It seems that, though composer was able to understand our constraint, php-cs-fixer wasn't

I updated it to use a new constraint that should be understood by everyone