### PR TITLE
fix: Include consistent index & placeholders for Example names in junit

### DIFF
--- a/features/json_format.feature
+++ b/features/json_format.feature
@@ -103,7 +103,7 @@ Feature: JSON Formatter
                                   ]
                               },
                               {
-                                  "name": "Passed & Failed #1",
+                                  "name": "Passed & Failed with value=5 #1",
                                   "time": -IGNORE-VALUE-,
                                   "status": "failed",
                                   "file": "features-DIRECTORY-SEPARATOR-single_feature.feature",
@@ -116,14 +116,14 @@ Feature: JSON Formatter
                                   ]
                               },
                               {
-                                  "name": "Passed & Failed #2",
+                                  "name": "Passed & Failed with value=10 #2",
                                   "time": -IGNORE-VALUE-,
                                   "status": "passed",
                                   "file": "features-DIRECTORY-SEPARATOR-single_feature.feature",
                                   "line": 29
                               },
                               {
-                                  "name": "Passed & Failed #3",
+                                  "name": "Passed & Failed with value=23 #3",
                                   "time": -IGNORE-VALUE-,
                                   "status": "failed",
                                   "file": "features-DIRECTORY-SEPARATOR-single_feature.feature",
@@ -136,14 +136,14 @@ Feature: JSON Formatter
                                   ]
                               },
                               {
-                                  "name": "Another Outline #1",
+                                  "name": "Another Outline (5 = 15) #1",
                                   "time": -IGNORE-VALUE-,
                                   "status": "passed",
                                   "file": "features-DIRECTORY-SEPARATOR-single_feature.feature",
                                   "line": 39
                               },
                               {
-                                  "name": "Another Outline #2",
+                                  "name": "Another Outline (10 = 20) #2",
                                   "time": -IGNORE-VALUE-,
                                   "status": "passed",
                                   "file": "features-DIRECTORY-SEPARATOR-single_feature.feature",

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -42,15 +42,15 @@ Feature: JUnit Formatter
           <testcase name="Failed" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="25">
             <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #1" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29">
+          <testcase name="Passed &amp; Failed with value=5 #1" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29">
             <failure message="Then I must have 16: Failed asserting that 15 matches expected '16'."/>
           </testcase>
-          <testcase name="Passed &amp; Failed #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29"/>
-          <testcase name="Passed &amp; Failed #3" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29">
+          <testcase name="Passed &amp; Failed with value=10 #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29"/>
+          <testcase name="Passed &amp; Failed with value=23 #3" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29">
             <failure message="Then I must have 32: Failed asserting that 33 matches expected '32'."/>
           </testcase>
-          <testcase name="Another Outline #1" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="39"/>
-          <testcase name="Another Outline #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="39"/>
+          <testcase name="Another Outline (5 = 15) #1" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="39"/>
+          <testcase name="Another Outline (10 = 20) #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="39"/>
         </testsuite>
       </testsuites>
       """

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -12,6 +12,7 @@ parameters:
             paths:
                 - src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
                 - src/Behat/Behat/EventDispatcher/Cli/StopOnFailureController.php
+                - src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
                 - src/Behat/Behat/Output/Node/Printer/ListPrinter.php
                 - src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
                 - src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
@@ -29,8 +29,6 @@ final class JUnitOutlineStoreListener implements EventListener
 {
     /**
      * @var array
-     *
-     * @deprecated This will be removed in the next major as the JUnit formatter no longer uses this information
      */
     private $lineScenarioMap = [];
 
@@ -52,8 +50,6 @@ final class JUnitOutlineStoreListener implements EventListener
 
     /**
      * Captures outline into the ivar on outline BEFORE event.
-     *
-     * @deprecated this method will be removed in the next major as the JUnit formatter no longer uses this information
      */
     private function captureOutlineOnBeforeOutlineEvent(Event $event)
     {

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
@@ -29,6 +29,8 @@ final class JUnitOutlineStoreListener implements EventListener
 {
     /**
      * @var array
+     *
+     * @deprecated This will be removed in the next major as the JUnit formatter no longer uses this information
      */
     private $lineScenarioMap = [];
 
@@ -50,6 +52,8 @@ final class JUnitOutlineStoreListener implements EventListener
 
     /**
      * Captures outline into the ivar on outline BEFORE event.
+     *
+     * @deprecated this method will be removed in the next major as the JUnit formatter no longer uses this information
      */
     private function captureOutlineOnBeforeOutlineEvent(Event $event)
     {
@@ -81,6 +85,8 @@ final class JUnitOutlineStoreListener implements EventListener
 
     /**
      * @return OutlineNode
+     *
+     * @deprecated this method will be removed in the next major as the JUnit formatter no longer uses this information
      */
     public function getCurrentOutline(ExampleNode $scenario)
     {

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitScenarioPrinter.php
@@ -30,7 +30,7 @@ final class JUnitScenarioPrinter
 {
     public function __construct(
         private readonly ResultToStringConverter $resultConverter,
-        /**
+        /*
          * @deprecated the outlineStoreListener is no longer used but kept for BC. It will be removed in the next major
          */
         JUnitOutlineStoreListener $outlineStoreListener,

--- a/tests/Fixtures/TestReportFormat/features/single_feature.feature
+++ b/tests/Fixtures/TestReportFormat/features/single_feature.feature
@@ -24,7 +24,7 @@ Feature: Adding numbers
     When I add 4
     Then I must have 13
 
-  Scenario Outline: Passed & Failed
+  Scenario Outline: Passed & Failed with value=<value>
     When I add <value>
     Then I must have <result>
 
@@ -34,7 +34,7 @@ Feature: Adding numbers
       |  10   | 20     |
       |  23   | 32     |
 
-  Scenario Outline: Another Outline
+  Scenario Outline: Another Outline (<value> = <result>)
     When I add <value>
     Then I must have <result>
 


### PR DESCRIPTION
Previously, when a feature file contained scenarios with `Example` nodes the junit report would append an index to each testcase name to differentiate them (e.g. `<testcase name="Some scenario outline #1"`, `<testcase name="Some scenario outline #2`, etc).

These indices were dynamically generated based on the examples that actually ran. As a result, on a `--rerun` the names would start from `#1` in sequence and be inconsistent with the numbering of the first execution. This makes it difficult to compare reports between each test run, for example to link a passing rerun to the previous failure.

With this change, examples are numbered consistently based on the order they appear in the feature file. This fixes #1448.

Additionally, we also now support placeholders in the Scenario Outline title. This allows users to include some or all of the values from the Examples: table in each `<testcase` name for additional clarity. This matches the behaviour of the official cucumber runners.

This PR builds on work done by @uuf6429 in #1459 and in particular the implementation of the numbering & placeholder replacement that he contributed in Behat/Gherkin#270 and Behat/Gherkin#271.