### PR TITLE
Check JSON file before running all tests

### DIFF
--- a/features/json_format.feature
+++ b/features/json_format.feature
@@ -510,7 +510,12 @@ Feature: JSON Formatter
       """
       cannot extend interface Behat\Behat\Context\Context
       """
-    And the "abort_on_php_error.json" file should not exist
+    And the "abort_on_php_error.json" file json should be like:
+      """
+      {
+          "suites": []
+      }
+      """
 
   Scenario: Aborting due to invalid output path
     When I run behat with the following additional options:

--- a/src/Behat/Testwork/Output/Printer/JSONOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JSONOutputPrinter.php
@@ -67,6 +67,8 @@ final class JSONOutputPrinter extends StreamOutputPrinter
         $this->exercise = [
             'suites' => &$this->suites,
         ];
+
+        $this->flush();
     }
 
     /**


### PR DESCRIPTION
With the current implementation, the checks for the JSON file (check that the output path had been passed, that it was not a directory, that we could create the file) would not happen until after all the tests had been run, which could be very inconvenient, run all tests only to find that you cannot write the file.

In this PR we change this to follow what the JUnit formatter does, which is to try to create the file at the beginning of the test run.