### PR TITLE
chore: Update .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,15 @@
 /features export-ignore
 /tests export-ignore
+.editorconfig export-ignore
+.git-blame-ignore-revs export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.scrutinizer.yml export-ignore
 .github export-ignore
-appveyor.yml export-ignore
+.php-cs-fixer.dist.php export-ignore
+AGENTS.md export-ignore
+behat.yml.dist
 box.json export-ignore
-phpunit.xml.dist export-ignore
 CONTRIBUTING.md export-ignore
+phpstan.dist.neon export-ignore
+phpunit.xml.dist export-ignore
+rector.php export-ignore


### PR DESCRIPTION
- Adds four files which should only be used for Behat development and don't need to be exported: `.php-cs-fixer.dist.php`, `AGENTS.md`, `phpstan.dist.neon` and `rector.php`
- Removes two files which don't seem to exist any longer `.scrutinizer.yml` and `appveyor.yml`