### PR TITLE
fix: Exit with correct exit code on sigint

### DIFF
--- a/src/Behat/Testwork/EventDispatcher/Cli/SigintController.php
+++ b/src/Behat/Testwork/EventDispatcher/Cli/SigintController.php
@@ -51,7 +51,7 @@ final class SigintController implements Controller
     /**
      * Dispatches AFTER exercise event and exits program.
      */
-    public function abortExercise(int $signal): never
+    public function abortExercise(int $signal = SIGINT): never
     {
         $this->eventDispatcher->dispatch(new AfterExerciseAborted(), ExerciseCompleted::AFTER);
 


### PR DESCRIPTION
Exit codes for fatal signals is typically 128 + the signal number.

For SIGINT, whose number is 2, it should be 130.

https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html