### PR TITLE
[4.x] feat: Add Symfony 8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,18 @@ jobs:
           - php: 8.2
             os: ubuntu-latest
             composer-mode: update
-            symfony-version: '5.4'
+            symfony-version: '5.4.*'
 
           - php: 8.2
             os: ubuntu-latest
             composer-mode: update
-            symfony-version: '6.4'
+            symfony-version: '6.4.*'
+
+          - php: 8.4
+            os: ubuntu-latest
+            composer-mode: update
+            composer-minimum-stability: RC
+            symfony-version: '8.0.*'
 
     steps:
       - uses: actions/checkout@v4
@@ -69,6 +75,10 @@ jobs:
           ini-values: "phar.readonly=0,zend.exception_ignore_args=Off"
           coverage: none
 
+      - name: Configure Composer minimum stability
+        if: matrix.composer-minimum-stability != ''
+        run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
+
       - name: Install symfony/flex
         if: matrix.symfony-version != ''
         run: |
@@ -78,7 +88,7 @@ jobs:
       - name: Install latest dependencies
         if: matrix.composer-mode == 'update'
         env:
-          SYMFONY_REQUIRE: ${{ matrix.symfony-version }}.*
+          SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
         run: composer update ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
 
       - name: Install lowest dependencies

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",
-        "symfony/config": "^5.4 || ^6.4 || ^7.0",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
-        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
-        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
-        "symfony/translation": "^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0"
+        "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/translation": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
 
     "require-dev": {
@@ -36,9 +36,9 @@
         "phpunit/phpunit": "^9.6",
         "rector/rector": "2.1.7",
         "sebastian/diff": "^4.0",
-        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/polyfill-php84": "^1.31",
-        "symfony/process": "^5.4 || ^6.4 || ^7.0"
+        "symfony/process": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
 
     "suggest": {

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -17,3 +17,7 @@ parameters:
                 - src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
                 - src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
                 - src/Behat/Testwork/Ordering/Cli/OrderController.php
+        -
+            identifier: function.impossibleType
+            paths:
+                - src/Behat/Testwork/Cli/Application.php

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -77,7 +77,7 @@ class SnippetExtension implements Extension
         $this->loadWriter($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processGenerators($container);
         $this->processAppenders($container);

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -96,7 +96,7 @@ class TesterExtension extends BaseExtension
         $this->loadPendingExceptionStringer($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         parent::process($container);
 

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -82,7 +82,7 @@ class TransformationExtension implements Extension
         $this->loadRepository($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processArgumentsTransformers($container);
     }

--- a/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
+++ b/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
@@ -79,7 +79,7 @@ final class AutoloaderExtension implements Extension
         $this->setLoaderPrefixes($container, $config);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processLoaderPrefixes($container);
     }

--- a/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
+++ b/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
@@ -78,7 +78,7 @@ final class CallExtension implements Extension
         $this->loadCallHandlers($container, $config['error_reporting']);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processCallFilters($container);
         $this->processCallHandlers($container);

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -126,7 +126,8 @@ final class Application extends BaseApplication
             $this->configurationLoader->setConfigurationFilePath($path);
         }
 
-        $this->add($this->createCommand($input, $output));
+        $command = $this->createCommand($input, $output);
+        method_exists($this, 'addCommand') ? $this->addCommand($command) : $this->add($command);
 
         return parent::doRun($input, $output);
     }

--- a/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
+++ b/src/Behat/Testwork/Cli/ServiceContainer/CliExtension.php
@@ -74,7 +74,7 @@ final class CliExtension implements Extension
         $this->loadSyntheticServices($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processControllers($container);
     }

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -75,7 +75,7 @@ class EventDispatcherExtension implements Extension
         $this->loadEventDispatchingSuiteTester($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processSubscribers($container);
     }

--- a/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
+++ b/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
@@ -56,7 +56,7 @@ class HookExtension implements Extension
         $this->loadHookableTesters($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -109,7 +109,7 @@ abstract class TesterExtension implements Extension
         $this->loadSpecificationTester($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processExerciseWrappers($container);
         $this->processSuiteTesterWrappers($container);


### PR DESCRIPTION
Related to https://github.com/FriendsOfBehat/SymfonyExtension/pull/218

This PR increase version constraints on `symfony/*` packages to allow Symfony 8, which will be released this month.

~~The CI fails because no version of PHP-CS-Fixer is compatible with Symfony 8, I'm on it.~~
EDIT: switched to `php-cs-fixer/shim` package