### PR TITLE
Update the pretty printer to handle future gherkin tag behavior

### DIFF
--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
@@ -112,6 +112,11 @@ final class PrettyFeaturePrinter implements FeaturePrinter
      */
     private function prependTagWithTagSign($tag)
     {
+        if (str_starts_with($tag, '@')) {
+            return $tag;
+        }
+
+        // The legacy mode of the behat/gherkin parser is trimming the `@` from tags so we need to re-add it for pretty-printing
         return '@' . $tag;
     }
 }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -130,6 +130,11 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
      */
     private function prependTagWithTagSign($tag)
     {
+        if (str_starts_with($tag, '@')) {
+            return $tag;
+        }
+
+        // The legacy mode of the behat/gherkin parser is trimming the `@` from tags so we need to re-add it for pretty-printing
         return '@' . $tag;
     }
 }


### PR DESCRIPTION
The legacy mode of the gherkin parser was trimming the `@` sign from tags when building the AST, so the pretty printer was prepending it back.
As the upstream cucumber gherkin AST preserve the `@` sign in tags, future versions of the behat/gherkin parser will preserve it as well.

Refs https://github.com/Behat/Gherkin/issues/336
Refs https://github.com/Behat/Behat/issues/1645

The pretty printer can handle that case by detecting the format of the tag, without any need of knowing the compatibility mode used by the parser.
Note that the filtering by tags is not updated in this PR because the implementation of the filter is done in behat/gherkin, not in this repo. 