### PR TITLE
Merge original 4.x branch back to 3.x series

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - 4.x
     paths-ignore:
       - '**.md'
   pull_request:

--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -91,7 +91,7 @@ final class ExerciseController implements Controller
                     'No specifications found at path(s) `%s`. This might be because of incorrect paths configuration in your `suites`.',
                     implode(', ', $paths)
                 ),
-                implode(', ', $paths)
+                $paths
             );
         }
 

--- a/src/Behat/Testwork/Tester/Exception/WrongPathsException.php
+++ b/src/Behat/Testwork/Tester/Exception/WrongPathsException.php
@@ -20,25 +20,41 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 final class WrongPathsException extends RuntimeException implements TesterException
 {
     /**
+     * @var list<string>
+     */
+    private readonly array $paths;
+
+    /**
      * Initializes exception.
      *
      * @param string $message
-     * @param string $path
+     * @param string|list<string> $paths
      */
     public function __construct(
         $message,
-        private $path,
+        string|array $paths,
     ) {
         parent::__construct($message);
+        $this->paths = (array) $paths;
     }
 
     /**
      * Returns path that caused exception.
      *
-     * @return string
+     * @return list<string>
      */
-    public function getPath()
+    public function getPaths(): array
     {
-        return $this->path;
+        return $this->paths;
+    }
+
+    /**
+     * Returns path that caused exception.
+     *
+     * @deprecated
+     */
+    public function getPath(): string
+    {
+        return implode(', ', $this->paths);
     }
 }


### PR DESCRIPTION
Brings the history of the old abandoned 4.x branch into the current master, ahead of creating a new 4.x branch. This will avoid us losing the record of these contributions when we restart development for 4.0.

There are only very limited changes - there was only one functional PR #1397 that was merged into 4.x in 2023. The same feature was subsequently implemented by a different contributor in #1611, merged into master and released in 3.23.0.

The solutions are essentially identical except for a change to WrongPathsException which I have kept both because it is more correct and in case anyone is already using the 4.x branch.

Once this PR is merged, I will delete the current 4.x branch and recreate it from master.

Replaces #1692 