### PR TITLE
test: Prove that Scenarios support multiple Examples tables

### DIFF
--- a/features/outlines.feature
+++ b/features/outlines.feature
@@ -209,6 +209,50 @@ Feature: Scenario Outlines
       30 steps (26 passed, 4 failed)
       """
 
+  Scenario: Outline with multiple examples and failing steps
+    Given a file named "features/math.feature" with:
+      """
+      Feature: Math
+        Background:
+          Given I have basic calculator
+
+        Scenario Outline:
+          Given I have entered <number1>
+          And I have entered <number2>
+          When I multiply
+          Then The result should be <result>
+
+          Examples: Small numbers
+            | number1 | number2 | result |
+            | 1       | 6       | 6      |
+            | 5       | 4       | 10     |
+            | 2       | 3       | 6      |
+
+          Examples: Big numbers
+            | number1 | number2 | result |
+            | 139     | 201     | 99     |
+            | 200     | 300     | 60000  |
+
+      """
+    When I run "behat --no-colors -f progress features/math.feature"
+    Then it should fail with:
+      """
+      .........F.........F.....
+
+      --- Failed steps:
+
+      001 Example: | 5       | 4       | 10     | # features/math.feature:14
+            Then The result should be 10          # features/math.feature:9
+              Failed asserting that 20 matches expected 10.
+
+      002 Example: | 139     | 201     | 99     | # features/math.feature:19
+            Then The result should be 99          # features/math.feature:9
+              Failed asserting that 27939 matches expected 99.
+
+      5 scenarios (3 passed, 2 failed)
+      25 steps (23 passed, 2 failed)
+      """
+
   Scenario: Scenario outline examples isolation
     Given a file named "features/bootstrap/FeatureContext.php" with:
       """


### PR DESCRIPTION
Feature writers should be able to structure examples into multiple tables, so that they can be clearly grouped into different kinds of values.

Historically, this was not supported - see #1082 - and was believed to be a BC break in Behat.

However, it was later implemented via a workaround in Behat/Gherkin#161 which was released in 2021.

I have added test coverage to prove that features like this are executed as expected. As can be seen, the current pretty printer output is not perfect (we lose the detail of the separate tables in the original file) however it looks like changing this would be a BC break due to the way the pretty printer is implemented.

Fixes #1082 - I will open a separate issue to improve the pretty printer output with example tables (which may also relate to the upcoming Gherkin improvements to support descriptions on these nodes).