### PR TITLE
refactor: Add backwards-compatible return types ahead of symfony8

### DIFF
--- a/features/config_inheritance.feature
+++ b/features/config_inheritance.feature
@@ -134,7 +134,7 @@ Feature: Config inheritance
               $definition->addTag('context.initializer', array('priority' => 100));
           }
 
-          public function process(ContainerBuilder $container) {}
+          public function process(ContainerBuilder $container): void {}
       }
 
       return new CustomExtension;

--- a/features/config_reference.feature
+++ b/features/config_reference.feature
@@ -48,7 +48,7 @@ Feature: Config reference
 
           public function load(ContainerBuilder $container, array $config) {}
 
-          public function process(ContainerBuilder $container) {}
+          public function process(ContainerBuilder $container): void {}
       }
 
       return new CustomExtension;

--- a/features/extension_inheritance.feature
+++ b/features/extension_inheritance.feature
@@ -40,7 +40,7 @@ Feature: Profile extension overrides
               $definition->addTag('context.initializer', array('priority' => 100));
           }
 
-          public function process(ContainerBuilder $container) {}
+          public function process(ContainerBuilder $container): void {}
       }
 
       return new CustomExtension;
@@ -81,7 +81,7 @@ Feature: Profile extension overrides
               $definition->addTag('context.initializer', array('priority' => 100));
           }
 
-          public function process(ContainerBuilder $container) {}
+          public function process(ContainerBuilder $container): void {}
       }
 
       return new CustomExtension2;

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -94,7 +94,7 @@ Feature: Extensions
               $definition->addTag('context.initializer', array('priority' => 100));
           }
 
-          public function process(ContainerBuilder $container) {}
+          public function process(ContainerBuilder $container): void {}
       }
 
       return new CustomExtension;
@@ -185,7 +185,7 @@ Feature: Extensions
           public function getConfigKey() { return 'custom_handlers'; }
           public function configure(ArrayNodeDefinition $builder) { }
           public function initialize(Behat\Testwork\ServiceContainer\ExtensionManager $extensionManager) {}
-          public function process(ContainerBuilder $container) {}
+          public function process(ContainerBuilder $container): void {}
 
           public function load(ContainerBuilder $container, array $config)
           {

--- a/features/helper_containers.feature
+++ b/features/helper_containers.feature
@@ -357,7 +357,7 @@ Feature: Per-suite helper containers
           public function getConfigKey() { return 'container_provider'; }
           public function configure(ArrayNodeDefinition $builder) { }
           public function initialize(ExtensionManager $extensionManager) {}
-          public function process(ContainerBuilder $container) {}
+          public function process(ContainerBuilder $container): void {}
 
           public function load(ContainerBuilder $container, array $config) {
               $definition = new Definition('MyContainer', array());

--- a/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
+++ b/src/Behat/Behat/Context/ServiceContainer/ContextExtension.php
@@ -117,7 +117,7 @@ final class ContextExtension implements Extension
         $this->loadDocblockHelper($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processClassResolvers($container);
         $this->processArgumentResolverFactories($container);

--- a/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
+++ b/src/Behat/Behat/Definition/ServiceContainer/DefinitionExtension.php
@@ -115,7 +115,7 @@ final class DefinitionExtension implements Extension
         $this->loadDocblockHelper($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processSearchEngines($container);
         $this->processPatternPolicies($container);

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -124,7 +124,7 @@ final class GherkinExtension implements Extension
         $this->loadFilesystemRerunScenariosListLocator($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processLoaders($container);
     }

--- a/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
+++ b/src/Behat/Behat/HelperContainer/ServiceContainer/HelperContainerExtension.php
@@ -76,7 +76,7 @@ final class HelperContainerExtension implements Extension
         $container->setDefinition(CallExtension::CALL_FILTER_TAG . '.helper_container', $definition);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::HELPER_CONTAINER_TAG);
 

--- a/src/Behat/Behat/Translator/ServiceContainer/GherkinTranslationsExtension.php
+++ b/src/Behat/Behat/Translator/ServiceContainer/GherkinTranslationsExtension.php
@@ -45,7 +45,7 @@ final class GherkinTranslationsExtension implements Extension
         $this->loadController($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 

--- a/src/Behat/Testwork/Argument/ServiceContainer/ArgumentExtension.php
+++ b/src/Behat/Testwork/Argument/ServiceContainer/ArgumentExtension.php
@@ -63,7 +63,7 @@ final class ArgumentExtension implements Extension
         $container->setDefinition(self::CONSTRUCTOR_ARGUMENT_ORGANISER_ID, $definition);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 }

--- a/src/Behat/Testwork/Cli/Command.php
+++ b/src/Behat/Testwork/Cli/Command.php
@@ -37,7 +37,7 @@ final class Command extends BaseCommand
     /**
      * Configures the command by running controllers prepare().
      */
-    protected function configure()
+    protected function configure(): void
     {
         foreach ($this->controllers as $controller) {
             $controller->configure($this);

--- a/src/Behat/Testwork/Environment/ServiceContainer/EnvironmentExtension.php
+++ b/src/Behat/Testwork/Environment/ServiceContainer/EnvironmentExtension.php
@@ -71,7 +71,7 @@ final class EnvironmentExtension implements Extension
         $this->loadStaticEnvironmentHandler($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processHandlers($container);
         $this->processReaders($container);

--- a/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
+++ b/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
@@ -89,7 +89,7 @@ final class ExceptionExtension implements Extension
         $this->loadVerbosityController($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processStringers($container);
     }

--- a/src/Behat/Testwork/Filesystem/ServiceContainer/FilesystemExtension.php
+++ b/src/Behat/Testwork/Filesystem/ServiceContainer/FilesystemExtension.php
@@ -49,7 +49,7 @@ final class FilesystemExtension implements Extension
         $this->loadFilesystemLogger($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 

--- a/src/Behat/Testwork/Ordering/ServiceContainer/OrderingExtension.php
+++ b/src/Behat/Testwork/Ordering/ServiceContainer/OrderingExtension.php
@@ -52,7 +52,7 @@ final class OrderingExtension implements Extension
      *
      * @api
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $definition = $container->getDefinition(CliExtension::CONTROLLER_TAG . '.order');
         $references = $this->processor->findAndSortTaggedServices($container, self::ORDERER_TAG);

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -43,7 +43,7 @@ final class NodeEventListeningFormatter implements Formatter
      *
      * @return array The event names to listen to
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [TestworkEventDispatcher::BEFORE_ALL_EVENTS => 'listenEvent'];
     }

--- a/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
@@ -103,7 +103,7 @@ final class OutputExtension implements Extension
         $this->loadManager($container, $config);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processFormatters($container);
         $this->processDynamicallyRegisteredFormatters($container);

--- a/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
+++ b/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
@@ -72,7 +72,7 @@ final class PathOptionsExtension implements Extension
         $this->loadPathOptionsController($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 

--- a/src/Behat/Testwork/Specification/ServiceContainer/SpecificationExtension.php
+++ b/src/Behat/Testwork/Specification/ServiceContainer/SpecificationExtension.php
@@ -66,7 +66,7 @@ final class SpecificationExtension implements Extension
         $this->loadFinder($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processLocators($container);
     }

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -133,7 +133,7 @@ final class SuiteExtension implements Extension
         $this->loadGenericSuiteGenerator($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processGenerators($container);
         $this->processSetups($container);

--- a/src/Behat/Testwork/Translator/ServiceContainer/TranslatorExtension.php
+++ b/src/Behat/Testwork/Translator/ServiceContainer/TranslatorExtension.php
@@ -71,7 +71,7 @@ final class TranslatorExtension implements Extension
         $this->loadController($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 

--- a/tests/Fixtures/ConvertConfig/class_references_loader.php
+++ b/tests/Fixtures/ConvertConfig/class_references_loader.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class CreateClassNamesExtension implements Extension
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 

--- a/tests/Fixtures/ConvertConfig/custom_extension.php
+++ b/tests/Fixtures/ConvertConfig/custom_extension.php
@@ -39,7 +39,7 @@ class CustomExtension implements Extension
         $formatterDefinition->addTag(OutputExtension::FORMATTER_TAG);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 }
@@ -51,7 +51,7 @@ class CustomFormatter implements Formatter
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [];
     }


### PR DESCRIPTION
Extracted from work by @Kocal in #1687 - these return types will be required in 4.x for symfony8 support, but can be added in 3.x without any BC impact as they are either final classes or internal test code. 

Adding them now will reduce potential for future conflicts merging 3.x up to 4.x.