### PR TITLE
docs: Add funding links and information

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [ acoulton, stof, carlos-granados ]

--- a/README.md
+++ b/README.md
@@ -63,8 +63,30 @@ Useful Links
 Contributors
 ------------
 
-- Konstantin Kudryashov [everzet](https://github.com/everzet) [lead developer]
+- Konstantin Kudryashov [everzet](https://github.com/everzet) [original developer]
+- Andrew Coulton [acoulton](https://github.com/acoulton) [current maintainer]
+- Carlos Granados [carlos-granados](https://github.com/carlos-granados) [current maintainer]
+- Christophe Coevoet [stof](https://github.com/stof) [current maintainer]
 - Other [awesome developers](https://github.com/Behat/Behat/graphs/contributors)
+
+Support the project
+-------------------
+
+Behat is free software, maintained by volunteers as a gift for users. If you'd like to see
+the project continue to thrive, and particularly if you use it for work, we'd encourage you
+to contribute.
+
+Contributions of time - whether code, documentation, or support reviewing PRs and triaging
+issues - are very welcome and valued by the maintainers and the wider Behat community.
+
+But we also believe that [financial sponsorship is an important part of a healthy Open Source
+ecosystem](https://opensourcepledge.com/about/). Maintaining a project like Behat requires a
+significant commitment from the core team: your support will help us to keep making that time
+available over the long term. Even small contributions make a big difference.
+
+You can support [@acoulton](https://github.com/acoulton), [@carlos-granados](https://github.com/carlos-granados) and
+[@stof](https://github.com/stof) on GitHub sponsors. If you'd like to discuss supporting us in a different way, please
+get in touch!
 
 Technology Sponsors
 -------------------


### PR DESCRIPTION
@carlos-granados @stof I've added sponsorship links and some readme text in line with #1695 

I think it might be most logical to put the funding links in alphabetical order. But I wasn't totally comfortable doing that as someone with an "a" name :laughing: It'd be nice if Github would randomise the order over time but I don't think they do...

So I ran the names through a random shuffle and have them in different orders in the composer.json and funding.yml. If we go with that, I can shuffle them again for the files in Behat/Gherkin...

Let me know what you think