### PR TITLE
Add option to set if we want to print skipped steps to pretty formatter

### DIFF
--- a/features/print_skipped_steps.feature
+++ b/features/print_skipped_steps.feature
@@ -1,0 +1,59 @@
+Feature: Pretty formatter print_skipped_steps option
+  In order to control whether skipped steps are printed
+  As a Behat user
+  I need a pretty formatter option to hide skipped steps
+
+  Background:
+    Given I initialise the working directory from the "PrintSkippedSteps" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option      | value |
+      | --no-colors |       |
+
+  Scenario: Pretty prints skipped steps by default
+    When I run behat with the following additional options:
+      | option    | value   |
+      | --profile | default |
+    Then it should fail with:
+      """
+      Feature: Skipped steps printing
+        In order to test the print_skipped_steps option
+        As a behat developer
+        I need a scenario with a skipped step
+
+        Scenario: Skips after a failure
+          When a passing step
+          And a failing step
+            step failed as supposed (Exception)
+          Then a skipped step
+
+      --- Failed scenarios:
+
+          features/skip.feature:6 (on line 8)
+
+      1 scenario (1 failed)
+      3 steps (1 passed, 1 failed, 1 skipped)
+      """
+
+  Scenario: Pretty does not print skipped steps when disabled
+    When I run behat with the following additional options:
+      | option    | value        |
+      | --profile | hide_skipped |
+    Then it should fail with:
+      """
+      Feature: Skipped steps printing
+        In order to test the print_skipped_steps option
+        As a behat developer
+        I need a scenario with a skipped step
+
+        Scenario: Skips after a failure
+          When a passing step
+          And a failing step
+            step failed as supposed (Exception)
+
+      --- Failed scenarios:
+
+          features/skip.feature:6 (on line 8)
+
+      1 scenario (1 failed)
+      3 steps (1 passed, 1 failed, 1 skipped)
+      """

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -16,6 +16,7 @@ use Behat\Behat\Output\Node\Printer\StepPrinter;
 use Behat\Behat\Tester\Result\DefinedStepResult;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Behat\Tester\Result\StepResult;
+use Behat\Config\Formatter\PrettyFormatter;
 use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Gherkin\Node\ArgumentInterface;
 use Behat\Gherkin\Node\PyStringNode;
@@ -26,6 +27,7 @@ use Behat\Testwork\Exception\ExceptionPresenter;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\OutputPrinter;
 use Behat\Testwork\Tester\Result\ExceptionResult;
+use Behat\Testwork\Tester\Result\TestResult;
 
 /**
  * Prints step.
@@ -63,6 +65,14 @@ final class PrettyStepPrinter implements StepPrinter
 
     public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result)
     {
+        if ($result->getResultCode() === TestResult::SKIPPED) {
+            $printSkipped = $formatter->getParameter(PrettyFormatter::PRINT_SKIPPED_STEPS_SETTING);
+
+            if ($printSkipped === false) {
+                return;
+            }
+        }
+
         $this->printText($formatter->getOutputPrinter(), $step->getKeyword(), $step->getText(), $result);
         $this->pathPrinter->printStepPath($formatter, $scenario, $step, $result, mb_strlen($this->indentText, 'utf8'));
         $this->printArguments($formatter, $step->getArguments(), $result);

--- a/src/Behat/Config/Formatter/Formatter.php
+++ b/src/Behat/Config/Formatter/Formatter.php
@@ -121,6 +121,9 @@ class Formatter implements FormatterConfigInterface, ConfigConverterInterface
             if ($name === self::SHORT_SUMMARY_SETTING) {
                 $name = self::SHORT_SUMMARY_PARAMETER_NAME;
             }
+            if ($name === PrettyFormatter::PRINT_SKIPPED_STEPS_SETTING) {
+                $name = PrettyFormatter::PRINT_SKIPPED_STEPS_PARAMETER_NAME;
+            }
             $arguments[$name] = $value;
         }
         if ($arguments !== []) {

--- a/src/Behat/Config/Formatter/PrettyFormatter.php
+++ b/src/Behat/Config/Formatter/PrettyFormatter.php
@@ -10,11 +10,14 @@ final class PrettyFormatter extends Formatter
 {
     public const NAME = 'pretty';
 
+    public const PRINT_SKIPPED_STEPS_PARAMETER_NAME = 'printSkippedSteps';
+
     private const TIMER_SETTING = 'timer';
     private const EXPAND_SETTING = 'expand';
     private const PATHS_SETTING = 'paths';
     private const MULTILINE_SETTING = 'multiline';
     private const SHORT_SUMMARY_SETTING = 'short_summary';
+    public const PRINT_SKIPPED_STEPS_SETTING = 'print_skipped_steps';
 
     /**
      * @param bool $timer show time and memory usage at the end of the test run
@@ -26,6 +29,7 @@ final class PrettyFormatter extends Formatter
      *                                     formatter output (yes, no, on-fail)
      * @param bool $shortSummary if we should print the short summary which just lists scenarios
      *                           or the long summary which lists steps
+     * @param bool $printSkippedSteps if we should print skipped steps in the output
      */
     public function __construct(
         bool $timer = true,
@@ -34,6 +38,7 @@ final class PrettyFormatter extends Formatter
         bool $multiline = true,
         ShowOutputOption $showOutput = ShowOutputOption::Yes,
         bool $shortSummary = true,
+        bool $printSkippedSteps = true,
         ...$baseOptions,
     ) {
         $settings = [
@@ -43,6 +48,7 @@ final class PrettyFormatter extends Formatter
             self::MULTILINE_SETTING => $multiline,
             ShowOutputOption::OPTION_NAME => $showOutput->value,
             self::SHORT_SUMMARY_SETTING => $shortSummary,
+            self::PRINT_SKIPPED_STEPS_SETTING => $printSkippedSteps,
         ];
         $settings = [...$settings, ...$baseOptions];
         parent::__construct(name: self::NAME, settings: $settings);

--- a/tests/Behat/Tests/Config/ProfileTest.php
+++ b/tests/Behat/Tests/Config/ProfileTest.php
@@ -147,6 +147,7 @@ final class ProfileTest extends TestCase
                     'output_verbosity' => 2,
                     'show_output' => 'yes',
                     'short_summary' => true,
+                    'print_skipped_steps' => true,
                 ],
                 'progress' => [
                     'timer' => false,

--- a/tests/Fixtures/PrintSkippedSteps/behat.php
+++ b/tests/Fixtures/PrintSkippedSteps/behat.php
@@ -1,0 +1,21 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Formatter\PrettyFormatter;
+use Behat\Config\Profile;
+
+return (new Config())
+    ->withProfile((new Profile('default'))
+        ->withFormatter(new PrettyFormatter(
+            timer: false,
+            paths: false,
+        ))
+    )
+    ->withProfile((new Profile('hide_skipped'))
+        ->withFormatter(new PrettyFormatter(
+            printSkippedSteps: false,
+            timer: false,
+            paths: false,
+        ))
+    )
+;

--- a/tests/Fixtures/PrintSkippedSteps/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/PrintSkippedSteps/features/bootstrap/FeatureContext.php
@@ -1,0 +1,24 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Step\Then;
+use Behat\Step\When;
+
+class FeatureContext implements Context
+{
+    #[When('a passing step')]
+    public function passingStep(): void
+    {
+    }
+
+    #[When('a failing step')]
+    public function failingStep(): void
+    {
+        throw new Exception('step failed as supposed');
+    }
+
+    #[Then('a skipped step')]
+    public function skippedStep(): void
+    {
+    }
+}

--- a/tests/Fixtures/PrintSkippedSteps/features/skip.feature
+++ b/tests/Fixtures/PrintSkippedSteps/features/skip.feature
@@ -1,0 +1,9 @@
+Feature: Skipped steps printing
+  In order to test the print_skipped_steps option
+  As a behat developer
+  I need a scenario with a skipped step
+
+  Scenario: Skips after a failure
+    When a passing step
+    And a failing step
+    Then a skipped step


### PR DESCRIPTION
If we have long scenarios, we may not be interested in seeing the list of skipped steps that is printed after a failed steps. This PR adds an option to the pretty printer to decide if you want to print skipped steps or not

Fixes https://github.com/Behat/Behat/issues/1658