### PR TITLE
Add translation cache

### DIFF
--- a/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
+++ b/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
@@ -21,6 +21,11 @@ use Behat\Testwork\Suite\Suite;
 final class DefinitionTranslator
 {
     /**
+     * @var array<string, string>
+     */
+    private array $translationCache = [];
+
+    /**
      * Initialises definition translator.
      */
     public function __construct(
@@ -39,8 +44,15 @@ final class DefinitionTranslator
     {
         $assetsId = $suite->getName();
         $pattern = $definition->getPattern();
+        $cacheKey = sprintf('%s|%s|%s', $assetsId, $pattern, $language ?? '');
 
-        $translatedPattern = $this->translator->trans($pattern, [], $assetsId, $language);
+        if (isset($this->translationCache[$cacheKey])) {
+            $translatedPattern = $this->translationCache[$cacheKey];
+        } else {
+            $translatedPattern = $this->translator->trans($pattern, [], $assetsId, $language);
+            $this->translationCache[$cacheKey] = $translatedPattern;
+        }
+
         if ($pattern != $translatedPattern) {
             return new TranslatedDefinition($definition, $translatedPattern, $language);
         }

--- a/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
+++ b/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
@@ -44,7 +44,7 @@ final class DefinitionTranslator
     {
         $assetsId = $suite->getName();
         $pattern = $definition->getPattern();
-        $cacheKey = sprintf('%s|%s|%s', $assetsId, $pattern, $language ?? '');
+        $cacheKey = sprintf('%s|%s|%s', $assetsId, $pattern, $language ?? $this->getLocale());
 
         if (isset($this->translationCache[$cacheKey])) {
             $translatedPattern = $this->translationCache[$cacheKey];


### PR DESCRIPTION
Adds a simple memory cache so that we don't have to call the `trans` function in the translator if we already have translated the current definition, should improve performance in the cases where steps are used many times

Fixes https://github.com/Behat/Behat/issues/1452