### PR TITLE
change: Drop `dev-master` composer branch alias & update actions branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - master
-      - 4.x
+      - '*.x'
     paths-ignore:
       - '**.md'
   pull_request:

--- a/composer.json
+++ b/composer.json
@@ -62,12 +62,6 @@
         }
     },
 
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.x-dev"
-        }
-    },
-
     "scripts": {
         "all-tests": [
             "@cs",


### PR DESCRIPTION
We have renamed the `master` branch to `3.x` as part of preparations for working towards a 4.0 release. In future, all main branches will be named for their release series in this fashion.

Anyone directly depending on `dev-master` in their own `composer.json` will see a failure on their next composer update. They will need to migrate to a more specific constraint for the actual version they require.

Github actions will build on all pushes to a `*.x` branch - we will no longer need to update the workflow when starting a new version series.

Fixes #1703 