### PR TITLE
chore:fix phpunit configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit colors="true" bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Behat test suite">
-            <directory>./tests/Behat/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/Behat/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./src/Behat/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Behat test suite">
+      <directory>./tests/Behat/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
When running phpunit I was seeing this warning:

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

So I followed the suggestion and migrated the configuration. No more deprecation warnings 🎉 