### PR TITLE
Fix static analysis in PHP 8.5

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,5 +29,6 @@ return (new Config())
         ],
         'single_line_throw' => false, //override Symfony
         'yoda_style' => false, //override Symfony
+        'phpdoc_to_comment' => false, //incorrectly changes @var tags
     ])
     ->setFinder($finder);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,6 +29,8 @@ return (new Config())
         ],
         'single_line_throw' => false, //override Symfony
         'yoda_style' => false, //override Symfony
-        'phpdoc_to_comment' => false, //incorrectly changes @var tags
+        'phpdoc_to_comment' => [ // Keep as a phpdoc if it contains the `@var` annotation
+            'ignored_tags' => ['var'],
+        ],
     ])
     ->setFinder($finder);

--- a/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
+++ b/src/Behat/Testwork/Autoloader/ServiceContainer/AutoloaderExtension.php
@@ -66,7 +66,7 @@ final class AutoloaderExtension implements Extension
             ->treatNullLike([])
             ->treatFalseLike([])
         ;
-        assert($builder instanceof ArrayNodeDefinition);
+        /** @var ArrayNodeDefinition $builder */
         $builder
             ->prototype('scalar')->end()
         ;

--- a/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
@@ -86,7 +86,7 @@ final class OutputExtension implements Extension
                     ->then(fn ($a) => array_merge($a, ['enabled' => true]))
                 ->end()
         ;
-        assert($builder instanceof ArrayNodeDefinition);
+        /** @var ArrayNodeDefinition $builder */
         $builder
                 ->useAttributeAsKey('name')
                 ->treatTrueLike(['enabled' => true])

--- a/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
+++ b/src/Behat/Testwork/PathOptions/ServiceContainer/PathOptionsExtension.php
@@ -47,7 +47,7 @@ final class PathOptionsExtension implements Extension
             ->scalarNode('print_absolute_paths')
             ->defaultFalse()
             ->end();
-        assert($builder instanceof NodeBuilder);
+        /** @var NodeBuilder $builder */
         $builder
             ->scalarNode('editor_url')
             ->defaultNull()

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -95,7 +95,7 @@ final class SuiteExtension implements Extension
                     })
                 ->end()
         ;
-        assert($builder instanceof ArrayNodeDefinition);
+        /** @var ArrayNodeDefinition $builder */
         $childrenBuilder = $builder
                 ->normalizeKeys(false)
                 ->addDefaultsIfNotSet()


### PR DESCRIPTION
The latest versions of the Symfony Config component improve the docs for some of the functions on the config objects and now use Template tags so that PHPStan is able to correctly guess the type returned. So some asserts are not needed any more. But they are still needed in older versions of Symfony which don't have these improved docs. The only solution I was able to find was to change these asserts into @var tags, this seems to work for both versions

Had to disable a PHP-CS-Fixer rule which was incorrectly trying to change these @var tag docblocks into normal comments