### PR TITLE
refactor: Resolve symfony/console deprecation in 7.4, fix phpstan

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -17,3 +17,8 @@ parameters:
                 - src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
                 - src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
                 - src/Behat/Testwork/Ordering/Cli/OrderController.php
+        -
+            # BC wrapper for symfony/console < 7.4.0
+            message: '#method_exists.+ ''(add|addCommand)'' will always evaluate to (true|false)#'
+            paths:
+                - src/Behat/Testwork/Cli/Application.php

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -126,9 +126,24 @@ final class Application extends BaseApplication
             $this->configurationLoader->setConfigurationFilePath($path);
         }
 
-        $this->add($this->createCommand($input, $output));
+        $this->addCommand($this->createCommand($input, $output));
 
         return parent::doRun($input, $output);
+    }
+
+    public function addCommand(callable|SymfonyCommand $command): ?SymfonyCommand
+    {
+        // Provide compatibility with all supported symfony/console versions
+        // Attempt to use the `addCommand` method added in symfony/console 7.4.0
+        // (`add` was deprecated in 7.4.0 and removed in 8.0.0)
+        if (method_exists(parent::class, 'addCommand')) {
+            return parent::addCommand($command);
+        }
+
+        // Otherwise assert we are on an older version with `add` and call that.
+        assert(method_exists($this, 'add'));
+
+        return $this->add($command);
     }
 
     protected function getDefaultCommands(): array


### PR DESCRIPTION
symfony/console 7.4.0 deprecates the `Application::add` method in favour of a new `Application::addCommand` method. `Application::add` is then removed in 8.0.

We had a fix for this in the 4.0 branch, but it started to cause phpstan errors once symfony 8.0 was released & installed for the phpstan job. Additionally, the errors varied depending on the symfony version installed.

This fix bumps us off the deprecated method for Behat 3.x and symfony >= 7.4.0. It also updates the phpstan ignore to cover all supported symfony versions.