### PR TITLE
[4.x] ci: Update symfony jobs to reflect 8.0 & 7.4 releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,11 +57,7 @@ jobs:
             composer-mode: update
             symfony-version: '6.4.*'
 
-          - php: 8.4
-            os: ubuntu-latest
-            composer-mode: update
-            composer-minimum-stability: RC
-            symfony-version: '8.0.*'
+          # Symfony 7.4 LTS already builds on our normal PHP 8.2 and PHP 8.3 jobs
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Now that symfony 8.0 is released, our normal matrix jobs are already installing 8.0 on supported php versions (8.4 and 8.5). Our default matrix builds are currently running:
 - 6.4 on PHP 8.1
 - 7.4 on PHP 8.2 (min supported PHP for 7.4)
 - 7.4 on PHP 8.3
 - 8.0 on PHP 8.4 (min supported PHP for 8.0)
 - 8.0 on PHP 8.5

Our additional builds then add:
 - 5.4 on PHP 8.1 (lowest)
 - 5.4 on PHP 8.2 (5.4 LTS)
 - 6.4 on PHP 8.2 (6.4 LTS)

Therefore we no longer need a separate 8.0 job in the matrix.

Given we're testing with 7.4 on PHP 8.2 & 8.3, I don't think there's a particular benefit to running additional 7.4 jobs on later PHP versions so I have not added a specific 7.4 LTS matrix entry.