### PR TITLE
ci: Add automated check for BC breaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,32 @@ jobs:
       - name: Run Rector
         run: ./vendor/bin/rector --dry-run
 
+  check-bc:
+    name: Check for BC breaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.5"
+
+      - name: "Install roave/backward-compatibility-check"
+        # Installing in a standalone directory to avoid any dependency conflicts / changes.
+        # There is a docker action, but it appears to be outdated compared to php releases and doesn't appear to support
+        # pinning to a major release.
+        run: |
+          mkdir bc-check
+          cd bc-check
+          composer require --no-interaction roave/backward-compatibility-check:^8.17
+
+      - name: "Check for BC breaks"
+        run: |
+          bc-check/vendor/bin/roave-backward-compatibility-check \
+            --format=github-actions
+
   build-phar:
     name: Build PHAR file
     runs-on: ubuntu-latest

--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<roave-bc-check
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://github.com/Roave/BackwardCompatibilityCheck/raw/refs/heads/8.18.x/Resources/schema.xsd">
+    <baseline>
+        <!--
+          Adding strict types to a parameter may be a technical BC break, but historically we have not considered them
+          to be if they match the phpdoc. Parameter type changes will be reviewed manually by maintainers.
+        -->
+        <ignored-regex>#CHANGED: The parameter .+? changed from no type to#</ignored-regex>
+    </baseline>
+</roave-bc-check>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,13 @@ so that we adhere to [Semantic Versioning v2.0.0](http://semver.org/spec/v2.0.0.
 6. Make sure you [ran the tests](#running-tests) and didn't break anything. That will save some time on
 [GitHub actions](https://github.com/Behat/Behat/actions)
 7. Commit your code and submit a Pull Request, providing a clear description of the change, including
-the motivation for the proposal. 
+the motivation for the proposal.
 
-Please note: Each Pull Request should contain only one new feature or bugfix. If the changes are large, 
+Please note: Each Pull Request should contain only one new feature or bugfix. If the changes are large,
 please structure them into multiple smaller commits. If you need to make small refactorings or internal
-changes - for example to fix an already-failing test, rename private variables, or reformat an existing 
-method to make your own change readable - this can be included in the Pull Request but must be 
-committed separately with its own commit message(s). If possible, make these the first commits on 
+changes - for example to fix an already-failing test, rename private variables, or reformat an existing
+method to make your own change readable - this can be included in the Pull Request but must be
+committed separately with its own commit message(s). If possible, make these the first commits on
 your branch to make review easier.
 
 ## Backwards compatibility
@@ -54,6 +54,26 @@ your change. Not following these rules will cause a rejection of your PR. Except
 where BC break is introduced as a measure to fix a serious issue.
 
 You can read detailed guidance on what BC means in [Symfony2 BC guide](http://symfony.com/doc/current/contributing/code/bc.html).
+
+### Running automated backwards compatibility checks
+
+We use `roave/backward-compatibility-check` in CI to automatically check for BC breaks. Due to dependency conflicts,
+this is not required as a composer dependency. Instead, you can:
+
+* Use it as a docker image (see
+  [the project docs](https://github.com/Roave/BackwardCompatibilityCheck?tab=readme-ov-file#install-with-docker)) - note
+  that at time of writing the docker images do not appear to be up to date with the latest package releases.
+* Require it as a standalone tool with composer. You could do this as a `composer global require`, or by
+  requiring it into an empty composer.json in any local directory. Note that the tool requires `git` to be installed as
+  well as number of PHP extensions.
+
+The `check-bc` job in our [GitHub actions workflow](.github/workflows/build.yml) provides an example of installing and
+running the tool in a standalone local directory for linux-based systems.
+
+After installation, switch back to your Behat directory (if required) and run the docker container / global / absolute
+path to `vendor/bin/roave-backward-compatibility-check`
+
+**NOTE:** the tool will only detect / report local changes that you have already committed.
 
 ## Running tests
 

--- a/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
+++ b/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
@@ -39,7 +39,7 @@ class EnvironmentCall implements Call
      *
      * @return Environment
      */
-    final public function getEnvironment(): Environment
+    final public function getEnvironment()
     {
         return $this->environment;
     }

--- a/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
+++ b/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
@@ -39,7 +39,7 @@ class EnvironmentCall implements Call
      *
      * @return Environment
      */
-    final public function getEnvironment()
+    final public function getEnvironment(): Environment
     {
         return $this->environment;
     }


### PR DESCRIPTION
Added a github action using roave/backward-compatibility-check to highlight potential breaking changes in PRs.