### PR TITLE
refactor: convert rerun-only tests to use fixtures

### DIFF
--- a/tests/Fixtures/Rerun/features/apples-no-error.feature
+++ b/tests/Fixtures/Rerun/features/apples-no-error.feature
@@ -1,0 +1,30 @@
+Feature: Apples story
+  In order to eat apple
+  As a little kid
+  I need to have an apple in my pocket
+
+  Background:
+    Given I have 3 apples
+
+  Scenario: I'm little hungry
+    When I ate 1 apple
+    Then I should have 2 apples
+
+  Scenario: Found more apples
+    When I found 5 apples
+    Then I should have 8 apples
+
+  Scenario: Found more apples
+    When I found 2 apples
+    Then I should have 5 apples
+
+  Scenario Outline: Other situations
+    When I ate <ate> apples
+    And I found <found> apples
+    Then I should have <result> apples
+
+    Examples:
+      | ate | found | result |
+      | 3   | 1     | 1      |
+      | 0   | 4     | 7      |
+      | 2   | 2     | 3      |


### PR DESCRIPTION
In this case we have re-used the fixtures that we had for the `rerun.feature` tests as they were almost identical, we have just added a new feature because the behaviour when we were fixing the tests was slightly different