### PR TITLE
refactor: convert rerun_strict tests to use fixtures

### DIFF
--- a/features/rerun_strict.feature
+++ b/features/rerun_strict.feature
@@ -4,44 +4,15 @@ Feature: Rerun with strict
   I need to have an ability to rerun failed previously scenarios, including those which failed due to the strict option
 
   Background:
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context;
-      use Behat\Step\When;
-
-      class FeatureContext implements Context
-      {
-          #[When('I have a failing step')]
-          public function iHaveAFailingStep(): void
-          {
-              throw new \Exception();
-          }
-
-          #[When('I have a passing step')]
-          public function iHaveAPassingStep(): void
-          {
-          }
-      }
-      """
-    And a file named "features/rerun_strict.feature" with:
-      """
-      Feature: test
-
-        Scenario: missing step
-          When I have a missing step
-
-        Scenario: failing step
-          When I have a failing step
-
-        Scenario: passing step
-          When I have a passing step
-      """
+    Given I initialise the working directory from the "RerunStrict" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option      | value    |
+      | --no-colors |          |
+      | --format    | progress |
 
   Scenario: Rerun feature without strict option
-    When I run "behat --no-colors -f progress -n features/rerun_strict.feature"
-    And I run "behat  --rerun --no-colors -f progress -n features/rerun_strict.feature"
+    When I run "behat features/rerun_strict.feature"
+    And I run "behat --rerun features/rerun_strict.feature"
     Then it should fail with:
       """
       F
@@ -57,9 +28,9 @@ Feature: Rerun with strict
       """
 
     Scenario: Rerun feature with strict option
-        When I run "behat --strict --no-colors -f progress -n features/rerun_strict.feature"
-        And I run "behat --strict --rerun --no-colors -f progress --rerun -n features/rerun_strict.feature"
-        Then it should fail with:
+    When I run "behat --strict features/rerun_strict.feature"
+    And I run "behat --strict --rerun features/rerun_strict.feature"
+    Then it should fail with:
       """
       UF
 

--- a/features/rerun_strict.feature
+++ b/features/rerun_strict.feature
@@ -12,6 +12,19 @@ Feature: Rerun with strict
 
   Scenario: Rerun feature without strict option
     When I run "behat features/rerun_strict.feature"
+    Then it should fail with:
+      """
+      UF.
+
+      --- Failed steps:
+
+      001 Scenario: failing step       # features/rerun_strict.feature:6
+            When I have a failing step # features/rerun_strict.feature:7
+              (Exception)
+
+      3 scenarios (1 passed, 1 failed, 1 undefined)
+      3 steps (1 passed, 1 failed, 1 undefined)
+      """
     And I run "behat --rerun features/rerun_strict.feature"
     Then it should fail with:
       """
@@ -29,6 +42,19 @@ Feature: Rerun with strict
 
     Scenario: Rerun feature with strict option
     When I run "behat --strict features/rerun_strict.feature"
+    Then it should fail with:
+      """
+      UF.
+
+      --- Failed steps:
+
+      001 Scenario: failing step       # features/rerun_strict.feature:6
+            When I have a failing step # features/rerun_strict.feature:7
+              (Exception)
+
+      3 scenarios (1 passed, 1 failed, 1 undefined)
+      3 steps (1 passed, 1 failed, 1 undefined)
+      """
     And I run "behat --strict --rerun features/rerun_strict.feature"
     Then it should fail with:
       """

--- a/tests/Fixtures/RerunStrict/behat.php
+++ b/tests/Fixtures/RerunStrict/behat.php
@@ -1,0 +1,8 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+
+return (new Config())
+    ->withProfile(new Profile('default'))
+;

--- a/tests/Fixtures/RerunStrict/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/RerunStrict/features/bootstrap/FeatureContext.php
@@ -1,0 +1,19 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Step\When;
+use Exception;
+
+class FeatureContext implements Context
+{
+    #[When('I have a failing step')]
+    public function iHaveAFailingStep(): void
+    {
+        throw new Exception();
+    }
+
+    #[When('I have a passing step')]
+    public function iHaveAPassingStep(): void
+    {
+    }
+}

--- a/tests/Fixtures/RerunStrict/features/rerun_strict.feature
+++ b/tests/Fixtures/RerunStrict/features/rerun_strict.feature
@@ -1,0 +1,10 @@
+Feature: test
+
+  Scenario: missing step
+    When I have a missing step
+
+  Scenario: failing step
+    When I have a failing step
+
+  Scenario: passing step
+    When I have a passing step


### PR DESCRIPTION
In this case we could not re-use the fixtures as they were very different from the existing ones