### PR TITLE
refactor: convert rerun multiple suite tests to use fixtures

### DIFF
--- a/features/rerun-only.feature
+++ b/features/rerun-only.feature
@@ -56,7 +56,8 @@ Feature: Rerun
       """
 
   Scenario: Nothing is run if no failure was recorded in the rerun file
-    When I run "behat features/apples-no-error.feature"
+    Given I copy "features/apples-no-error.feature" to "features/apples.feature"
+    When I run "behat features/apples.feature"
     Then it should pass with:
       """
       .....................
@@ -64,7 +65,7 @@ Feature: Rerun
       6 scenarios (6 passed)
       21 steps (21 passed)
       """
-    When I run "behat features/apples-no-error.feature --rerun-only"
+    When I run "behat features/apples.feature --rerun-only"
     Then it should pass with:
     """
     No failure found, exiting

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -10,8 +10,8 @@ Feature: Rerun with multiple suite
       | --no-colors |          |
       | --format    | progress |
 
-  Scenario: Run feature with 6 failed and 12 passing scenarios
-    When I run "behat"
+  Scenario: Rerun only failed scenarios, 4 from default suite and 2 from suite2
+    Given I run "behat"
     Then it should fail with:
       """
       ..F.............F......F.............F......F.............F....
@@ -45,9 +45,6 @@ Feature: Rerun with multiple suite
       18 scenarios (12 passed, 6 failed)
       63 steps (57 passed, 6 failed)
       """
-
-  Scenario: Rerun only failed scenarios, 4 from default suite and 2 from suite2
-    Given I run "behat"
     When I run "behat --rerun"
     Then it should fail with:
     """
@@ -85,6 +82,23 @@ Feature: Rerun with multiple suite
 
   Scenario: Fixing scenarios removes it from the rerun log
     Given I run "behat features/apples.feature"
+    Then it should fail with:
+      """
+      ..F.............F....
+
+      --- Failed steps:
+
+      001 Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+            Then I should have 8 apples     # features/apples.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      6 scenarios (4 passed, 2 failed)
+      21 steps (19 passed, 2 failed)
+      """
     And I copy "features/bananas-fixed.feature" to "features/bananas.feature"
     When I run "behat"
     Then it should fail with:

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -81,10 +81,10 @@ Feature: Rerun with multiple suite
     """
 
   Scenario: Fixing scenarios removes it from the rerun log
-    Given I run "behat features/apples.feature"
+    Given I run "behat"
     Then it should fail with:
       """
-      ..F.............F....
+      ..F.............F......F.............F......F.............F....
 
       --- Failed steps:
 
@@ -96,8 +96,24 @@ Feature: Rerun with multiple suite
             Then I should have 8 apples     # features/apples.feature:24
               Failed asserting that 7 matches expected 8.
 
-      6 scenarios (4 passed, 2 failed)
-      21 steps (19 passed, 2 failed)
+      003 Scenario: I'm little hungry    # features/bananas.feature:9
+            Then I should have 3 bananas # features/bananas.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      004 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+            Then I should have 8 bananas    # features/bananas.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      005 Scenario: I'm little hungry    # features/bananas.feature:9
+            Then I should have 3 bananas # features/bananas.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      006 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+            Then I should have 8 bananas    # features/bananas.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      18 scenarios (12 passed, 6 failed)
+      63 steps (57 passed, 6 failed)
       """
     And I copy "features/bananas-fixed.feature" to "features/bananas.feature"
     When I run "behat"

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -4,141 +4,14 @@ Feature: Rerun with multiple suite
   I need to have an ability to rerun failed previously scenarios
 
   Background:
-    Given a file named "behat.yml" with:
-      """
-      default:
-        suites:
-          default:
-            paths:
-              - features/apples.feature
-              - features/bananas.feature
-            contexts:
-              - FeatureContext: [ { param1: val1, param2: val1 } ]
-          suite1:
-            paths: {}
-          suite2:
-            paths:
-              - features/bananas.feature
-      """
-    And a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-
-      use Behat\Behat\Context\Context;
-      use Behat\Step\Given;
-      use Behat\Step\Then;
-      use Behat\Step\When;
-
-      class FeatureContext implements Context
-      {
-          private $fruits = array();
-          private $parameters;
-
-          public function __construct(array $parameters = array()) {
-              $this->parameters = $parameters;
-          }
-
-          #[Given('/^I have (\d+) (apples|bananas)$/')]
-          public function iHaveFruit($count, $fruit) {
-              $this->fruits[$fruit] = intval($count);
-          }
-
-          #[When('/^I ate (\d+) (apples|bananas)$/')]
-          public function iAteFruit($count, $fruit) {
-              $this->fruits[$fruit] -= intval($count);
-          }
-
-          #[When('/^I found (\d+) (apples|bananas)$/')]
-          public function iFoundFruit($count, $fruit) {
-              $this->fruits[$fruit] += intval($count);
-          }
-
-          #[Then('/^I should have (\d+) (apples|bananas)$/')]
-          public function iShouldHaveFruit($count, $fruit) {
-              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->fruits[$fruit]);
-          }
-
-          #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]
-          public function contextParameterShouldBeEqualTo($key, $val) {
-              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
-          }
-
-          #[Given('/^context parameter "([^"]*)" should be array with (\d+) elements$/')]
-          public function contextParameterShouldBeArrayWithElements($key, $count) {
-              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
-              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
-          }
-      }
-      """
-    And a file named "features/apples.feature" with:
-      """
-      Feature: Apples story
-        In order to eat apple
-        As a little kid
-        I need to have an apple in my pocket
-
-        Background:
-          Given I have 3 apples
-
-        Scenario: I'm little hungry
-          When I ate 1 apples
-          Then I should have 3 apples
-
-        Scenario: Found more apples
-          When I found 5 apples
-          Then I should have 8 apples
-
-        Scenario: Found more apples
-          When I found 2 apples
-          Then I should have 5 apples
-
-        Scenario Outline: Other situations
-          When I ate <ate> apples
-          And I found <found> apples
-          Then I should have <result> apples
-
-          Examples:
-            | ate | found | result |
-            | 3   | 1     | 1      |
-            | 0   | 4     | 8      |
-            | 2   | 2     | 3      |
-      """
-    And a file named "features/bananas.feature" with:
-      """
-      Feature: Banana story
-        In order to eat banana
-        As a little kid
-        I need to have an banana in my pocket
-
-        Background:
-          Given I have 3 bananas
-
-        Scenario: I'm little hungry
-          When I ate 1 bananas
-          Then I should have 3 bananas
-
-        Scenario: Found more bananas
-          When I found 5 bananas
-          Then I should have 8 bananas
-
-        Scenario: Found more bananas
-          When I found 2 bananas
-          Then I should have 5 bananas
-
-        Scenario Outline: Other situations
-          When I ate <ate> bananas
-          And I found <found> bananas
-          Then I should have <result> bananas
-
-          Examples:
-            | ate | found | result |
-            | 3   | 1     | 1      |
-            | 0   | 4     | 8      |
-            | 2   | 2     | 3      |
-      """
+    Given I initialise the working directory from the "Rerun" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option      | value    |
+      | --no-colors |          |
+      | --format    | progress |
 
   Scenario: Run feature with 6 failed and 12 passing scenarios
-    When I run "behat --no-colors -f progress"
+    When I run "behat"
     Then it should fail with:
       """
       ..F.............F......F.............F......F.............F....
@@ -174,8 +47,8 @@ Feature: Rerun with multiple suite
       """
 
   Scenario: Rerun only failed scenarios, 4 from default suite and 2 from suite2
-    Given I run "behat --no-colors -f progress"
-    When I run "behat --no-colors -f progress --rerun"
+    Given I run "behat"
+    When I run "behat --rerun"
     Then it should fail with:
     """
     ..F...F..F...F..F...F
@@ -211,77 +84,79 @@ Feature: Rerun with multiple suite
     """
 
   Scenario: Fixing scenarios removes it from the rerun log
-    Given I run "behat --no-colors -f progress features/apples.feature"
-    And there is a file named "features/bananas.feature" with:
-      """
-      Feature: Banana story
-        In order to eat banana
-        As a little kid
-        I need to have an banana in my pocket
-
-        Background:
-          Given I have 3 bananas
-
-        Scenario: I'm little hungry
-          When I ate 1 bananas
-          Then I should have 2 bananas
-
-        Scenario: Found more bananas
-          When I found 5 bananas
-          Then I should have 8 bananas
-
-        Scenario: Found more bananas
-          When I found 2 bananas
-          Then I should have 5 bananas
-
-        Scenario Outline: Other situations
-          When I ate <ate> bananas
-          And I found <found> bananas
-          Then I should have <result> bananas
-
-          Examples:
-            | ate | found | result |
-            | 3   | 1     | 1      |
-            | 0   | 4     | 7      |
-            | 2   | 2     | 3      |
-      """
-    When I run "behat --no-colors -f progress"
-    And I run "behat --no-colors -f progress --rerun"
+    Given I run "behat features/apples.feature"
+    And I copy "features/bananas-fixed.feature" to "features/bananas.feature"
+    When I run "behat"
     Then it should fail with:
-    """
-    ..F...F
+      """
+      ..F.............F..............................................
 
-    --- Failed steps:
+      --- Failed steps:
 
-    001 Scenario: I'm little hungry   # features/apples.feature:9
-          Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+      001 Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
 
-    002 Example: | 0   | 4     | 8      | # features/apples.feature:29
-          Then I should have 8 apples     # features/apples.feature:24
-            Failed asserting that 7 matches expected 8.
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+            Then I should have 8 apples     # features/apples.feature:24
+              Failed asserting that 7 matches expected 8.
 
-    2 scenarios (2 failed)
+      18 scenarios (16 passed, 2 failed)
+      63 steps (61 passed, 2 failed)
+      """
+    When I run "behat --rerun"
+    Then it should fail with:
+      """
+      ..F...F
+
+      --- Failed steps:
+
+      001 Scenario: I'm little hungry   # features/apples.feature:9
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+            Then I should have 8 apples     # features/apples.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      2 scenarios (2 failed)
     7 steps (5 passed, 2 failed)
     """
 
   Scenario: Rerun only suite failed scenarios from suite2 suite
-    Given I run "behat --no-colors -f progress --suite suite2"
-    When I run "behat --no-colors -f progress --suite suite2 --rerun"
+    When I run "behat --suite suite2"
     Then it should fail with:
-    """
-    ..F...F
+      """
+      ..F.............F....
+      
+      --- Failed steps:
+      
+      001 Scenario: I'm little hungry    # features/bananas.feature:9
+            Then I should have 3 bananas # features/bananas.feature:11
+              Failed asserting that 2 matches expected 3.
+      
+      002 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+            Then I should have 8 bananas    # features/bananas.feature:24
+              Failed asserting that 7 matches expected 8.
+      
+      6 scenarios (4 passed, 2 failed)
+      21 steps (19 passed, 2 failed)
+      """
+    When I run "behat --suite suite2 --rerun"
+    And it should fail with:
+      """
+      ..F...F
 
-    --- Failed steps:
+      --- Failed steps:
 
-    001 Scenario: I'm little hungry    # features/bananas.feature:9
-          Then I should have 3 bananas # features/bananas.feature:11
-            Failed asserting that 2 matches expected 3.
+      001 Scenario: I'm little hungry    # features/bananas.feature:9
+            Then I should have 3 bananas # features/bananas.feature:11
+              Failed asserting that 2 matches expected 3.
 
-    002 Example: | 0   | 4     | 8      | # features/bananas.feature:29
-          Then I should have 8 bananas    # features/bananas.feature:24
-            Failed asserting that 7 matches expected 8.
+      002 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+            Then I should have 8 bananas    # features/bananas.feature:24
+              Failed asserting that 7 matches expected 8.
 
-    2 scenarios (2 failed)
-    7 steps (5 passed, 2 failed)
-    """
+      2 scenarios (2 failed)
+      7 steps (5 passed, 2 failed)
+      """

--- a/tests/Fixtures/Rerun/behat.php
+++ b/tests/Fixtures/Rerun/behat.php
@@ -4,9 +4,20 @@ declare(strict_types=1);
 
 use Behat\Config\Config;
 use Behat\Config\Profile;
+use Behat\Config\Suite;
 
 return (new Config())
     ->withProfile(
-        new Profile('default')
+        (new Profile('default'))
+            ->withSuite(
+                (new Suite('default'))
+                    ->withPaths('features/apples.feature', 'features/bananas.feature')
+                    ->withContexts('FeatureContext')
+            )
+            ->withSuite(
+                (new Suite('suite2'))
+                    ->withPaths('features/bananas.feature')
+                    ->withContexts('FeatureContext')
+            )
     )
 ;

--- a/tests/Fixtures/Rerun/features/apples-fixed.feature
+++ b/tests/Fixtures/Rerun/features/apples-fixed.feature
@@ -7,7 +7,7 @@ Feature: Apples story
     Given I have 3 apples
 
   Scenario: I'm little hungry
-    When I ate 1 apple
+    When I ate 1 apples
     Then I should have 3 apples
 
   Scenario: Found more apples

--- a/tests/Fixtures/Rerun/features/apples-no-error.feature
+++ b/tests/Fixtures/Rerun/features/apples-no-error.feature
@@ -7,7 +7,7 @@ Feature: Apples story
     Given I have 3 apples
 
   Scenario: I'm little hungry
-    When I ate 1 apple
+    When I ate 1 apples
     Then I should have 2 apples
 
   Scenario: Found more apples

--- a/tests/Fixtures/Rerun/features/apples.feature
+++ b/tests/Fixtures/Rerun/features/apples.feature
@@ -7,7 +7,7 @@ Feature: Apples story
     Given I have 3 apples
 
   Scenario: I'm little hungry
-    When I ate 1 apple
+    When I ate 1 apples
     Then I should have 3 apples
 
   Scenario: Found more apples

--- a/tests/Fixtures/Rerun/features/bananas-fixed.feature
+++ b/tests/Fixtures/Rerun/features/bananas-fixed.feature
@@ -1,0 +1,30 @@
+Feature: Banana story
+  In order to eat banana
+  As a little kid
+  I need to have an banana in my pocket
+
+  Background:
+    Given I have 3 bananas
+
+  Scenario: I'm little hungry
+    When I ate 1 bananas
+    Then I should have 2 bananas
+
+  Scenario: Found more bananas
+    When I found 5 bananas
+    Then I should have 8 bananas
+
+  Scenario: Found more bananas
+    When I found 2 bananas
+    Then I should have 5 bananas
+
+  Scenario Outline: Other situations
+    When I ate <ate> bananas
+    And I found <found> bananas
+    Then I should have <result> bananas
+
+    Examples:
+      | ate | found | result |
+      | 3   | 1     | 1      |
+      | 0   | 4     | 7      |
+      | 2   | 2     | 3      |

--- a/tests/Fixtures/Rerun/features/bananas.feature
+++ b/tests/Fixtures/Rerun/features/bananas.feature
@@ -1,0 +1,30 @@
+Feature: Banana story
+  In order to eat banana
+  As a little kid
+  I need to have an banana in my pocket
+
+  Background:
+    Given I have 3 bananas
+  
+  Scenario: I'm little hungry
+    When I ate 1 bananas
+    Then I should have 3 bananas
+  
+  Scenario: Found more bananas
+    When I found 5 bananas
+    Then I should have 8 bananas
+
+  Scenario: Found more bananas
+    When I found 2 bananas
+    Then I should have 5 bananas
+
+  Scenario Outline: Other situations
+    When I ate <ate> bananas
+    And I found <found> bananas
+    Then I should have <result> bananas
+
+      Examples:
+      | ate | found | result |
+      | 3   | 1     | 1      |
+      | 0   | 4     | 8      |
+      | 2   | 2     | 3      |

--- a/tests/Fixtures/Rerun/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Rerun/features/bootstrap/FeatureContext.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Assert;
 class FeatureContext implements Context
 {
     private int $apples = 0;
+    private int $bananas = 0;
     private array $parameters;
 
     public function __construct(array $parameters = [])
@@ -18,28 +19,28 @@ class FeatureContext implements Context
         $this->parameters = $parameters;
     }
 
-    #[Given('/^I have (\\d+) apples?$/')]
-    public function iHaveApples(string $count): void
+    #[Given('/^I have (\\d+) (apples|bananas)$/')]
+    public function iHaveFruit(string $count, string $fruit): void
     {
-        $this->apples = (int) $count;
+        $this->{$fruit} = (int) $count;
     }
 
-    #[When('/^I ate (\\d+) apples?$/')]
-    public function iAteApples(string $count): void
+    #[When('/^I ate (\\d+) (apples|bananas)$/')]
+    public function iAteFruit(string $count, string $fruit): void
     {
-        $this->apples -= (int) $count;
+        $this->{$fruit} -= (int) $count;
     }
 
-    #[When('/^I found (\\d+) apples?$/')]
-    public function iFoundApples(string $count): void
+    #[When('/^I found (\\d+) (apples|bananas)$/')]
+    public function iFoundFruit(string $count, string $fruit): void
     {
-        $this->apples += (int) $count;
+        $this->{$fruit} += (int) $count;
     }
 
-    #[Then('/^I should have (\\d+) apples$/')]
-    public function iShouldHaveApples(string $count): void
+    #[Then('/^I should have (\\d+) (apples|bananas)$/')]
+    public function iShouldHaveFruit(string $count, string $fruit): void
     {
-        Assert::assertEquals((int) $count, $this->apples);
+        Assert::assertEquals((int) $count, $this->{$fruit});
     }
 
     #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]


### PR DESCRIPTION
These tests also re-use the fixtures in the `Rerun` folder. The context file has been modified a little so we have needed to modify existing tests a little bit as well