### PR TITLE
[3.x] refactor: Improve type-safety of regex string replacement operations

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -7,9 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 use Behat\Behat\Context\Context;
 use Behat\Behat\Output\Printer\Formatter\ConsoleFormatter;
+use Behat\Behat\Util\StrictRegex;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Hook\AfterSuite;
@@ -126,7 +126,7 @@ class FeatureContext implements Context
      * @param string $destination destination file path (relative to workdir)
      */
     #[Given('/^I copy "([^"]*)" to "([^"]*)"$/')]
-    public function iCopyFileTo($source, $destination)
+    public function iCopyFileTo($source, $destination): void
     {
         $sourcePath = $this->workingDir . '/' . $source;
         $destinationPath = $this->workingDir . '/' . $destination;
@@ -524,41 +524,41 @@ EOL;
 
         // windows path fix
         if ('/' !== DIRECTORY_SEPARATOR) {
-            $text = preg_replace_callback(
+            $text = StrictRegex::replaceCallback(
                 '/[ "](features|tests)\/[^\n "]+/',
                 fn ($matches): string => str_replace('/', DIRECTORY_SEPARATOR, $matches[0]),
                 $text
             );
-            $text = preg_replace_callback(
+            $text = StrictRegex::replaceCallback(
                 '/\<span class\="path"\>features\/[^\<]+/',
                 fn ($matches): string => str_replace('/', DIRECTORY_SEPARATOR, $matches[0]),
-                (string) $text
+                $text
             );
-            $text = preg_replace_callback(
+            $text = StrictRegex::replaceCallback(
                 '/\+[fd] [^ ]+/',
                 fn ($matches): string => str_replace('/', DIRECTORY_SEPARATOR, $matches[0]),
-                (string) $text
+                $text
             );
 
             // error stacktrace
-            $text = preg_replace_callback(
+            $text = StrictRegex::replaceCallback(
                 '/#\d+ [^:]+:/',
                 fn ($matches): string => str_replace('/', DIRECTORY_SEPARATOR, $matches[0]),
-                (string) $text
+                $text
             );
 
             // texts with absolute paths
-            $text = preg_replace_callback(
+            $text = StrictRegex::replaceCallback(
                 '/\{BASE_PATH\}[^\n \<"]+/',
                 fn ($matches): string => str_replace('/', DIRECTORY_SEPARATOR, $matches[0]),
-                (string) $text
+                $text
             );
 
             // texts in editor URLs
-            $text = preg_replace_callback(
+            $text = StrictRegex::replaceCallback(
                 '/open\?file[^\<"]+/',
                 fn ($matches): string => str_replace('/', DIRECTORY_SEPARATOR, $matches[0]),
-                (string) $text
+                $text
             );
         }
 

--- a/src/Behat/Behat/Context/Annotation/DocBlockHelper.php
+++ b/src/Behat/Behat/Context/Annotation/DocBlockHelper.php
@@ -10,6 +10,8 @@
 
 namespace Behat\Behat\Context\Annotation;
 
+use Behat\Behat\Util\StrictRegex;
+
 /**
  * Helper class for DocBlock parsing.
  */
@@ -22,20 +24,20 @@ class DocBlockHelper
     public function extractDescription(string $docBlock): string
     {
         // Remove indentation
-        $description = preg_replace('/^[\s\t]*/m', '', $docBlock);
+        $description = StrictRegex::replace('/^[\s\t]*/m', '', $docBlock);
 
         // normalize line endings
-        $description = str_replace("\r\n", "\n", (string) $description);
+        $description = str_replace("\r\n", "\n", $description);
 
         // Remove block comment syntax
-        $description = preg_replace('/^\/\*\*\s*|^\s*\*\s|^\s*\*\/$/m', '', (string) $description);
+        $description = StrictRegex::replace('/^\/\*\*\s*|^\s*\*\s|^\s*\*\/$/m', '', (string) $description);
 
         // Remove annotations
-        $description = preg_replace('/^@.*$/m', '', (string) $description);
+        $description = StrictRegex::replace('/^@.*$/m', '', $description);
 
         // Ignore docs after a "--" separator
-        if (preg_match('/^--.*$/m', (string) $description)) {
-            $descriptionParts = preg_split('/^--.*$/m', (string) $description);
+        if (preg_match('/^--.*$/m', $description)) {
+            $descriptionParts = preg_split('/^--.*$/m', $description);
             $description = array_shift($descriptionParts);
         }
 

--- a/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AnnotatedContextReader.php
@@ -13,6 +13,7 @@ namespace Behat\Behat\Context\Reader;
 use Behat\Behat\Context\Annotation\AnnotationReader;
 use Behat\Behat\Context\Annotation\DocBlockHelper;
 use Behat\Behat\Context\Environment\ContextEnvironment;
+use Behat\Behat\Util\StrictRegex;
 use Behat\Testwork\Call\Callee;
 use ReflectionClass;
 use ReflectionException;
@@ -119,7 +120,7 @@ final class AnnotatedContextReader implements ContextReader
         $docBlock = $this->mergeMultilines($docBlock);
 
         foreach (explode("\n", $docBlock) as $docLine) {
-            $docLine = preg_replace(self::DOCLINE_TRIMMER_REGEX, '', $docLine);
+            $docLine = StrictRegex::replace(self::DOCLINE_TRIMMER_REGEX, '', $docLine);
 
             if ($this->isEmpty($docLine)) {
                 continue;
@@ -141,12 +142,10 @@ final class AnnotatedContextReader implements ContextReader
      * Merges multiline strings (strings ending with "\").
      *
      * @param string $docBlock
-     *
-     * @return string
      */
-    private function mergeMultilines($docBlock)
+    private function mergeMultilines($docBlock): string
     {
-        return preg_replace("#\\\\$\s*+\*\s*+([^\\\\$]++)#m", '$1', $docBlock);
+        return StrictRegex::replace("#\\\\$\s*+\*\s*+([^\\\\$]++)#m", '$1', $docBlock);
     }
 
     /**

--- a/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
+++ b/src/Behat/Behat/Context/Snippet/Appender/ContextSnippetAppender.php
@@ -13,6 +13,7 @@ namespace Behat\Behat\Context\Snippet\Appender;
 use Behat\Behat\Snippet\AggregateSnippet;
 use Behat\Behat\Snippet\Appender\SnippetAppender;
 use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Util\StrictRegex;
 use Behat\Testwork\Filesystem\FilesystemLogger;
 use ReflectionClass;
 
@@ -48,7 +49,7 @@ final class ContextSnippetAppender implements SnippetAppender
             }
 
             $generated = rtrim(strtr($snippet->getSnippet(), ['\\' => '\\\\', '$' => '\\$']));
-            $content = preg_replace('/}\s*$/', "\n" . $generated . "\n}\n", $content);
+            $content = StrictRegex::replace('/}\s*$/', "\n" . $generated . "\n}\n", $content);
             $path = $reflection->getFileName();
 
             file_put_contents($path, $content);
@@ -78,14 +79,12 @@ final class ContextSnippetAppender implements SnippetAppender
      *
      * @param string $class
      * @param string $contextFileContent
-     *
-     * @return string
      */
-    private function importClass($class, $contextFileContent)
+    private function importClass($class, $contextFileContent): string
     {
         $replaceWith = '$1use ' . $class . ";\n\$2;";
 
-        return preg_replace('@^(.*)(use\s+[^;]*);@m', $replaceWith, $contextFileContent, 1);
+        return StrictRegex::replace('@^(.*)(use\s+[^;]*);@m', $replaceWith, $contextFileContent, 1);
     }
 
     /**

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -19,6 +19,7 @@ use Behat\Behat\Snippet\Exception\EnvironmentSnippetGenerationException;
 use Behat\Behat\Snippet\Generator\SnippetGenerator;
 use Behat\Behat\Snippet\Snippet;
 use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Util\StrictRegex;
 use Behat\Gherkin\Node\ArgumentInterface;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
@@ -228,7 +229,7 @@ TPL;
     private function getMethodNameNotExistentInContext(ReflectionClass $reflection, string $methodName, int $methodNumber): array
     {
         while ($reflection->hasMethod($methodName)) {
-            $methodName = preg_replace('/\d+$/', '', $methodName);
+            $methodName = StrictRegex::replace('/\d+$/', '', $methodName);
             $methodName .= $methodNumber++;
         }
 
@@ -246,7 +247,7 @@ TPL;
             }
 
             while ($proposedMethod === $name) {
-                $name = preg_replace('/\d+$/', '', $name);
+                $name = StrictRegex::replace('/\d+$/', '', $name);
                 $name .= $number++;
             }
         }

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -14,9 +14,9 @@ use Behat\Behat\Definition\Exception\InvalidPatternException;
 use Behat\Behat\Definition\Pattern\Pattern;
 use Behat\Behat\Definition\Pattern\SimpleStepMethodNameSuggester;
 use Behat\Behat\Definition\Pattern\StepMethodNameSuggester;
+use Behat\Behat\Util\StrictRegex;
 
 use function array_keys;
-use function preg_replace;
 
 /**
  * Defines a way to handle regex patterns.
@@ -47,7 +47,7 @@ final class RegexPatternPolicy implements PatternPolicy
     public function generatePattern($stepText): Pattern
     {
         $methodName = $this->methodNameSuggester->suggest(
-            preg_replace(array_keys(self::$replacePatterns), '', $this->escapeStepText($stepText)),
+            StrictRegex::replace(array_keys(self::$replacePatterns), '', $this->escapeStepText($stepText)),
         );
         $stepRegex = $this->generateRegex($stepText);
         $placeholderCount = $this->countPlaceholders($stepText, $stepRegex);
@@ -76,12 +76,10 @@ final class RegexPatternPolicy implements PatternPolicy
      * Generates regex from step text.
      *
      * @param string $stepText
-     *
-     * @return string
      */
-    private function generateRegex($stepText)
+    private function generateRegex($stepText): string
     {
-        return preg_replace(
+        return StrictRegex::replace(
             array_keys(self::$replacePatterns),
             array_values(self::$replacePatterns),
             $this->escapeStepText($stepText)
@@ -105,11 +103,9 @@ final class RegexPatternPolicy implements PatternPolicy
      * Returns escaped step text.
      *
      * @param string $stepText
-     *
-     * @return string
      */
-    private function escapeStepText($stepText)
+    private function escapeStepText($stepText): string
     {
-        return preg_replace('/([\/\[\]\(\)\\\^\$\.\|\?\*\+\'])/', '\\\\$1', $stepText);
+        return StrictRegex::replace('/([\/\[\]\(\)\\\^\$\.\|\?\*\+\'])/', '\\\\$1', $stepText);
     }
 }

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -56,12 +56,12 @@ final class TurnipPatternPolicy implements PatternPolicy
     public function generatePattern($stepText): Pattern
     {
         $count = 0;
-        $pattern = $stepText;
+        $pattern = (string) $stepText;
         foreach (self::$placeholderPatterns as $replacePattern) {
-            $pattern = preg_replace_callback(
+            $pattern = StrictRegex::replaceCallback(
                 $replacePattern,
                 function () use (&$count) { return ':arg' . ++$count; },
-                (string) $pattern
+                $pattern
             );
         }
         $pattern = $this->escapeAlternationSyntax($pattern);
@@ -111,7 +111,7 @@ final class TurnipPatternPolicy implements PatternPolicy
     {
         $tokenRegex = self::TOKEN_REGEX;
 
-        return preg_replace_callback(
+        return StrictRegex::replaceCallback(
             self::PLACEHOLDER_REGEXP,
             [$this, 'replaceTokenWithRegexCaptureGroup'],
             $regex

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -104,16 +104,14 @@ final class TurnipPatternPolicy implements PatternPolicy
      * Replaces turnip tokens with regex capture groups.
      *
      * @param string $regex
-     *
-     * @return string
      */
-    private function replaceTokensWithRegexCaptureGroups($regex)
+    private function replaceTokensWithRegexCaptureGroups($regex): string
     {
         $tokenRegex = self::TOKEN_REGEX;
 
         return StrictRegex::replaceCallback(
             self::PLACEHOLDER_REGEXP,
-            [$this, 'replaceTokenWithRegexCaptureGroup'],
+            $this->replaceTokenWithRegexCaptureGroup(...),
             $regex
         );
     }

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -14,8 +14,7 @@ use Behat\Behat\Definition\Exception\InvalidPatternException;
 use Behat\Behat\Definition\Pattern\Pattern;
 use Behat\Behat\Definition\Pattern\SimpleStepMethodNameSuggester;
 use Behat\Behat\Definition\Pattern\StepMethodNameSuggester;
-
-use function preg_replace;
+use Behat\Behat\Util\StrictRegex;
 
 /**
  * Defines a way to handle turnip patterns.
@@ -67,7 +66,7 @@ final class TurnipPatternPolicy implements PatternPolicy
         }
         $pattern = $this->escapeAlternationSyntax($pattern);
         $methodName = $this->methodNameSuggester->suggest(
-            preg_replace(self::$placeholderPatterns, '', $stepText),
+            StrictRegex::replace(self::$placeholderPatterns, '', $stepText),
         );
 
         return new Pattern($methodName, $pattern, $count);
@@ -134,12 +133,10 @@ final class TurnipPatternPolicy implements PatternPolicy
      * Replaces turnip optional ending with regex non-capturing optional group.
      *
      * @param string $regex
-     *
-     * @return string
      */
-    private function replaceTurnipOptionalEndingWithRegex($regex)
+    private function replaceTurnipOptionalEndingWithRegex($regex): string
     {
-        return preg_replace(self::OPTIONAL_WORD_REGEXP, '(?:\1)?(?:\2)?(?:\3)?', $regex);
+        return StrictRegex::replace(self::OPTIONAL_WORD_REGEXP, '(?:\1)?(?:\2)?(?:\3)?', $regex);
     }
 
     /**
@@ -149,7 +146,7 @@ final class TurnipPatternPolicy implements PatternPolicy
      */
     private function replaceTurnipAlternativeWordsWithRegex($regex): string
     {
-        $regex = preg_replace(self::ALTERNATIVE_WORD_REGEXP, '(?:\1|\2)', $regex);
+        $regex = StrictRegex::replace(self::ALTERNATIVE_WORD_REGEXP, '(?:\1|\2)', $regex);
         $regex = $this->removeEscapingOfAlternationSyntax($regex);
 
         return $regex;

--- a/src/Behat/Behat/Definition/Pattern/SimpleStepMethodNameSuggester.php
+++ b/src/Behat/Behat/Definition/Pattern/SimpleStepMethodNameSuggester.php
@@ -2,6 +2,8 @@
 
 namespace Behat\Behat\Definition\Pattern;
 
+use Behat\Behat\Util\StrictRegex;
+
 final class SimpleStepMethodNameSuggester implements StepMethodNameSuggester
 {
     public const DEFAULT_NAME = 'stepDefinition1';
@@ -12,10 +14,10 @@ final class SimpleStepMethodNameSuggester implements StepMethodNameSuggester
         $name = mb_convert_case($stepTextWithoutPlaceholders, MB_CASE_TITLE);
 
         // Remove characters that are never valid in a method name
-        $name = preg_replace('/[^a-zA-Z0-9_\x80-\xff]/u', '', $name);
+        $name = StrictRegex::replace('/[^a-zA-Z0-9_\x80-\xff]/u', '', $name);
 
         // Remove leading digits (these are the only characters that are valid in a name except at the beginning)
-        $name = preg_replace('/^\d+/', '', (string) $name);
+        $name = StrictRegex::replace('/^\d+/', '', $name);
 
         if ($name === '') {
             // ContextSnippetGenerator::getUniqueMethodName will increment the trailing number if necessary so that

--- a/src/Behat/Behat/Gherkin/Cli/SyntaxController.php
+++ b/src/Behat/Behat/Gherkin/Cli/SyntaxController.php
@@ -11,6 +11,7 @@
 namespace Behat\Behat\Gherkin\Cli;
 
 use Behat\Behat\Definition\Translator\TranslatorInterface;
+use Behat\Behat\Util\StrictRegex;
 use Behat\Gherkin\Keywords\KeywordsDumper;
 use Behat\Testwork\Cli\Controller;
 use Symfony\Component\Console\Command\Command;
@@ -72,7 +73,7 @@ final class SyntaxController implements Controller
         $output->getFormatter()->setStyle('gherkin_comment', new OutputFormatterStyle('yellow'));
 
         $story = $this->keywordsDumper->dump($this->translator->getLocale());
-        $story = preg_replace('/^\#.*/', '<gherkin_comment>$0</gherkin_comment>', $story);
+        $story = StrictRegex::replace('/^\#.*/', '<gherkin_comment>$0</gherkin_comment>', $story);
         $output->writeln($story);
         $output->writeln('');
 

--- a/src/Behat/Behat/Output/Node/Printer/Helper/StepTextPainter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/StepTextPainter.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Output\Node\Printer\Helper;
 
 use Behat\Behat\Definition\Definition;
 use Behat\Behat\Definition\Pattern\PatternTransformer;
+use Behat\Behat\Util\StrictRegex;
 use Behat\Testwork\Tester\Result\TestResult;
 
 /**
@@ -81,7 +82,7 @@ final class StepTextPainter
         }
 
         // Replace "<", ">" with colorized ones
-        $text = preg_replace(
+        $text = StrictRegex::replace(
             '/(<[^>]+>)/',
             "{-$style}{+$paramStyle}\$1{-$paramStyle}{+$style}",
             $text

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -35,7 +35,7 @@ final class ConsoleFormatter extends BaseOutputFormatter
     public function format($message): string
     {
         try {
-            $formattedMessage = StrictRegex::replaceCallback(self::CUSTOM_PATTERN, [$this, 'replaceStyle'], $message);
+            $formattedMessage = StrictRegex::replaceCallback(self::CUSTOM_PATTERN, $this->replaceStyle(...), $message);
         } catch (RegexException $e) {
             $formattedMessage = 'Error formatting output: '.$e->getMessage();
         }

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -10,6 +10,8 @@
 
 namespace Behat\Behat\Output\Printer\Formatter;
 
+use Behat\Behat\Util\RegexException;
+use Behat\Behat\Util\StrictRegex;
 use Symfony\Component\Console\Formatter\OutputFormatter as BaseOutputFormatter;
 
 /**
@@ -32,8 +34,11 @@ final class ConsoleFormatter extends BaseOutputFormatter
      */
     public function format($message): string
     {
-        $formattedMessage = preg_replace_callback(self::CUSTOM_PATTERN, [$this, 'replaceStyle'], $message) ??
-            'Error formatting output: ' . preg_last_error_msg();
+        try {
+            $formattedMessage = StrictRegex::replaceCallback(self::CUSTOM_PATTERN, [$this, 'replaceStyle'], $message);
+        } catch (RegexException $e) {
+            $formattedMessage = 'Error formatting output: '.$e->getMessage();
+        }
 
         return self::replaceHref($formattedMessage);
     }
@@ -65,7 +70,7 @@ final class ConsoleFormatter extends BaseOutputFormatter
      */
     public static function replaceHref(string $message): string
     {
-        return preg_replace_callback(
+        return StrictRegex::replaceCallback(
             self::HREF_PATTERN,
             function ($matches) {
                 $url = $matches[1];

--- a/src/Behat/Behat/Util/RegexException.php
+++ b/src/Behat/Behat/Util/RegexException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Behat\Util;
+
+use Exception;
+
+/**
+ * @internal
+ */
+class RegexException extends Exception
+{
+}

--- a/src/Behat/Behat/Util/StrictRegex.php
+++ b/src/Behat/Behat/Util/StrictRegex.php
@@ -46,7 +46,8 @@ final class StrictRegex
      *
      * @throws RegexException if the regex fails
      */
-    public static function replaceCallback(array|string $pattern,
+    public static function replaceCallback(
+        array|string $pattern,
         callable $callback,
         string $subject,
     ): string {

--- a/src/Behat/Behat/Util/StrictRegex.php
+++ b/src/Behat/Behat/Util/StrictRegex.php
@@ -41,6 +41,24 @@ final class StrictRegex
     }
 
     /**
+     * @param string|list<string> $pattern
+     * @param callable(array<mixed,string>):string $callback
+     *
+     * @throws RegexException if the regex fails
+     */
+    public static function replaceCallback(array|string $pattern,
+        callable $callback,
+        string $subject,
+    ): string {
+        $result = self::callWithErrorCapture(fn (): ?string => preg_replace_callback($pattern, $callback, $subject));
+        if ($result === null) {
+            throw new RegexException('Regex failed: '.preg_last_error_msg(), preg_last_error());
+        }
+
+        return $result;
+    }
+
+    /**
      * @template T of mixed
      *
      * @param callable():T $callable

--- a/src/Behat/Behat/Util/StrictRegex.php
+++ b/src/Behat/Behat/Util/StrictRegex.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Behat\Util;
+
+use InvalidArgumentException;
+
+/**
+ * @internal
+ */
+final class StrictRegex
+{
+    /**
+     * @param string|list<string> $pattern
+     * @param string|list<string> $replacement
+     *
+     * @throws RegexException if the regex fails
+     * @throws InvalidArgumentException if passing pattern & replacements as arrays and the number of entries does not match
+     */
+    public static function replace(
+        string|array $pattern,
+        string|array $replacement,
+        string $subject,
+        int $limit = -1,
+    ): string {
+        if (is_array($pattern) && is_array($replacement) && count($pattern) !== count($replacement)) {
+            // If the number of replacements does not match the number of patterns, PHP treats missing replacements as
+            // empty strings. However, it is safer to force the caller to be explicit about this.
+            throw new InvalidArgumentException(
+                sprintf('Expected %d entries in $replacement array, got %d', count($pattern), count($replacement)),
+            );
+        }
+
+        $result = self::callWithErrorCapture(fn (): ?string => preg_replace($pattern, $replacement, $subject, $limit));
+        if ($result === null) {
+            throw new RegexException('Regex failed: '.preg_last_error_msg(), preg_last_error());
+        }
+
+        return $result;
+    }
+
+    /**
+     * @template T of mixed
+     *
+     * @param callable():T $callable
+     *
+     * @return T
+     */
+    private static function callWithErrorCapture(callable $callable): mixed
+    {
+        set_error_handler(fn ($level, $msg) => throw new RegexException($msg, $level));
+        try {
+            return $callable();
+        } finally {
+            restore_error_handler();
+        }
+    }
+}

--- a/src/Behat/Testwork/Cli/ConvertConfigCommand.php
+++ b/src/Behat/Testwork/Cli/ConvertConfigCommand.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\Cli;
 
+use Behat\Behat\Util\StrictRegex;
 use Behat\Config\Config;
 use Behat\Config\Converter\ConfigConverterTools;
 use Behat\Config\Converter\CustomPrettyPrinter;
@@ -94,9 +95,9 @@ final class ConvertConfigCommand extends BaseCommand
         // Find the name of the output file
         $outputFileName = $filePath;
         // First, handle cases where `.dist` is part of the extension
-        $outputFileName = preg_replace('/(\.ya?ml)\.dist$|\.dist\.(ya?ml)$/', '.dist.php', $outputFileName);
+        $outputFileName = StrictRegex::replace('/(\.ya?ml)\.dist$|\.dist\.(ya?ml)$/', '.dist.php', $outputFileName);
         // Then, handle regular `.yaml` or `.yml` files
-        $outputFileName = preg_replace('/\.(ya?ml)$/', '.php', (string) $outputFileName);
+        $outputFileName = StrictRegex::replace('/\.(ya?ml)$/', '.php', $outputFileName);
 
         $printer = new CustomPrettyPrinter();
 

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\Output\Printer;
 
+use Behat\Behat\Util\StrictRegex;
 use Behat\Testwork\Output\Exception\MissingExtensionException;
 use Behat\Testwork\Output\Exception\MissingOutputPathException;
 use Behat\Testwork\Output\Printer\Factory\FilesystemOutputFactory;
@@ -56,7 +57,7 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
         if (!extension_loaded('dom')) {
             throw new MissingExtensionException('The PHP DOM extension is required to generate JUnit reports.');
         }
-        $this->setFileName(strtolower(trim((string) preg_replace('/[^[:alnum:]_]+/', '_', $name), '_')));
+        $this->setFileName(strtolower(trim(StrictRegex::replace('/[^[:alnum:]_]+/', '_', $name), '_')));
 
         $this->domDocument = new DOMDocument(self::XML_VERSION, self::XML_ENCODING);
         $this->domDocument->formatOutput = true;

--- a/src/Behat/Testwork/PathOptions/Printer/ConfigurablePathPrinter.php
+++ b/src/Behat/Testwork/PathOptions/Printer/ConfigurablePathPrinter.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\PathOptions\Printer;
 
+use Behat\Behat\Util\StrictRegex;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
 final class ConfigurablePathPrinter
@@ -75,7 +76,7 @@ final class ConfigurablePathPrinter
         $basePathPattern = preg_quote($this->basePath . DIRECTORY_SEPARATOR, '/');
         $pattern = '/(' . $basePathPattern . '[^:\s]+)((:|\s+line\s+)(\d+))?/';
 
-        return preg_replace_callback($pattern, function (array $matches): string {
+        return StrictRegex::replaceCallback($pattern, function (array $matches): string {
             $filePath = $matches[1];
             $line = $matches[4] ?? null;
 

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\ServiceContainer;
 
+use Behat\Behat\Util\StrictRegex;
 use Behat\Testwork\ServiceContainer\Exception\ExtensionInitializationException;
 
 /**
@@ -132,7 +133,7 @@ final class ExtensionManager
     public static function guessFullExtensionClassName(string $locator): string
     {
         $parts = explode('\\', $locator);
-        $name = preg_replace('/Extension$/', '', end($parts)) . 'Extension';
+        $name = StrictRegex::replace('/Extension$/', '', end($parts)) . 'Extension';
 
         return $locator . '\\ServiceContainer\\' . $name;
     }

--- a/tests/Behat/Tests/Output/Printer/Formatter/ConsoleFormatterTest.php
+++ b/tests/Behat/Tests/Output/Printer/Formatter/ConsoleFormatterTest.php
@@ -29,14 +29,13 @@ class ConsoleFormatterTest extends TestCase
     {
         $consoleFormatter = new ConsoleFormatter(true);
 
-        $original_backtrack_limit = ini_get('pcre.backtrack_limit');
+        $originalBacktrackLimit = ini_set('pcre.backtrack_limit', '100');
+        try {
+            $formattedText = $consoleFormatter->format('{+info}'.str_repeat('a', 1000).'{-info}');
+        } finally {
+            ini_set('pcre.backtrack_limit', $originalBacktrackLimit);
+        }
 
-        ini_set('pcre.backtrack_limit', '100');
-
-        $formattedText = $consoleFormatter->format('{+info}' . str_repeat('a', 1000) . '{-info}');
-
-        ini_set('pcre.backtrack_limit', $original_backtrack_limit);
-
-        $this->assertEquals('Error formatting output: Backtrack limit exhausted', $formattedText);
+        $this->assertEquals('Error formatting output: Regex failed: Backtrack limit exhausted', $formattedText);
     }
 }

--- a/tests/Behat/Tests/Util/StrictRegexTest.php
+++ b/tests/Behat/Tests/Util/StrictRegexTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 final class StrictRegexTest extends TestCase
 {
-    private string $original_backtrack_limit;
+    private string $originalBacktrackLimit;
 
     public static function providerReplaceValidCases(): iterable
     {
@@ -202,12 +202,12 @@ final class StrictRegexTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->original_backtrack_limit = ini_set('pcre.backtrack_limit', '2');
+        $this->originalBacktrackLimit = ini_set('pcre.backtrack_limit', '2');
     }
 
     protected function tearDown(): void
     {
-        ini_set('pcre.backtrack_limit', $this->original_backtrack_limit);
+        ini_set('pcre.backtrack_limit', $this->originalBacktrackLimit);
         parent::tearDown();
     }
 }

--- a/tests/Behat/Tests/Util/StrictRegexTest.php
+++ b/tests/Behat/Tests/Util/StrictRegexTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Behat\Tests\Util;
 
+use BadMethodCallException;
 use Behat\Behat\Util\RegexException;
 use Behat\Behat\Util\StrictRegex;
 use InvalidArgumentException;
@@ -113,6 +114,89 @@ final class StrictRegexTest extends TestCase
         $this->expectException($expectException);
         $this->expectExceptionMessage($expectMsg);
         StrictRegex::replace(...$args);
+    }
+
+    public static function providerReplaceCallbackValidCases(): iterable
+    {
+        return [
+            'no replacement' => [
+                [
+                    '/^old/',
+                    fn () => 'new',
+                    'some thing',
+                ],
+                'some thing',
+            ],
+            'simple replacement' => [
+                [
+                    '/^old/',
+                    fn () => 'new',
+                    'old thing',
+                ],
+                'new thing',
+            ],
+            'replacement with params' => [
+                [
+                    '/[a-z]/',
+                    fn (array $matches) => strtoupper($matches[0]),
+                    'Abcdef',
+                ],
+                'ABCDEF',
+            ],
+            'array replacements' => [
+                [
+                    ['/^old/', '/(thing|object)/'],
+                    fn (array $matches) => strrev($matches[0]),
+                    'old things',
+                ],
+                'dlo gnihts',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerReplaceCallbackValidCases
+     */
+    public function testReplaceCallbackValidCases(array $args, string $expect): void
+    {
+        $this->assertSame(
+            $expect,
+            StrictRegex::replaceCallback(...$args),
+        );
+    }
+
+    public static function providerReplaceCallbackInvalidCases(): iterable
+    {
+        return [
+            'invalid regex pattern' => [
+                [
+                    '/broken',
+                    fn () => throw new BadMethodCallException('Not expected to be called'),
+                    'anything',
+                ],
+                RegexException::class,
+                'No ending delimiter',
+            ],
+            'excessive backtracking' => [
+                [
+                    '/(x+x+)+y/',
+                    fn () => throw new BadMethodCallException('Not expected to be called'),
+                    'xxxxxxxxxxxxy',
+                ],
+                RegexException::class,
+                'Regex failed: Backtrack limit exhausted',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerReplaceCallbackInvalidCases
+     */
+    public function testReplaceCallbackInvalidCases(array $args, string $expectException, string $expectMsg): void
+    {
+        $this->expectException($expectException);
+        $this->expectExceptionMessage($expectMsg);
+        StrictRegex::replaceCallback(...$args);
     }
 
     protected function setUp(): void

--- a/tests/Behat/Tests/Util/StrictRegexTest.php
+++ b/tests/Behat/Tests/Util/StrictRegexTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Tests\Util;
+
+use Behat\Behat\Util\RegexException;
+use Behat\Behat\Util\StrictRegex;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class StrictRegexTest extends TestCase
+{
+    private string $original_backtrack_limit;
+
+    public static function providerReplaceValidCases(): iterable
+    {
+        return [
+            'no replacement' => [
+                [
+                    '/^old/',
+                    'new',
+                    'some thing',
+                ],
+                'some thing',
+            ],
+            'simple replacement' => [
+                [
+                    '/^old/',
+                    'new',
+                    'old thing',
+                ],
+                'new thing',
+            ],
+            'simple replacement with limit' => [
+                [
+                    '/[a-z]/',
+                    '1',
+                    'Abcdef',
+                    1,
+                ],
+                'A1cdef',
+            ],
+            'simple replacement with longer limit' => [
+                [
+                    '/[a-z]/',
+                    '1',
+                    'Abcdef',
+                    3,
+                ],
+                'A111ef',
+            ],
+            'array replacements' => [
+                [
+                    ['/^old/', '/(thing|object)/'],
+                    ['new', 'item'],
+                    'old things',
+                ],
+                'new items',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerReplaceValidCases
+     */
+    public function testReplaceValidCases(array $args, string $expect): void
+    {
+        $this->assertSame(
+            $expect,
+            StrictRegex::replace(...$args),
+        );
+    }
+
+    public static function providerReplaceInvalidCases(): iterable
+    {
+        return [
+            'incorrect number of replacements in array' => [
+                [
+                    ['/one/', '/two/'],
+                    ['uhoh'],
+                    'anything',
+                ],
+                InvalidArgumentException::class,
+                'Expected 2 entries in $replacement array, got 1',
+            ],
+            'invalid regex pattern' => [
+                [
+                    '/broken',
+                    'anything',
+                    'anything',
+                ],
+                RegexException::class,
+                'No ending delimiter',
+            ],
+            'excessive backtracking' => [
+                [
+                    '/(x+x+)+y/',
+                    '',
+                    'xxxxxxxxxxxxy',
+                ],
+                RegexException::class,
+                'Regex failed: Backtrack limit exhausted',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerReplaceInvalidCases
+     */
+    public function testReplaceInvalidCases(array $args, string $expectException, string $expectMsg): void
+    {
+        $this->expectException($expectException);
+        $this->expectExceptionMessage($expectMsg);
+        StrictRegex::replace(...$args);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->original_backtrack_limit = ini_set('pcre.backtrack_limit', '2');
+    }
+
+    protected function tearDown(): void
+    {
+        ini_set('pcre.backtrack_limit', $this->original_backtrack_limit);
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
While starting work on the next iteration of adding strict return types, Rector picked up a number of methods that had phpdoc of `@return string` but could theoretically also have been returning `null`.

This is because `preg_replace` and `preg_replace_callback` can return null in some cases (e.g. if the pattern is valid but it hits the runtime backtrack_limit). We were not always handling this - sometimes casting back to empty string, sometimes just assuming the result would be a string.

This can also happen if there is an issue with the regex itself (e.g. the pattern is invalid) and the runtime PHP error is not captured by an error handler that converts it to an exception - generally in Behat we do, but the static analyser cannot detect this.

This commit introduces thin wrapper functions to ensure that the preg_replace / preg_replace_callback was successful. This will reduce the need for assertions elsewhere in the code as we move towards stricter typing.

Note that the native PHP functions can also return an `array` if passed an `array $subject` however we never use this feature so I have limited the utility functions to `string $subject` and ` string` return type. If we needed to support arrays in future I'd be inclined to do that as separate methods (e.g. `replaceArray`) so that we only have to handle array return types in places we expect them.