### PR TITLE
[3.x] refactor: Use first-class callables for internal callbacks

### DIFF
--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
@@ -37,7 +37,7 @@ final class ServicesResolver implements ArgumentResolver
      */
     public function resolveArguments(ReflectionClass $classReflection, array $arguments)
     {
-        return array_map([$this, 'resolveArgument'], $arguments);
+        return array_map($this->resolveArgument(...), $arguments);
     }
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
@@ -134,7 +134,7 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
         }
 
         $text = $this->exceptionPresenter->presentException($result->getException());
-        $indentedText = implode("\n", array_map([$this, 'subIndent'], explode("\n", $text)));
+        $indentedText = implode("\n", array_map($this->subIndent(...), explode("\n", $text)));
         $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $indentedText, $style));
     }
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
@@ -67,7 +67,7 @@ final class PrettyFeaturePrinter implements FeaturePrinter
             return;
         }
 
-        $tags = array_map([$this, 'prependTagWithTagSign'], $tags);
+        $tags = array_map($this->prependTagWithTagSign(...), $tags);
         $printer->writeln(sprintf('%s{+tag}%s{-tag}', $this->indentText, implode(' ', $tags)));
     }
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -77,7 +77,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
             return;
         }
 
-        $tags = array_map([$this, 'prependTagWithTagSign'], $tags);
+        $tags = array_map($this->prependTagWithTagSign(...), $tags);
         $printer->writeln(sprintf('%s{+tag}%s{-tag}', $this->indentText, implode(' ', $tags)));
     }
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -99,7 +99,7 @@ final class PrettySkippedStepPrinter implements StepPrinter
         foreach ($arguments as $argument) {
             $text = $this->getArgumentString($argument, !$formatter->getParameter('multiline'));
 
-            $indentedText = implode("\n", array_map([$this, 'subIndent'], explode("\n", $text)));
+            $indentedText = implode("\n", array_map($this->subIndent(...), explode("\n", $text)));
             $formatter->getOutputPrinter()->writeln(sprintf('{+%s}%s{-%s}', $style, $indentedText, $style));
         }
     }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -113,7 +113,7 @@ final class PrettyStepPrinter implements StepPrinter
         foreach ($arguments as $argument) {
             $text = $this->getArgumentString($argument, !$formatter->getParameter('multiline'));
 
-            $indentedText = implode("\n", array_map([$this, 'subIndent'], explode("\n", $text)));
+            $indentedText = implode("\n", array_map($this->subIndent(...), explode("\n", $text)));
             $formatter->getOutputPrinter()->writeln(sprintf('{+%s}%s{-%s}', $style, $indentedText, $style));
         }
     }
@@ -151,7 +151,7 @@ final class PrettyStepPrinter implements StepPrinter
         }
 
         $text = $this->exceptionPresenter->presentException($result->getException());
-        $indentedText = implode("\n", array_map([$this, 'subIndent'], explode("\n", $text)));
+        $indentedText = implode("\n", array_map($this->subIndent(...), explode("\n", $text)));
         $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $indentedText, $style));
     }
 

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -223,7 +223,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
             $parameters,
             $candidates,
             $arguments,
-            [$this, 'classMatchingPredicateForTypehintedArguments']
+            $this->classMatchingPredicateForTypehintedArguments(...)
         );
 
         // This iteration maps up everything else, providing the argument is an instanceof the parameter.
@@ -231,7 +231,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
             $parameters,
             $candidates,
             $arguments,
-            [$this, 'isInstancePredicateForTypehintedArguments']
+            $this->isInstancePredicateForTypehintedArguments(...)
         );
 
         return $arguments;


### PR DESCRIPTION
We still had a few uses of array callables within our internal code, which I found when starting to look at adding parameter types to internal methods.

Rector has a rule to fix these as part of the PHP 8.1 set that we are running, but it had skipped over them because they were not public methods, even though they are defined and used in their own scope. 

I think this may actually be a Rector bug - see https://github.com/rectorphp/rector-src/pull/7760 for the patch which I have temporarily used locally to convert these.

Refactoring them to first-class callables will help Rector (and possibly phpstan) to make better decisions about parameter & return types in future.