### PR TITLE
Drop PHP 8.1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,25 +23,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
         os: [ubuntu-latest]
         composer-mode: [update]
         symfony-version: ['']
         include:
           # Build on the lowest supported PHP with the lowest supported dependencies
-          - php: 8.1
+          - php: 8.2
             os: ubuntu-latest
             composer-mode: lowest
             symfony-version: ''
 
           # MacOS on latest PHP only
-          - php: 8.4
+          - php: 8.5
             os: macos-latest
             composer-mode: update
             symfony-version: ''
 
           # Windows on latest PHP only
-          - php: 8.4
+          - php: 8.5
             os: windows-latest
             composer-mode: update
             symfony-version: ''
@@ -78,7 +78,7 @@ jobs:
         if: matrix.composer-mode == 'update'
         env:
           SYMFONY_REQUIRE: ${{ matrix.symfony-version }}.*
-        run: composer update ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
+        run: composer update
 
       - name: Install lowest dependencies
         if: matrix.composer-mode == 'lowest'
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.5]
+        php: [8.2, 8.5]
     steps:
       - uses: actions/checkout@v4
 
@@ -122,7 +122,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.2"
           ini-values: "zend.exception_ignore_args=Off"
           coverage: none
 
@@ -141,7 +141,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.2"
           ini-values: "zend.exception_ignore_args=Off"
           coverage: none
 
@@ -191,14 +191,6 @@ jobs:
           coverage: none
           tools: box
 
-      # We have to force the composer platform because box only runs on ^8.2, but we need to make sure the dependencies
-      # inside the phar support 8.1.0 (our lowest supported PHP version).
-      # When we drop 8.1, we may be able to drop this (if we can still get box to run on 8.2).
-      - name: Force dependencies for lowest supported PHP version
-        run: |
-          composer config platform.php 8.1.0
-          composer update --no-dev -o
-
       - name: Build the PHAR
         run: box compile
 
@@ -215,7 +207,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,9 @@ jobs:
           coverage: none
           tools: box
 
+      - name: Install dependencies
+        run: composer update --no-dev -o
+
       - name: Build the PHAR
         run: box compile
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
 
     "require": {
-        "php": ">=8.1 <8.6",
+        "php": ">=8.2 <8.6",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.2",
         "behat/gherkin": "^4.12.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
+        "symfony/console": "^5.4.9 || ^6.4 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
         "symfony/translation": "^5.4 || ^6.4 || ^7.0",

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
+use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -12,9 +13,10 @@ return RectorConfig::configure()
     ])
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
-    ->withPhpSets(php81: true)
+    ->withPhpSets(php82: true)
     ->withSkip([
         StringableForToStringRector::class,
+        ReadOnlyClassRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,


### PR DESCRIPTION
Now that support for PHP 8.1 has been officially dropped, update our project to drop support for this version. Also updates all code to fully support PHP 8.5 as the latest version