### PR TITLE
fix: Normalize PHP file line numbers in test output to avoid fragile tests

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -456,6 +456,8 @@ EOL;
 
         $fileContent = preg_replace('/time="\d\.\d{3}"/U', 'time="-IGNORE-VALUE-"', $fileContent);
 
+        $fileContent = $this->normalizePhpFileLineNumbers((string) $fileContent);
+
         // The placeholder is necessary because of different separators on Unix and Windows environments
         $text = str_replace('-DIRECTORY-SEPARATOR-', DIRECTORY_SEPARATOR, $text);
         // used for absolute paths
@@ -479,6 +481,8 @@ EOL;
         Assert::assertIsArray($data);
 
         $fileContent = preg_replace('/"time": [\d.]+/', '"time": -IGNORE-VALUE-', $fileContent);
+
+        $fileContent = $this->normalizePhpFileLineNumbers((string) $fileContent);
 
         $text = str_replace(
             '-DIRECTORY-SEPARATOR-',
@@ -665,7 +669,22 @@ EOL;
         // Replace wrong warning message of HHVM
         $output = str_replace('Notice: Undefined index: ', 'Notice: Undefined offset: ', $output);
 
-        return trim((string) preg_replace('/ +$/m', '', $output));
+        $output = $this->normalizePhpFileLineNumbers($output);
+
+        return trim((string) preg_replace('/ +$/m', '', (string) $output));
+    }
+
+    /**
+     * Normalizes PHP file line numbers to XX to avoid fragile tests.
+     */
+    private function normalizePhpFileLineNumbers(string $content): string
+    {
+        $content = preg_replace('/\.php line \d+/', '.php line XX', $content);
+        $content = preg_replace('/\.php:\d+/', '.php:XX', (string) $content);
+        $content = preg_replace('/\.php\(\d+\)/', '.php(XX)', (string) $content);
+        $content = preg_replace('/\.php&line=\d+/', '.php&line=XX', (string) $content);
+
+        return (string) $content;
     }
 
     private function createFileInWorkingDir(string $filename, string $content): void

--- a/features/definitions_patterns_annotations.feature
+++ b/features/definitions_patterns_annotations.feature
@@ -74,7 +74,7 @@ Feature: Step Definition Pattern Annotations
       | features/broken_regex.feature  |              |
     Then it should fail with:
       """
-      In RegexPatternPolicy.php line 69:
+      In RegexPatternPolicy.php line XX:
       
         The regex `/I am (foo/` is invalid: preg_match(): Compilation failed: missing closing parenthesis at offset 9
       """

--- a/features/definitions_patterns_attributes.feature
+++ b/features/definitions_patterns_attributes.feature
@@ -74,7 +74,7 @@ Feature: Step Definition Pattern Attributes
       | features/broken_regex.feature  |              |
     Then it should fail with:
       """
-      In RegexPatternPolicy.php line 69:
+      In RegexPatternPolicy.php line XX:
       
         The regex `/I am (foo/` is invalid: preg_match(): Compilation failed: missing closing parenthesis at offset 9
       """

--- a/features/editor_url.feature
+++ b/features/editor_url.feature
@@ -18,7 +18,7 @@ Feature: Editor URL
         Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>features/test.feature:3</>
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>features/bootstrap/FeatureContext.php line 16</>
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=XX>features/bootstrap/FeatureContext.php line XX</>
 
       --- Failed scenarios:
 
@@ -34,7 +34,7 @@ Feature: Editor URL
         Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>features/test.feature:3</>
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>features/bootstrap/FeatureContext.php line 16</>
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=XX>features/bootstrap/FeatureContext.php line XX</>
 
       --- Failed scenarios:
 
@@ -50,7 +50,7 @@ Feature: Editor URL
         Scenario:                                    # <href=phpstorm://open?file=%%WORKING_DIR%%features/test.feature&line=3>features/test.feature:3</>
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in <href=phpstorm://open?file=%%WORKING_DIR%%features/bootstrap/FeatureContext.php&line=16>features/bootstrap/FeatureContext.php line 16</>
+            Warning: Undefined variable $b in <href=phpstorm://open?file=%%WORKING_DIR%%features/bootstrap/FeatureContext.php&line=XX>features/bootstrap/FeatureContext.php line XX</>
 
       --- Failed scenarios:
 
@@ -67,7 +67,7 @@ Feature: Editor URL
         Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>%%WORKING_DIR%%features/test.feature:3</>
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>%%WORKING_DIR%%features/bootstrap/FeatureContext.php line 16</>
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=XX>%%WORKING_DIR%%features/bootstrap/FeatureContext.php line XX</>
 
       --- Failed scenarios:
 
@@ -113,7 +113,7 @@ Feature: Editor URL
                                   "line": 5,
                                   "failures": [
                                       {
-                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line 16",
+                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line XX",
                                           "type": "failed"
                                       }
                                   ]
@@ -138,7 +138,7 @@ Feature: Editor URL
       <testsuites name="default">
         <testsuite name="" file="features-DIRECTORY-SEPARATOR-test.feature" tests="1" skipped="0" failures="1" errors="0">
           <testcase name="" classname="" status="failed" file="features-DIRECTORY-SEPARATOR-test.feature" line="5">
-            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line 16"></failure>
+            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line XX"></failure>
           </testcase>
         </testsuite>
       </testsuites>

--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -22,11 +22,11 @@ Feature: Error Reporting
 
     001 Scenario: Access undefined index # features/php_errors_in_scenario.feature:9
           When I access array index 0    # features/php_errors_in_scenario.feature:10
-            Warning: Undefined array key 0 in features/bootstrap/FeatureContext.php line 23
+            Warning: Undefined array key 0 in features/bootstrap/FeatureContext.php line XX
 
     002 Scenario: Trigger PHP deprecation # features/php_errors_in_scenario.feature:18
           When I trim NULL                # features/php_errors_in_scenario.feature:19
-            Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in features/bootstrap/FeatureContext.php line 53
+            Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in features/bootstrap/FeatureContext.php line XX
 
     3 scenarios (1 passed, 2 failed)
     9 steps (6 passed, 2 failed, 1 skipped)
@@ -57,7 +57,7 @@ Feature: Error Reporting
 
     001 Scenario: Access undefined index # features/php_errors_in_scenario.feature:9
           When I access array index 0    # features/php_errors_in_scenario.feature:10
-            Warning: Undefined array key 0 in features/bootstrap/FeatureContext.php line 23
+            Warning: Undefined array key 0 in features/bootstrap/FeatureContext.php line XX
 
     3 scenarios (2 passed, 1 failed)
     9 steps (7 passed, 1 failed, 1 skipped)
@@ -75,11 +75,11 @@ Feature: Error Reporting
 
     001 Scenario: Access undefined index # features/php_errors_in_scenario.feature:9
           When I access array index 0    # features/php_errors_in_scenario.feature:10
-            Warning: Undefined array key 0 in features/bootstrap/FeatureContext.php line 23
+            Warning: Undefined array key 0 in features/bootstrap/FeatureContext.php line XX
 
     002 Scenario: Trigger PHP deprecation # features/php_errors_in_scenario.feature:18
           When I trim NULL                # features/php_errors_in_scenario.feature:19
-            Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in features/bootstrap/FeatureContext.php line 53
+            Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in features/bootstrap/FeatureContext.php line XX
 
     3 scenarios (1 passed, 2 failed)
     9 steps (6 passed, 2 failed, 1 skipped)
@@ -98,7 +98,7 @@ Feature: Error Reporting
 
     001 Scenario: Exception thrown    # features/exception_in_scenario.feature:6
           When an exception is thrown # features/exception_in_scenario.feature:7
-            Exception: Exception is thrown in features/bootstrap/FeatureContext.php:47
+            Exception: Exception is thrown in features/bootstrap/FeatureContext.php:XX
             Stack trace:
 
     1 scenario (1 failed)
@@ -118,8 +118,8 @@ Feature: Error Reporting
 
     001 Scenario: Exception thrown    # features/exception_in_scenario.feature:6
           When an exception is thrown # features/exception_in_scenario.feature:7
-            Exception: Exception is thrown in features/bootstrap/FeatureContext.php:47
+            Exception: Exception is thrown in features/bootstrap/FeatureContext.php:XX
             Stack trace:
-            #0 {BASE_PATH}src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(93): FeatureContext->anExceptionIsThrown()
-            #1 {BASE_PATH}src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(53): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(
+            #0 {BASE_PATH}src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(XX): FeatureContext->anExceptionIsThrown()
+            #1 {BASE_PATH}src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php(XX): Behat\Testwork\Call\Handler\RuntimeCallHandler->executeCall(
     """

--- a/features/phpunit_exceptions.feature
+++ b/features/phpunit_exceptions.feature
@@ -51,7 +51,7 @@ Feature: Stringifying PHPUnit exceptions
               !! There was an error trying to render more details of this PHPUnit\Framework\ExpectationFailedException.
                  You are probably using a PHPUnit version that Behat cannot automatically display failures for.
                  See Behat\Testwork\Exception\Stringer\PHPUnitExceptionStringer for details of PHPUnit support.
-                 [RuntimeException] Some internal problem at features/bootstrap/IncompatibleThrowableToStringMapper.php:11
+                 [RuntimeException] Some internal problem at features/bootstrap/IncompatibleThrowableToStringMapper.php:XX
 
       002 Scenario: Compare mismatched ints  # features/with_phpunit_10_broken.feature:13
             Then an integer 1 should equal 2 # features/with_phpunit_10_broken.feature:14
@@ -60,7 +60,7 @@ Feature: Stringifying PHPUnit exceptions
               !! There was an error trying to render more details of this PHPUnit\Framework\ExpectationFailedException.
                  You are probably using a PHPUnit version that Behat cannot automatically display failures for.
                  See Behat\Testwork\Exception\Stringer\PHPUnitExceptionStringer for details of PHPUnit support.
-                 [RuntimeException] Some internal problem at features/bootstrap/IncompatibleThrowableToStringMapper.php:11
+                 [RuntimeException] Some internal problem at features/bootstrap/IncompatibleThrowableToStringMapper.php:XX
 
       4 scenarios (2 passed, 2 failed)
       4 steps (2 passed, 2 failed)

--- a/features/print_absolute_paths.feature
+++ b/features/print_absolute_paths.feature
@@ -18,7 +18,7 @@ Feature: Print absolute paths
         Scenario:                                    # %%WORKING_DIR%%features%%DS%%test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in %%WORKING_DIR%%features%%DS%%bootstrap%%DS%%FeatureContext.php line 16
+            Warning: Undefined variable $b in %%WORKING_DIR%%features%%DS%%bootstrap%%DS%%FeatureContext.php line XX
 
       --- Failed scenarios:
 
@@ -34,7 +34,7 @@ Feature: Print absolute paths
         Scenario:                                    # %%WORKING_DIR%%features%%DS%%test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in %%WORKING_DIR%%features%%DS%%bootstrap%%DS%%FeatureContext.php line 16
+            Warning: Undefined variable $b in %%WORKING_DIR%%features%%DS%%bootstrap%%DS%%FeatureContext.php line XX
 
       --- Failed scenarios:
 
@@ -80,7 +80,7 @@ Feature: Print absolute paths
                                   "line": 5,
                                   "failures": [
                                       {
-                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in %%WORKING_DIR%%features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line 16",
+                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in %%WORKING_DIR%%features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line XX",
                                           "type": "failed"
                                       }
                                   ]
@@ -105,7 +105,7 @@ Feature: Print absolute paths
       <testsuites name="default">
         <testsuite name="" file="%%WORKING_DIR%%features-DIRECTORY-SEPARATOR-test.feature" tests="1" skipped="0" failures="1" errors="0">
           <testcase name="" classname="" status="failed" file="%%WORKING_DIR%%features-DIRECTORY-SEPARATOR-test.feature" line="5">
-            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in %%WORKING_DIR%%features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line 16"></failure>
+            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in %%WORKING_DIR%%features-DIRECTORY-SEPARATOR-bootstrap-DIRECTORY-SEPARATOR-FeatureContext.php line XX"></failure>
           </testcase>
         </testsuite>
       </testsuites>

--- a/features/remove_prefix.feature
+++ b/features/remove_prefix.feature
@@ -18,7 +18,7 @@ Feature: Remove prefix
         Scenario:                                    # test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in FeatureContext.php line 16
+            Warning: Undefined variable $b in FeatureContext.php line XX
 
       --- Failed scenarios:
 
@@ -34,7 +34,7 @@ Feature: Remove prefix
         Scenario:                                    # test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in FeatureContext.php line 16
+            Warning: Undefined variable $b in FeatureContext.php line XX
 
       --- Failed scenarios:
 
@@ -51,7 +51,7 @@ Feature: Remove prefix
         Scenario:                                    # <href=phpstorm://open?file=features/test.feature&line=3>test.feature:3</>
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=16>FeatureContext.php line 16</>
+            Warning: Undefined variable $b in <href=phpstorm://open?file=features/bootstrap/FeatureContext.php&line=XX>FeatureContext.php line XX</>
 
       --- Failed scenarios:
 
@@ -68,7 +68,7 @@ Feature: Remove prefix
         Scenario:                                    # features%%DS%%test.feature:3
           Given I have a passing step                # FeatureContext::iHaveAPassingStep()
           And I have a step that throws an exception # FeatureContext::iHaveAFailingStep()
-            Warning: Undefined variable $b in features%%DS%%bootstrap%%DS%%FeatureContext.php line 16
+            Warning: Undefined variable $b in features%%DS%%bootstrap%%DS%%FeatureContext.php line XX
 
       --- Failed scenarios:
 
@@ -115,7 +115,7 @@ Feature: Remove prefix
                                   "line": 5,
                                   "failures": [
                                       {
-                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in FeatureContext.php line 16",
+                                          "message": "And I have a step that throws an exception: Warning: Undefined variable $b in FeatureContext.php line XX",
                                           "type": "failed"
                                       }
                                   ]
@@ -141,7 +141,7 @@ Feature: Remove prefix
       <testsuites name="default">
         <testsuite name="" file="test.feature" tests="1" skipped="0" failures="1" errors="0">
           <testcase name="" classname="" status="failed" file="test.feature" line="5">
-            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in FeatureContext.php line 16"></failure>
+            <failure message="And I have a step that throws an exception: Warning: Undefined variable $b in FeatureContext.php line XX"></failure>
           </testcase>
         </testsuite>
       </testsuites>

--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -210,7 +210,7 @@ Feature: Different result types
 
       001 Scenario: Redundant menu       # features/warning.feature:6
             Given customer bought coffee # features/warning.feature:7
-              User Warning: some warning in features/bootstrap/WarningContext.php line 11
+              User Warning: some warning in features/bootstrap/WarningContext.php line XX
 
       1 scenario (1 failed)
       2 steps (1 failed, 1 skipped)


### PR DESCRIPTION
There are several places in our tests where we check the expected output and it contains line numbers of php files. This makes these tests fragile because whenever we update those php files, for example when doing a refactor, these line numbers may change. And the actual line numbers in php files are unimportant for our tests

This PR adds a function that convert these line numbers in the output to a placeholder and updates our feature files to use this placeholder. 

This PR does not change the expected line numbers when they are related to feature files. These line numbers are more stable and provide information that may be important