### PR TITLE
refactor: Make `Extension::process()` explicit & document dependencies

### DIFF
--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -43,13 +43,29 @@ interface Extension extends CompilerPassInterface
 
     /**
      * Setups configuration for the extension.
+     *
+     * NOTE: If your extension implements this method, your composer.json should declare
+     * a direct dependency on the version(s) of symfony/config that you support.
      */
     public function configure(ArrayNodeDefinition $builder);
 
     /**
      * Loads extension services into temporary container.
      *
+     * NOTE: If your extension implements this method, your composer.json should declare
+     * a direct dependency on the version(s) of symfony/dependency-injection that you support.
+     *
      * @param array<string, mixed> $config
      */
     public function load(ContainerBuilder $container, array $config);
+
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     *  NOTE: If your extension implements this method, your composer.json should declare
+     *  a direct dependency on the version(s) of symfony/dependency-injection that you support.
+     *
+     * @return void
+     */
+    public function process(ContainerBuilder $container);
 }


### PR DESCRIPTION
The `Extension` interface currently extends the `CompilerPassInterface` from `symfony/dependency-injection`. This forces Behat (and all third-party extensions) into potentially breaking changes to support new `symfony/dependency-injection` major releases even if the extension does not interact with the container.

Making the `process` method explicit in 3.x will make it easier to then drop the inheritance in 4.0 so that the `Extension` interface is fully under our control.

The methods in the interface are still called with objects defined in symfony/config and symfony/dependency-injection. Replacing these with generic interfaces or wrappers would be a major refactor for us and for extension authors and is out of scope for 4.0.

I have instead highlighted that extension authors who implement these methods should define their own constraints on those packages. This will protect them from BC breaks if e.g. we add support for a new symfony version that removes a method their extension depends on.

Refs #1316