### PR TITLE
[4.0] refactor: Extension interface should not extend third-party interface

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -65,5 +65,12 @@
         <ignored-regex>#REMOVED: These ancestors of Behat\\Config\\.+? have been removed: \["Behat\\\\Config\\\\ConfigConverterInterface"\]#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Config\\.+?\#toPhpExpr\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Constant Behat\\Config\\Formatter\\PrettyFormatter::PRINT_SKIPPED_STEPS_PARAMETER_NAME was removed#</ignored-regex>
+
+
+        <!--
+        `Behat\Testwork\ServiceContainer\Extension` is now a standalone interface and no longer extends the third-party
+        `CompilerPassInterface`
+        -->
+        <ignored-regex>#REMOVED: These ancestors of .+?Extension have been removed: \["Symfony\\\\Component\\\\DependencyInjection\\\\Compiler\\\\CompilerPassInterface"\]#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/src/Behat/Testwork/ServiceContainer/ContainerLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/ContainerLoader.php
@@ -141,6 +141,6 @@ final class ContainerLoader
         $tempContainer->addObjectResource($extension);
         $extension->load($container, $config);
         $container->merge($tempContainer);
-        $container->addCompilerPass($extension);
+        $container->addCompilerPass(new ExtensionCompilerPass($extension));
     }
 }

--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -43,13 +43,29 @@ interface Extension extends CompilerPassInterface
 
     /**
      * Setups configuration for the extension.
+     *
+     * NOTE: If your extension implements this method, your composer.json should declare
+     * a direct dependency on the version(s) of symfony/config that you support.
      */
     public function configure(ArrayNodeDefinition $builder);
 
     /**
      * Loads extension services into temporary container.
      *
+     * NOTE: If your extension implements this method, your composer.json should declare
+     * a direct dependency on the version(s) of symfony/dependency-injection that you support.
+     *
      * @param array<string, mixed> $config
      */
     public function load(ContainerBuilder $container, array $config);
+
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     *  NOTE: If your extension implements this method, your composer.json should declare
+     *  a direct dependency on the version(s) of symfony/dependency-injection that you support.
+     *
+     * @return void
+     */
+    public function process(ContainerBuilder $container);
 }

--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -11,7 +11,6 @@
 namespace Behat\Testwork\ServiceContainer;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -22,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-interface Extension extends CompilerPassInterface
+interface Extension
 {
     /**
      * Returns the extension config key.

--- a/src/Behat/Testwork/ServiceContainer/ExtensionCompilerPass.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionCompilerPass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Behat\Testwork\ServiceContainer;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final readonly class ExtensionCompilerPass implements CompilerPassInterface
+{
+    public function __construct(
+        private Extension $extension,
+    ) {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $this->extension->process($container);
+    }
+}


### PR DESCRIPTION
For 4.0, the Extension interface no longer extends the symfony CompilerPassInterface. This reduces the risk of having to make breaking changes and/or force extension authors to update their extensions for future symfony majors.

Instead, we satisfy the CompilerPassInterface by wrapping the Extension internally as an implementation detail.

Follows #1795 and refs #1316 - I will rebase this once #1795 is merged to 3.x and 3.x has been merged up.