### PR TITLE
feat: Move `gherkin` configuration to dedicated object

### DIFF
--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -335,7 +335,7 @@ Feature: Convert config
       """
     And the "class_references.yaml" file should have been removed from the working directory
 
-  Scenario: Profile filters
+  Scenario: Gherkin filters
     When I run behat with the following additional options:
       | option   | value                |
       | --config | profile_filters.yaml |
@@ -347,12 +347,14 @@ Feature: Convert config
       use Behat\Config\Config;
       use Behat\Config\Filter\NameFilter;
       use Behat\Config\Filter\RoleFilter;
+      use Behat\Config\GherkinOptions;
       use Behat\Config\Profile;
 
       return (new Config())
           ->withProfile((new Profile('default'))
-              ->withFilter(new NameFilter('john'))
-              ->withFilter(new RoleFilter('admin')));
+              ->withGherkinOptions((new GherkinOptions())
+                  ->withFilter(new NameFilter('john'))
+                  ->withFilter(new RoleFilter('admin'))));
       """
     And the "profile_filters.yaml" file should have been removed from the working directory
 
@@ -496,6 +498,7 @@ Feature: Convert config
       use Behat\Config\Formatter\Formatter;
       use Behat\Config\Formatter\PrettyFormatter;
       use Behat\Config\Formatter\ProgressFormatter;
+      use Behat\Config\GherkinOptions;
       use Behat\Config\Profile;
       use Behat\Config\Suite;
       use Behat\Config\TesterOptions;
@@ -512,8 +515,9 @@ Feature: Convert config
                   'other_property' => 'value',
               ]))
                   ->withOutputVerbosity(OutputFactory::VERBOSITY_VERBOSE))
-              ->withFilter(new NameFilter('john'))
-              ->withFilter(new RoleFilter('admin'))
+              ->withGherkinOptions((new GherkinOptions())
+                  ->withFilter(new NameFilter('john'))
+                  ->withFilter(new RoleFilter('admin')))
               ->withPrintUnusedDefinitions()
               ->withPathOptions(
                   printAbsolutePaths: true,

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -516,6 +516,7 @@ Feature: Convert config
               ]))
                   ->withOutputVerbosity(OutputFactory::VERBOSITY_VERBOSE))
               ->withGherkinOptions((new GherkinOptions())
+                  ->withCacheDir('/tmp/gherkin-cache')
                   ->withFilter(new NameFilter('john'))
                   ->withFilter(new RoleFilter('admin')))
               ->withPrintUnusedDefinitions()

--- a/features/profile_filters.feature
+++ b/features/profile_filters.feature
@@ -9,8 +9,8 @@ Feature: Filters
       | option      | value |
       | --no-colors |       |
 
-  Scenario: Tag filters
-    When I run "behat --config=behat-tag-filter.php"
+  Scenario Outline: Tag filters
+    When I run "behat --config=<config_file>"
     Then it should pass with:
       """
       @tag2
@@ -48,6 +48,11 @@ Feature: Filters
       4 scenarios (4 passed)
       10 steps (10 passed)
       """
+
+    Examples:
+      | config_file                     | comment                                   |
+      | behat-tag-filter.php            | Using new method on GherkinOptions object |
+      | behat-tag-filter-on-profile.php | Using deprecated method on Profile object |
 
   Scenario: Role filters
     When I run "behat --config=behat-role-filter.php"

--- a/src/Behat/Config/GherkinOptions.php
+++ b/src/Behat/Config/GherkinOptions.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Behat\Config;
+
+use Behat\Config\Converter\ConfigConverterTools;
+use Behat\Config\Filter\FilterInterface;
+use Behat\Config\Filter\NameFilter;
+use Behat\Config\Filter\NarrativeFilter;
+use Behat\Config\Filter\RoleFilter;
+use Behat\Config\Filter\TagFilter;
+use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
+use PhpParser\Node\Expr;
+
+final class GherkinOptions implements ConfigConverterInterface
+{
+    private const FILTERS_SETTING = 'filters';
+
+    private const FILTER_FUNCTION = 'withFilter';
+
+    public function __construct(
+        private array $settings = [],
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return $this->settings;
+    }
+
+    public function withFilter(FilterInterface $filter): self
+    {
+        if (array_key_exists($filter->name(), $this->settings[self::FILTERS_SETTING] ?? [])) {
+            throw new ConfigurationLoadingException(sprintf('The filter "%s" already exists.', $filter->name()));
+        }
+
+        $this->settings[self::FILTERS_SETTING][$filter->name()] = $filter->value();
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     */
+    public function toPhpExpr(): Expr
+    {
+        $optionsObject = ConfigConverterTools::createObject(self::class);
+        $expr = $optionsObject;
+
+        $this->addFiltersToExpr($expr);
+
+        $arguments = count($this->settings) === 0 ? [] : [$this->settings];
+        ConfigConverterTools::addArgumentsToConstructor($arguments, $optionsObject);
+
+        return $expr;
+    }
+
+    private function addFiltersToExpr(Expr &$expr): void
+    {
+        if (!isset($this->settings[self::FILTERS_SETTING])) {
+            return;
+        }
+
+        foreach ($this->settings[self::FILTERS_SETTING] as $name => $filterValue) {
+            $filter = match ($name) {
+                NameFilter::NAME => new NameFilter($filterValue),
+                NarrativeFilter::NAME => new NarrativeFilter($filterValue),
+                RoleFilter::NAME => new RoleFilter($filterValue),
+                TagFilter::NAME => new TagFilter($filterValue),
+                default => null,
+            };
+            if ($filter !== null) {
+                $expr = ConfigConverterTools::addMethodCall(
+                    self::class,
+                    self::FILTER_FUNCTION,
+                    [$filter->toPhpExpr()],
+                    $expr
+                );
+                unset($this->settings[self::FILTERS_SETTING][$name]);
+            }
+        }
+        if ($this->settings[self::FILTERS_SETTING] === []) {
+            unset($this->settings[self::FILTERS_SETTING]);
+        }
+    }
+}

--- a/src/Behat/Config/GherkinOptions.php
+++ b/src/Behat/Config/GherkinOptions.php
@@ -13,8 +13,10 @@ use PhpParser\Node\Expr;
 
 final class GherkinOptions implements ConfigConverterInterface
 {
+    private const CACHE_SETTING = 'cache';
     private const FILTERS_SETTING = 'filters';
 
+    private const CACHE_FUNCTION = 'withCacheDir';
     private const FILTER_FUNCTION = 'withFilter';
 
     public function __construct(
@@ -25,6 +27,16 @@ final class GherkinOptions implements ConfigConverterInterface
     public function toArray(): array
     {
         return $this->settings;
+    }
+
+    /**
+     * Sets the parser cache directory (defaults to the system tmp dir, if writable).
+     */
+    public function withCacheDir(string $dir): self
+    {
+        $this->settings[self::CACHE_SETTING] = $dir;
+
+        return $this;
     }
 
     public function withFilter(FilterInterface $filter): self
@@ -46,12 +58,26 @@ final class GherkinOptions implements ConfigConverterInterface
         $optionsObject = ConfigConverterTools::createObject(self::class);
         $expr = $optionsObject;
 
+        $this->addCacheToExpr($expr);
         $this->addFiltersToExpr($expr);
 
         $arguments = count($this->settings) === 0 ? [] : [$this->settings];
         ConfigConverterTools::addArgumentsToConstructor($arguments, $optionsObject);
 
         return $expr;
+    }
+
+    private function addCacheToExpr(Expr &$expr): void
+    {
+        if (isset($this->settings[self::CACHE_SETTING])) {
+            $expr = ConfigConverterTools::addMethodCall(
+                self::class,
+                self::CACHE_FUNCTION,
+                [$this->settings[self::CACHE_SETTING]],
+                $expr
+            );
+            unset($this->settings[self::CACHE_SETTING]);
+        }
     }
 
     private function addFiltersToExpr(Expr &$expr): void

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -76,7 +76,7 @@ final class Profile implements ConfigConverterInterface
     }
 
     /**
-     * @deprecated see withGherkinOptions()->withFilter(). This method will be removed in 4.0
+     * @deprecated use withGherkinOptions()->withFilter(). This method will be removed in 4.0
      */
     public function withFilter(FilterInterface $filter): self
     {

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -6,10 +6,6 @@ namespace Behat\Config;
 
 use Behat\Config\Converter\ConfigConverterTools;
 use Behat\Config\Filter\FilterInterface;
-use Behat\Config\Filter\NameFilter;
-use Behat\Config\Filter\NarrativeFilter;
-use Behat\Config\Filter\RoleFilter;
-use Behat\Config\Filter\TagFilter;
 use Behat\Config\Formatter\Formatter;
 use Behat\Config\Formatter\FormatterConfigInterface;
 use Behat\Config\Formatter\JSONFormatter;
@@ -25,7 +21,6 @@ final class Profile implements ConfigConverterInterface
     private const SUITES_SETTING = 'suites';
     private const EXTENSIONS_SETTING = 'extensions';
     private const GHERKIN_SETTING = 'gherkin';
-    private const FILTERS_SETTING = 'filters';
     private const FORMATTERS_SETTING = 'formatters';
     private const DEFINITIONS_SETTING = 'definitions';
     private const PRINT_UNUSED_DEFINITIONS_SETTING = 'print_unused_definitions';
@@ -36,7 +31,7 @@ final class Profile implements ConfigConverterInterface
 
     private const DISABLE_FORMATTER_FUNCTION = 'disableFormatter';
     private const FORMATTER_FUNCTION = 'withFormatter';
-    private const FILTER_FUNCTION = 'withFilter';
+    private const GHERKIN_FUNCTION = 'withGherkinOptions';
     private const UNUSED_DEFINITIONS_FUNCTION = 'withPrintUnusedDefinitions';
     private const EXTENSION_FUNCTION = 'withExtension';
     private const SUITE_FUNCTION = 'withSuite';
@@ -80,15 +75,15 @@ final class Profile implements ConfigConverterInterface
         return $this;
     }
 
+    /**
+     * @deprecated see withGherkinOptions()->withFilter(). This method will be removed in 4.0
+     */
     public function withFilter(FilterInterface $filter): self
     {
-        if (array_key_exists($filter->name(), $this->settings[self::GHERKIN_SETTING][self::FILTERS_SETTING] ?? [])) {
-            throw new ConfigurationLoadingException(sprintf('The filter "%s" already exists.', $filter->name()));
-        }
-
-        $this->settings[self::GHERKIN_SETTING][self::FILTERS_SETTING][$filter->name()] = $filter->value();
-
-        return $this;
+        return $this->withGherkinOptions(
+            (new GherkinOptions($this->settings[self::GHERKIN_SETTING] ?? []))
+                ->withFilter($filter)
+        );
     }
 
     public function withFormatter(FormatterConfigInterface $formatter): self
@@ -101,6 +96,13 @@ final class Profile implements ConfigConverterInterface
     public function disableFormatter(string $name): self
     {
         $this->settings[self::FORMATTERS_SETTING][$name] = false;
+
+        return $this;
+    }
+
+    public function withGherkinOptions(GherkinOptions $gherkin): self
+    {
+        $this->settings[self::GHERKIN_SETTING] = $gherkin->toArray();
 
         return $this;
     }
@@ -157,7 +159,7 @@ final class Profile implements ConfigConverterInterface
         $expr = $profileObject;
 
         $this->addFormattersToExpr($expr);
-        $this->addFiltersToExpr($expr);
+        $this->addGherkinOptionsToExpr($expr);
         $this->addUnusedDefinitionsToExpr($expr);
         $this->addPathOptionsToExpr($expr);
         $this->addTesterOptionsToExpr($expr);
@@ -211,35 +213,21 @@ final class Profile implements ConfigConverterInterface
         unset($this->settings[self::FORMATTERS_SETTING]);
     }
 
-    private function addFiltersToExpr(Expr &$expr): void
+    private function addGherkinOptionsToExpr(Expr &$expr): void
     {
-        if (!isset($this->settings[self::GHERKIN_SETTING][self::FILTERS_SETTING])) {
+        if (!isset($this->settings[self::GHERKIN_SETTING])) {
             return;
         }
-        foreach ($this->settings[self::GHERKIN_SETTING][self::FILTERS_SETTING] as $name => $filterValue) {
-            $filter = match ($name) {
-                NameFilter::NAME => new NameFilter($filterValue),
-                NarrativeFilter::NAME => new NarrativeFilter($filterValue),
-                RoleFilter::NAME => new RoleFilter($filterValue),
-                TagFilter::NAME => new TagFilter($filterValue),
-                default => null,
-            };
-            if ($filter !== null) {
-                $expr = ConfigConverterTools::addMethodCall(
-                    self::class,
-                    self::FILTER_FUNCTION,
-                    [$filter->toPhpExpr()],
-                    $expr
-                );
-                unset($this->settings[self::GHERKIN_SETTING][self::FILTERS_SETTING][$name]);
-            }
-        }
-        if ($this->settings[self::GHERKIN_SETTING][self::FILTERS_SETTING] === []) {
-            unset($this->settings[self::GHERKIN_SETTING][self::FILTERS_SETTING]);
-            if ($this->settings[self::GHERKIN_SETTING] === []) {
-                unset($this->settings[self::GHERKIN_SETTING]);
-            }
-        }
+
+        $optionsObject = new GherkinOptions($this->settings[self::GHERKIN_SETTING]);
+        $expr = ConfigConverterTools::addMethodCall(
+            self::class,
+            self::GHERKIN_FUNCTION,
+            [$optionsObject->toPhpExpr()],
+            $expr
+        );
+
+        unset($this->settings[self::GHERKIN_SETTING]);
     }
 
     private function addUnusedDefinitionsToExpr(Expr &$expr): void

--- a/tests/Fixtures/ConvertConfig/full_configuration.yaml
+++ b/tests/Fixtures/ConvertConfig/full_configuration.yaml
@@ -24,6 +24,7 @@ default:
             filters:
                 tags: "@run"
     gherkin:
+        cache: '/tmp/gherkin-cache'
         filters:
             name: "john"
             role: "admin"

--- a/tests/Fixtures/ProfileFilters/behat-filters-override.php
+++ b/tests/Fixtures/ProfileFilters/behat-filters-override.php
@@ -5,15 +5,20 @@ declare(strict_types=1);
 use Behat\Config\Config;
 use Behat\Config\Filter\NameFilter;
 use Behat\Config\Filter\TagFilter;
+use Behat\Config\GherkinOptions;
 use Behat\Config\Profile;
 
 return (new Config())
     ->withProfile(
         (new Profile('default'))
-            ->withFilter(new TagFilter('~@wip'))
+            ->withGherkinOptions((new GherkinOptions())
+                ->withFilter(new TagFilter('~@wip'))
+            )
     )
     ->withProfile(
         (new Profile('wip'))
-            ->withFilter(new NameFilter('A simple feature'))
+            ->withGherkinOptions((new GherkinOptions())
+                ->withFilter(new NameFilter('A simple feature'))
+            )
     )
 ;

--- a/tests/Fixtures/ProfileFilters/behat-name-filter.php
+++ b/tests/Fixtures/ProfileFilters/behat-name-filter.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 use Behat\Config\Config;
 use Behat\Config\Filter\NameFilter;
+use Behat\Config\GherkinOptions;
 use Behat\Config\Profile;
 
 return (new Config())
     ->withProfile(
         (new Profile('default'))
-            ->withFilter(new NameFilter('simple feature'))
+            ->withGherkinOptions((new GherkinOptions())
+                ->withFilter(new NameFilter('simple feature'))
+            )
     )
 ;

--- a/tests/Fixtures/ProfileFilters/behat-narrative-filter.php
+++ b/tests/Fixtures/ProfileFilters/behat-narrative-filter.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 use Behat\Config\Config;
 use Behat\Config\Filter\NarrativeFilter;
+use Behat\Config\GherkinOptions;
 use Behat\Config\Profile;
 
 return (new Config())
     ->withProfile(
         (new Profile('default'))
-            ->withFilter(new NarrativeFilter('/As a (?:second|third) user/'))
+            ->withGherkinOptions((new GherkinOptions())
+                ->withFilter(new NarrativeFilter('/As a (?:second|third) user/'))
+            )
     )
 ;

--- a/tests/Fixtures/ProfileFilters/behat-role-filter.php
+++ b/tests/Fixtures/ProfileFilters/behat-role-filter.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 use Behat\Config\Config;
 use Behat\Config\Filter\RoleFilter;
+use Behat\Config\GherkinOptions;
 use Behat\Config\Profile;
 
 return (new Config())
     ->withProfile(
         (new Profile('default'))
-            ->withFilter(new RoleFilter('second user'))
+            ->withGherkinOptions((new GherkinOptions())
+                ->withFilter(new RoleFilter('second user'))
+            )
     )
 ;

--- a/tests/Fixtures/ProfileFilters/behat-tag-filter-on-profile.php
+++ b/tests/Fixtures/ProfileFilters/behat-tag-filter-on-profile.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 use Behat\Config\Config;
 use Behat\Config\Filter\TagFilter;
-use Behat\Config\GherkinOptions;
 use Behat\Config\Profile;
 
 return (new Config())
     ->withProfile(
         (new Profile('default'))
-            ->withGherkinOptions((new GherkinOptions())
-                ->withFilter(new TagFilter('tag2'))
-            )
+            ->withFilter(new TagFilter('tag2'))
     )
 ;


### PR DESCRIPTION
Currently, the only way to set Gherkin configuration through the new config objects is via `Profile::withFilter()`, which internally adds the filter to the `$settings['gherkin']['filters']` array. This is the only config setter we expose for any settings in the `gherkin` group.

However, the `GherkinExtension` already defines a `cache` option (which we do not have a setter for) and we need to add an option in #1799 to configure the gherkin parser mode. It's possible that we will need other gherkin settings in future (and that users will want to share these settings between profiles).

Therefore, I have extracted the Gherkin `withFilter()` setting to a standalone DTO. The existing `Profile::withFilter()` method is retained but deprecated and will be removed in 4.0.