### PR TITLE
feat: Support configuring `GherkinCompatibilityMode`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=8.2 <8.6",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.2",
-        "behat/gherkin": "^4.12.0",
+        "behat/gherkin": "^4.15.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",

--- a/features/convert_config.feature
+++ b/features/convert_config.feature
@@ -502,6 +502,7 @@ Feature: Convert config
       use Behat\Config\Profile;
       use Behat\Config\Suite;
       use Behat\Config\TesterOptions;
+      use Behat\Gherkin\GherkinCompatibilityMode;
       use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 
       return (new Config())
@@ -517,6 +518,7 @@ Feature: Convert config
                   ->withOutputVerbosity(OutputFactory::VERBOSITY_VERBOSE))
               ->withGherkinOptions((new GherkinOptions())
                   ->withCacheDir('/tmp/gherkin-cache')
+                  ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32)
                   ->withFilter(new NameFilter('john'))
                   ->withFilter(new RoleFilter('admin')))
               ->withPrintUnusedDefinitions()

--- a/features/gherkin_compatibility_mode.feature
+++ b/features/gherkin_compatibility_mode.feature
@@ -1,0 +1,34 @@
+Feature: Gherkin compatibility mode
+  In order to have my feature files parsed as they would be by other cucumber-based tools
+  As a tester
+  I need to be able to configure the Gherkin parser compatibility mode
+
+  Background:
+    Given I initialise the working directory from the GherkinCompatibility fixtures folder
+    And   I provide the following options for all behat invocations:
+      | option      | value    |
+      | --no-colors |          |
+      | --format    | progress |
+
+  Scenario: Legacy parsing by default (ignores invalid language)
+    When I run behat with the following additional options:
+      | option    | value   |
+      | --profile | default |
+    Then it should pass with:
+      """
+      UUU
+
+      1 scenario (1 undefined)
+      3 steps (3 undefined)
+      """
+
+  Scenario: Opt in to cucumber-compatible parsing
+    When I run behat with the following additional options:
+      | option    | value      |
+      | --profile | gherkin-32 |
+    Then it should fail with:
+      """
+      In KeywordsDialectProvider.php line XX:
+
+        Language not supported: martian
+      """

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -100,13 +100,10 @@ final class GherkinExtension implements Extension
             ->enumNode('compatibility')
             ->info('Controls the extent to which gherkin is parsed equivalent to other cucumber tools')
                 // enumFqcn is not available until symfony 7.3
-                ->values([
-                    ...GherkinCompatibilityMode::cases(),
-                    ...array_map(
-                        fn (GherkinCompatibilityMode $m) => $m->value,
-                        GherkinCompatibilityMode::cases(),
-                    ),
-                ])
+                ->values(array_map(
+                    fn (GherkinCompatibilityMode $m) => $m->value,
+                    GherkinCompatibilityMode::cases(),
+                ))
                 ->defaultValue(GherkinCompatibilityMode::LEGACY->value)
         ;
         $childrenBuilder
@@ -181,15 +178,11 @@ final class GherkinExtension implements Extension
     /**
      * Loads gherkin parser.
      */
-    private function loadParser(ContainerBuilder $container, GherkinCompatibilityMode|string $compatibilityMode): void
+    private function loadParser(ContainerBuilder $container, string $compatibilityMode): void
     {
-        if (is_string($compatibilityMode)) {
-            $compatibilityMode = GherkinCompatibilityMode::from($compatibilityMode);
-        }
-
         $definition = new Definition(Parser::class, [
             new Reference('gherkin.lexer'),
-            $compatibilityMode,
+            GherkinCompatibilityMode::from($compatibilityMode),
         ]);
         $container->setDefinition('gherkin.parser', $definition);
 

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -101,7 +101,7 @@ final class GherkinExtension implements Extension
             ->info('Controls the extent to which gherkin is parsed equivalent to other cucumber tools')
                 // enumFqcn is not available until symfony 7.3
                 ->values(array_map(
-                    fn(GherkinCompatibilityMode $m) => $m->value,
+                    fn (GherkinCompatibilityMode $m) => $m->value,
                     GherkinCompatibilityMode::cases(),
                 ))
                 ->defaultValue(GherkinCompatibilityMode::LEGACY->value)

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -100,10 +100,13 @@ final class GherkinExtension implements Extension
             ->enumNode('compatibility')
             ->info('Controls the extent to which gherkin is parsed equivalent to other cucumber tools')
                 // enumFqcn is not available until symfony 7.3
-                ->values(array_map(
-                    fn (GherkinCompatibilityMode $m) => $m->value,
-                    GherkinCompatibilityMode::cases(),
-                ))
+                ->values([
+                    ...GherkinCompatibilityMode::cases(),
+                    ...array_map(
+                        fn (GherkinCompatibilityMode $m) => $m->value,
+                        GherkinCompatibilityMode::cases(),
+                    ),
+                ])
                 ->defaultValue(GherkinCompatibilityMode::LEGACY->value)
         ;
         $childrenBuilder
@@ -178,11 +181,15 @@ final class GherkinExtension implements Extension
     /**
      * Loads gherkin parser.
      */
-    private function loadParser(ContainerBuilder $container, string $compatibilityMode): void
+    private function loadParser(ContainerBuilder $container, GherkinCompatibilityMode|string $compatibilityMode): void
     {
+        if (is_string($compatibilityMode)) {
+            $compatibilityMode = GherkinCompatibilityMode::from($compatibilityMode);
+        }
+
         $definition = new Definition(Parser::class, [
             new Reference('gherkin.lexer'),
-            GherkinCompatibilityMode::from($compatibilityMode),
+            $compatibilityMode,
         ]);
         $container->setDefinition('gherkin.parser', $definition);
 

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -99,8 +99,12 @@ final class GherkinExtension implements Extension
         $childrenBuilder
             ->enumNode('compatibility')
             ->info('Controls the extent to which gherkin is parsed equivalent to other cucumber tools')
-                ->enumFqcn(GherkinCompatibilityMode::class)
-                ->defaultValue(GherkinCompatibilityMode::LEGACY)
+                // enumFqcn is not available until symfony 7.3
+                ->values(array_map(
+                    fn(GherkinCompatibilityMode $m) => $m->value,
+                    GherkinCompatibilityMode::cases(),
+                ))
+                ->defaultValue(GherkinCompatibilityMode::LEGACY->value)
         ;
         $childrenBuilder
             ->arrayNode('filters')
@@ -174,11 +178,11 @@ final class GherkinExtension implements Extension
     /**
      * Loads gherkin parser.
      */
-    private function loadParser(ContainerBuilder $container, GherkinCompatibilityMode $compatibilityMode): void
+    private function loadParser(ContainerBuilder $container, string $compatibilityMode): void
     {
         $definition = new Definition(Parser::class, [
             new Reference('gherkin.lexer'),
-            $compatibilityMode,
+            GherkinCompatibilityMode::from($compatibilityMode),
         ]);
         $container->setDefinition('gherkin.parser', $definition);
 

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -23,6 +23,7 @@ use Behat\Gherkin\Filter\NarrativeFilter;
 use Behat\Gherkin\Filter\RoleFilter;
 use Behat\Gherkin\Filter\TagFilter;
 use Behat\Gherkin\Gherkin;
+use Behat\Gherkin\GherkinCompatibilityMode;
 use Behat\Gherkin\Keywords\CachedArrayKeywords;
 use Behat\Gherkin\Keywords\KeywordsDumper;
 use Behat\Gherkin\Lexer;
@@ -96,6 +97,12 @@ final class GherkinExtension implements Extension
                 )
         ;
         $childrenBuilder
+            ->enumNode('compatibility')
+            ->info('Controls the extent to which gherkin is parsed equivalent to other cucumber tools')
+                ->enumFqcn(GherkinCompatibilityMode::class)
+                ->defaultValue(GherkinCompatibilityMode::LEGACY)
+        ;
+        $childrenBuilder
             ->arrayNode('filters')
                 ->info('Sets the gherkin filters (overridable by CLI options)')
                 ->performNoDeepMerging()
@@ -110,7 +117,7 @@ final class GherkinExtension implements Extension
         $this->loadParameters($container);
         $this->loadGherkin($container);
         $this->loadKeywords($container);
-        $this->loadParser($container);
+        $this->loadParser($container, $config['compatibility']);
         $this->loadDefaultLoaders($container, $config['cache']);
         $this->loadProfileFilters($container, $config['filters']);
         $this->loadSyntaxController($container);
@@ -167,10 +174,11 @@ final class GherkinExtension implements Extension
     /**
      * Loads gherkin parser.
      */
-    private function loadParser(ContainerBuilder $container): void
+    private function loadParser(ContainerBuilder $container, GherkinCompatibilityMode $compatibilityMode): void
     {
         $definition = new Definition(Parser::class, [
             new Reference('gherkin.lexer'),
+            $compatibilityMode,
         ]);
         $container->setDefinition('gherkin.parser', $definition);
 

--- a/src/Behat/Config/GherkinOptions.php
+++ b/src/Behat/Config/GherkinOptions.php
@@ -43,7 +43,7 @@ final class GherkinOptions implements ConfigConverterInterface
     }
 
     /**
-     * Controls the extent to which gherkin is parsed equivalent to other cucumber tools
+     * Controls the extent to which gherkin is parsed equivalent to other cucumber tools.
      *
      * In legacy mode (the default), feature files are parsed as they have been in previous versions of Behat. This
      * differs slightly from the behaviour of current versions of the official cucumber parsers and runners.

--- a/src/Behat/Config/GherkinOptions.php
+++ b/src/Behat/Config/GherkinOptions.php
@@ -52,7 +52,7 @@ final class GherkinOptions implements ConfigConverterInterface
      */
     public function withCompatibilityMode(GherkinCompatibilityMode $mode): self
     {
-        $this->settings[self::COMPATIBILITY_SETTING] = $mode;
+        $this->settings[self::COMPATIBILITY_SETTING] = $mode->value;
 
         return $this;
     }

--- a/src/Behat/Config/GherkinOptions.php
+++ b/src/Behat/Config/GherkinOptions.php
@@ -52,7 +52,7 @@ final class GherkinOptions implements ConfigConverterInterface
      */
     public function withCompatibilityMode(GherkinCompatibilityMode $mode): self
     {
-        $this->settings[self::COMPATIBILITY_SETTING] = $mode->value;
+        $this->settings[self::COMPATIBILITY_SETTING] = $mode;
 
         return $this;
     }

--- a/src/Behat/Config/GherkinOptions.php
+++ b/src/Behat/Config/GherkinOptions.php
@@ -8,15 +8,18 @@ use Behat\Config\Filter\NameFilter;
 use Behat\Config\Filter\NarrativeFilter;
 use Behat\Config\Filter\RoleFilter;
 use Behat\Config\Filter\TagFilter;
+use Behat\Gherkin\GherkinCompatibilityMode;
 use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use PhpParser\Node\Expr;
 
 final class GherkinOptions implements ConfigConverterInterface
 {
     private const CACHE_SETTING = 'cache';
+    private const COMPATIBILITY_SETTING = 'compatibility';
     private const FILTERS_SETTING = 'filters';
 
     private const CACHE_FUNCTION = 'withCacheDir';
+    private const COMPATIBILITY_FUNCTION = 'withCompatibilityMode';
     private const FILTER_FUNCTION = 'withFilter';
 
     public function __construct(
@@ -35,6 +38,21 @@ final class GherkinOptions implements ConfigConverterInterface
     public function withCacheDir(string $dir): self
     {
         $this->settings[self::CACHE_SETTING] = $dir;
+
+        return $this;
+    }
+
+    /**
+     * Controls the extent to which gherkin is parsed equivalent to other cucumber tools
+     *
+     * In legacy mode (the default), feature files are parsed as they have been in previous versions of Behat. This
+     * differs slightly from the behaviour of current versions of the official cucumber parsers and runners.
+     *
+     * Other modes will parse identical to the official cucumber parsers.
+     */
+    public function withCompatibilityMode(GherkinCompatibilityMode $mode): self
+    {
+        $this->settings[self::COMPATIBILITY_SETTING] = $mode->value;
 
         return $this;
     }
@@ -59,6 +77,7 @@ final class GherkinOptions implements ConfigConverterInterface
         $expr = $optionsObject;
 
         $this->addCacheToExpr($expr);
+        $this->addCompatibilityModeToExpr($expr);
         $this->addFiltersToExpr($expr);
 
         $arguments = count($this->settings) === 0 ? [] : [$this->settings];
@@ -77,6 +96,19 @@ final class GherkinOptions implements ConfigConverterInterface
                 $expr
             );
             unset($this->settings[self::CACHE_SETTING]);
+        }
+    }
+
+    private function addCompatibilityModeToExpr(Expr &$expr): void
+    {
+        if (isset($this->settings[self::COMPATIBILITY_SETTING])) {
+            $expr = ConfigConverterTools::addMethodCall(
+                self::class,
+                self::COMPATIBILITY_FUNCTION,
+                [GherkinCompatibilityMode::from($this->settings[self::COMPATIBILITY_SETTING])],
+                $expr
+            );
+            unset($this->settings[self::COMPATIBILITY_SETTING]);
         }
     }
 

--- a/tests/Fixtures/ConvertConfig/full_configuration.yaml
+++ b/tests/Fixtures/ConvertConfig/full_configuration.yaml
@@ -25,6 +25,7 @@ default:
                 tags: "@run"
     gherkin:
         cache: '/tmp/gherkin-cache'
+        compatibility: 'gherkin-32'
         filters:
             name: "john"
             role: "admin"

--- a/tests/Fixtures/GherkinCompatibility/behat.php
+++ b/tests/Fixtures/GherkinCompatibility/behat.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Config\Config;
+use Behat\Config\Formatter\PrettyFormatter;
+use Behat\Config\GherkinOptions;
+use Behat\Config\Profile;
+use Behat\Gherkin\GherkinCompatibilityMode;
+
+return (new Config())
+    ->withProfile((new Profile('default'))
+        ->withFormatter(new PrettyFormatter(
+            timer: false,
+            paths: false,
+        ))
+    )->withProfile((new Profile('gherkin-32'))
+        ->withGherkinOptions((new GherkinOptions())
+            ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32)
+            ->withCacheDir('/tmp/gc')
+        )
+    )
+;

--- a/tests/Fixtures/GherkinCompatibility/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/GherkinCompatibility/features/bootstrap/FeatureContext.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Behat\Context\Context;
+
+class FeatureContext implements Context
+{
+
+}

--- a/tests/Fixtures/GherkinCompatibility/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/GherkinCompatibility/features/bootstrap/FeatureContext.php
@@ -6,5 +6,4 @@ use Behat\Behat\Context\Context;
 
 class FeatureContext implements Context
 {
-
 }

--- a/tests/Fixtures/GherkinCompatibility/features/invalid_language.feature
+++ b/tests/Fixtures/GherkinCompatibility/features/invalid_language.feature
@@ -1,0 +1,10 @@
+# language: martian
+Feature: Gherkin compatibility mode
+  In order to have my feature files parsed as they would be by other cucumber-based tools
+  As a tester
+  I need to be able to configure the Gherkin parser compatibility mode
+
+  Scenario: Enforce language validation
+      Given I have a feature file like this with an invalid language tag
+      When  I run Behat
+      Then  it should pass in legacy mode and fail in gherkin-32 compatibility mode


### PR DESCRIPTION
This PR is based on #1798 (the first two commits can be reviewed in that PR & I will rebase after it is merged) and is the first part of the work required for #1645.

I have limited the feature coverage here to the simplest case that proves which parser mode is active (pass or fail on presence of an invalid language tag, using the pretty formatter).

There is more work to do to make the output of the pretty formatter the same regardless of the parsing mode (padding is handled slightly differently, and there are more significant changes to how escapes and newlines are processed within tables). I will tackle these in separate PRs once we have the config option.