### PR TITLE
test: Run Behat's own features in `gherkin-32` mode

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,1 +1,3 @@
 default:
+  gherkin:
+    compatibility: gherkin-32


### PR DESCRIPTION
`gherkin-32` will become the default in 4.0. Before that, we need to see what (if anything) needs to change in Behat's own test suite to support this. This will also help to identify any unexpected issues with the new parsing mode.

Follows #1799 (only the last commit is new)