### PR TITLE
docs: Clarify advice for on dependencies for extension authors

### DIFF
--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -44,7 +44,7 @@ interface Extension extends CompilerPassInterface
     /**
      * Setups configuration for the extension.
      *
-     * NOTE: If your extension implements this method, your composer.json should declare
+     * NOTE: If your extension uses the ArrayNodeDefinition passed to this method, your composer.json should declare
      * a direct dependency on the version(s) of symfony/config that you support.
      */
     public function configure(ArrayNodeDefinition $builder);
@@ -52,7 +52,7 @@ interface Extension extends CompilerPassInterface
     /**
      * Loads extension services into temporary container.
      *
-     * NOTE: If your extension implements this method, your composer.json should declare
+     * NOTE: If your extension uses the ContainerBuilder passed to this method, your composer.json should declare
      * a direct dependency on the version(s) of symfony/dependency-injection that you support.
      *
      * @param array<string, mixed> $config
@@ -62,7 +62,7 @@ interface Extension extends CompilerPassInterface
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
-     *  NOTE: If your extension implements this method, your composer.json should declare
+     * NOTE: If your extension uses the ContainerBuilder passed to this method, your composer.json should declare
      *  a direct dependency on the version(s) of symfony/dependency-injection that you support.
      *
      * @return void


### PR DESCRIPTION
As per https://github.com/Behat/Behat/pull/1796#discussion_r2848376629 the previous wording was not totally clear. All extensions have to implement the methods in the interface, and in theory you could implement logic that does not reference the third-party objects that are passed in.

Make the wording explicit that the dependency issue only arises if your implementation references the third-party objects.