### PR TITLE
PHP8.5: make string cast for array_key_exists

### DIFF
--- a/src/Behat/Testwork/Ordering/Cli/OrderController.php
+++ b/src/Behat/Testwork/Ordering/Cli/OrderController.php
@@ -67,7 +67,7 @@ final class OrderController implements Controller
             return null;
         }
 
-        if (!array_key_exists($orderer, $this->orderers)) {
+        if (!array_key_exists((string)$orderer, $this->orderers)) {
             throw new InvalidOrderException(sprintf("Order option '%s' was not recognised", $orderer));
         }
 

--- a/src/Behat/Testwork/Ordering/Cli/OrderController.php
+++ b/src/Behat/Testwork/Ordering/Cli/OrderController.php
@@ -67,7 +67,7 @@ final class OrderController implements Controller
             return null;
         }
 
-        if (!array_key_exists((string)$orderer, $this->orderers)) {
+        if (!array_key_exists((string) $orderer, $this->orderers)) {
             throw new InvalidOrderException(sprintf("Order option '%s' was not recognised", $orderer));
         }
 


### PR DESCRIPTION
As part of preparing for php8.5 have been using [rector](https://github.com/rectorphp/rector) and there is a single issue in current behat that it has found/suggested to fix.