### PR TITLE
docs: Explicitly mark up interfaces, classes & methods in the public API

### DIFF
--- a/src/Behat/Behat/Context/Argument/ArgumentResolver.php
+++ b/src/Behat/Behat/Context/Argument/ArgumentResolver.php
@@ -19,6 +19,8 @@ use ReflectionClass;
  * @see ContextEnvironmentHandler
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ArgumentResolver
 {

--- a/src/Behat/Behat/Context/Context.php
+++ b/src/Behat/Behat/Context/Context.php
@@ -14,6 +14,8 @@ namespace Behat\Behat\Context;
  * Marks a custom user-defined class as a behat context.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface Context
 {

--- a/src/Behat/Behat/Context/ContextClass/ClassResolver.php
+++ b/src/Behat/Behat/Context/ContextClass/ClassResolver.php
@@ -18,6 +18,8 @@ use Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler;
  * @see ContextEnvironmentHandler
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ClassResolver
 {

--- a/src/Behat/Behat/Context/Environment/ContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/ContextEnvironment.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Environment\Environment;
  * @see ContextEnvironmentHandler
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ContextEnvironment extends Environment
 {

--- a/src/Behat/Behat/Context/Initializer/ContextInitializer.php
+++ b/src/Behat/Behat/Context/Initializer/ContextInitializer.php
@@ -16,6 +16,8 @@ use Behat\Behat\Context\Context;
  * Initializes contexts using custom logic.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ContextInitializer
 {

--- a/src/Behat/Behat/Context/TranslatableContext.php
+++ b/src/Behat/Behat/Context/TranslatableContext.php
@@ -18,6 +18,8 @@ use Behat\Behat\Context\Reader\TranslatableContextReader;
  * @see TranslatableContextReader
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface TranslatableContext extends Context
 {

--- a/src/Behat/Behat/Definition/Definition.php
+++ b/src/Behat/Behat/Definition/Definition.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Call\Callee;
  * Represents a step definition.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface Definition extends Callee
 {

--- a/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
@@ -19,6 +19,8 @@ use Behat\Behat\Definition\Pattern\PatternTransformer;
  * @see PatternTransformer
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface PatternPolicy
 {

--- a/src/Behat/Behat/Definition/Pattern/StepMethodNameSuggester.php
+++ b/src/Behat/Behat/Definition/Pattern/StepMethodNameSuggester.php
@@ -7,6 +7,8 @@ namespace Behat\Behat\Definition\Pattern;
  *
  * Suggested names do not have to be unique - the ContextSnippetGenerator will add a numerical suffix if the Context
  * already contains a method with the suggested name.
+ *
+ * @api
  */
 interface StepMethodNameSuggester
 {

--- a/src/Behat/Behat/Definition/Printer/DefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/DefinitionPrinter.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Suite\Suite;
  * Prints provided definition.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface DefinitionPrinter
 {

--- a/src/Behat/Behat/Definition/Printer/UnusedDefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/UnusedDefinitionPrinter.php
@@ -12,6 +12,9 @@ namespace Behat\Behat\Definition\Printer;
 
 use Behat\Behat\Definition\Definition;
 
+/**
+ * @api
+ */
 interface UnusedDefinitionPrinter
 {
     /**

--- a/src/Behat/Behat/Definition/Search/SearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/SearchEngine.php
@@ -22,6 +22,8 @@ use Behat\Testwork\Environment\Environment;
  * @see DefinitionFinder
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface SearchEngine
 {

--- a/src/Behat/Behat/Definition/Translator/TranslatorInterface.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatorInterface.php
@@ -4,6 +4,8 @@ namespace Behat\Behat\Definition\Translator;
 
 /**
  * @method string getLocale()
+ *
+ * @api
  */
 interface TranslatorInterface extends \Symfony\Contracts\Translation\TranslatorInterface
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
@@ -21,6 +21,8 @@ use Behat\Testwork\Tester\Setup\Setup;
  * Represents an event right after background was setup for testing.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterBackgroundSetup extends BackgroundTested implements AfterSetup
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
@@ -22,6 +22,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents an event in which background was tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterBackgroundTested extends BackgroundTested implements AfterTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterFeatureSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterFeatureSetup.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Tester\Setup\Setup;
  * Represents an event right after feature is setup for a test.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterFeatureSetup extends FeatureTested implements AfterSetup
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterFeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterFeatureTested.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents an event right after feature was tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterFeatureTested extends FeatureTested implements AfterTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterOutlineSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterOutlineSetup.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Setup\Setup;
  * Represents an event right after outline setup.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterOutlineSetup extends OutlineTested implements AfterSetup
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterOutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterOutlineTested.php
@@ -21,6 +21,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents an event after outline was tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterOutlineTested extends OutlineTested implements AfterTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterScenarioSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterScenarioSetup.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Setup\Setup;
  * Represents an event after scenario setup.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterScenarioSetup extends ScenarioTested implements AfterSetup
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterScenarioTested.php
@@ -21,6 +21,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents an event after scenario has been tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterScenarioTested extends ScenarioTested implements AfterTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Setup\Setup;
  * Represents an event after step setup.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterStepSetup extends StepTested implements AfterSetup
 {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
@@ -23,6 +23,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents an event after step has been tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterStepTested extends StepTested implements AfterTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
@@ -18,6 +18,8 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  * Represents a background event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 abstract class BackgroundTested extends LifecycleEvent implements ScenarioLikeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
@@ -21,6 +21,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an event right before background teardown.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeBackgroundTeardown extends BackgroundTested implements BeforeTeardown
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
@@ -20,6 +20,8 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  * Represents a BeforeBackgroundTested event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeBackgroundTested extends BackgroundTested implements BeforeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTeardown.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an event right before feature is teardown.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeFeatureTeardown extends FeatureTested implements BeforeTeardown
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTested.php
@@ -18,6 +18,8 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  * Represents an event before feature tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeFeatureTested extends FeatureTested implements BeforeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTeardown.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an event right before outline teardown.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeOutlineTeardown extends OutlineTested implements BeforeTeardown
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTested.php
@@ -19,6 +19,8 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  * Represents an event before outline is tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeOutlineTested extends OutlineTested implements BeforeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTeardown.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an event before scenario teardown.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeScenarioTeardown extends ScenarioTested implements BeforeTeardown
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTested.php
@@ -19,6 +19,8 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  * Represents an event before scenario is tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeScenarioTested extends ScenarioTested implements BeforeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
@@ -23,6 +23,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an event before step teardown.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeStepTeardown extends StepTested implements BeforeTeardown
 {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTested.php
@@ -19,6 +19,8 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  * Represents an event before step test.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeStepTested extends StepTested implements BeforeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/ExampleTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ExampleTested.php
@@ -14,6 +14,8 @@ namespace Behat\Behat\EventDispatcher\Event;
  * Represents an example event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ExampleTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
@@ -18,6 +18,8 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  * Represents a feature event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 abstract class FeatureTested extends LifecycleEvent implements GherkinNodeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/GherkinNodeTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/GherkinNodeTested.php
@@ -16,6 +16,8 @@ use Behat\Gherkin\Node\NodeInterface;
  * Represents a Gherkin node based event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface GherkinNodeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
@@ -19,6 +19,8 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  * Represents an outline event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 abstract class OutlineTested extends LifecycleEvent implements GherkinNodeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/ScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ScenarioTested.php
@@ -16,6 +16,8 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  * Represents a scenario event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 abstract class ScenarioTested extends LifecycleEvent implements ScenarioLikeTested
 {

--- a/src/Behat/Behat/EventDispatcher/Event/StepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/StepTested.php
@@ -18,6 +18,8 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  * Represents a step event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 abstract class StepTested extends LifecycleEvent implements GherkinNodeTested
 {

--- a/src/Behat/Behat/Hook/Scope/AfterFeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterFeatureScope.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an AfterFeature hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterFeatureScope implements FeatureScope, AfterTestScope
 {

--- a/src/Behat/Behat/Hook/Scope/AfterScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterScenarioScope.php
@@ -21,6 +21,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an AfterScenario hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterScenarioScope implements ScenarioScope, AfterTestScope
 {

--- a/src/Behat/Behat/Hook/Scope/AfterStepScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterStepScope.php
@@ -22,6 +22,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an AfterStep hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterStepScope implements StepScope, AfterTestScope
 {

--- a/src/Behat/Behat/Hook/Scope/BeforeFeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeFeatureScope.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Suite\Suite;
  * Represents a BeforeFeature hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeFeatureScope implements FeatureScope
 {

--- a/src/Behat/Behat/Hook/Scope/BeforeScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeScenarioScope.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Suite\Suite;
  * Represents a BeforeScenario hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeScenarioScope implements ScenarioScope
 {

--- a/src/Behat/Behat/Hook/Scope/BeforeStepScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeStepScope.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Suite\Suite;
  * Represents a BeforeStep hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeStepScope implements StepScope
 {

--- a/src/Behat/Behat/Hook/Scope/FeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/FeatureScope.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Hook\Scope\HookScope;
  * Represents a feature hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface FeatureScope extends HookScope
 {

--- a/src/Behat/Behat/Hook/Scope/ScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/ScenarioScope.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Hook\Scope\HookScope;
  * Represents a scenario hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ScenarioScope extends HookScope
 {

--- a/src/Behat/Behat/Hook/Scope/StepScope.php
+++ b/src/Behat/Behat/Hook/Scope/StepScope.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Hook\Scope\HookScope;
  * Represents a step hook scope.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface StepScope extends HookScope
 {

--- a/src/Behat/Behat/Output/Node/Printer/ExamplePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ExamplePrinter.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Prints example headers and footers.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ExamplePrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/ExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ExampleRowPrinter.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Output\Formatter;
  * Prints outline example row results.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ExampleRowPrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/ExercisePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ExercisePrinter.php
@@ -12,6 +12,9 @@ namespace Behat\Behat\Output\Node\Printer;
 
 use Behat\Testwork\Output\Formatter;
 
+/**
+ * @api
+ */
 interface ExercisePrinter
 {
     public function printHeader(Formatter $formatter): void;

--- a/src/Behat/Behat/Output/Node/Printer/FeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/FeaturePrinter.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Prints feature headers and footers.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface FeaturePrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/OutlinePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/OutlinePrinter.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Prints outline headers and footers.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface OutlinePrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/OutlineTablePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/OutlineTablePrinter.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Prints outline table representation headers and footers.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface OutlineTablePrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/ScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ScenarioPrinter.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Prints scenario headers and footers.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ScenarioPrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/SetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/SetupPrinter.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Behat setup printer interface.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface SetupPrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/StatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/StatisticsPrinter.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Output\Formatter;
  * Prints exercise statistics.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface StatisticsPrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/StepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/StepPrinter.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Output\Formatter;
  * Prints step with optional results.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface StepPrinter
 {

--- a/src/Behat/Behat/Output/Node/Printer/SuitePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/SuitePrinter.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Suite\Suite;
  * Prints suite headers and footers.
  *
  * @author Wouter J <wouter@wouterj.nl>
+ *
+ * @api
  */
 interface SuitePrinter
 {

--- a/src/Behat/Behat/Output/Statistics/HookStat.php
+++ b/src/Behat/Behat/Output/Statistics/HookStat.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Hook\Scope\HookScope;
  * Represents hook stat.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class HookStat
 {

--- a/src/Behat/Behat/Output/Statistics/PhaseStatistics.php
+++ b/src/Behat/Behat/Output/Statistics/PhaseStatistics.php
@@ -22,6 +22,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * in a single suite for instance.
  *
  * @author Wouter J <wouter@wouterj.nl>
+ *
+ * @api
  */
 final class PhaseStatistics implements Statistics
 {

--- a/src/Behat/Behat/Output/Statistics/ScenarioStat.php
+++ b/src/Behat/Behat/Output/Statistics/ScenarioStat.php
@@ -18,6 +18,8 @@ use Stringable;
  * Behat scenario stat.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class ScenarioStat implements Stringable
 {

--- a/src/Behat/Behat/Output/Statistics/Statistics.php
+++ b/src/Behat/Behat/Output/Statistics/Statistics.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Collects and provided exercise statistics.
  *
  * @author Wouter J <wouter@wouterj.nl>
+ *
+ * @api
  */
 interface Statistics
 {

--- a/src/Behat/Behat/Output/Statistics/StepStatV2.php
+++ b/src/Behat/Behat/Output/Statistics/StepStatV2.php
@@ -17,6 +17,8 @@ use Stringable;
  * Second iteration of Behat step stat, with a scenario information.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class StepStatV2 extends StepStat implements Stringable
 {

--- a/src/Behat/Behat/Output/Statistics/TotalStatistics.php
+++ b/src/Behat/Behat/Output/Statistics/TotalStatistics.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Tester\Result\TestResults;
  * Collects and provided exercise statistics.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class TotalStatistics implements Statistics
 {

--- a/src/Behat/Behat/Tester/Result/DefinedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/DefinedStepResult.php
@@ -16,6 +16,8 @@ use Behat\Behat\Definition\Definition;
  * Represents a step result that contains step definition.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface DefinedStepResult extends StepResult
 {

--- a/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
@@ -21,6 +21,8 @@ use Exception;
  * Represents an executed (successfully or not) step result.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class ExecutedStepResult implements StepResult, DefinedStepResult, ExceptionResult
 {

--- a/src/Behat/Behat/Tester/Result/FailedStepSearchResult.php
+++ b/src/Behat/Behat/Tester/Result/FailedStepSearchResult.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Tester\Result\ExceptionResult;
  * Represents a step test result with a failed definition search.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class FailedStepSearchResult implements StepResult, ExceptionResult
 {

--- a/src/Behat/Behat/Tester/Result/SkippedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/SkippedStepResult.php
@@ -17,6 +17,8 @@ use Behat\Behat\Definition\SearchResult;
  * Represents a skipped step result.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class SkippedStepResult implements StepResult, DefinedStepResult
 {

--- a/src/Behat/Behat/Tester/Result/StepResult.php
+++ b/src/Behat/Behat/Tester/Result/StepResult.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Extends Testwork test result with support for undefined status.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface StepResult extends TestResult
 {

--- a/src/Behat/Behat/Tester/Result/UndefinedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/UndefinedStepResult.php
@@ -14,6 +14,8 @@ namespace Behat\Behat\Tester\Result;
  * Represents an undefined step result.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class UndefinedStepResult implements StepResult
 {

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -18,6 +18,7 @@ use ReflectionMethod;
  * Represents a simple self-contained transformation capable of changing a single argument.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
  * @api
  */
 interface SimpleArgumentTransformation extends Transformation

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -18,6 +18,7 @@ use ReflectionMethod;
  * Represents a simple self-contained transformation capable of changing a single argument.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ * @api
  */
 interface SimpleArgumentTransformation extends Transformation
 {

--- a/src/Behat/Behat/Transformation/Transformation.php
+++ b/src/Behat/Behat/Transformation/Transformation.php
@@ -16,6 +16,7 @@ use Behat\Testwork\Call\Callee;
  * Step transformation interface.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ * @api
  */
 interface Transformation extends Callee
 {

--- a/src/Behat/Behat/Transformation/Transformation.php
+++ b/src/Behat/Behat/Transformation/Transformation.php
@@ -16,6 +16,7 @@ use Behat\Testwork\Call\Callee;
  * Step transformation interface.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
  * @api
  */
 interface Transformation extends Callee

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -16,6 +16,8 @@ use Behat\Behat\Definition\Call\DefinitionCall;
  * Transforms a single argument value.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ArgumentTransformer
 {

--- a/src/Behat/Config/Config.php
+++ b/src/Behat/Config/Config.php
@@ -10,6 +10,9 @@ use PhpParser\Node\Expr;
 
 use function is_string;
 
+/**
+ * @api
+ */
 final class Config implements ConfigInterface, ConfigConverterInterface
 {
     public const IMPORTS_SETTING = 'imports';
@@ -19,6 +22,9 @@ final class Config implements ConfigInterface, ConfigConverterInterface
     private const PROFILE_FUNCTION = 'withProfile';
     private const PREFERRED_PROFILE_FUNCTION = 'withPreferredProfile';
 
+    /**
+     * @api
+     */
     public function __construct(
         private array $settings = [],
     ) {

--- a/src/Behat/Config/ConfigInterface.php
+++ b/src/Behat/Config/ConfigInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Behat\Config;
 
+/**
+ * @api
+ */
 interface ConfigInterface
 {
     public function toArray(): array;

--- a/src/Behat/Config/Extension.php
+++ b/src/Behat/Config/Extension.php
@@ -8,8 +8,14 @@ use Behat\Config\Converter\ConfigConverterTools;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 final class Extension implements ExtensionConfigInterface
 {
+    /**
+     * @api
+     */
     public function __construct(
         private readonly string $name,
         private readonly array $settings = [],

--- a/src/Behat/Config/ExtensionConfigInterface.php
+++ b/src/Behat/Config/ExtensionConfigInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Behat\Config;
 
+/**
+ * @api
+ */
 interface ExtensionConfigInterface extends ConfigInterface
 {
     public function name(): string;

--- a/src/Behat/Config/Filter/Filter.php
+++ b/src/Behat/Config/Filter/Filter.php
@@ -8,8 +8,14 @@ use Behat\Config\ConfigConverterInterface;
 use Behat\Config\Converter\ConfigConverterTools;
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 class Filter implements FilterInterface, ConfigConverterInterface
 {
+    /**
+     * @api
+     */
     public function __construct(
         private readonly string $name,
         private readonly string $value,

--- a/src/Behat/Config/Filter/FilterInterface.php
+++ b/src/Behat/Config/Filter/FilterInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Behat\Config\Filter;
 
+/**
+ * @api
+ */
 interface FilterInterface
 {
     public function name(): string;

--- a/src/Behat/Config/Filter/NameFilter.php
+++ b/src/Behat/Config/Filter/NameFilter.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Behat\Config\Filter;
 
+/**
+ * @api
+ */
 final class NameFilter extends Filter
 {
     public const NAME = 'name';
 
+    /**
+     * @api
+     */
     public function __construct(
         string $value,
     ) {

--- a/src/Behat/Config/Filter/NarrativeFilter.php
+++ b/src/Behat/Config/Filter/NarrativeFilter.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Behat\Config\Filter;
 
+/**
+ * @api
+ */
 final class NarrativeFilter extends Filter
 {
     public const NAME = 'narrative';
 
+    /**
+     * @api
+     */
     public function __construct(
         string $value,
     ) {

--- a/src/Behat/Config/Filter/RoleFilter.php
+++ b/src/Behat/Config/Filter/RoleFilter.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Behat\Config\Filter;
 
+/**
+ * @api
+ */
 final class RoleFilter extends Filter
 {
     public const NAME = 'role';
 
+    /**
+     * @api
+     */
     public function __construct(
         string $value,
     ) {

--- a/src/Behat/Config/Filter/TagFilter.php
+++ b/src/Behat/Config/Filter/TagFilter.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Behat\Config\Filter;
 
+/**
+ * @api
+ */
 final class TagFilter extends Filter
 {
     public const NAME = 'tags';
 
+    /**
+     * @api
+     */
     public function __construct(
         string $value,
     ) {

--- a/src/Behat/Config/Formatter/Formatter.php
+++ b/src/Behat/Config/Formatter/Formatter.php
@@ -9,6 +9,9 @@ use Behat\Config\Converter\ConfigConverterTools;
 use Behat\Testwork\Output\Printer\Factory\OutputFactory;
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 class Formatter implements FormatterConfigInterface, ConfigConverterInterface
 {
     private const OUTPUT_VERBOSITY_SETTING = 'output_verbosity';
@@ -31,6 +34,9 @@ class Formatter implements FormatterConfigInterface, ConfigConverterInterface
         self::OUTPUT_STYLES_SETTING => self::OUTPUT_STYLES_FUNCTION,
     ];
 
+    /**
+     * @api
+     */
     public function __construct(
         private readonly string $name,
         private array $settings = [],

--- a/src/Behat/Config/Formatter/FormatterConfigInterface.php
+++ b/src/Behat/Config/Formatter/FormatterConfigInterface.php
@@ -6,6 +6,9 @@ namespace Behat\Config\Formatter;
 
 use Behat\Config\ConfigInterface;
 
+/**
+ * @api
+ */
 interface FormatterConfigInterface extends ConfigInterface
 {
     public function name(): string;

--- a/src/Behat/Config/Formatter/JSONFormatter.php
+++ b/src/Behat/Config/Formatter/JSONFormatter.php
@@ -14,6 +14,9 @@ namespace Behat\Config\Formatter;
 
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 final class JSONFormatter extends Formatter
 {
     public const NAME = 'json';
@@ -21,6 +24,8 @@ final class JSONFormatter extends Formatter
     private const TIMER_SETTING = 'timer';
 
     /**
+     * @api
+     *
      * @param bool $timer include run time attributes in generated report
      */
     public function __construct(

--- a/src/Behat/Config/Formatter/JUnitFormatter.php
+++ b/src/Behat/Config/Formatter/JUnitFormatter.php
@@ -6,6 +6,9 @@ namespace Behat\Config\Formatter;
 
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 final class JUnitFormatter extends Formatter
 {
     public const NAME = 'junit';
@@ -13,6 +16,8 @@ final class JUnitFormatter extends Formatter
     private const TIMER_SETTING = 'timer';
 
     /**
+     * @api
+     *
      * @param bool $timer include run time attributes in generated report
      */
     public function __construct(

--- a/src/Behat/Config/Formatter/PrettyFormatter.php
+++ b/src/Behat/Config/Formatter/PrettyFormatter.php
@@ -6,6 +6,9 @@ namespace Behat\Config\Formatter;
 
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 final class PrettyFormatter extends Formatter
 {
     public const NAME = 'pretty';
@@ -20,6 +23,8 @@ final class PrettyFormatter extends Formatter
     public const PRINT_SKIPPED_STEPS_SETTING = 'print_skipped_steps';
 
     /**
+     * @api
+     *
      * @param bool $timer show time and memory usage at the end of the test run
      * @param bool $expand print each example of a scenario outline separately
      * @param bool $paths display the file path and line number for each scenario

--- a/src/Behat/Config/Formatter/ProgressFormatter.php
+++ b/src/Behat/Config/Formatter/ProgressFormatter.php
@@ -6,6 +6,9 @@ namespace Behat\Config\Formatter;
 
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 final class ProgressFormatter extends Formatter
 {
     public const NAME = 'progress';
@@ -14,6 +17,8 @@ final class ProgressFormatter extends Formatter
     private const SHORT_SUMMARY_SETTING = 'short_summary';
 
     /**
+     * @api
+     *
      * @param bool $timer show time and memory usage at the end of the test run
      * @param ShowOutputOption $showOutput show the test stdout output as part of the
      *                                     formatter output (yes, no, on-fail, in-summary)

--- a/src/Behat/Config/Formatter/ShowOutputOption.php
+++ b/src/Behat/Config/Formatter/ShowOutputOption.php
@@ -2,6 +2,9 @@
 
 namespace Behat\Config\Formatter;
 
+/**
+ * @api
+ */
 enum ShowOutputOption: string
 {
     public const OPTION_NAME = 'show_output';

--- a/src/Behat/Config/Profile.php
+++ b/src/Behat/Config/Profile.php
@@ -16,6 +16,9 @@ use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 final class Profile implements ConfigConverterInterface
 {
     private const SUITES_SETTING = 'suites';
@@ -42,6 +45,9 @@ final class Profile implements ConfigConverterInterface
     private const EDITOR_URL_PARAMETER = 'editorUrl';
     private const REMOVE_PREFIX_PARAMETER = 'removePrefix';
 
+    /**
+     * @api
+     */
     public function __construct(
         private readonly string $name,
         private array $settings = [],

--- a/src/Behat/Config/Suite.php
+++ b/src/Behat/Config/Suite.php
@@ -13,6 +13,9 @@ use Behat\Config\Filter\TagFilter;
 use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 final class Suite implements ConfigConverterInterface
 {
     private const CONTEXTS_SETTING = 'contexts';
@@ -24,6 +27,9 @@ final class Suite implements ConfigConverterInterface
     private const PATHS_FUNCTION = 'withPaths';
     private const FILTER_FUNCTION = 'withFilter';
 
+    /**
+     * @api
+     */
     public function __construct(
         private readonly string $name,
         private array $settings = [],

--- a/src/Behat/Config/TesterOptions.php
+++ b/src/Behat/Config/TesterOptions.php
@@ -5,6 +5,9 @@ namespace Behat\Config;
 use Behat\Config\Converter\ConfigConverterTools;
 use PhpParser\Node\Expr;
 
+/**
+ * @api
+ */
 final class TesterOptions implements ConfigConverterInterface
 {
     private const TESTERS_SETTINGS_GROUP = 'testers';
@@ -68,6 +71,9 @@ final class TesterOptions implements ConfigConverterInterface
         return new self($settings);
     }
 
+    /**
+     * @api
+     */
     public function __construct(
         private array $settings = [],
     ) {

--- a/src/Behat/Hook/AfterFeature.php
+++ b/src/Behat/Hook/AfterFeature.php
@@ -14,11 +14,15 @@ use Attribute;
 
 /**
  * Represents an Attribute for AfterFeature hook.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class AfterFeature implements Hook
 {
     /**
+     * @api
+     *
      * @param string|null $filterString
      */
     public function __construct(

--- a/src/Behat/Hook/AfterScenario.php
+++ b/src/Behat/Hook/AfterScenario.php
@@ -14,11 +14,15 @@ use Attribute;
 
 /**
  * Represents an Attribute for AfterScenario hook.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class AfterScenario implements Hook
 {
     /**
+     * @api
+     *
      * @param string|null $filterString
      */
     public function __construct(

--- a/src/Behat/Hook/AfterStep.php
+++ b/src/Behat/Hook/AfterStep.php
@@ -14,11 +14,15 @@ use Attribute;
 
 /**
  * Represents an Attribute for AfterStep hook.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class AfterStep implements Hook
 {
     /**
+     * @api
+     *
      * @param string|null $filterString
      */
     public function __construct(

--- a/src/Behat/Hook/AfterSuite.php
+++ b/src/Behat/Hook/AfterSuite.php
@@ -14,11 +14,15 @@ use Attribute;
 
 /**
  * Represents an Attribute for AfterSuite hook.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class AfterSuite implements Hook
 {
     /**
+     * @api
+     *
      * @param string|null $filterString
      */
     public function __construct(

--- a/src/Behat/Hook/BeforeFeature.php
+++ b/src/Behat/Hook/BeforeFeature.php
@@ -14,12 +14,16 @@ use Attribute;
 
 /**
  * Represents an Attribute for BeforeFeature hook.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class BeforeFeature implements Hook
 {
     /**
      * @param string|null $filterString
+     *
+     * @api
      */
     public function __construct(
         public $filterString = null,

--- a/src/Behat/Hook/BeforeScenario.php
+++ b/src/Behat/Hook/BeforeScenario.php
@@ -14,12 +14,16 @@ use Attribute;
 
 /**
  * Represents an Attribute for BeforeScenario hook.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class BeforeScenario implements Hook
 {
     /**
      * @param string|null $filterString
+     *
+     * @api
      */
     public function __construct(
         public $filterString = null,

--- a/src/Behat/Hook/BeforeStep.php
+++ b/src/Behat/Hook/BeforeStep.php
@@ -14,12 +14,16 @@ use Attribute;
 
 /**
  * Represents an Attribute for BeforeStep hook.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class BeforeStep implements Hook
 {
     /**
      * @param string|null $filterString
+     *
+     * @api
      */
     public function __construct(
         public $filterString = null,

--- a/src/Behat/Hook/BeforeSuite.php
+++ b/src/Behat/Hook/BeforeSuite.php
@@ -14,12 +14,16 @@ use Attribute;
 
 /**
  * Represents an Attribute for BeforeSuite hook.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class BeforeSuite implements Hook
 {
     /**
      * @param string|null $filterString
+     *
+     * @api
      */
     public function __construct(
         public $filterString = null,

--- a/src/Behat/Step/Given.php
+++ b/src/Behat/Step/Given.php
@@ -14,12 +14,16 @@ use Attribute;
 
 /**
  * Represents an Attribute for Given steps.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Given implements Definition
 {
     /**
      * @param string|null $pattern
+     *
+     * @api
      */
     public function __construct(
         public $pattern = null,

--- a/src/Behat/Step/Then.php
+++ b/src/Behat/Step/Then.php
@@ -14,12 +14,16 @@ use Attribute;
 
 /**
  * Represents an Attribute for Then steps.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Then implements Definition
 {
     /**
      * @param string|null $pattern
+     *
+     * @api
      */
     public function __construct(
         public $pattern = null,

--- a/src/Behat/Step/When.php
+++ b/src/Behat/Step/When.php
@@ -14,12 +14,16 @@ use Attribute;
 
 /**
  * Represents an Attribute for When steps.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class When implements Definition
 {
     /**
      * @param string|null $pattern
+     *
+     * @api
      */
     public function __construct(
         public $pattern = null,

--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -16,6 +16,8 @@ use ReflectionFunctionAbstract;
  * Represents callable object.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface Callee
 {

--- a/src/Behat/Testwork/Cli/Controller.php
+++ b/src/Behat/Testwork/Cli/Controller.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * All testwork console controllers should implement this interface.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface Controller
 {

--- a/src/Behat/Testwork/Event/Event.php
+++ b/src/Behat/Testwork/Event/Event.php
@@ -2,6 +2,9 @@
 
 namespace Behat\Testwork\Event;
 
+/**
+ * @api
+ */
 class Event extends \Symfony\Contracts\EventDispatcher\Event
 {
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseAborted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseAborted.php
@@ -14,6 +14,8 @@ namespace Behat\Testwork\EventDispatcher\Event;
  * Represents an event in which exercise was aborted.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterExerciseAborted extends ExerciseCompleted
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseCompleted.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents an event in which exercise was completed.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterExerciseCompleted extends ExerciseCompleted implements AfterTested
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseSetup.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Tester\Setup\Setup;
  * Represents an event in which exercise is prepared to be executed.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterExerciseSetup extends ExerciseCompleted implements AfterSetup
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSetup.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Tester\Setup\Setup;
  * Represents an event right after a test setup.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface AfterSetup
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteAborted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteAborted.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Specification\SpecificationIterator;
  * Represents an event in which suite was aborted.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterSuiteAborted extends SuiteTested
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteSetup.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Tester\Setup\Setup;
  * Represents an event right after a suite setup.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterSuiteSetup extends SuiteTested implements AfterSetup
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteTested.php
@@ -19,6 +19,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents an event in which suite was tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterSuiteTested extends SuiteTested implements AfterTested
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterTested.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents an event right after a test was completed.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface AfterTested
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseCompleted.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Specification\SpecificationIterator;
  * Represents an event in which exercise is prepared to be executed.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeExerciseCompleted extends ExerciseCompleted implements BeforeTested
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseTeardown.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an event right before exercise teardown.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeExerciseTeardown extends ExerciseCompleted implements BeforeTeardown
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTeardown.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an event right before suite teardown.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeSuiteTeardown extends SuiteTested implements BeforeTeardown
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTested.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Specification\SpecificationIterator;
  * Represents an event in which suite is prepared to be tested.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeSuiteTested extends SuiteTested implements BeforeTested
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeTeardown.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents an event right before a teardown.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface BeforeTeardown
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeTested.php
@@ -14,6 +14,8 @@ namespace Behat\Testwork\EventDispatcher\Event;
  * Represents an event just before test setup is started.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface BeforeTested
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Specification\SpecificationIterator;
  * Represents an exercise event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 abstract class ExerciseCompleted extends Event
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/LifecycleEvent.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/LifecycleEvent.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Suite\Suite;
  * Represents an event which holds references to current suite and environment.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 abstract class LifecycleEvent extends Event
 {

--- a/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Specification\SpecificationIterator;
  * Represents a suite event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 abstract class SuiteTested extends LifecycleEvent
 {

--- a/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
@@ -19,6 +19,8 @@ use Exception;
  * @see ExceptionPresenter
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ExceptionStringer
 {

--- a/src/Behat/Testwork/Hook/Scope/AfterSuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/AfterSuiteScope.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents a scope for AfterSuite hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class AfterSuiteScope implements SuiteScope, AfterTestScope
 {

--- a/src/Behat/Testwork/Hook/Scope/AfterTestScope.php
+++ b/src/Behat/Testwork/Hook/Scope/AfterTestScope.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Tester\Result\TestResult;
  * Represents a hook scope for After* hooks.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface AfterTestScope extends HookScope
 {

--- a/src/Behat/Testwork/Hook/Scope/BeforeSuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/BeforeSuiteScope.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Specification\SpecificationIterator;
  * Represents a scope for BeforeSuite hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class BeforeSuiteScope implements SuiteScope
 {

--- a/src/Behat/Testwork/Hook/Scope/HookScope.php
+++ b/src/Behat/Testwork/Hook/Scope/HookScope.php
@@ -22,6 +22,8 @@ use Behat\Testwork\Suite\Suite;
  * @see HookRepository
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface HookScope
 {

--- a/src/Behat/Testwork/Ordering/Orderer/Orderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/Orderer.php
@@ -16,6 +16,8 @@ use Behat\Testwork\Specification\SpecificationIterator;
  * Algorithm for prioritising Specification execution.
  *
  * @author Ciaran McNulty <mail@ciaranmcnulty.com>
+ *
+ * @api
  */
 interface Orderer
 {

--- a/src/Behat/Testwork/Output/Formatter.php
+++ b/src/Behat/Testwork/Output/Formatter.php
@@ -19,6 +19,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @see OutputManager
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface Formatter extends EventSubscriberInterface
 {

--- a/src/Behat/Testwork/Output/Node/EventListener/EventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/EventListener.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Output\Formatter;
  * Used to define formatter event listeners.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface EventListener
 {

--- a/src/Behat/Testwork/Output/Printer/OutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/OutputPrinter.php
@@ -14,6 +14,8 @@ namespace Behat\Testwork\Output\Printer;
  * Isolates all console/filesystem writing.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface OutputPrinter
 {

--- a/src/Behat/Testwork/Output/ServiceContainer/Formatter/FormatterFactory.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/Formatter/FormatterFactory.php
@@ -16,6 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * Provides a way to easily define custom formatters.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface FormatterFactory
 {

--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -21,6 +21,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * implementations is provided through extensions.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface Extension extends CompilerPassInterface
 {

--- a/src/Behat/Testwork/Tester/Result/ExceptionResult.php
+++ b/src/Behat/Testwork/Tester/Result/ExceptionResult.php
@@ -16,6 +16,8 @@ use Throwable;
  * Represents a result, that possibly produced an exception.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface ExceptionResult extends TestResult
 {

--- a/src/Behat/Testwork/Tester/Result/TestResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestResult.php
@@ -14,6 +14,8 @@ namespace Behat\Testwork\Tester\Result;
  * Represents a test result.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface TestResult
 {

--- a/src/Behat/Testwork/Tester/Result/TestResults.php
+++ b/src/Behat/Testwork/Tester/Result/TestResults.php
@@ -20,6 +20,8 @@ use IteratorAggregate;
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * @implements IteratorAggregate<int, TestResult>
+ *
+ * @api
  */
 final class TestResults implements TestResult, Countable, IteratorAggregate
 {

--- a/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
@@ -17,6 +17,8 @@ use Behat\Testwork\Tester\Setup\Teardown;
  * Represents a test result with both setup and teardown attached.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 final class TestWithSetupResult implements TestResult
 {

--- a/src/Behat/Testwork/Tester/Setup/Setup.php
+++ b/src/Behat/Testwork/Tester/Setup/Setup.php
@@ -14,6 +14,8 @@ namespace Behat\Testwork\Tester\Setup;
  * Represents a result of test setUp action.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface Setup
 {

--- a/src/Behat/Testwork/Tester/Setup/Teardown.php
+++ b/src/Behat/Testwork/Tester/Setup/Teardown.php
@@ -14,6 +14,8 @@ namespace Behat\Testwork\Tester\Setup;
  * Represents a result of test tearDown action.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
  */
 interface Teardown
 {

--- a/src/Behat/Transformation/Transform.php
+++ b/src/Behat/Transformation/Transform.php
@@ -14,10 +14,15 @@ use Attribute;
 
 /**
  * Represents an Attribute for a Transform transformation.
+ *
+ * @api
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Transform
 {
+    /**
+     * @api
+     */
     public function __construct(
         public readonly string $pattern = '',
     ) {


### PR DESCRIPTION
Introduces explicit `@api` tags on interfaces, classes and methods that form the Behat public API for end-users and extension authors.

From 4.0, our backwards compatibility promise will only apply to code that is tagged as `@api` - everything else will be treated as `@internal`.

I have limited this initial PR to things I am fairly certain need to be public, including:

* DTO classes for things like events, hooks, results, configuration.
* Interfaces that I think people should / might need to implement to usefully customise Behat's behaviour.

It might be easier to review the individual commits, which explain why groups of classes/interfaces are included.

For the moment, I have not included any of our runtime implementations of the interfaces. I think generally we'd want people to either re-implement the interface, or use the decorator pattern to wrap our implementation - though we might make some exceptions.

I've also not included the `ScenarioLikeTested` interface for now, per discussion on #1805. We definitely shouldn't make that part of our future public API.

I think we can merge this to 3.x now - we can always add more `@api` tags in future PRs.

I've also begun work on the phpstan extension to check that Behat extensions follow our recommended practices. This includes checking that they only use our public API. 

Before we release 4.0, I will complete that tooling and run it against some of the common Behat extensions, to see if it finds any more API that we need to make public.

Works towards #1745