### PR TITLE
refactor: move StopOnFailureController to Testwork\Tester\Cli namespace

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -72,5 +72,13 @@
         `CompilerPassInterface`
         -->
         <ignored-regex>#REMOVED: These ancestors of .+?Extension have been removed: \["Symfony\\\\Component\\\\DependencyInjection\\\\Compiler\\\\CompilerPassInterface"\]#</ignored-regex>
+
+        <!--
+        The `StopOnFailureController` had been added to the `Behat\Behat\EventDispatcher\Cli` namespace but it
+        better belongs in the `Behat\Testwork\Tester\Cli` namespace, so it has been moved
+        -->
+        <ignored-regex>#REMOVED: Class Behat\\Behat\\EventDispatcher\\Cli\\StopOnFailureController has been deleted#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadStopOnFailureController\(\) was removed#</ignored-regex>
+
     </baseline>
 </roave-bc-check>

--- a/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -10,7 +10,6 @@
 
 namespace Behat\Behat\EventDispatcher\ServiceContainer;
 
-use Behat\Behat\EventDispatcher\Cli\StopOnFailureController;
 use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Behat\EventDispatcher\Tester\EventDispatchingBackgroundTester;
@@ -19,9 +18,7 @@ use Behat\Behat\EventDispatcher\Tester\EventDispatchingOutlineTester;
 use Behat\Behat\EventDispatcher\Tester\EventDispatchingScenarioTester;
 use Behat\Behat\EventDispatcher\Tester\EventDispatchingStepTester;
 use Behat\Behat\Tester\ServiceContainer\TesterExtension;
-use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\EventDispatcher\ServiceContainer\EventDispatcherExtension as BaseExtension;
-use Behat\Testwork\Tester\ServiceContainer\TesterExtension as TestworkTesterExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -37,7 +34,6 @@ class EventDispatcherExtension extends BaseExtension
     {
         parent::load($container, $config);
 
-        $this->loadStopOnFailureController($container);
         $this->loadEventDispatchingBackgroundTester($container);
         $this->loadEventDispatchingFeatureTester($container);
         $this->loadEventDispatchingOutlineTester($container);
@@ -45,18 +41,6 @@ class EventDispatcherExtension extends BaseExtension
         $this->loadEventDispatchingExampleTester($container);
         $this->loadEventDispatchingStepTester($container);
         $this->loadTickingStepTester($container);
-    }
-
-    /**
-     * Loads stop on failure controller.
-     */
-    protected function loadStopOnFailureController(ContainerBuilder $container)
-    {
-        $definition = new Definition(StopOnFailureController::class, [
-        ]);
-        $definition->addMethodCall('setStopOnFailureHandler', [new Reference(TestworkTesterExtension::STOP_ON_FAILURE_ID)]);
-        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 100]);
-        $container->setDefinition(CliExtension::CONTROLLER_TAG . '.stop_on_failure', $definition);
     }
 
     /**

--- a/src/Behat/Testwork/Tester/Cli/StopOnFailureController.php
+++ b/src/Behat/Testwork/Tester/Cli/StopOnFailureController.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Behat\Behat\EventDispatcher\Cli;
+namespace Behat\Testwork\Tester\Cli;
 
 use Behat\Testwork\Cli\Controller;
 use Behat\Testwork\Tester\Handler\StopOnFailureHandler;
@@ -19,8 +19,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Stops tests on first scenario failure.
- *
- * TODO this should be moved in the Behat\Testwork\Tester\Cli namespace
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -19,6 +19,7 @@ use Behat\Testwork\ServiceContainer\ServiceProcessor;
 use Behat\Testwork\Specification\ServiceContainer\SpecificationExtension;
 use Behat\Testwork\Suite\ServiceContainer\SuiteExtension;
 use Behat\Testwork\Tester\Cli\ExerciseController;
+use Behat\Testwork\Tester\Cli\StopOnFailureController;
 use Behat\Testwork\Tester\Cli\StrictController;
 use Behat\Testwork\Tester\Handler\StopOnFailureHandler;
 use Behat\Testwork\Tester\Result\Interpretation\SoftInterpretation;
@@ -98,6 +99,7 @@ abstract class TesterExtension implements Extension
     public function load(ContainerBuilder $container, array $config)
     {
         $this->loadExerciseController($container, $config['skip']);
+        $this->loadStopOnFailureController($container);
         $this->loadStopOnFailureHandler($container, $config['stop_on_failure']);
         $this->loadStrictController($container, $config['strict']);
         $this->loadResultInterpreter($container);
@@ -130,6 +132,17 @@ abstract class TesterExtension implements Extension
         ]);
         $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 0]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.exercise', $definition);
+    }
+
+    /**
+     * Loads stop on failure controller.
+     */
+    protected function loadStopOnFailureController(ContainerBuilder $container): void
+    {
+        $definition = new Definition(StopOnFailureController::class);
+        $definition->addMethodCall('setStopOnFailureHandler', [new Reference(self::STOP_ON_FAILURE_ID)]);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 100]);
+        $container->setDefinition(CliExtension::CONTROLLER_TAG . '.stop_on_failure', $definition);
     }
 
     /**


### PR DESCRIPTION
The StopOnFailureController had been added to the Behat\Behat\EventDispatcher\Cli namespace but it better belongs in the  Behat\Testwork\Tester\Cli namespace. There was a TODO comment indicating that this should be moved in the 4.x version. This PR just performs this move
