### PR TITLE
[4.0] feat: Use GherkinCompatibilityMode::GHERKIN_32 by default

### DIFF
--- a/features/gherkin_compatibility_mode.feature
+++ b/features/gherkin_compatibility_mode.feature
@@ -11,27 +11,28 @@ Feature: Gherkin compatibility mode
       | --format    | progress |
 
   @gherkin-mode:has-explicit
-  Scenario: Legacy parsing by default (ignores invalid language)
+  Scenario: Cucumber-compatible parsing by default (fails on invalid language)
     Given the test runner does not configure a default gherkin compatibility mode
     When I run behat with the following additional options:
       | option    | value   |
       | --profile | default |
+    Then it should fail with:
+      """
+      In KeywordsDialectProvider.php line XX:
+
+        Language not supported: martian
+      """
+  
+    
+  @gherkin-mode:has-explicit
+  Scenario: Opt in to legacy parsing (ignores invalid language)
+    When I run behat with the following additional options:
+      | option    | value          |
+      | --profile | gherkin-legacy |
     Then it should pass with:
       """
       UUU
 
       1 scenario (1 undefined)
       3 steps (3 undefined)
-      """
-
-  @gherkin-mode:has-explicit
-  Scenario: Opt in to cucumber-compatible parsing
-    When I run behat with the following additional options:
-      | option    | value      |
-      | --profile | gherkin-32 |
-    Then it should fail with:
-      """
-      In KeywordsDialectProvider.php line XX:
-
-        Language not supported: martian
       """

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -104,7 +104,7 @@ final class GherkinExtension implements Extension
                     fn (GherkinCompatibilityMode $m) => $m->value,
                     GherkinCompatibilityMode::cases(),
                 ))
-                ->defaultValue(GherkinCompatibilityMode::LEGACY->value)
+                ->defaultValue(GherkinCompatibilityMode::GHERKIN_32->value)
         ;
         $childrenBuilder
             ->arrayNode('filters')

--- a/tests/Fixtures/GherkinCompatibility/behat.php
+++ b/tests/Fixtures/GherkinCompatibility/behat.php
@@ -14,9 +14,9 @@ return (new Config())
             timer: false,
             paths: false,
         ))
-    )->withProfile((new Profile('gherkin-32'))
+    )->withProfile((new Profile('gherkin-legacy'))
         ->withGherkinOptions((new GherkinOptions())
-            ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32)
+            ->withCompatibilityMode(GherkinCompatibilityMode::LEGACY)
             ->withCacheDir('/tmp/gc')
         )
     )


### PR DESCRIPTION
In the 4.0 series, by default we will switch to parsing feature files in a way that is compatible with the official cucumber/gherkin parsers. Users can switch back to legacy mode if they have any issues.

Although the GHERKIN_32 mode is still technically experimental, we plan to complete it and mark it stable before Behat v4.0.0.

See https://docs.behat.org/en/latest/user_guide/gherkin/parser_mode.html

We therefore no longer need behat.yml.dist (which was being ignored in 4.0 anyway once we dropped support for YAML config) as this was only there to run our own tests in gherkin-32 mode, which is now the default.