### PR TITLE
[4.0] refactor: Finalise all non-API classes that are not extended

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -107,5 +107,157 @@
         <ignored-regex>#CHANGED: Default parameter value for parameter \$defaultVerbosity of Behat\\Testwork\\Exception\\ExceptionPresenter\#__construct\(\) changed#</ignored-regex>
         <ignored-regex>#CHANGED: The number of required arguments for Behat\\Testwork\\Exception\\ExceptionPresenter\#__construct\(\) increased#</ignored-regex>
         <ignored-regex>#CHANGED: The parameter \$.+? of Behat\\Testwork\\Exception\\ExceptionPresenter\#__construct\(\) changed#</ignored-regex>
+
+        <!--
+        Make all non-API classes final unless they are extended by Behat (also "removes" protected methods)
+        NB that methods that changed from protected to private are listed twice - once as "removed" and once with the
+        visibility changes.
+        -->
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\PathOptions\\Cli\\PathOptionsController became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Call\\Exception\\FatalThrowableError became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Printer\\Factory\\FilesystemOutputFactory became final#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Printer\\Factory\\FilesystemOutputFactory\#configureOutputStream\(\) was removed#</ignored-regex>
+        <ignored-regex>#CHANGED: Method configureOutputStream\(\) of class Behat\\Testwork\\Output\\Printer\\Factory\\FilesystemOutputFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Cli\\OutputController became final#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Cli\\OutputController\#configureFormatters\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Cli\\OutputController\#enableFormatters\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Cli\\OutputController\#setFormattersParameters\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Cli\\OutputController\#locateOutputPath\(\) was removed#</ignored-regex>
+        <ignored-regex>#CHANGED: Method configureFormatters\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method enableFormatters\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method setFormattersParameters\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method locateOutputPath\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Node\\EventListener\\ChainEventListener became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Node\\EventListener\\Flow\\FireOnlyIfFormatterParameterListener became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Argument\\Exception\\UnexpectedMultilineArgumentException became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Exception\\MissingExtensionException became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Exception\\MissingOutputPathException became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Exception\\FormatterNotFoundException became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Context\\Annotation\\DocBlockHelper became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension became final#</ignored-regex>
+        <ignored-regex>#REMOVED: Constant Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension::DEFINITION_ARGUMENT_TRANSFORMER_ID was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension\#loadDefinitionArgumentsTransformer\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension\#loadDefaultTransformers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension\#loadRepository\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension\#processArgumentsTransformers\(\) was removed#</ignored-regex>
+        <ignored-regex>#CHANGED: Constant Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension::DEFINITION_ARGUMENT_TRANSFORMER_ID visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadDefinitionArgumentsTransformer\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadDefaultTransformers\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadRepository\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method processArgumentsTransformers\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Exception\\NodeVisitorNotFoundException became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory became final#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#loadRootNodeListener\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#loadCorePrinters\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#loadPrinterHelpers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#loadFormatter\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#createOutputPrinterDefinition\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#processListenerWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadRootNodeListener\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadCorePrinters\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadPrinterHelpers\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadFormatter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method createOutputPrinterDefinition\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method processListenerWrappers\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory became final#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadRootNodeListener\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadFormatter\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadCorePrinters\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadTableOutlinePrinter\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadExpandedOutlinePrinter\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadHookPrinters\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadStatisticsPrinter\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadPrinterHelpers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#createOutputPrinterDefinition\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#rearrangeBackgroundEvents\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#proxySiblingEvents\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#proxyEventsIfParameterIsSet\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#processListenerWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadRootNodeListener\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadFormatter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadCorePrinters\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadTableOutlinePrinter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadExpandedOutlinePrinter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadHookPrinters\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadStatisticsPrinter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadPrinterHelpers\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method createOutputPrinterDefinition\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method rearrangeBackgroundEvents\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method proxySiblingEvents\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method proxyEventsIfParameterIsSet\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method processListenerWrappers\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Node\\EventListener\\Flow\\FirstBackgroundFiresFirstListener became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Node\\EventListener\\Flow\\FireOnlySiblingsListener became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Node\\EventListener\\Flow\\OnlyFirstBackgroundFiresListener became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Node\\Printer\\JUnit\\JUnitStepPrinter became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Node\\Printer\\JUnit\\JUnitSetupPrinter became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Tester\\Exception\\Stringer\\PendingExceptionStringer became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Snippet\\Printer\\ConsoleSnippetPrinter became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension became final#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension\#loadController\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension\#loadRegistry\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension\#loadWriter\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension\#processGenerators\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension\#processAppenders\(\) was removed#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadController\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadRegistry\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method loadWriter\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method processGenerators\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method processAppenders\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Behat\\Definition\\Translator\\Translator became final#</ignored-regex>
+        <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Exception\\BadOutputPathException became final#</ignored-regex>
+
+        <!-- Make all non-API classes final: methods that remained `protected` in the final classes due to inheritance
+        These methods are still `protected` in the class because they inherit a `protected` method from the parent
+        -->
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#loadSpecificationTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#loadScenarioTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#loadOutlineTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#loadExampleTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#loadBackgroundTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#loadStepTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#loadRerunController\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#loadPendingExceptionStringer\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#processScenarioTesterWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#processOutlineTesterWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#processExampleTesterWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#processBackgroundTesterWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\Tester\\ServiceContainer\\TesterExtension\#processStepTesterWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingBackgroundTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingFeatureTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingOutlineTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingScenarioTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingExampleTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingStepTester\(\) was removed#</ignored-regex>
+
+        <!-- Make all non-API classes final: misleading reported class
+        These are protected methods / properties that a now-final class previously inherited from the parent. They
+        have of course now been "removed" since it is no longer possible to access them by extending our final class.
+        But obviously I have not actually changed the `Exception` class or these other base classes and the properties/
+        methods are still available to anyone who extends the base.
+        I may look at a PR to roave-bc-checker to fix which class is reported as the BC break location here.
+        -->
+        <ignored-regex>#REMOVED: Property Exception\#.+ was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Property ErrorException\#.+ was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Property Symfony\\Component\\Translation\\Translator\#.+ was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Symfony\\Component\\Translation\\Translator\#.+ was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#loadExerciseController\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#loadStrictController\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#loadResultInterpreter\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#loadExercise\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#loadSuiteTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#processExerciseWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#processSuiteTesterWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#processSpecificationTesterWrappers\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Tester\\ServiceContainer\\TesterExtension\#processResultInterpretations\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Property Behat\\Testwork\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#\$processor was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadSigintController\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatcher\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingExercise\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingSuiteTester\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#processSubscribers\(\) was removed#</ignored-regex>
+
     </baseline>
 </roave-bc-check>

--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -117,16 +117,13 @@
         <ignored-regex>#CHANGED: Class Behat\\Testwork\\Call\\Exception\\FatalThrowableError became final#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Printer\\Factory\\FilesystemOutputFactory became final#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Printer\\Factory\\FilesystemOutputFactory\#configureOutputStream\(\) was removed#</ignored-regex>
-        <ignored-regex>#CHANGED: Method configureOutputStream\(\) of class Behat\\Testwork\\Output\\Printer\\Factory\\FilesystemOutputFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method .+\(\) of class Behat\\Testwork\\Output\\Printer\\Factory\\FilesystemOutputFactory visibility reduced from protected to private#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Cli\\OutputController became final#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Cli\\OutputController\#configureFormatters\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Cli\\OutputController\#enableFormatters\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Cli\\OutputController\#setFormattersParameters\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Testwork\\Output\\Cli\\OutputController\#locateOutputPath\(\) was removed#</ignored-regex>
-        <ignored-regex>#CHANGED: Method configureFormatters\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method enableFormatters\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method setFormattersParameters\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method locateOutputPath\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method .+\(\) of class Behat\\Testwork\\Output\\Cli\\OutputController visibility reduced from protected to private#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Node\\EventListener\\ChainEventListener became final#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Node\\EventListener\\Flow\\FireOnlyIfFormatterParameterListener became final#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Testwork\\Argument\\Exception\\UnexpectedMultilineArgumentException became final#</ignored-regex>
@@ -141,10 +138,7 @@
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension\#loadRepository\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension\#processArgumentsTransformers\(\) was removed#</ignored-regex>
         <ignored-regex>#CHANGED: Constant Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension::DEFINITION_ARGUMENT_TRANSFORMER_ID visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadDefinitionArgumentsTransformer\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadDefaultTransformers\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadRepository\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method processArgumentsTransformers\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method .+\(\) of class Behat\\Behat\\Transformation\\ServiceContainer\\TransformationExtension visibility reduced from protected to private#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Exception\\NodeVisitorNotFoundException became final#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory became final#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#loadRootNodeListener\(\) was removed#</ignored-regex>
@@ -153,12 +147,7 @@
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#loadFormatter\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#createOutputPrinterDefinition\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory\#processListenerWrappers\(\) was removed#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadRootNodeListener\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadCorePrinters\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadPrinterHelpers\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadFormatter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method createOutputPrinterDefinition\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method processListenerWrappers\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method .+\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\ProgressFormatterFactory visibility reduced from protected to private#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory became final#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadRootNodeListener\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#loadFormatter\(\) was removed#</ignored-regex>
@@ -173,19 +162,7 @@
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#proxySiblingEvents\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#proxyEventsIfParameterIsSet\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory\#processListenerWrappers\(\) was removed#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadRootNodeListener\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadFormatter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadCorePrinters\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadTableOutlinePrinter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadExpandedOutlinePrinter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadHookPrinters\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadStatisticsPrinter\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadPrinterHelpers\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method createOutputPrinterDefinition\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method rearrangeBackgroundEvents\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method proxySiblingEvents\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method proxyEventsIfParameterIsSet\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method processListenerWrappers\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method .+\(\) of class Behat\\Behat\\Output\\ServiceContainer\\Formatter\\PrettyFormatterFactory visibility reduced from protected to private#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Node\\EventListener\\Flow\\FirstBackgroundFiresFirstListener became final#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Node\\EventListener\\Flow\\FireOnlySiblingsListener became final#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Behat\\Output\\Node\\EventListener\\Flow\\OnlyFirstBackgroundFiresListener became final#</ignored-regex>
@@ -200,11 +177,7 @@
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension\#loadWriter\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension\#processGenerators\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension\#processAppenders\(\) was removed#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadController\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadRegistry\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method loadWriter\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method processGenerators\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
-        <ignored-regex>#CHANGED: Method processAppenders\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
+        <ignored-regex>#CHANGED: Method .+\(\) of class Behat\\Behat\\Snippet\\ServiceContainer\\SnippetExtension visibility reduced from protected to private#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Behat\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension became final#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Behat\\Definition\\Translator\\Translator became final#</ignored-regex>
         <ignored-regex>#CHANGED: Class Behat\\Testwork\\Output\\Exception\\BadOutputPathException became final#</ignored-regex>

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -31,7 +31,7 @@ use Symfony\Component\Process\Process;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class FeatureContext implements Context
+final class FeatureContext implements Context
 {
     private string $phpBin;
 

--- a/src/Behat/Behat/Context/Annotation/DocBlockHelper.php
+++ b/src/Behat/Behat/Context/Annotation/DocBlockHelper.php
@@ -15,7 +15,7 @@ use Behat\Behat\Util\StrictRegex;
 /**
  * Helper class for DocBlock parsing.
  */
-class DocBlockHelper
+final class DocBlockHelper
 {
     /**
      * Extracts a description from the provided docblock,

--- a/src/Behat/Behat/Definition/Translator/Translator.php
+++ b/src/Behat/Behat/Definition/Translator/Translator.php
@@ -2,6 +2,6 @@
 
 namespace Behat\Behat\Definition\Translator;
 
-class Translator extends \Symfony\Component\Translation\Translator implements TranslatorInterface
+final class Translator extends \Symfony\Component\Translation\Translator implements TranslatorInterface
 {
 }

--- a/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -28,7 +28,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class EventDispatcherExtension extends BaseExtension
+final class EventDispatcherExtension extends BaseExtension
 {
     public function load(ContainerBuilder $container, array $config)
     {

--- a/src/Behat/Behat/Output/Exception/NodeVisitorNotFoundException.php
+++ b/src/Behat/Behat/Output/Exception/NodeVisitorNotFoundException.php
@@ -18,6 +18,6 @@ use InvalidArgumentException;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class NodeVisitorNotFoundException extends InvalidArgumentException implements OutputException
+final class NodeVisitorNotFoundException extends InvalidArgumentException implements OutputException
 {
 }

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
@@ -22,7 +22,7 @@ use Behat\Testwork\Output\Node\EventListener\EventListener;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class FireOnlySiblingsListener implements EventListener
+final class FireOnlySiblingsListener implements EventListener
 {
     private bool $inContext = false;
 

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
@@ -27,7 +27,7 @@ use Behat\Testwork\Output\Node\EventListener\EventListener;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class FirstBackgroundFiresFirstListener implements EventListener
+final class FirstBackgroundFiresFirstListener implements EventListener
 {
     private bool $firstBackgroundEnded = false;
     /**

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
@@ -29,7 +29,7 @@ use Behat\Testwork\Output\Node\EventListener\EventListener;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class OnlyFirstBackgroundFiresListener implements EventListener
+final class OnlyFirstBackgroundFiresListener implements EventListener
 {
     private bool $firstBackgroundEnded = false;
     private bool $inBackground = false;

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
@@ -16,7 +16,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
 /**
  * @author: Jakob Erdmann <jakob.erdmann@rocket-internet.com>
  */
-class JUnitSetupPrinter implements SetupPrinter
+final class JUnitSetupPrinter implements SetupPrinter
 {
     public function __construct(
         private readonly ExceptionPresenter $exceptionPresenter,

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
@@ -26,7 +26,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  * @author Wouter J <wouter@wouterj.nl>
  * @author James Watson <james@sitepulse.org>
  */
-class JUnitStepPrinter implements StepPrinter
+final class JUnitStepPrinter implements StepPrinter
 {
     public function __construct(
         private readonly ExceptionPresenter $exceptionPresenter,

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -65,7 +65,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class PrettyFormatterFactory implements FormatterFactory
+final class PrettyFormatterFactory implements FormatterFactory
 {
     private readonly ServiceProcessor $processor;
 

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -110,7 +110,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads pretty formatter node event listener.
      */
-    protected function loadRootNodeListener(ContainerBuilder $container)
+    private function loadRootNodeListener(ContainerBuilder $container)
     {
         $definition = new Definition(ChainEventListener::class, [
             [
@@ -187,7 +187,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads formatter itself.
      */
-    protected function loadFormatter(ContainerBuilder $container)
+    private function loadFormatter(ContainerBuilder $container)
     {
         $definition = new Definition(TotalStatistics::class);
         $container->setDefinition('output.pretty.statistics', $definition);
@@ -230,7 +230,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads feature, scenario and step printers.
      */
-    protected function loadCorePrinters(ContainerBuilder $container)
+    private function loadCorePrinters(ContainerBuilder $container)
     {
         $definition = new Definition(PrettyFeaturePrinter::class);
         $container->setDefinition('output.node.printer.pretty.feature', $definition);
@@ -266,7 +266,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads table outline printer.
      */
-    protected function loadTableOutlinePrinter(ContainerBuilder $container)
+    private function loadTableOutlinePrinter(ContainerBuilder $container)
     {
         $definition = new Definition(PrettyOutlineTablePrinter::class, [
             new Reference('output.node.printer.pretty.scenario'),
@@ -286,7 +286,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads expanded outline printer.
      */
-    protected function loadExpandedOutlinePrinter(ContainerBuilder $container)
+    private function loadExpandedOutlinePrinter(ContainerBuilder $container)
     {
         $definition = new Definition(PrettyOutlinePrinter::class, [
             new Reference('output.node.printer.pretty.scenario'),
@@ -313,7 +313,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads hook printers.
      */
-    protected function loadHookPrinters(ContainerBuilder $container)
+    private function loadHookPrinters(ContainerBuilder $container)
     {
         $definition = new Definition(PrettySetupPrinter::class, [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
@@ -365,7 +365,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads statistics printer.
      */
-    protected function loadStatisticsPrinter(ContainerBuilder $container)
+    private function loadStatisticsPrinter(ContainerBuilder $container)
     {
         $definition = new Definition(CounterPrinter::class, [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
@@ -391,7 +391,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads printer helpers.
      */
-    protected function loadPrinterHelpers(ContainerBuilder $container)
+    private function loadPrinterHelpers(ContainerBuilder $container)
     {
         $definition = new Definition(WidthCalculator::class);
         $container->setDefinition('output.node.printer.pretty.width_calculator', $definition);
@@ -411,7 +411,7 @@ final class PrettyFormatterFactory implements FormatterFactory
      *
      * @return Definition
      */
-    protected function createOutputPrinterDefinition()
+    private function createOutputPrinterDefinition()
     {
         return new Definition(StreamOutputPrinter::class, [
             new Definition(ConsoleOutputFactory::class),
@@ -423,7 +423,7 @@ final class PrettyFormatterFactory implements FormatterFactory
      *
      * @return Definition
      */
-    protected function rearrangeBackgroundEvents($listener)
+    private function rearrangeBackgroundEvents($listener)
     {
         return new Definition(FirstBackgroundFiresFirstListener::class, [
             new Definition(OnlyFirstBackgroundFiresListener::class, [
@@ -441,7 +441,7 @@ final class PrettyFormatterFactory implements FormatterFactory
      *
      * @return Definition
      */
-    protected function proxySiblingEvents($beforeEventName, $afterEventName, array $listeners)
+    private function proxySiblingEvents($beforeEventName, $afterEventName, array $listeners)
     {
         return new Definition(
             FireOnlySiblingsListener::class,
@@ -460,7 +460,7 @@ final class PrettyFormatterFactory implements FormatterFactory
      *
      * @return Definition
      */
-    protected function proxyEventsIfParameterIsSet($name, $value, Definition $listener)
+    private function proxyEventsIfParameterIsSet($name, $value, Definition $listener)
     {
         return new Definition(
             FireOnlyIfFormatterParameterListener::class,
@@ -471,7 +471,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Processes all registered pretty formatter node listener wrappers.
      */
-    protected function processListenerWrappers(ContainerBuilder $container)
+    private function processListenerWrappers(ContainerBuilder $container)
     {
         $this->processor->processWrapperServices($container, self::ROOT_LISTENER_ID, self::ROOT_LISTENER_WRAPPER_TAG);
     }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -80,7 +80,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Loads progress formatter node event listener.
      */
-    protected function loadRootNodeListener(ContainerBuilder $container)
+    private function loadRootNodeListener(ContainerBuilder $container)
     {
         $definition = new Definition(StepListener::class, [
             new Reference('output.node.printer.progress.step'),
@@ -91,7 +91,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Loads feature, scenario and step printers.
      */
-    protected function loadCorePrinters(ContainerBuilder $container)
+    private function loadCorePrinters(ContainerBuilder $container)
     {
         $definition = new Definition(CounterPrinter::class, [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
@@ -122,7 +122,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Loads printer helpers.
      */
-    protected function loadPrinterHelpers(ContainerBuilder $container)
+    private function loadPrinterHelpers(ContainerBuilder $container)
     {
         $definition = new Definition(ResultToStringConverter::class);
         $container->setDefinition(self::RESULT_TO_STRING_CONVERTER_ID, $definition);
@@ -131,7 +131,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Loads formatter itself.
      */
-    protected function loadFormatter(ContainerBuilder $container)
+    private function loadFormatter(ContainerBuilder $container)
     {
         $definition = new Definition(TotalStatistics::class);
         $container->setDefinition('output.progress.statistics', $definition);
@@ -174,7 +174,7 @@ final class ProgressFormatterFactory implements FormatterFactory
      *
      * @return Definition
      */
-    protected function createOutputPrinterDefinition()
+    private function createOutputPrinterDefinition()
     {
         return new Definition(StreamOutputPrinter::class, [
             new Definition(ConsoleOutputFactory::class),
@@ -184,7 +184,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Processes all registered pretty formatter node listener wrappers.
      */
-    protected function processListenerWrappers(ContainerBuilder $container)
+    private function processListenerWrappers(ContainerBuilder $container)
     {
         $this->processor->processWrapperServices($container, self::ROOT_LISTENER_ID, self::ROOT_LISTENER_WRAPPER_TAG);
     }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -41,7 +41,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class ProgressFormatterFactory implements FormatterFactory
+final class ProgressFormatterFactory implements FormatterFactory
 {
     private readonly ServiceProcessor $processor;
 

--- a/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
@@ -26,7 +26,7 @@ use function count;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class ConsoleSnippetPrinter implements SnippetPrinter
+final class ConsoleSnippetPrinter implements SnippetPrinter
 {
     /**
      * Initializes printer.

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -80,7 +80,7 @@ final class SnippetExtension implements Extension
         $this->processAppenders($container);
     }
 
-    protected function loadController(ContainerBuilder $container)
+    private function loadController(ContainerBuilder $container)
     {
         $definition = new Definition(ConsoleSnippetPrinter::class, [
             new Reference(CliExtension::OUTPUT_ID),
@@ -98,19 +98,19 @@ final class SnippetExtension implements Extension
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.snippet', $definition);
     }
 
-    protected function loadRegistry(ContainerBuilder $container)
+    private function loadRegistry(ContainerBuilder $container)
     {
         $definition = new Definition(SnippetRegistry::class);
         $container->setDefinition(self::REGISTRY_ID, $definition);
     }
 
-    protected function loadWriter(ContainerBuilder $container)
+    private function loadWriter(ContainerBuilder $container)
     {
         $definition = new Definition(SnippetWriter::class);
         $container->setDefinition(self::WRITER_ID, $definition);
     }
 
-    protected function processGenerators(ContainerBuilder $container)
+    private function processGenerators(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::GENERATOR_TAG);
         $definition = $container->getDefinition(self::REGISTRY_ID);
@@ -120,7 +120,7 @@ final class SnippetExtension implements Extension
         }
     }
 
-    protected function processAppenders(ContainerBuilder $container)
+    private function processAppenders(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::APPENDER_TAG);
         $definition = $container->getDefinition(self::WRITER_ID);

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -30,7 +30,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class SnippetExtension implements Extension
+final class SnippetExtension implements Extension
 {
     /*
      * Available services

--- a/src/Behat/Behat/Tester/Exception/Stringer/PendingExceptionStringer.php
+++ b/src/Behat/Behat/Tester/Exception/Stringer/PendingExceptionStringer.php
@@ -19,7 +19,7 @@ use Exception;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class PendingExceptionStringer implements ExceptionStringer
+final class PendingExceptionStringer implements ExceptionStringer
 {
     public function supportsException(Exception $exception)
     {

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -37,7 +37,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class TesterExtension extends BaseExtension
+final class TesterExtension extends BaseExtension
 {
     /*
      * Available services

--- a/src/Behat/Behat/Transformation/Context/Factory/TransformationCalleeFactory.php
+++ b/src/Behat/Behat/Transformation/Context/Factory/TransformationCalleeFactory.php
@@ -29,7 +29,7 @@ use ReflectionMethod;
  *
  * @internal
  */
-class TransformationCalleeFactory
+final class TransformationCalleeFactory
 {
     public static function create(string $contextClass, ReflectionMethod $method, string $pattern, ?string $description): Transformation
     {

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -32,7 +32,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class TransformationExtension implements Extension
+final class TransformationExtension implements Extension
 {
     /*
      * Available services

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -44,7 +44,7 @@ final class TransformationExtension implements Extension
      */
     public const ARGUMENT_TRANSFORMER_TAG = 'transformation.argument_transformer';
 
-    protected const DEFINITION_ARGUMENT_TRANSFORMER_ID = CallExtension::CALL_FILTER_TAG . '.definition_argument_transformer';
+    private const DEFINITION_ARGUMENT_TRANSFORMER_ID = CallExtension::CALL_FILTER_TAG . '.definition_argument_transformer';
 
     private readonly ServiceProcessor $processor;
 
@@ -85,7 +85,7 @@ final class TransformationExtension implements Extension
     /**
      * Loads definition arguments transformer.
      */
-    protected function loadDefinitionArgumentsTransformer(ContainerBuilder $container)
+    private function loadDefinitionArgumentsTransformer(ContainerBuilder $container)
     {
         $definition = new Definition(DefinitionArgumentsTransformer::class);
         $definition->addTag(CallExtension::CALL_FILTER_TAG, ['priority' => 200]);
@@ -95,7 +95,7 @@ final class TransformationExtension implements Extension
     /**
      * Loads default transformers.
      */
-    protected function loadDefaultTransformers(ContainerBuilder $container)
+    private function loadDefaultTransformers(ContainerBuilder $container)
     {
         $definition = new Definition(RepositoryArgumentTransformer::class, [
             new Reference(self::REPOSITORY_ID),
@@ -122,7 +122,7 @@ final class TransformationExtension implements Extension
     /**
      * Loads transformations repository.
      */
-    protected function loadRepository(ContainerBuilder $container)
+    private function loadRepository(ContainerBuilder $container)
     {
         $definition = new Definition(TransformationRepository::class, [
             new Reference(EnvironmentExtension::MANAGER_ID),
@@ -133,7 +133,7 @@ final class TransformationExtension implements Extension
     /**
      * Processes all available argument transformers.
      */
-    protected function processArgumentsTransformers(ContainerBuilder $container)
+    private function processArgumentsTransformers(ContainerBuilder $container)
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::ARGUMENT_TRANSFORMER_TAG);
         $definition = $container->getDefinition(self::DEFINITION_ARGUMENT_TRANSFORMER_ID);

--- a/src/Behat/Behat/Util/RegexException.php
+++ b/src/Behat/Behat/Util/RegexException.php
@@ -9,6 +9,6 @@ use Exception;
 /**
  * @internal
  */
-class RegexException extends Exception
+final class RegexException extends Exception
 {
 }

--- a/src/Behat/Testwork/Argument/Exception/UnexpectedMultilineArgumentException.php
+++ b/src/Behat/Testwork/Argument/Exception/UnexpectedMultilineArgumentException.php
@@ -4,6 +4,6 @@ namespace Behat\Testwork\Argument\Exception;
 
 use InvalidArgumentException;
 
-class UnexpectedMultilineArgumentException extends InvalidArgumentException implements ArgumentException
+final class UnexpectedMultilineArgumentException extends InvalidArgumentException implements ArgumentException
 {
 }

--- a/src/Behat/Testwork/Call/Exception/FatalThrowableError.php
+++ b/src/Behat/Testwork/Call/Exception/FatalThrowableError.php
@@ -21,7 +21,7 @@ use TypeError;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class FatalThrowableError extends ErrorException
+final class FatalThrowableError extends ErrorException
 {
     public function __construct(Throwable $e)
     {

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class OutputController implements Controller
+final class OutputController implements Controller
 {
     /**
      * Initializes controller.

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -75,7 +75,7 @@ final class OutputController implements Controller
     /**
      * Configures formatters based on container, input and output configurations.
      */
-    protected function configureFormatters(array $formats, InputInterface $input, OutputInterface $output)
+    private function configureFormatters(array $formats, InputInterface $input, OutputInterface $output)
     {
         $this->enableFormatters($formats);
         $this->setFormattersParameters($input, $output);
@@ -84,7 +84,7 @@ final class OutputController implements Controller
     /**
      * Enables formatters.
      */
-    protected function enableFormatters(array $formats)
+    private function enableFormatters(array $formats)
     {
         if (count($formats)) {
             $this->manager->disableAllFormatters();
@@ -97,7 +97,7 @@ final class OutputController implements Controller
     /**
      * Sets formatters parameters based on input & output.
      */
-    protected function setFormattersParameters(InputInterface $input, OutputInterface $output)
+    private function setFormattersParameters(InputInterface $input, OutputInterface $output)
     {
         $this->manager->setFormattersParameter('output_decorate', $output->isDecorated());
 
@@ -115,7 +115,7 @@ final class OutputController implements Controller
      *
      * @return string
      */
-    protected function locateOutputPath($path)
+    private function locateOutputPath($path)
     {
         if ($this->isAbsolutePath($path)) {
             return $path;

--- a/src/Behat/Testwork/Output/Exception/BadOutputPathException.php
+++ b/src/Behat/Testwork/Output/Exception/BadOutputPathException.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class BadOutputPathException extends InvalidArgumentException implements PrinterException
+final class BadOutputPathException extends InvalidArgumentException implements PrinterException
 {
     /**
      * Initializes exception.

--- a/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
+++ b/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class FormatterNotFoundException extends InvalidArgumentException implements OutputException
+final class FormatterNotFoundException extends InvalidArgumentException implements OutputException
 {
     /**
      * Initializes exception.

--- a/src/Behat/Testwork/Output/Exception/MissingExtensionException.php
+++ b/src/Behat/Testwork/Output/Exception/MissingExtensionException.php
@@ -17,6 +17,6 @@ use RuntimeException;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class MissingExtensionException extends RuntimeException implements PrinterException
+final class MissingExtensionException extends RuntimeException implements PrinterException
 {
 }

--- a/src/Behat/Testwork/Output/Exception/MissingOutputPathException.php
+++ b/src/Behat/Testwork/Output/Exception/MissingOutputPathException.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class MissingOutputPathException extends InvalidArgumentException implements PrinterException
+final class MissingOutputPathException extends InvalidArgumentException implements PrinterException
 {
     public function __construct(string $message)
     {

--- a/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
@@ -23,7 +23,7 @@ use IteratorAggregate;
  *
  * @implements IteratorAggregate<int, EventListener>
  */
-class ChainEventListener implements EventListener, Countable, IteratorAggregate
+final class ChainEventListener implements EventListener, Countable, IteratorAggregate
 {
     /**
      * Initializes collection.

--- a/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
@@ -19,7 +19,7 @@ use Behat\Testwork\Output\Node\EventListener\EventListener;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class FireOnlyIfFormatterParameterListener implements EventListener
+final class FireOnlyIfFormatterParameterListener implements EventListener
 {
     /**
      * Initializes listener.

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\StreamOutput;
  *
  * @author Wouter J <wouter@wouterj.nl>
  */
-class FilesystemOutputFactory extends OutputFactory
+final class FilesystemOutputFactory extends OutputFactory
 {
     private $fileName;
 

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -33,7 +33,7 @@ final class FilesystemOutputFactory extends OutputFactory
     /**
      * Configure output stream parameters.
      */
-    protected function configureOutputStream(OutputInterface $output)
+    private function configureOutputStream(OutputInterface $output)
     {
         $verbosity = $this->getOutputVerbosity() ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL;
         $output->setVerbosity($verbosity);

--- a/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
+++ b/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class PathOptionsController implements Controller
+final class PathOptionsController implements Controller
 {
     public function __construct(
         private readonly ConfigurablePathPrinter $configurablePathPrinter,


### PR DESCRIPTION
This PR starts work towards #1748 with the goal that we use `final` classes wherever possible in 4.0.

As a first step, I have finalised all classes that:

* Are not tagged `@api` (and therefore should not be used or extended in third-party code from 4.0 onwards).
* Are not extended by Behat itself.

Making these classes final also allows us to make a number of methods `private` rather than `protected`.