### PR TITLE
fix: Return type on ScenarioLikeTested, and add strict returns to `final` events

### DIFF
--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\Event\AfterSetup;
 use Behat\Testwork\Tester\Setup\Setup;
@@ -50,8 +49,6 @@ final class AfterBackgroundSetup extends BackgroundTested implements AfterSetup
      * Returns scenario node.
      *
      * @deprecated Use getBackground() instead
-     *
-     * @return ScenarioLikeInterface
      */
     public function getScenario(): BackgroundNode
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
@@ -53,7 +53,7 @@ final class AfterBackgroundSetup extends BackgroundTested implements AfterSetup
      *
      * @return ScenarioLikeInterface
      */
-    public function getScenario()
+    public function getScenario(): BackgroundNode
     {
         return $this->background;
     }

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\Event\AfterTested;
 use Behat\Testwork\Tester\Result\TestResult;
@@ -52,8 +51,6 @@ final class AfterBackgroundTested extends BackgroundTested implements AfterTeste
      * Returns scenario node.
      *
      * @deprecated Use getBackground() instead
-     *
-     * @return ScenarioLikeInterface
      */
     public function getScenario(): BackgroundNode
     {

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
@@ -55,7 +55,7 @@ final class AfterBackgroundTested extends BackgroundTested implements AfterTeste
      *
      * @return ScenarioLikeInterface
      */
-    public function getScenario()
+    public function getScenario(): BackgroundNode
     {
         return $this->background;
     }

--- a/src/Behat/Behat/EventDispatcher/Event/AfterScenarioSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterScenarioSetup.php
@@ -39,28 +39,21 @@ final class AfterScenarioSetup extends ScenarioTested implements AfterSetup
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature()
+    public function getFeature(): FeatureNode
     {
         return $this->feature;
     }
 
-    /**
-     * @return Scenario
-     */
-    public function getScenario()
+    public function getScenario(): Scenario
     {
         return $this->scenario;
     }
 
     /**
      * Returns current test setup.
-     *
-     * @return Setup
      */
-    public function getSetup()
+    public function getSetup(): Setup
     {
         return $this->setup;
     }

--- a/src/Behat/Behat/EventDispatcher/Event/AfterScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterScenarioTested.php
@@ -41,38 +41,29 @@ final class AfterScenarioTested extends ScenarioTested implements AfterTested
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature()
+    public function getFeature(): FeatureNode
     {
         return $this->feature;
     }
 
-    /**
-     * @return Scenario
-     */
-    public function getScenario()
+    public function getScenario(): Scenario
     {
         return $this->scenario;
     }
 
     /**
      * Returns current test result.
-     *
-     * @return TestResult
      */
-    public function getTestResult()
+    public function getTestResult(): TestResult
     {
         return $this->result;
     }
 
     /**
      * Returns current test teardown.
-     *
-     * @return Teardown
      */
-    public function getTeardown()
+    public function getTeardown(): Teardown
     {
         return $this->teardown;
     }

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
@@ -40,10 +40,8 @@ final class BeforeBackgroundTeardown extends BackgroundTested implements BeforeT
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature()
+    public function getFeature(): FeatureNode
     {
         return $this->feature;
     }
@@ -55,27 +53,23 @@ final class BeforeBackgroundTeardown extends BackgroundTested implements BeforeT
      *
      * @return ScenarioLikeInterface
      */
-    public function getScenario()
+    public function getScenario(): BackgroundNode
     {
         return $this->background;
     }
 
     /**
      * Returns background node.
-     *
-     * @return BackgroundNode
      */
-    public function getBackground()
+    public function getBackground(): BackgroundNode
     {
         return $this->background;
     }
 
     /**
      * Returns current test result.
-     *
-     * @return TestResult
      */
-    public function getTestResult()
+    public function getTestResult(): TestResult
     {
         return $this->result;
     }

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\Event\BeforeTeardown;
 use Behat\Testwork\Tester\Result\TestResult;
@@ -50,8 +49,6 @@ final class BeforeBackgroundTeardown extends BackgroundTested implements BeforeT
      * Returns scenario node.
      *
      * @deprecated Use getBackground() instead
-     *
-     * @return ScenarioLikeInterface
      */
     public function getScenario(): BackgroundNode
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
@@ -38,10 +38,8 @@ final class BeforeBackgroundTested extends BackgroundTested implements BeforeTes
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature()
+    public function getFeature(): FeatureNode
     {
         return $this->feature;
     }
@@ -53,17 +51,15 @@ final class BeforeBackgroundTested extends BackgroundTested implements BeforeTes
      *
      * @return ScenarioLikeInterface
      */
-    public function getScenario()
+    public function getScenario(): BackgroundNode
     {
         return $this->background;
     }
 
     /**
      * Returns background node.
-     *
-     * @return BackgroundNode
      */
-    public function getBackground()
+    public function getBackground(): BackgroundNode
     {
         return $this->background;
     }

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\Event\BeforeTested;
 
@@ -48,8 +47,6 @@ final class BeforeBackgroundTested extends BackgroundTested implements BeforeTes
      * Returns scenario node.
      *
      * @deprecated Use getBackground() instead
-     *
-     * @return ScenarioLikeInterface
      */
     public function getScenario(): BackgroundNode
     {

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTeardown.php
@@ -39,28 +39,21 @@ final class BeforeScenarioTeardown extends ScenarioTested implements BeforeTeard
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature()
+    public function getFeature(): FeatureNode
     {
         return $this->feature;
     }
 
-    /**
-     * @return Scenario
-     */
-    public function getScenario()
+    public function getScenario(): Scenario
     {
         return $this->scenario;
     }
 
     /**
      * Returns current test result.
-     *
-     * @return TestResult
      */
-    public function getTestResult()
+    public function getTestResult(): TestResult
     {
         return $this->result;
     }

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTested.php
@@ -37,18 +37,13 @@ final class BeforeScenarioTested extends ScenarioTested implements BeforeTested
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature()
+    public function getFeature(): FeatureNode
     {
         return $this->feature;
     }
 
-    /**
-     * @return Scenario
-     */
-    public function getScenario()
+    public function getScenario(): Scenario
     {
         return $this->scenario;
     }

--- a/src/Behat/Behat/EventDispatcher/Event/ScenarioLikeTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ScenarioLikeTested.php
@@ -11,7 +11,7 @@
 namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioInterface;
+use Behat\Gherkin\Node\ScenarioLikeInterface;
 
 /**
  * Represents an event of scenario-like structure (Scenario, Background, Example).
@@ -30,7 +30,7 @@ interface ScenarioLikeTested extends GherkinNodeTested
     /**
      * Returns scenario node.
      *
-     * @return ScenarioInterface
+     * @return ScenarioLikeInterface
      */
     public function getScenario();
 }


### PR DESCRIPTION
The `ScenarioLikeTested::getScenario()` method had a phpdoc claiming that it would always return a `ScenarioInterface`.

In fact, that has never been true:

* The `BackgroundTested` family of implementations in fact return a `BackgroundNode`. This does *not* implement `ScenarioInterface` - it implements the parent `ScenarioLikeInterface`.
* The `ScenarioTested` family of implementations return a `ScenarioLikeInterface` - this might be a `ScenarioInterface` but there is no guarantee that it is.

The typehint on the interface is (and always has been) incorrect.

Additionally, the event objects here have always been `final` but the previous PRs to add backwards compatible return types missed them. I'm not sure if I accidentally excluded them as non-BC, or if Rector has got better at spotting them.

Either way, this is safe to go into 3.x.

Continues #1744 