### PR TITLE
refactor: Bump phpstan & rector and apply new refactorings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
     "require-dev": {
         "opis/json-schema": "^2.5",
         "php-cs-fixer/shim": "^3.89",
-        "phpstan/phpstan": "2.1.18",
+        "phpstan/phpstan": "2.1.46",
         "phpunit/phpunit": "^9.6",
-        "rector/rector": "2.1.7",
+        "rector/rector": "2.3.9",
         "sebastian/diff": "^4.0",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
         "symfony/polyfill-php84": "^1.31",

--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 
 return RectorConfig::configure()
@@ -19,7 +19,7 @@ return RectorConfig::configure()
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,
         // DI setFactory does not support closures
-        FirstClassCallableRector::class => [__DIR__ . '/src/Behat/Testwork/Deprecation/ServiceContainer/DeprecationExtension.php'],
+        ArrayToFirstClassCallableRector::class => [__DIR__ . '/src/Behat/Testwork/Deprecation/ServiceContainer/DeprecationExtension.php'],
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -156,9 +156,15 @@ TPL;
 
         $keywordType = $step->getKeywordType();
         assert(
-            $keywordType === DefinitionCall\Given::KEYWORD
-            || $keywordType === DefinitionCall\When::KEYWORD
-            || $keywordType === DefinitionCall\Then::KEYWORD
+            in_array(
+                $keywordType,
+                [
+                    DefinitionCall\Given::KEYWORD,
+                    DefinitionCall\When::KEYWORD,
+                    DefinitionCall\Then::KEYWORD,
+                ],
+                true,
+            ),
         );
         $usedClasses[] = match ($keywordType) {
             DefinitionCall\Given::KEYWORD => Given::class,

--- a/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
@@ -105,6 +105,7 @@ final class RepositorySearchEngine implements SearchEngine
             // knowledge of the concept of a Step.
             throw new UnexpectedMultilineArgumentException(
                 $e->getMessage() . PHP_EOL . 'This is probably an error in your step implementation or in ' . $stepLocation,
+                code: $e->getCode(),
                 previous: $e
             );
         }

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingBackgroundTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingBackgroundTester.php
@@ -41,13 +41,13 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
     {
         $event = new BeforeBackgroundTested($env, $feature, $feature->getBackground());
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE);
+        $this->eventDispatcher->dispatch($event, BeforeBackgroundTested::BEFORE);
 
         $setup = $this->baseTester->setUp($env, $feature, $skip);
 
         $event = new AfterBackgroundSetup($env, $feature, $feature->getBackground(), $setup);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER_SETUP);
+        $this->eventDispatcher->dispatch($event, AfterBackgroundSetup::AFTER_SETUP);
 
         return $setup;
     }

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
@@ -44,13 +44,13 @@ final class EventDispatchingFeatureTester implements SpecificationTester
     {
         $event = new BeforeFeatureTested($env, $spec);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE);
+        $this->eventDispatcher->dispatch($event, BeforeFeatureTested::BEFORE);
 
         $setup = $this->baseTester->setUp($env, $spec, $skip);
 
         $event = new AfterFeatureSetup($env, $spec, $setup);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER_SETUP);
+        $this->eventDispatcher->dispatch($event, AfterFeatureSetup::AFTER_SETUP);
 
         return $setup;
     }
@@ -64,13 +64,13 @@ final class EventDispatchingFeatureTester implements SpecificationTester
     {
         $event = new BeforeFeatureTeardown($env, $spec, $result);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
+        $this->eventDispatcher->dispatch($event, BeforeFeatureTeardown::BEFORE_TEARDOWN);
 
         $teardown = $this->baseTester->tearDown($env, $spec, $skip, $result);
 
         $event = new AfterFeatureTested($env, $spec, $result, $teardown);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER);
+        $this->eventDispatcher->dispatch($event, AfterFeatureTested::AFTER);
 
         return $teardown;
     }

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php
@@ -41,13 +41,13 @@ final class EventDispatchingOutlineTester implements OutlineTester
     {
         $event = new BeforeOutlineTested($env, $feature, $outline);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE);
+        $this->eventDispatcher->dispatch($event, BeforeOutlineTested::BEFORE);
 
         $setup = $this->baseTester->setUp($env, $feature, $outline, $skip);
 
         $event = new AfterOutlineSetup($env, $feature, $outline, $setup);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER_SETUP);
+        $this->eventDispatcher->dispatch($event, AfterOutlineSetup::AFTER_SETUP);
 
         return $setup;
     }
@@ -61,13 +61,13 @@ final class EventDispatchingOutlineTester implements OutlineTester
     {
         $event = new BeforeOutlineTeardown($env, $feature, $outline, $result);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
+        $this->eventDispatcher->dispatch($event, BeforeOutlineTeardown::BEFORE_TEARDOWN);
 
         $teardown = $this->baseTester->tearDown($env, $feature, $outline, $skip, $result);
 
         $event = new AfterOutlineTested($env, $feature, $outline, $result, $teardown);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER);
+        $this->eventDispatcher->dispatch($event, AfterOutlineTested::AFTER);
 
         return $teardown;
     }

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingStepTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingStepTester.php
@@ -41,13 +41,13 @@ final class EventDispatchingStepTester implements StepTester
     {
         $event = new BeforeStepTested($env, $feature, $step);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE);
+        $this->eventDispatcher->dispatch($event, BeforeStepTested::BEFORE);
 
         $setup = $this->baseTester->setUp($env, $feature, $step, $skip);
 
         $event = new AfterStepSetup($env, $feature, $step, $setup);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER_SETUP);
+        $this->eventDispatcher->dispatch($event, AfterStepSetup::AFTER_SETUP);
 
         return $setup;
     }
@@ -61,13 +61,13 @@ final class EventDispatchingStepTester implements StepTester
     {
         $event = new BeforeStepTeardown($env, $feature, $step, $result);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
+        $this->eventDispatcher->dispatch($event, BeforeStepTeardown::BEFORE_TEARDOWN);
 
         $teardown = $this->baseTester->tearDown($env, $feature, $step, $skip, $result);
 
         $event = new AfterStepTested($env, $feature, $step, $result, $teardown);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER);
+        $this->eventDispatcher->dispatch($event, AfterStepTested::AFTER);
 
         return $teardown;
     }

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -127,8 +127,8 @@ final class FilesystemFeatureLocator implements SpecificationLocator
             RegexIterator::MATCH
         );
 
-        $paths = array_map('strval', iterator_to_array($iterator));
-        uasort($paths, 'strnatcasecmp');
+        $paths = array_map(strval(...), iterator_to_array($iterator));
+        uasort($paths, strnatcasecmp(...));
 
         return $paths;
     }

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
@@ -76,7 +76,7 @@ final class ProgressStepPrinter implements StepPrinter
             $this->printStdOut($formatter->getOutputPrinter(), $result);
         }
 
-        if (++$this->stepsPrinted % 70 == 0) {
+        if (++$this->stepsPrinted % 70 === 0) {
             $printer->writeln(' ' . $this->stepsPrinted);
         }
     }

--- a/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
@@ -84,6 +84,6 @@ final class ExecutedStepResult implements StepResult, DefinedStepResult, Excepti
 
     public function isPassed(): bool
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED === $this->getResultCode();
     }
 }

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -134,7 +134,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
             $this->getClassReflection()
         );
 
-        if (count($parameters) == 0) {
+        if (count($parameters) === 0) {
             return null;
         }
 

--- a/src/Behat/Config/Suite.php
+++ b/src/Behat/Config/Suite.php
@@ -114,7 +114,7 @@ final class Suite implements ConfigConverterInterface
         unset($this->settings[self::CONTEXTS_SETTING]);
 
         // Contexts can be configured with or without constructor arguments.
-        $hasAnyWithArguments = (bool) array_filter($contexts, fn ($c): bool => is_array($c));
+        $hasAnyWithArguments = (bool) array_filter($contexts, is_array(...));
 
         if (!$hasAnyWithArguments) {
             // All the contexts are just class names, we can add them as a single `->withContexts` call

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
@@ -44,13 +44,13 @@ final class EventDispatchingExercise implements Exercise
     {
         $event = new BeforeExerciseCompleted($iterators);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE);
+        $this->eventDispatcher->dispatch($event, BeforeExerciseCompleted::BEFORE);
 
         $setup = $this->baseExercise->setUp($iterators, $skip);
 
         $event = new AfterExerciseSetup($iterators, $setup);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER_SETUP);
+        $this->eventDispatcher->dispatch($event, AfterExerciseSetup::AFTER_SETUP);
 
         return $setup;
     }
@@ -64,13 +64,13 @@ final class EventDispatchingExercise implements Exercise
     {
         $event = new BeforeExerciseTeardown($iterators, $result);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
+        $this->eventDispatcher->dispatch($event, BeforeExerciseTeardown::BEFORE_TEARDOWN);
 
         $teardown = $this->baseExercise->tearDown($iterators, $skip, $result);
 
         $event = new AfterExerciseCompleted($iterators, $result, $teardown);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER);
+        $this->eventDispatcher->dispatch($event, AfterExerciseCompleted::AFTER);
 
         return $teardown;
     }

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
@@ -46,13 +46,13 @@ final class EventDispatchingSuiteTester implements SuiteTester
     {
         $event = new BeforeSuiteTested($env, $iterator);
 
-        $this->eventDispatcher->dispatch($event, $event::BEFORE);
+        $this->eventDispatcher->dispatch($event, BeforeSuiteTested::BEFORE);
 
         $setup = $this->baseTester->setUp($env, $iterator, $skip);
 
         $event = new AfterSuiteSetup($env, $iterator, $setup);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER_SETUP);
+        $this->eventDispatcher->dispatch($event, AfterSuiteSetup::AFTER_SETUP);
 
         return $setup;
     }
@@ -65,13 +65,13 @@ final class EventDispatchingSuiteTester implements SuiteTester
     public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
     {
         $event = new BeforeSuiteTeardown($env, $iterator, $result);
-        $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
+        $this->eventDispatcher->dispatch($event, BeforeSuiteTeardown::BEFORE_TEARDOWN);
 
         $teardown = $this->baseTester->tearDown($env, $iterator, $skip, $result);
 
         $event = new AfterSuiteTested($env, $iterator, $result, $teardown);
 
-        $this->eventDispatcher->dispatch($event, $event::AFTER);
+        $this->eventDispatcher->dispatch($event, AfterSuiteTested::AFTER);
 
         return $teardown;
     }

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -139,7 +139,7 @@ class OutputController implements Controller
      */
     private function configureOutputs(array $formats, array $outputs, bool $decorated = false): void
     {
-        if (1 == count($outputs) && !$this->isStandardOutput($outputs[0])) {
+        if (1 === count($outputs) && !$this->isStandardOutput($outputs[0])) {
             $outputPath = $this->locateOutputPath($outputs[0]);
 
             $this->manager->setFormattersParameter('output_path', $outputPath);


### PR DESCRIPTION
We have pinned rector to a specific version, to avoid unexpected changes in CI. This means that we also had to pin phpstan as (in #1786) we found that our Rector version was not fully compatible with newer phpstan.

This PR updates both dependencies to their latest version, and applies a small number of new internal refactorings that Rector proposed.