### PR TITLE
refactor: Apply further strict types to 3.x

### DIFF
--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -67,7 +67,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
         return count($this->contexts) > 0;
     }
 
-    public function getContextClasses()
+    public function getContextClasses(): array
     {
         return array_keys($this->contexts);
     }
@@ -82,7 +82,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
      *
      * @return list<Context>
      */
-    public function getContexts()
+    public function getContexts(): array
     {
         return array_values($this->contexts);
     }

--- a/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
@@ -65,7 +65,7 @@ final class UninitializedContextEnvironment extends StaticEnvironment implements
         return count($this->contextClasses) > 0;
     }
 
-    public function getContextClasses()
+    public function getContextClasses(): array
     {
         return array_keys($this->contextClasses);
     }

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -77,7 +77,7 @@ final class TurnipPatternPolicy implements PatternPolicy
         return true;
     }
 
-    public function transformPatternToRegex($pattern)
+    public function transformPatternToRegex($pattern): string
     {
         if (!isset($this->regexCache[$pattern])) {
             $this->regexCache[$pattern] = $this->createTransformedRegex($pattern);

--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -33,7 +33,7 @@ final class LazyFeatureIterator implements SpecificationIterator
     /**
      * @var list<string>
      */
-    private $paths = [];
+    private array $paths;
     /**
      * @var list<FeatureFilterInterface>
      */

--- a/src/Behat/Behat/Snippet/Cli/SnippetsController.php
+++ b/src/Behat/Behat/Snippet/Cli/SnippetsController.php
@@ -104,7 +104,7 @@ final class SnippetsController implements Controller
     public function appendAllSnippets(): void
     {
         $snippets = $this->registry->getSnippets();
-        if ($snippets) {
+        if ($snippets !== []) {
             $this->output->writeln('');
         }
 
@@ -117,7 +117,7 @@ final class SnippetsController implements Controller
     public function printAllSnippets(): void
     {
         $snippets = $this->registry->getSnippets();
-        if ($snippets) {
+        if ($snippets !== []) {
             $this->output->writeln('');
         }
 
@@ -140,7 +140,7 @@ final class SnippetsController implements Controller
     public function printUndefinedSteps(): void
     {
         $undefined = $this->registry->getUndefinedSteps();
-        if ($undefined) {
+        if ($undefined !== []) {
             $this->output->writeln('');
         }
 

--- a/src/Behat/Behat/Snippet/SnippetRegistry.php
+++ b/src/Behat/Behat/Snippet/SnippetRegistry.php
@@ -64,7 +64,7 @@ final class SnippetRegistry implements SnippetRepository
      *
      * @return list<AggregateSnippet>
      */
-    public function getSnippets()
+    public function getSnippets(): array
     {
         $this->generateSnippets();
 
@@ -76,7 +76,7 @@ final class SnippetRegistry implements SnippetRepository
      *
      * @return list<UndefinedStep>
      */
-    public function getUndefinedSteps()
+    public function getUndefinedSteps(): array
     {
         $this->generateSnippets();
 

--- a/src/Behat/Behat/Snippet/SnippetRegistry.php
+++ b/src/Behat/Behat/Snippet/SnippetRegistry.php
@@ -29,11 +29,11 @@ final class SnippetRegistry implements SnippetRepository
     /**
      * @var list<UndefinedStep>
      */
-    private $undefinedSteps = [];
+    private array $undefinedSteps = [];
     /**
      * @var list<AggregateSnippet>
      */
-    private $snippets = [];
+    private array $snippets = [];
     private bool $snippetsGenerated = false;
 
     /**

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -146,7 +146,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
      *
      * @return list<ReflectionParameter>
      */
-    private function getCallParameters(DefinitionCall $definitionCall)
+    private function getCallParameters(DefinitionCall $definitionCall): array
     {
         return $definitionCall->getCallee()->getReflection()->getParameters();
     }

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -99,7 +99,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
     /**
      * Splits arguments into three separate arrays - named, numbered and typehinted.
      *
-     * @param ReflectionParameter[] $parameters
+     * @param list<ReflectionParameter> $parameters
      * @param mixed[]               $arguments
      *
      * @return array{array<string, mixed>, list<mixed>, list<mixed>}
@@ -140,7 +140,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
     /**
      * Check if a given value is typehinted in the argument list.
      *
-     * @param  ReflectionParameter[] $parameters
+     * @param  list<ReflectionParameter> $parameters
      */
     private function isParameterTypehintedInArgumentList(array $parameters, $value): bool
     {
@@ -174,8 +174,8 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
     /**
      * Captures argument values based on their respective names.
      *
-     * @param ReflectionParameter[] $parameters
-     * @param mixed[]               $namedArguments
+     * @param list<ReflectionParameter> $parameters
+     * @param mixed[]                   $namedArguments
      *
      * @return mixed[]
      */
@@ -209,8 +209,8 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      *
      * As such, this requires two passes of the $parameters array to ensure it is mapped as accurately as possible.
      *
-     * @param ReflectionParameter[] $parameters          Reflection Parameters (constructor argument requirements)
-     * @param mixed[]               $typehintedArguments Resolved arguments
+     * @param list<ReflectionParameter> $parameters          Reflection Parameters (constructor argument requirements)
+     * @param mixed[]                   $typehintedArguments Resolved arguments
      *
      * @return mixed[] Ordered list of arguments, index is the constructor argument position, value is what will be injected
      */
@@ -249,7 +249,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
     {
         return array_filter(
             $parameters,
-            fn ($parameter, $num): bool => !$this->isArgumentDefined($num)
+            fn ($parameter, int $num): bool => !$this->isArgumentDefined($num)
             && $this->getReflectionClassesFromParameter($parameter),
             ARRAY_FILTER_USE_BOTH
         );
@@ -305,10 +305,10 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      * This passes through to another loop of the candidates in @matchParameterToCandidateUsingPredicate,
      * because this method is "too complex" with two loops...
      *
-     * @param  ReflectionParameter[] $parameters Reflection Parameters (constructor argument requirements)
-     * @param  mixed[]               &$candidates Resolved arguments
-     * @param  mixed[]               &$arguments  Argument mapping
-     * @param  Closure               $predicate   Callable predicate to apply to each candidate
+     * @param  list<ReflectionParameter> $parameters Reflection Parameters (constructor argument requirements)
+     * @param  mixed[]                   &$candidates Resolved arguments
+     * @param  mixed[]                   &$arguments  Argument mapping
+     * @param  Closure                   $predicate   Callable predicate to apply to each candidate
      */
     private function applyPredicateToTypehintedArguments(
         array $parameters,
@@ -384,8 +384,8 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
     /**
      * Captures argument values for undefined arguments based on their respective numbers.
      *
-     * @param ReflectionParameter[] $parameters
-     * @param mixed[]               $numberedArguments
+     * @param list<ReflectionParameter> $parameters
+     * @param mixed[]                   $numberedArguments
      *
      * @return mixed[]
      */
@@ -411,7 +411,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
     /**
      * Captures argument values for undefined arguments based on parameters defaults.
      *
-     * @param ReflectionParameter[] $parameters
+     * @param list<ReflectionParameter> $parameters
      *
      * @return mixed[]
      */
@@ -469,10 +469,8 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
 
     /**
      * Marks an argument at provided position as defined.
-     *
-     * @param int $position
      */
-    private function markArgumentDefined($position): void
+    private function markArgumentDefined(int $position): void
     {
         $this->definedArguments[$position] = true;
     }

--- a/src/Behat/Testwork/Call/Exception/FatalThrowableError.php
+++ b/src/Behat/Testwork/Call/Exception/FatalThrowableError.php
@@ -47,7 +47,7 @@ class FatalThrowableError extends ErrorException
         $this->setTrace($e->getTrace());
     }
 
-    private function setTrace($trace): void
+    private function setTrace(array $trace): void
     {
         $traceReflector = new ReflectionProperty('Exception', 'trace');
         $traceReflector->setValue($this, $trace);

--- a/src/Behat/Testwork/Suite/SuiteRegistry.php
+++ b/src/Behat/Testwork/Suite/SuiteRegistry.php
@@ -68,7 +68,7 @@ final class SuiteRegistry implements SuiteRepository
      *
      * @return list<Suite>
      */
-    public function getSuites()
+    public function getSuites(): array
     {
         if ($this->suitesGenerated) {
             return $this->suites;


### PR DESCRIPTION
In #1808 I took Rector up to the maximum set of type coverage rules that we could apply in 3.x without BC breaks. However, this was before #1817 where I bumped Rector to the latest version.

Rector is now able to find a few more places where we can safely add strict types in 3.x - and this also highlighted some phpdoc types that I was able to tighten manually.

Continues #1744 