### PR TITLE
[4.0] refactor: Add strict types to interface method params & returns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "composer-runtime-api": "^2.2",
         "behat/gherkin": "^4.15.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
+        "ingenerator/risky-rector-rules": "^1.1",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "composer-runtime-api": "^2.2",
         "behat/gherkin": "^4.15.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
-        "ingenerator/risky-rector-rules": "dev-main@dev",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer-runtime-api": "^2.2",
         "behat/gherkin": "^4.15.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
-        "ingenerator/risky-rector-rules": "^1.1",
+        "ingenerator/risky-rector-rules": "dev-main@dev",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -26,6 +27,9 @@ return RectorConfig::configure()
     ])
     ->withConfiguredRule(AddParamTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
     ->withConfiguredRule(AddReturnTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
+    ->withRules([
+        AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
+    ])
     ->withImportNames(
         removeUnusedImports: true,
     )

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Ingenerator\RiskyRectorRules\AddStrictTypes\AddParamTypeBasedOnParentClassMethodRector;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddImplicitVoidInterfaceReturnTypeRector;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddMethodTypeConfig;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
@@ -31,6 +32,7 @@ return RectorConfig::configure()
     ->withRules([
         AddImplicitVoidInterfaceReturnTypeRector::class,
         AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
+        AddParamTypeBasedOnParentClassMethodRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddImplicitVoidInterfaceReturnTypeRector;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddMethodTypeConfig;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
@@ -9,7 +10,6 @@ use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -28,7 +28,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(AddParamTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
     ->withConfiguredRule(AddReturnTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
     ->withRules([
-        AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
+        AddImplicitVoidInterfaceReturnTypeRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddMethodTypeConfig;
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
@@ -13,14 +16,16 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-    ->withPreparedSets(codeQuality: true)
-    ->withPhpSets(php82: true)
+//    ->withPreparedSets(codeQuality: true)
+//    ->withPhpSets(php82: true)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,
         // DI setFactory does not support closures
         ArrayToFirstClassCallableRector::class => [__DIR__ . '/src/Behat/Testwork/Deprecation/ServiceContainer/DeprecationExtension.php'],
     ])
+    ->withConfiguredRule(AddParamTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
+    ->withConfiguredRule(AddReturnTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
     ->withImportNames(
         removeUnusedImports: true,
     )

--- a/rector.php
+++ b/rector.php
@@ -1,17 +1,10 @@
 <?php
 
 declare(strict_types=1);
-
-use Ingenerator\RiskyRectorRules\AddStrictTypes\AddParamTypeBasedOnParentClassMethodRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddImplicitVoidInterfaceReturnTypeRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddMethodTypeConfig;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -19,20 +12,13 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-//    ->withPreparedSets(codeQuality: true)
-//    ->withPhpSets(php82: true)
+    ->withPreparedSets(codeQuality: true)
+    ->withPhpSets(php82: true)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,
         // DI setFactory does not support closures
         ArrayToFirstClassCallableRector::class => [__DIR__ . '/src/Behat/Testwork/Deprecation/ServiceContainer/DeprecationExtension.php'],
-    ])
-    ->withConfiguredRule(AddParamTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
-    ->withConfiguredRule(AddReturnTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
-    ->withRules([
-        AddImplicitVoidInterfaceReturnTypeRector::class,
-        AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
-        AddParamTypeBasedOnParentClassMethodRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -29,6 +30,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(AddReturnTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
     ->withRules([
         AddImplicitVoidInterfaceReturnTypeRector::class,
+        AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/src/Behat/Behat/Context/Argument/ArgumentResolver.php
+++ b/src/Behat/Behat/Context/Argument/ArgumentResolver.php
@@ -31,5 +31,5 @@ interface ArgumentResolver
      *
      * @return mixed[]
      */
-    public function resolveArguments(ReflectionClass $classReflection, array $arguments);
+    public function resolveArguments(ReflectionClass $classReflection, array $arguments): array;
 }

--- a/src/Behat/Behat/Context/Argument/ArgumentResolverFactory.php
+++ b/src/Behat/Behat/Context/Argument/ArgumentResolverFactory.php
@@ -26,5 +26,5 @@ interface ArgumentResolverFactory
      *
      * @return ArgumentResolver[]
      */
-    public function createArgumentResolvers(Environment $environment);
+    public function createArgumentResolvers(Environment $environment): array;
 }

--- a/src/Behat/Behat/Context/Attribute/AttributeReader.php
+++ b/src/Behat/Behat/Context/Attribute/AttributeReader.php
@@ -27,5 +27,5 @@ interface AttributeReader
      *
      * @return list<RuntimeCallee>
      */
-    public function readCallees(string $contextClass, ReflectionMethod $method);
+    public function readCallees(string $contextClass, ReflectionMethod $method): array;
 }

--- a/src/Behat/Behat/Context/ContextClass/ClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/ClassGenerator.php
@@ -24,19 +24,13 @@ interface ClassGenerator
 {
     /**
      * Checks if generator supports provided context class.
-     *
-     * @param string $contextClass
-     *
-     * @return bool
      */
-    public function supportsSuiteAndClass(Suite $suite, $contextClass);
+    public function supportsSuiteAndClass(Suite $suite, string $contextClass): bool;
 
     /**
      * Generates context class code.
      *
-     * @param string $contextClass
-     *
      * @return string The context class source code
      */
-    public function generateClass(Suite $suite, $contextClass);
+    public function generateClass(Suite $suite, string $contextClass): string;
 }

--- a/src/Behat/Behat/Context/ContextClass/ClassResolver.php
+++ b/src/Behat/Behat/Context/ContextClass/ClassResolver.php
@@ -25,19 +25,11 @@ interface ClassResolver
 {
     /**
      * Checks if resolvers supports provided class.
-     *
-     * @param string $contextString
-     *
-     * @return bool
      */
-    public function supportsClass($contextString);
+    public function supportsClass(string $contextString): bool;
 
     /**
      * Resolves context class.
-     *
-     * @param string $contextClass
-     *
-     * @return string
      */
-    public function resolveClass($contextClass);
+    public function resolveClass(string $contextClass): string;
 }

--- a/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
@@ -45,12 +45,12 @@ class {className} implements Context
 
 PHP;
 
-    public function supportsSuiteAndClass(Suite $suite, $contextClass): bool
+    public function supportsSuiteAndClass(Suite $suite, string $contextClass): bool
     {
         return true;
     }
 
-    public function generateClass(Suite $suite, $contextClass): string
+    public function generateClass(Suite $suite, string $contextClass): string
     {
         $fqn = $contextClass;
 

--- a/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
@@ -55,9 +55,9 @@ PHP;
         $fqn = $contextClass;
 
         $namespace = '';
-        if (false !== $pos = strrpos((string) $fqn, '\\')) {
-            $namespace = 'namespace ' . substr((string) $fqn, 0, $pos) . ";\n\n";
-            $contextClass = substr((string) $fqn, $pos + 1);
+        if (false !== $pos = strrpos($fqn, '\\')) {
+            $namespace = 'namespace ' . substr($fqn, 0, $pos) . ";\n\n";
+            $contextClass = substr($fqn, $pos + 1);
         }
 
         return strtr(

--- a/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
+++ b/src/Behat/Behat/Context/ContextClass/SimpleClassGenerator.php
@@ -55,9 +55,9 @@ PHP;
         $fqn = $contextClass;
 
         $namespace = '';
-        if (false !== $pos = strrpos($fqn, '\\')) {
-            $namespace = 'namespace ' . substr($fqn, 0, $pos) . ";\n\n";
-            $contextClass = substr($fqn, $pos + 1);
+        if (false !== $pos = strrpos((string) $fqn, '\\')) {
+            $namespace = 'namespace ' . substr((string) $fqn, 0, $pos) . ";\n\n";
+            $contextClass = substr((string) $fqn, $pos + 1);
         }
 
         return strtr(

--- a/src/Behat/Behat/Context/Environment/ContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/ContextEnvironment.php
@@ -27,24 +27,20 @@ interface ContextEnvironment extends Environment
 {
     /**
      * Checks if environment has any contexts registered.
-     *
-     * @return bool
      */
-    public function hasContexts();
+    public function hasContexts(): bool;
 
     /**
      * Returns list of registered context classes.
      *
      * @return list<class-string<Context>>
      */
-    public function getContextClasses();
+    public function getContextClasses(): array;
 
     /**
      * Checks if environment contains context with the specified class name.
      *
      * @param class-string<Context> $class
-     *
-     * @return bool
      */
-    public function hasContextClass($class);
+    public function hasContextClass(string $class): bool;
 }

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -56,7 +56,7 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
         $this->classResolvers[] = $resolver;
     }
 
-    public function supportsSuite(Suite $suite)
+    public function supportsSuite(Suite $suite): bool
     {
         return $suite->hasSetting('contexts');
     }

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -72,7 +72,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
         return array_keys($this->contexts);
     }
 
-    public function hasContextClass($class): bool
+    public function hasContextClass(string $class): bool
     {
         return isset($this->contexts[$class]);
     }

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -115,7 +115,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
         return $this->serviceContainer;
     }
 
-    public function bindCallee(Callee $callee)
+    public function bindCallee(Callee $callee): callable
     {
         $callable = $callee->getCallable();
 

--- a/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
@@ -70,7 +70,7 @@ final class UninitializedContextEnvironment extends StaticEnvironment implements
         return array_keys($this->contextClasses);
     }
 
-    public function hasContextClass($class): bool
+    public function hasContextClass(string $class): bool
     {
         return isset($this->contextClasses[$class]);
     }

--- a/src/Behat/Behat/Context/Initializer/ContextInitializer.php
+++ b/src/Behat/Behat/Context/Initializer/ContextInitializer.php
@@ -24,5 +24,5 @@ interface ContextInitializer
     /**
      * Initializes provided context.
      */
-    public function initializeContext(Context $context);
+    public function initializeContext(Context $context): void;
 }

--- a/src/Behat/Behat/Context/Reader/AttributeContextReader.php
+++ b/src/Behat/Behat/Context/Reader/AttributeContextReader.php
@@ -40,7 +40,7 @@ final class AttributeContextReader implements ContextReader
     /**
      * @return list<RuntimeCallee>
      */
-    public function readContextCallees(ContextEnvironment $environment, $contextClass): array
+    public function readContextCallees(ContextEnvironment $environment, string $contextClass): array
     {
         $reflection = new ReflectionClass($contextClass);
 

--- a/src/Behat/Behat/Context/Reader/ContextReader.php
+++ b/src/Behat/Behat/Context/Reader/ContextReader.php
@@ -23,9 +23,7 @@ interface ContextReader
     /**
      * Reads callees from specific environment & context.
      *
-     * @param string             $contextClass
-     *
      * @return Callee[]
      */
-    public function readContextCallees(ContextEnvironment $environment, $contextClass);
+    public function readContextCallees(ContextEnvironment $environment, string $contextClass): array;
 }

--- a/src/Behat/Behat/Context/Reader/ContextReaderCachedPerContext.php
+++ b/src/Behat/Behat/Context/Reader/ContextReaderCachedPerContext.php
@@ -33,7 +33,7 @@ final class ContextReaderCachedPerContext implements ContextReader
     ) {
     }
 
-    public function readContextCallees(ContextEnvironment $environment, $contextClass)
+    public function readContextCallees(ContextEnvironment $environment, $contextClass): array
     {
         return $this->cachedCallees[$contextClass] ?? $this->cachedCallees[$contextClass] = $this->childReader->readContextCallees(
             $environment,

--- a/src/Behat/Behat/Context/Reader/ContextReaderCachedPerContext.php
+++ b/src/Behat/Behat/Context/Reader/ContextReaderCachedPerContext.php
@@ -33,7 +33,7 @@ final class ContextReaderCachedPerContext implements ContextReader
     ) {
     }
 
-    public function readContextCallees(ContextEnvironment $environment, $contextClass): array
+    public function readContextCallees(ContextEnvironment $environment, string $contextClass): array
     {
         return $this->cachedCallees[$contextClass] ?? $this->cachedCallees[$contextClass] = $this->childReader->readContextCallees(
             $environment,

--- a/src/Behat/Behat/Context/Reader/ContextReaderCachedPerSuite.php
+++ b/src/Behat/Behat/Context/Reader/ContextReaderCachedPerSuite.php
@@ -33,7 +33,7 @@ final class ContextReaderCachedPerSuite implements ContextReader
     ) {
     }
 
-    public function readContextCallees(ContextEnvironment $environment, $contextClass): array
+    public function readContextCallees(ContextEnvironment $environment, string $contextClass): array
     {
         $key = $this->generateCacheKey($environment, $contextClass);
 

--- a/src/Behat/Behat/Context/Reader/ContextReaderCachedPerSuite.php
+++ b/src/Behat/Behat/Context/Reader/ContextReaderCachedPerSuite.php
@@ -33,7 +33,7 @@ final class ContextReaderCachedPerSuite implements ContextReader
     ) {
     }
 
-    public function readContextCallees(ContextEnvironment $environment, $contextClass)
+    public function readContextCallees(ContextEnvironment $environment, $contextClass): array
     {
         $key = $this->generateCacheKey($environment, $contextClass);
 

--- a/src/Behat/Behat/Context/Reader/TranslatableContextReader.php
+++ b/src/Behat/Behat/Context/Reader/TranslatableContextReader.php
@@ -34,7 +34,7 @@ final class TranslatableContextReader implements ContextReader
     /**
      * @see TranslatableContext
      */
-    public function readContextCallees(ContextEnvironment $environment, $contextClass): array
+    public function readContextCallees(ContextEnvironment $environment, string $contextClass): array
     {
         $reflClass = new ReflectionClass($contextClass);
 

--- a/src/Behat/Behat/Context/Snippet/Generator/AggregatePatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/AggregatePatternIdentifier.php
@@ -26,7 +26,7 @@ final class AggregatePatternIdentifier implements PatternIdentifier
     ) {
     }
 
-    public function guessPatternType($contextClass): ?string
+    public function guessPatternType(string $contextClass): ?string
     {
         foreach ($this->identifiers as $identifier) {
             $pattern = $identifier->guessPatternType($contextClass);

--- a/src/Behat/Behat/Context/Snippet/Generator/AggregatePatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/AggregatePatternIdentifier.php
@@ -26,7 +26,7 @@ final class AggregatePatternIdentifier implements PatternIdentifier
     ) {
     }
 
-    public function guessPatternType($contextClass)
+    public function guessPatternType($contextClass): ?string
     {
         foreach ($this->identifiers as $identifier) {
             $pattern = $identifier->guessPatternType($contextClass);

--- a/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/FixedPatternIdentifier.php
@@ -22,7 +22,7 @@ final class FixedPatternIdentifier implements PatternIdentifier
     ) {
     }
 
-    public function guessPatternType($contextClass): ?string
+    public function guessPatternType(string $contextClass): ?string
     {
         return $this->patternType;
     }

--- a/src/Behat/Behat/Context/Snippet/Generator/PatternIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/PatternIdentifier.php
@@ -19,10 +19,6 @@ interface PatternIdentifier
 {
     /**
      * Attempts to guess the target pattern type from the context.
-     *
-     * @param string $contextClass
-     *
-     * @return string|null
      */
-    public function guessPatternType($contextClass);
+    public function guessPatternType(string $contextClass): ?string;
 }

--- a/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
+++ b/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
@@ -47,7 +47,7 @@ final class SuiteWithContextsSetup implements SuiteSetup
         $this->classGenerators[] = $generator;
     }
 
-    public function supportsSuite(Suite $suite)
+    public function supportsSuite(Suite $suite): bool
     {
         return $suite->hasSetting('contexts');
     }

--- a/src/Behat/Behat/Context/TranslatableContext.php
+++ b/src/Behat/Behat/Context/TranslatableContext.php
@@ -34,5 +34,5 @@ interface TranslatableContext extends Context
      *
      * @return string[]
      */
-    public static function getTranslationResources();
+    public static function getTranslationResources(): array;
 }

--- a/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
+++ b/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
@@ -42,17 +42,17 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Stringable, De
         parent::__construct($callable, $description);
     }
 
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    public function getPattern()
+    public function getPattern(): string
     {
         return $this->pattern;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getType() . ' ' . $this->getPattern();
     }

--- a/src/Behat/Behat/Definition/Definition.php
+++ b/src/Behat/Behat/Definition/Definition.php
@@ -23,22 +23,16 @@ interface Definition extends Callee
 {
     /**
      * Returns definition type (Given|When|Then).
-     *
-     * @return string
      */
-    public function getType();
+    public function getType(): string;
 
     /**
      * Returns step pattern exactly as it was defined.
-     *
-     * @return string
      */
-    public function getPattern();
+    public function getPattern(): string;
 
     /**
      * Represents definition as a string.
-     *
-     * @return string
      */
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
@@ -26,10 +26,8 @@ interface PatternPolicy
 {
     /**
      * Checks if policy supports pattern type.
-     *
-     * @param string|null $type
      */
-    public function supportsPatternType($type): bool;
+    public function supportsPatternType(?string $type): bool;
 
     /**
      * Generates pattern for step text.

--- a/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/PatternPolicy.php
@@ -28,35 +28,21 @@ interface PatternPolicy
      * Checks if policy supports pattern type.
      *
      * @param string|null $type
-     *
-     * @return bool
      */
-    public function supportsPatternType($type);
+    public function supportsPatternType($type): bool;
 
     /**
      * Generates pattern for step text.
-     *
-     * @param string $stepText
-     *
-     * @return Pattern
      */
-    public function generatePattern($stepText);
+    public function generatePattern(string $stepText): Pattern;
 
     /**
      * Checks if policy supports pattern.
-     *
-     * @param string $pattern
-     *
-     * @return bool
      */
-    public function supportsPattern($pattern);
+    public function supportsPattern(string $pattern): bool;
 
     /**
      * Transforms pattern string to regex.
-     *
-     * @param string $pattern
-     *
-     * @return string
      */
-    public function transformPatternToRegex($pattern);
+    public function transformPatternToRegex(string $pattern): string;
 }

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -39,12 +39,12 @@ final class RegexPatternPolicy implements PatternPolicy
     ) {
     }
 
-    public function supportsPatternType($type): bool
+    public function supportsPatternType(?string $type): bool
     {
         return 'regex' === $type;
     }
 
-    public function generatePattern($stepText): Pattern
+    public function generatePattern(string $stepText): Pattern
     {
         $methodName = $this->methodNameSuggester->suggest(
             StrictRegex::replace(array_keys(self::$replacePatterns), '', $this->escapeStepText($stepText)),
@@ -55,12 +55,12 @@ final class RegexPatternPolicy implements PatternPolicy
         return new Pattern($methodName, '/^' . $stepRegex . '$/', $placeholderCount);
     }
 
-    public function supportsPattern($pattern): bool
+    public function supportsPattern(string $pattern): bool
     {
         return (bool) preg_match('/^(?:\\{.*\\}|([~\\/#`]).*\1)[imsxADSUXJu]*$/s', (string) $pattern);
     }
 
-    public function transformPatternToRegex($pattern): string
+    public function transformPatternToRegex(string $pattern): string
     {
         if (false === @preg_match($pattern, 'anything')) {
             $error = error_get_last();

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -57,7 +57,7 @@ final class RegexPatternPolicy implements PatternPolicy
 
     public function supportsPattern(string $pattern): bool
     {
-        return (bool) preg_match('/^(?:\\{.*\\}|([~\\/#`]).*\1)[imsxADSUXJu]*$/s', (string) $pattern);
+        return (bool) preg_match('/^(?:\\{.*\\}|([~\\/#`]).*\1)[imsxADSUXJu]*$/s', $pattern);
     }
 
     public function transformPatternToRegex(string $pattern): string

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -57,10 +57,10 @@ final class RegexPatternPolicy implements PatternPolicy
 
     public function supportsPattern($pattern): bool
     {
-        return (bool) preg_match('/^(?:\\{.*\\}|([~\\/#`]).*\1)[imsxADSUXJu]*$/s', $pattern);
+        return (bool) preg_match('/^(?:\\{.*\\}|([~\\/#`]).*\1)[imsxADSUXJu]*$/s', (string) $pattern);
     }
 
-    public function transformPatternToRegex($pattern)
+    public function transformPatternToRegex($pattern): string
     {
         if (false === @preg_match($pattern, 'anything')) {
             $error = error_get_last();

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -48,12 +48,12 @@ final class TurnipPatternPolicy implements PatternPolicy
     ) {
     }
 
-    public function supportsPatternType($type): bool
+    public function supportsPatternType(?string $type): bool
     {
         return null === $type || 'turnip' === $type;
     }
 
-    public function generatePattern($stepText): Pattern
+    public function generatePattern(string $stepText): Pattern
     {
         $count = 0;
         $pattern = (string) $stepText;
@@ -72,12 +72,12 @@ final class TurnipPatternPolicy implements PatternPolicy
         return new Pattern($methodName, $pattern, $count);
     }
 
-    public function supportsPattern($pattern): bool
+    public function supportsPattern(string $pattern): bool
     {
         return true;
     }
 
-    public function transformPatternToRegex($pattern): string
+    public function transformPatternToRegex(string $pattern): string
     {
         if (!isset($this->regexCache[$pattern])) {
             $this->regexCache[$pattern] = $this->createTransformedRegex($pattern);

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
@@ -35,7 +35,7 @@ final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
         $this->searchCriterion = $criterion;
     }
 
-    public function printDefinitions(Suite $suite, $definitions): void
+    public function printDefinitions(Suite $suite, array $definitions): void
     {
         $this->printDefinitionsWithOptionalSuite($definitions, $suite);
     }

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
@@ -112,7 +112,8 @@ final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
     private function extractDescription(?Suite $suite, Definition $definition): array
     {
         $lines = [];
-        if ($description = $definition->getDescription()) {
+        $description = $definition->getDescription();
+        if ($description !== '' && $description !== '0') {
             $indent = $suite instanceof Suite ? '{space}<def_dimmed>|</def_dimmed> ' : '';
             foreach (explode("\n", $description) as $descriptionLine) {
                 $lines[] = strtr(

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
@@ -112,8 +112,7 @@ final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
     private function extractDescription(?Suite $suite, Definition $definition): array
     {
         $lines = [];
-        $description = $definition->getDescription();
-        if ($description !== '' && $description !== '0') {
+        if ($description = $definition->getDescription()) {
             $indent = $suite instanceof Suite ? '{space}<def_dimmed>|</def_dimmed> ' : '';
             foreach (explode("\n", $description) as $descriptionLine) {
                 $lines[] = strtr(

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionListPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionListPrinter.php
@@ -19,7 +19,7 @@ use Behat\Testwork\Suite\Suite;
  */
 final class ConsoleDefinitionListPrinter extends ConsoleDefinitionPrinter
 {
-    public function printDefinitions(Suite $suite, $definitions): void
+    public function printDefinitions(Suite $suite, array $definitions): void
     {
         $output = [];
 

--- a/src/Behat/Behat/Definition/Printer/DefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/DefinitionPrinter.php
@@ -27,5 +27,5 @@ interface DefinitionPrinter
      *
      * @param Definition[] $definitions
      */
-    public function printDefinitions(Suite $suite, array $definitions);
+    public function printDefinitions(Suite $suite, array $definitions): void;
 }

--- a/src/Behat/Behat/Definition/Printer/DefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/DefinitionPrinter.php
@@ -27,5 +27,5 @@ interface DefinitionPrinter
      *
      * @param Definition[] $definitions
      */
-    public function printDefinitions(Suite $suite, $definitions);
+    public function printDefinitions(Suite $suite, array $definitions);
 }

--- a/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
@@ -64,7 +64,7 @@ final class TranslatedDefinition implements Stringable, Definition
         return $this->language;
     }
 
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->definition->getDescription();
     }

--- a/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
@@ -11,6 +11,7 @@
 namespace Behat\Behat\Definition\Translator;
 
 use Behat\Behat\Definition\Definition;
+use ReflectionFunctionAbstract;
 use Stringable;
 
 /**
@@ -33,12 +34,12 @@ final class TranslatedDefinition implements Stringable, Definition
     ) {
     }
 
-    public function getType()
+    public function getType(): string
     {
         return $this->definition->getType();
     }
 
-    public function getPattern()
+    public function getPattern(): string
     {
         return $this->translatedPattern;
     }
@@ -63,22 +64,22 @@ final class TranslatedDefinition implements Stringable, Definition
         return $this->language;
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->definition->getDescription();
     }
 
-    public function getPath()
+    public function getPath(): string
     {
         return $this->definition->getPath();
     }
 
-    public function isAMethod()
+    public function isAMethod(): bool
     {
         return $this->definition->isAMethod();
     }
 
-    public function isAnInstanceMethod()
+    public function isAnInstanceMethod(): bool
     {
         return $this->definition->isAnInstanceMethod();
     }
@@ -88,7 +89,7 @@ final class TranslatedDefinition implements Stringable, Definition
         return $this->definition->getCallable();
     }
 
-    public function getReflection()
+    public function getReflection(): ReflectionFunctionAbstract
     {
         return $this->definition->getReflection();
     }

--- a/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
@@ -37,10 +37,8 @@ abstract class BackgroundTested extends LifecycleEvent implements ScenarioLikeTe
 
     /**
      * Returns node.
-     *
-     * @return NodeInterface
      */
-    final public function getNode()
+    final public function getNode(): NodeInterface
     {
         return $this->getBackground();
     }

--- a/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
@@ -37,10 +37,8 @@ abstract class FeatureTested extends LifecycleEvent implements GherkinNodeTested
 
     /**
      * Returns node.
-     *
-     * @return NodeInterface
      */
-    final public function getNode()
+    final public function getNode(): NodeInterface
     {
         return $this->getFeature();
     }

--- a/src/Behat/Behat/EventDispatcher/Event/GherkinNodeTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/GherkinNodeTested.php
@@ -23,8 +23,6 @@ interface GherkinNodeTested
 {
     /**
      * Returns node.
-     *
-     * @return NodeInterface
      */
-    public function getNode();
+    public function getNode(): NodeInterface;
 }

--- a/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
@@ -45,10 +45,8 @@ abstract class OutlineTested extends LifecycleEvent implements GherkinNodeTested
 
     /**
      * Returns node.
-     *
-     * @return NodeInterface
      */
-    final public function getNode()
+    final public function getNode(): NodeInterface
     {
         return $this->getOutline();
     }

--- a/src/Behat/Behat/EventDispatcher/Event/ScenarioLikeTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ScenarioLikeTested.php
@@ -22,15 +22,11 @@ interface ScenarioLikeTested extends GherkinNodeTested
 {
     /**
      * Returns feature node.
-     *
-     * @return FeatureNode
      */
-    public function getFeature();
+    public function getFeature(): FeatureNode;
 
     /**
      * Returns scenario node.
-     *
-     * @return ScenarioLikeInterface
      */
-    public function getScenario();
+    public function getScenario(): ScenarioLikeInterface;
 }

--- a/src/Behat/Behat/EventDispatcher/Event/ScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ScenarioTested.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\EventDispatcher\Event;
 
+use Behat\Gherkin\Node\NodeInterface;
 use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
 
 /**
@@ -26,7 +27,7 @@ abstract class ScenarioTested extends LifecycleEvent implements ScenarioLikeTest
     public const BEFORE_TEARDOWN = 'tester.scenario_tested.before_teardown';
     public const AFTER = 'tester.scenario_tested.after';
 
-    final public function getNode()
+    final public function getNode(): NodeInterface
     {
         return $this->getScenario();
     }

--- a/src/Behat/Behat/EventDispatcher/Event/StepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/StepTested.php
@@ -11,6 +11,7 @@
 namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\NodeInterface;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
 
@@ -42,7 +43,7 @@ abstract class StepTested extends LifecycleEvent implements GherkinNodeTested
      */
     abstract public function getStep();
 
-    final public function getNode()
+    final public function getNode(): NodeInterface
     {
         return $this->getStep();
     }

--- a/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -30,7 +30,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class EventDispatcherExtension extends BaseExtension
 {
-    public function load(ContainerBuilder $container, array $config)
+    public function load(ContainerBuilder $container, array $config): void
     {
         parent::load($container, $config);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingBackgroundTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingBackgroundTester.php
@@ -39,7 +39,7 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, bool $skip): Setup
     {
         $event = new BeforeBackgroundTested($env, $feature, $feature->getBackground());
 
@@ -54,12 +54,12 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
         return $setup;
     }
 
-    public function test(Environment $env, FeatureNode $feature, $skip): TestResult
+    public function test(Environment $env, FeatureNode $feature, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $feature, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, bool $skip, TestResult $result): Teardown
     {
         $event = new BeforeBackgroundTeardown($env, $feature, $feature->getBackground(), $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingBackgroundTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingBackgroundTester.php
@@ -19,6 +19,8 @@ use Behat\Behat\Tester\BackgroundTester;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -37,7 +39,7 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, $skip)
+    public function setUp(Environment $env, FeatureNode $feature, $skip): Setup
     {
         $event = new BeforeBackgroundTested($env, $feature, $feature->getBackground());
 
@@ -52,12 +54,12 @@ final class EventDispatchingBackgroundTester implements BackgroundTester
         return $setup;
     }
 
-    public function test(Environment $env, FeatureNode $feature, $skip)
+    public function test(Environment $env, FeatureNode $feature, $skip): TestResult
     {
         return $this->baseTester->test($env, $feature, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result)
+    public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result): Teardown
     {
         $event = new BeforeBackgroundTeardown($env, $feature, $feature->getBackground(), $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
@@ -42,7 +42,7 @@ final class EventDispatchingFeatureTester implements SpecificationTester
     ) {
     }
 
-    public function setUp(Environment $env, $spec, $skip): Setup
+    public function setUp(Environment $env, mixed $spec, bool $skip): Setup
     {
         $event = new BeforeFeatureTested($env, $spec);
 
@@ -57,12 +57,12 @@ final class EventDispatchingFeatureTester implements SpecificationTester
         return $setup;
     }
 
-    public function test(Environment $env, $spec, bool $skip): TestResult
+    public function test(Environment $env, mixed $spec, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $spec, $skip);
     }
 
-    public function tearDown(Environment $env, $spec, bool $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, mixed $spec, bool $skip, TestResult $result): Teardown
     {
         $event = new BeforeFeatureTeardown($env, $spec, $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
@@ -17,6 +17,8 @@ use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Behat\Testwork\Tester\SpecificationTester;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -40,7 +42,7 @@ final class EventDispatchingFeatureTester implements SpecificationTester
     ) {
     }
 
-    public function setUp(Environment $env, $spec, $skip)
+    public function setUp(Environment $env, $spec, $skip): Setup
     {
         $event = new BeforeFeatureTested($env, $spec);
 
@@ -55,12 +57,12 @@ final class EventDispatchingFeatureTester implements SpecificationTester
         return $setup;
     }
 
-    public function test(Environment $env, $spec, $skip)
+    public function test(Environment $env, $spec, $skip): TestResult
     {
         return $this->baseTester->test($env, $spec, $skip);
     }
 
-    public function tearDown(Environment $env, $spec, $skip, TestResult $result)
+    public function tearDown(Environment $env, $spec, $skip, TestResult $result): Teardown
     {
         $event = new BeforeFeatureTeardown($env, $spec, $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingFeatureTester.php
@@ -57,12 +57,12 @@ final class EventDispatchingFeatureTester implements SpecificationTester
         return $setup;
     }
 
-    public function test(Environment $env, $spec, $skip): TestResult
+    public function test(Environment $env, $spec, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $spec, $skip);
     }
 
-    public function tearDown(Environment $env, $spec, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, $spec, bool $skip, TestResult $result): Teardown
     {
         $event = new BeforeFeatureTeardown($env, $spec, $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php
@@ -19,6 +19,8 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -37,7 +39,7 @@ final class EventDispatchingOutlineTester implements OutlineTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip)
+    public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip): Setup
     {
         $event = new BeforeOutlineTested($env, $feature, $outline);
 
@@ -52,12 +54,12 @@ final class EventDispatchingOutlineTester implements OutlineTester
         return $setup;
     }
 
-    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip)
+    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip): TestResult
     {
         return $this->baseTester->test($env, $feature, $outline, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result)
+    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result): Teardown
     {
         $event = new BeforeOutlineTeardown($env, $feature, $outline, $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingOutlineTester.php
@@ -39,7 +39,7 @@ final class EventDispatchingOutlineTester implements OutlineTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip): Setup
     {
         $event = new BeforeOutlineTested($env, $feature, $outline);
 
@@ -54,12 +54,12 @@ final class EventDispatchingOutlineTester implements OutlineTester
         return $setup;
     }
 
-    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip): TestResult
+    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $feature, $outline, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip, TestResult $result): Teardown
     {
         $event = new BeforeOutlineTeardown($env, $feature, $outline, $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
@@ -19,6 +19,8 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioInterface as Scenario;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -46,7 +48,7 @@ final class EventDispatchingScenarioTester implements ScenarioTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): Setup
     {
         $event = new BeforeScenarioTested($env, $feature, $scenario);
 
@@ -61,12 +63,12 @@ final class EventDispatchingScenarioTester implements ScenarioTester
         return $setup;
     }
 
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): TestResult
     {
         return $this->baseTester->test($env, $feature, $scenario, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result): Teardown
     {
         $event = new BeforeScenarioTeardown($env, $feature, $scenario, $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
@@ -48,7 +48,7 @@ final class EventDispatchingScenarioTester implements ScenarioTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): Setup
     {
         $event = new BeforeScenarioTested($env, $feature, $scenario);
 
@@ -63,12 +63,12 @@ final class EventDispatchingScenarioTester implements ScenarioTester
         return $setup;
     }
 
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): TestResult
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $feature, $scenario, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip, TestResult $result): Teardown
     {
         $event = new BeforeScenarioTeardown($env, $feature, $scenario, $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingStepTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingStepTester.php
@@ -19,6 +19,8 @@ use Behat\Behat\Tester\StepTester;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -37,7 +39,7 @@ final class EventDispatchingStepTester implements StepTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip): Setup
     {
         $event = new BeforeStepTested($env, $feature, $step);
 
@@ -52,12 +54,12 @@ final class EventDispatchingStepTester implements StepTester
         return $setup;
     }
 
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip): StepResult
     {
         return $this->baseTester->test($env, $feature, $step, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result): Teardown
     {
         $event = new BeforeStepTeardown($env, $feature, $step, $result);
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingStepTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingStepTester.php
@@ -39,7 +39,7 @@ final class EventDispatchingStepTester implements StepTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, bool $skip): Setup
     {
         $event = new BeforeStepTested($env, $feature, $step);
 
@@ -54,12 +54,12 @@ final class EventDispatchingStepTester implements StepTester
         return $setup;
     }
 
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip): StepResult
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, bool $skip): StepResult
     {
         return $this->baseTester->test($env, $feature, $step, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, bool $skip, StepResult $result): Teardown
     {
         $event = new BeforeStepTeardown($env, $feature, $step, $result);
 

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -54,7 +54,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
         ];
     }
 
-    public function locateSpecifications(Suite $suite, $locator): SpecificationIterator
+    public function locateSpecifications(Suite $suite, ?string $locator): SpecificationIterator
     {
         if (!$suite->hasSetting('paths')) {
             return new NoSpecificationsIterator($suite);

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemRerunScenariosListLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemRerunScenariosListLocator.php
@@ -40,7 +40,7 @@ final class FilesystemRerunScenariosListLocator implements SpecificationLocator
         return [];
     }
 
-    public function locateSpecifications(Suite $suite, $locator): SpecificationIterator
+    public function locateSpecifications(Suite $suite, ?string $locator): SpecificationIterator
     {
         if (null === $locator || !is_file($locator) || 'rerun' !== pathinfo($locator, PATHINFO_EXTENSION)) {
             return new NoSpecificationsIterator($suite);

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemScenariosListLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemScenariosListLocator.php
@@ -40,7 +40,7 @@ final class FilesystemScenariosListLocator implements SpecificationLocator
         return ['a scenarios list file <comment>(*.scenarios)</comment>.'];
     }
 
-    public function locateSpecifications(Suite $suite, $locator): SpecificationIterator
+    public function locateSpecifications(Suite $suite, ?string $locator): SpecificationIterator
     {
         if (null === $locator || !is_file($locator) || 'scenarios' !== pathinfo($locator, PATHINFO_EXTENSION)) {
             return new NoSpecificationsIterator($suite);

--- a/src/Behat/Behat/HelperContainer/Argument/AutowiringResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/AutowiringResolver.php
@@ -34,7 +34,7 @@ final class AutowiringResolver implements ArgumentResolver
         $this->autowirer = new ArgumentAutowirer($container);
     }
 
-    public function resolveArguments(ReflectionClass $classReflection, array $arguments)
+    public function resolveArguments(ReflectionClass $classReflection, array $arguments): array
     {
         if ($constructor = $classReflection->getConstructor()) {
             return $this->autowirer->autowireArguments($constructor, $arguments);

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -36,12 +36,12 @@ final class BuiltInServiceContainer implements PsrContainerInterface
     ) {
     }
 
-    public function has($id): bool
+    public function has(string $id): bool
     {
         return array_key_exists($id, $this->schema);
     }
 
-    public function get($id)
+    public function get(string $id)
     {
         if (!$this->has($id)) {
             throw new ServiceNotFoundException(

--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -38,12 +38,10 @@ final class ServicesResolver implements CallFilter
     /**
      * Filters a call and returns a new one.
      *
-     * @return Call
-     *
      * @throws UnsupportedCallException
      * @throws ContainerExceptionInterface
      */
-    public function filterCall(Call $call)
+    public function filterCall(Call $call): Call
     {
         if ($container = $this->getContainer($call)) {
             $autowirer = new ArgumentAutowirer($container);

--- a/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
+++ b/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
@@ -25,7 +25,7 @@ interface ServiceContainerEnvironment extends Environment
     /**
      * Sets/unsets service container for the environment.
      */
-    public function setServiceContainer(?ContainerInterface $container = null);
+    public function setServiceContainer(?ContainerInterface $container = null): void;
 
     /**
      * Returns environment service container if set.

--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -41,7 +41,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
         $this->throwIfInstanceMethod($callable, 'Feature');
     }
 
-    public function filterMatches(HookScope $scope)
+    public function filterMatches(HookScope $scope): bool
     {
         if (!$scope instanceof FeatureScope) {
             return false;

--- a/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
@@ -25,7 +25,7 @@ use Behat\Testwork\Hook\Scope\HookScope;
  */
 abstract class RuntimeScenarioHook extends RuntimeFilterableHook
 {
-    public function filterMatches(HookScope $scope)
+    public function filterMatches(HookScope $scope): bool
     {
         if (!$scope instanceof ScenarioScope) {
             return false;

--- a/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Hook\Scope\HookScope;
  */
 abstract class RuntimeStepHook extends RuntimeFilterableHook
 {
-    public function filterMatches(HookScope $scope)
+    public function filterMatches(HookScope $scope): bool
     {
         if (!$scope instanceof StepScope) {
             return false;

--- a/src/Behat/Behat/Hook/Scope/AfterFeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterFeatureScope.php
@@ -45,10 +45,8 @@ final class AfterFeatureScope implements FeatureScope, AfterTestScope
 
     /**
      * Returns hook suite.
-     *
-     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }

--- a/src/Behat/Behat/Hook/Scope/AfterScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterScenarioScope.php
@@ -47,10 +47,8 @@ final class AfterScenarioScope implements ScenarioScope, AfterTestScope
 
     /**
      * Returns hook suite.
-     *
-     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }

--- a/src/Behat/Behat/Hook/Scope/AfterStepScope.php
+++ b/src/Behat/Behat/Hook/Scope/AfterStepScope.php
@@ -48,10 +48,8 @@ final class AfterStepScope implements StepScope, AfterTestScope
 
     /**
      * Returns hook suite.
-     *
-     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }

--- a/src/Behat/Behat/Hook/Scope/BeforeFeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeFeatureScope.php
@@ -42,10 +42,8 @@ final class BeforeFeatureScope implements FeatureScope
 
     /**
      * Returns hook suite.
-     *
-     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }

--- a/src/Behat/Behat/Hook/Scope/BeforeScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeScenarioScope.php
@@ -44,10 +44,8 @@ final class BeforeScenarioScope implements ScenarioScope
 
     /**
      * Returns hook suite.
-     *
-     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }

--- a/src/Behat/Behat/Hook/Scope/BeforeStepScope.php
+++ b/src/Behat/Behat/Hook/Scope/BeforeStepScope.php
@@ -44,10 +44,8 @@ final class BeforeStepScope implements StepScope
 
     /**
      * Returns hook suite.
-     *
-     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }

--- a/src/Behat/Behat/Hook/Scope/FeatureScope.php
+++ b/src/Behat/Behat/Hook/Scope/FeatureScope.php
@@ -27,8 +27,6 @@ interface FeatureScope extends HookScope
 
     /**
      * Returns scope feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature();
+    public function getFeature(): FeatureNode;
 }

--- a/src/Behat/Behat/Hook/Scope/ScenarioScope.php
+++ b/src/Behat/Behat/Hook/Scope/ScenarioScope.php
@@ -28,15 +28,11 @@ interface ScenarioScope extends HookScope
 
     /**
      * Returns scope feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature();
+    public function getFeature(): FeatureNode;
 
     /**
      * Returns scenario.
-     *
-     * @return ScenarioInterface
      */
-    public function getScenario();
+    public function getScenario(): ScenarioInterface;
 }

--- a/src/Behat/Behat/Hook/Scope/StepScope.php
+++ b/src/Behat/Behat/Hook/Scope/StepScope.php
@@ -28,15 +28,11 @@ interface StepScope extends HookScope
 
     /**
      * Returns scope feature.
-     *
-     * @return FeatureNode
      */
-    public function getFeature();
+    public function getFeature(): FeatureNode;
 
     /**
      * Returns scope step.
-     *
-     * @return StepNode
      */
-    public function getStep();
+    public function getStep(): StepNode;
 }

--- a/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Hook\HookDispatcher;
 use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
 use Behat\Testwork\Hook\Tester\Setup\HookedTeardown;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Behat\Testwork\Tester\SpecificationTester;
 
 /**
@@ -40,7 +42,7 @@ final class HookableFeatureTester implements SpecificationTester
     ) {
     }
 
-    public function setUp(Environment $env, $spec, $skip)
+    public function setUp(Environment $env, $spec, $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $spec, $skip);
 
@@ -54,12 +56,12 @@ final class HookableFeatureTester implements SpecificationTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, $spec, $skip)
+    public function test(Environment $env, $spec, $skip): TestResult
     {
         return $this->baseTester->test($env, $spec, $skip);
     }
 
-    public function tearDown(Environment $env, $spec, $skip, TestResult $result)
+    public function tearDown(Environment $env, $spec, $skip, TestResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $spec, $skip, $result);
 

--- a/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
@@ -42,7 +42,7 @@ final class HookableFeatureTester implements SpecificationTester
     ) {
     }
 
-    public function setUp(Environment $env, $spec, bool $skip): Setup
+    public function setUp(Environment $env, mixed $spec, bool $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $spec, $skip);
 
@@ -56,12 +56,12 @@ final class HookableFeatureTester implements SpecificationTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, $spec, bool $skip): TestResult
+    public function test(Environment $env, mixed $spec, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $spec, $skip);
     }
 
-    public function tearDown(Environment $env, $spec, bool $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, mixed $spec, bool $skip, TestResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $spec, $skip, $result);
 

--- a/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableFeatureTester.php
@@ -42,7 +42,7 @@ final class HookableFeatureTester implements SpecificationTester
     ) {
     }
 
-    public function setUp(Environment $env, $spec, $skip): Setup
+    public function setUp(Environment $env, $spec, bool $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $spec, $skip);
 
@@ -56,12 +56,12 @@ final class HookableFeatureTester implements SpecificationTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, $spec, $skip): TestResult
+    public function test(Environment $env, $spec, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $spec, $skip);
     }
 
-    public function tearDown(Environment $env, $spec, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, $spec, bool $skip, TestResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $spec, $skip, $result);
 

--- a/src/Behat/Behat/Hook/Tester/HookableScenarioTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableScenarioTester.php
@@ -39,7 +39,7 @@ final class HookableScenarioTester implements ScenarioTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $feature, $scenario, $skip);
 
@@ -53,12 +53,12 @@ final class HookableScenarioTester implements ScenarioTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): TestResult
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $feature, $scenario, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip, TestResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $feature, $scenario, $skip, $result);
 

--- a/src/Behat/Behat/Hook/Tester/HookableScenarioTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableScenarioTester.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Hook\HookDispatcher;
 use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
 use Behat\Testwork\Hook\Tester\Setup\HookedTeardown;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 
 /**
  * Scenario tester which dispatches hooks during its execution.
@@ -37,7 +39,7 @@ final class HookableScenarioTester implements ScenarioTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $feature, $scenario, $skip);
 
@@ -51,12 +53,12 @@ final class HookableScenarioTester implements ScenarioTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip)
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): TestResult
     {
         return $this->baseTester->test($env, $feature, $scenario, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result)
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $feature, $scenario, $skip, $result);
 

--- a/src/Behat/Behat/Hook/Tester/HookableStepTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableStepTester.php
@@ -39,7 +39,7 @@ final class HookableStepTester implements StepTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, bool $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $feature, $step, $skip);
 
@@ -53,12 +53,12 @@ final class HookableStepTester implements StepTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip): StepResult
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, bool $skip): StepResult
     {
         return $this->baseTester->test($env, $feature, $step, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, bool $skip, StepResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $feature, $step, $skip, $result);
 

--- a/src/Behat/Behat/Hook/Tester/HookableStepTester.php
+++ b/src/Behat/Behat/Hook/Tester/HookableStepTester.php
@@ -20,6 +20,8 @@ use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Hook\HookDispatcher;
 use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
 use Behat\Testwork\Hook\Tester\Setup\HookedTeardown;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 
 /**
  * Step tester which dispatches hooks during its execution.
@@ -37,7 +39,7 @@ final class HookableStepTester implements StepTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $feature, $step, $skip);
 
@@ -51,12 +53,12 @@ final class HookableStepTester implements StepTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip)
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip): StepResult
     {
         return $this->baseTester->test($env, $feature, $step, $skip);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result)
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $feature, $step, $skip, $result);
 

--- a/src/Behat/Behat/Output/Node/EventListener/AST/FeatureListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/FeatureListener.php
@@ -35,7 +35,7 @@ final class FeatureListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if (!$event instanceof FeatureTested) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/AST/OutlineListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/OutlineListener.php
@@ -44,7 +44,7 @@ final class OutlineListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->printAndCaptureOutlineHeaderOnBeforeEvent($formatter, $event);
         $this->printAndForgetOutlineFooterOnAfterEvent($formatter, $event);

--- a/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
@@ -61,7 +61,7 @@ final class OutlineTableListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if ($event instanceof StepTested) {
             $this->captureStepEvent($event);

--- a/src/Behat/Behat/Output/Node/EventListener/AST/ScenarioNodeListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/ScenarioNodeListener.php
@@ -34,7 +34,7 @@ final class ScenarioNodeListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if (!$event instanceof ScenarioLikeTested) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
@@ -37,7 +37,7 @@ final class StepListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->captureScenarioOnScenarioEvent($event);
         $this->forgetScenarioOnAfterEvent($eventName);

--- a/src/Behat/Behat/Output/Node/EventListener/AST/SuiteListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/SuiteListener.php
@@ -32,7 +32,7 @@ final class SuiteListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if ($event instanceof AfterSuiteSetup) {
             $this->setupPrinter->printSetup($formatter, $event->getSetup());

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
@@ -39,7 +39,7 @@ final class FireOnlySiblingsListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if ($this->beforeEventName === $eventName) {
             $this->inContext = true;

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
@@ -39,7 +39,7 @@ final class FireOnlySiblingsListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName)
+    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
     {
         if ($this->beforeEventName === $eventName) {
             $this->inContext = true;

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
@@ -43,7 +43,7 @@ final class FirstBackgroundFiresFirstListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->flushStatesIfBeginningOfTheFeature($eventName);
         $this->markFirstBackgroundPrintedAfterBackground($eventName);

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
@@ -43,7 +43,7 @@ final class FirstBackgroundFiresFirstListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName)
+    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
     {
         $this->flushStatesIfBeginningOfTheFeature($eventName);
         $this->markFirstBackgroundPrintedAfterBackground($eventName);

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
@@ -43,7 +43,7 @@ final class OnlyFirstBackgroundFiresListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName)
+    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
     {
         $this->flushStatesIfBeginningOfTheFeature($eventName);
         $this->markBeginningOrEndOfTheBackground($eventName);

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
@@ -43,7 +43,7 @@ final class OnlyFirstBackgroundFiresListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->flushStatesIfBeginningOfTheFeature($eventName);
         $this->markBeginningOrEndOfTheBackground($eventName);

--- a/src/Behat/Behat/Output/Node/EventListener/JSON/JSONDurationListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JSON/JSONDurationListener.php
@@ -36,7 +36,7 @@ final class JSONDurationListener extends DurationListener
 
     private ?float $exerciseResult = null;
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         parent::listenEvent($formatter, $event, $eventName);
         $this->captureExerciseStartEvent($event);

--- a/src/Behat/Behat/Output/Node/EventListener/JSON/JSONElementListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JSON/JSONElementListener.php
@@ -45,7 +45,7 @@ final class JSONElementListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->onExerciseStart($formatter, $event);
         $this->onSuiteStart($formatter, $event);

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitFeatureElementListener.php
@@ -61,7 +61,7 @@ final class JUnitFeatureElementListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->captureSuiteSetupEvent($formatter, $event);
         $this->printFeatureOnBeforeEvent($formatter, $event);

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
@@ -32,7 +32,7 @@ final class JUnitOutlineStoreListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->printHeaderOnBeforeSuiteTestedEvent($formatter, $event);
         $this->printFooterOnAfterSuiteTestedEvent($formatter, $event);

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/DurationListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/DurationListener.php
@@ -43,7 +43,7 @@ class DurationListener implements EventListener
      */
     private array $featureResultStore = [];
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->captureBeforeScenarioEvent($event);
         $this->captureBeforeFeatureTested($event);

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
@@ -41,7 +41,7 @@ final class HookStatsListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->captureHookStatsOnEvent($event);
     }

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/ScenarioStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/ScenarioStatsListener.php
@@ -33,7 +33,7 @@ final class ScenarioStatsListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->captureCurrentFeaturePathOnBeforeFeatureEvent($event);
         $this->forgetCurrentFeaturePathOnAfterFeatureEvent($event);

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StatisticsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StatisticsListener.php
@@ -33,7 +33,7 @@ final class StatisticsListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->startTimerOnBeforeExercise($eventName);
         $this->printStatisticsOnAfterExerciseEvent($formatter, $eventName);

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
@@ -47,7 +47,7 @@ final class StepStatsListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         $this->captureCurrentFeaturePathOnBeforeFeatureEvent($event);
         $this->forgetCurrentFeaturePathOnAfterFeatureEvent($eventName);

--- a/src/Behat/Behat/Output/Node/Printer/ExamplePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ExamplePrinter.php
@@ -27,10 +27,10 @@ interface ExamplePrinter
     /**
      * Prints example header using provided printer.
      */
-    public function printHeader(Formatter $formatter, FeatureNode $feature, ExampleNode $example);
+    public function printHeader(Formatter $formatter, FeatureNode $feature, ExampleNode $example): void;
 
     /**
      * Prints example footer using provided printer.
      */
-    public function printFooter(Formatter $formatter, TestResult $result);
+    public function printFooter(Formatter $formatter, TestResult $result): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/ExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ExampleRowPrinter.php
@@ -29,5 +29,5 @@ interface ExampleRowPrinter
      *
      * @param AfterStepTested[] $events
      */
-    public function printExampleRow(Formatter $formatter, OutlineNode $outline, ExampleNode $example, array $events);
+    public function printExampleRow(Formatter $formatter, OutlineNode $outline, ExampleNode $example, array $events): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/FeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/FeaturePrinter.php
@@ -26,10 +26,10 @@ interface FeaturePrinter
     /**
      * Prints feature header using provided formatter.
      */
-    public function printHeader(Formatter $formatter, FeatureNode $feature);
+    public function printHeader(Formatter $formatter, FeatureNode $feature): void;
 
     /**
      * Prints feature footer using provided printer.
      */
-    public function printFooter(Formatter $formatter, TestResult $result);
+    public function printFooter(Formatter $formatter, TestResult $result): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
@@ -23,14 +23,14 @@ final class JUnitSetupPrinter implements SetupPrinter
     ) {
     }
 
-    public function printSetup(Formatter $formatter, Setup $setup)
+    public function printSetup(Formatter $formatter, Setup $setup): void
     {
         if (!$setup->isSuccessful() && $setup instanceof HookedSetup) {
             $this->handleHookCalls($formatter, $setup->getHookCallResults(), 'setup');
         }
     }
 
-    public function printTeardown(Formatter $formatter, Teardown $teardown)
+    public function printTeardown(Formatter $formatter, Teardown $teardown): void
     {
         if (!$teardown->isSuccessful() && $teardown instanceof HookedTeardown) {
             $this->handleHookCalls($formatter, $teardown->getHookCallResults(), 'teardown');

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
@@ -36,7 +36,7 @@ final class JUnitStepPrinter implements StepPrinter
     /**
      * Prints step using provided printer.
      */
-    public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result)
+    public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result): void
     {
         /** @var JUnitOutputPrinter $outputPrinter */
         $outputPrinter = $formatter->getOutputPrinter();

--- a/src/Behat/Behat/Output/Node/Printer/OutlinePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/OutlinePrinter.php
@@ -27,10 +27,10 @@ interface OutlinePrinter
     /**
      * Prints outline header using provided printer.
      */
-    public function printHeader(Formatter $formatter, FeatureNode $feature, OutlineNode $outline);
+    public function printHeader(Formatter $formatter, FeatureNode $feature, OutlineNode $outline): void;
 
     /**
      * Prints outline footer using provided printer.
      */
-    public function printFooter(Formatter $formatter, TestResult $result);
+    public function printFooter(Formatter $formatter, TestResult $result): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/OutlineTablePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/OutlineTablePrinter.php
@@ -30,10 +30,10 @@ interface OutlineTablePrinter
      *
      * @param StepResult[] $results
      */
-    public function printHeader(Formatter $formatter, FeatureNode $feature, OutlineNode $outline, array $results);
+    public function printHeader(Formatter $formatter, FeatureNode $feature, OutlineNode $outline, array $results): void;
 
     /**
      * Prints outline footer using provided printer.
      */
-    public function printFooter(Formatter $formatter, TestResult $result);
+    public function printFooter(Formatter $formatter, TestResult $result): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/ScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ScenarioPrinter.php
@@ -27,10 +27,10 @@ interface ScenarioPrinter
     /**
      * Prints scenario header using provided printer.
      */
-    public function printHeader(Formatter $formatter, FeatureNode $feature, Scenario $scenario);
+    public function printHeader(Formatter $formatter, FeatureNode $feature, Scenario $scenario): void;
 
     /**
      * Prints scenario footer using provided printer.
      */
-    public function printFooter(Formatter $formatter, TestResult $result);
+    public function printFooter(Formatter $formatter, TestResult $result): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/SetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/SetupPrinter.php
@@ -26,10 +26,10 @@ interface SetupPrinter
     /**
      * Prints setup state.
      */
-    public function printSetup(Formatter $formatter, Setup $setup);
+    public function printSetup(Formatter $formatter, Setup $setup): void;
 
     /**
      * Prints teardown state.
      */
-    public function printTeardown(Formatter $formatter, Teardown $teardown);
+    public function printTeardown(Formatter $formatter, Teardown $teardown): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/StatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/StatisticsPrinter.php
@@ -25,5 +25,5 @@ interface StatisticsPrinter
     /**
      * Prints test suite statistics after run.
      */
-    public function printStatistics(Formatter $formatter, Statistics $statistics);
+    public function printStatistics(Formatter $formatter, Statistics $statistics): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/StepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/StepPrinter.php
@@ -27,5 +27,5 @@ interface StepPrinter
     /**
      * Prints step using provided printer.
      */
-    public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result);
+    public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result): void;
 }

--- a/src/Behat/Behat/Output/Node/Printer/SuitePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/SuitePrinter.php
@@ -25,10 +25,10 @@ interface SuitePrinter
     /**
      * Prints suite header using provided formatter.
      */
-    public function printHeader(Formatter $formatter, Suite $suite);
+    public function printHeader(Formatter $formatter, Suite $suite): void;
 
     /**
      * Prints suite footer using provided printer.
      */
-    public function printFooter(Formatter $formatter, Suite $suite);
+    public function printFooter(Formatter $formatter, Suite $suite): void;
 }

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -32,7 +32,7 @@ final class ConsoleFormatter extends BaseOutputFormatter
      *
      * @return string The styled message
      */
-    public function format($message): string
+    public function format(?string $message): string
     {
         try {
             $formattedMessage = StrictRegex::replaceCallback(self::CUSTOM_PATTERN, $this->replaceStyle(...), $message);

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -88,7 +88,7 @@ final class PrettyFormatterFactory implements FormatterFactory
         $this->processor = $processor ?: new ServiceProcessor();
     }
 
-    public function buildFormatter(ContainerBuilder $container)
+    public function buildFormatter(ContainerBuilder $container): void
     {
         $this->loadRootNodeListener($container);
 
@@ -102,7 +102,7 @@ final class PrettyFormatterFactory implements FormatterFactory
         $this->loadFormatter($container);
     }
 
-    public function processFormatter(ContainerBuilder $container)
+    public function processFormatter(ContainerBuilder $container): void
     {
         $this->processListenerWrappers($container);
     }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -64,7 +64,7 @@ final class ProgressFormatterFactory implements FormatterFactory
         $this->processor = $processor ?: new ServiceProcessor();
     }
 
-    public function buildFormatter(ContainerBuilder $container)
+    public function buildFormatter(ContainerBuilder $container): void
     {
         $this->loadRootNodeListener($container);
         $this->loadCorePrinters($container);
@@ -72,7 +72,7 @@ final class ProgressFormatterFactory implements FormatterFactory
         $this->loadFormatter($container);
     }
 
-    public function processFormatter(ContainerBuilder $container)
+    public function processFormatter(ContainerBuilder $container): void
     {
         $this->processListenerWrappers($container);
     }

--- a/src/Behat/Behat/Output/Statistics/Statistics.php
+++ b/src/Behat/Behat/Output/Statistics/Statistics.php
@@ -36,17 +36,13 @@ interface Statistics
 
     /**
      * Returns timer object.
-     *
-     * @return Timer
      */
-    public function getTimer();
+    public function getTimer(): Timer;
 
     /**
      * Returns memory usage object.
-     *
-     * @return Memory
      */
-    public function getMemory();
+    public function getMemory(): Memory;
 
     /**
      * Registers scenario stat.
@@ -68,47 +64,47 @@ interface Statistics
      *
      * @return array<TestResult::*, int>
      */
-    public function getScenarioStatCounts();
+    public function getScenarioStatCounts(): array;
 
     /**
      * Returns skipped scenario stats.
      *
      * @return ScenarioStat[]
      */
-    public function getSkippedScenarios();
+    public function getSkippedScenarios(): array;
 
     /**
      * Returns failed scenario stats.
      *
      * @return ScenarioStat[]
      */
-    public function getFailedScenarios();
+    public function getFailedScenarios(): array;
 
     /**
      * Returns counters for different step result codes.
      *
      * @return array<StepResult::*, int>
      */
-    public function getStepStatCounts();
+    public function getStepStatCounts(): array;
 
     /**
      * Returns failed step stats.
      *
      * @return StepStatV2[]
      */
-    public function getFailedSteps();
+    public function getFailedSteps(): array;
 
     /**
      * Returns pending step stats.
      *
      * @return StepStatV2[]
      */
-    public function getPendingSteps();
+    public function getPendingSteps(): array;
 
     /**
      * Returns failed hook stats.
      *
      * @return HookStat[]
      */
-    public function getFailedHookStats();
+    public function getFailedHookStats(): array;
 }

--- a/src/Behat/Behat/Output/Statistics/Statistics.php
+++ b/src/Behat/Behat/Output/Statistics/Statistics.php
@@ -27,12 +27,12 @@ interface Statistics
     /**
      * Starts timer.
      */
-    public function startTimer();
+    public function startTimer(): void;
 
     /**
      * Stops timer.
      */
-    public function stopTimer();
+    public function stopTimer(): void;
 
     /**
      * Returns timer object.
@@ -47,17 +47,17 @@ interface Statistics
     /**
      * Registers scenario stat.
      */
-    public function registerScenarioStat(ScenarioStat $stat);
+    public function registerScenarioStat(ScenarioStat $stat): void;
 
     /**
      * Registers step stat.
      */
-    public function registerStepStat(StepStatV2 $stat);
+    public function registerStepStat(StepStatV2 $stat): void;
 
     /**
      * Registers hook stat.
      */
-    public function registerHookStat(HookStat $stat);
+    public function registerHookStat(HookStat $stat): void;
 
     /**
      * Returns counters for different scenario result codes.

--- a/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
+++ b/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
@@ -24,10 +24,8 @@ interface SnippetAppender
 {
     /**
      * Checks if appender supports snippet.
-     *
-     * @return bool
      */
-    public function supportsSnippet(AggregateSnippet $snippet);
+    public function supportsSnippet(AggregateSnippet $snippet): bool;
 
     /**
      * Appends snippet to the source.

--- a/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
+++ b/src/Behat/Behat/Snippet/Appender/SnippetAppender.php
@@ -30,5 +30,5 @@ interface SnippetAppender
     /**
      * Appends snippet to the source.
      */
-    public function appendSnippet(AggregateSnippet $snippet);
+    public function appendSnippet(AggregateSnippet $snippet): void;
 }

--- a/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
+++ b/src/Behat/Behat/Snippet/Generator/SnippetGenerator.php
@@ -27,17 +27,13 @@ interface SnippetGenerator
 {
     /**
      * Checks if generator supports search query.
-     *
-     * @return bool
      */
-    public function supportsEnvironmentAndStep(Environment $environment, StepNode $step);
+    public function supportsEnvironmentAndStep(Environment $environment, StepNode $step): bool;
 
     /**
      * Generates snippet from search.
      *
-     * @return Snippet
-     *
      * @throws CannotGenerateStepPatternException if the step text cannot be automatically converted to a pattern
      */
-    public function generateSnippet(Environment $environment, StepNode $step);
+    public function generateSnippet(Environment $environment, StepNode $step): Snippet;
 }

--- a/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
@@ -43,10 +43,9 @@ final class ConsoleSnippetPrinter implements SnippetPrinter
     /**
      * Prints snippets of specific target.
      *
-     * @param string             $targetName
      * @param AggregateSnippet[] $snippets
      */
-    public function printSnippets($targetName, array $snippets): void
+    public function printSnippets(string $targetName, array $snippets): void
     {
         $message = $this->translator->trans('snippet_proposal_title', ['%count%' => $targetName], 'output');
 
@@ -67,10 +66,9 @@ final class ConsoleSnippetPrinter implements SnippetPrinter
     /**
      * Prints undefined steps of specific suite.
      *
-     * @param string     $suiteName
      * @param StepNode[] $steps
      */
-    public function printUndefinedSteps($suiteName, array $steps): void
+    public function printUndefinedSteps(string $suiteName, array $steps): void
     {
         $message = $this->translator->trans('snippet_missing_title', ['%count%' => $suiteName], 'output');
 

--- a/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
@@ -46,7 +46,7 @@ final class ConsoleSnippetPrinter implements SnippetPrinter
      * @param string             $targetName
      * @param AggregateSnippet[] $snippets
      */
-    public function printSnippets($targetName, array $snippets)
+    public function printSnippets($targetName, array $snippets): void
     {
         $message = $this->translator->trans('snippet_proposal_title', ['%count%' => $targetName], 'output');
 
@@ -70,7 +70,7 @@ final class ConsoleSnippetPrinter implements SnippetPrinter
      * @param string     $suiteName
      * @param StepNode[] $steps
      */
-    public function printUndefinedSteps($suiteName, array $steps)
+    public function printUndefinedSteps($suiteName, array $steps): void
     {
         $message = $this->translator->trans('snippet_missing_title', ['%count%' => $suiteName], 'output');
 

--- a/src/Behat/Behat/Snippet/Printer/SnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/SnippetPrinter.php
@@ -25,12 +25,12 @@ interface SnippetPrinter
      *
      * @param AggregateSnippet[] $snippets
      */
-    public function printSnippets(string $targetName, array $snippets);
+    public function printSnippets(string $targetName, array $snippets): void;
 
     /**
      * Prints undefined steps of the specific suite.
      *
      * @param StepNode[] $steps
      */
-    public function printUndefinedSteps(string $suiteName, array $steps);
+    public function printUndefinedSteps(string $suiteName, array $steps): void;
 }

--- a/src/Behat/Behat/Snippet/Printer/SnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/SnippetPrinter.php
@@ -23,16 +23,14 @@ interface SnippetPrinter
     /**
      * Prints snippets of the specific target.
      *
-     * @param string             $targetName
      * @param AggregateSnippet[] $snippets
      */
-    public function printSnippets($targetName, array $snippets);
+    public function printSnippets(string $targetName, array $snippets);
 
     /**
      * Prints undefined steps of the specific suite.
      *
-     * @param string     $suiteName
      * @param StepNode[] $steps
      */
-    public function printUndefinedSteps($suiteName, array $steps);
+    public function printUndefinedSteps(string $suiteName, array $steps);
 }

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -59,15 +59,15 @@ final class SnippetExtension implements Extension
         return 'snippets';
     }
 
-    public function initialize(ExtensionManager $extensionManager)
+    public function initialize(ExtensionManager $extensionManager): void
     {
     }
 
-    public function configure(ArrayNodeDefinition $builder)
+    public function configure(ArrayNodeDefinition $builder): void
     {
     }
 
-    public function load(ContainerBuilder $container, array $config)
+    public function load(ContainerBuilder $container, array $config): void
     {
         $this->loadController($container);
         $this->loadRegistry($container);

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -54,7 +54,7 @@ final class SnippetExtension implements Extension
         $this->processor = $processor ?: new ServiceProcessor();
     }
 
-    public function getConfigKey()
+    public function getConfigKey(): string
     {
         return 'snippets';
     }

--- a/src/Behat/Behat/Snippet/Snippet.php
+++ b/src/Behat/Behat/Snippet/Snippet.php
@@ -21,36 +21,26 @@ interface Snippet
 {
     /**
      * Returns snippet type.
-     *
-     * @return string
      */
-    public function getType();
+    public function getType(): string;
 
     /**
      * Returns snippet unique ID (step type independent).
-     *
-     * @return string
      */
-    public function getHash();
+    public function getHash(): string;
 
     /**
      * Returns definition snippet text.
-     *
-     * @return string
      */
-    public function getSnippet();
+    public function getSnippet(): string;
 
     /**
      * Returns step which asked for this snippet.
-     *
-     * @return StepNode
      */
-    public function getStep();
+    public function getStep(): StepNode;
 
     /**
      * Returns snippet target.
-     *
-     * @return string
      */
-    public function getTarget();
+    public function getTarget(): string;
 }

--- a/src/Behat/Behat/Snippet/SnippetRepository.php
+++ b/src/Behat/Behat/Snippet/SnippetRepository.php
@@ -22,12 +22,12 @@ interface SnippetRepository
      *
      * @return AggregateSnippet[]
      */
-    public function getSnippets();
+    public function getSnippets(): array;
 
     /**
      * Returns steps for which there was no snippet generated.
      *
      * @return UndefinedStep[]
      */
-    public function getUndefinedSteps();
+    public function getUndefinedSteps(): array;
 }

--- a/src/Behat/Behat/Tester/BackgroundTester.php
+++ b/src/Behat/Behat/Tester/BackgroundTester.php
@@ -25,28 +25,16 @@ interface BackgroundTester
 {
     /**
      * Sets up background for a test.
-     *
-     * @param bool     $skip
-     *
-     * @return Setup
      */
-    public function setUp(Environment $env, FeatureNode $feature, $skip);
+    public function setUp(Environment $env, FeatureNode $feature, bool $skip): Setup;
 
     /**
      * Tests background.
-     *
-     * @param bool     $skip
-     *
-     * @return TestResult
      */
-    public function test(Environment $env, FeatureNode $feature, $skip);
+    public function test(Environment $env, FeatureNode $feature, bool $skip): TestResult;
 
     /**
      * Tears down background after a test.
-     *
-     * @param bool     $skip
-     *
-     * @return Teardown
      */
-    public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result);
+    public function tearDown(Environment $env, FeatureNode $feature, bool $skip, TestResult $result): Teardown;
 }

--- a/src/Behat/Behat/Tester/Exception/Stringer/PendingExceptionStringer.php
+++ b/src/Behat/Behat/Tester/Exception/Stringer/PendingExceptionStringer.php
@@ -21,12 +21,12 @@ use Exception;
  */
 final class PendingExceptionStringer implements ExceptionStringer
 {
-    public function supportsException(Exception $exception)
+    public function supportsException(Exception $exception): bool
     {
         return $exception instanceof PendingException;
     }
 
-    public function stringException(Exception $exception, $verbosity)
+    public function stringException(Exception $exception, $verbosity): string
     {
         return trim($exception->getMessage());
     }

--- a/src/Behat/Behat/Tester/Exception/Stringer/PendingExceptionStringer.php
+++ b/src/Behat/Behat/Tester/Exception/Stringer/PendingExceptionStringer.php
@@ -26,7 +26,7 @@ final class PendingExceptionStringer implements ExceptionStringer
         return $exception instanceof PendingException;
     }
 
-    public function stringException(Exception $exception, $verbosity): string
+    public function stringException(Exception $exception, int $verbosity): string
     {
         return trim($exception->getMessage());
     }

--- a/src/Behat/Behat/Tester/OutlineTester.php
+++ b/src/Behat/Behat/Tester/OutlineTester.php
@@ -26,28 +26,16 @@ interface OutlineTester
 {
     /**
      * Sets up background for a test.
-     *
-     * @param bool     $skip
-     *
-     * @return Setup
      */
-    public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip);
+    public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip): Setup;
 
     /**
      * Tests outline.
-     *
-     * @param bool     $skip
-     *
-     * @return TestResult
      */
-    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip);
+    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip): TestResult;
 
     /**
      * Sets up background for a test.
-     *
-     * @param bool     $skip
-     *
-     * @return Teardown
      */
-    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result);
+    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip, TestResult $result): Teardown;
 }

--- a/src/Behat/Behat/Tester/Runtime/IsolatingScenarioTester.php
+++ b/src/Behat/Behat/Tester/Runtime/IsolatingScenarioTester.php
@@ -39,12 +39,12 @@ final class IsolatingScenarioTester implements ScenarioTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): TestResult
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): TestResult
     {
         $isolatedEnvironment = $this->envManager->isolateEnvironment($env, $scenario);
 
@@ -58,7 +58,7 @@ final class IsolatingScenarioTester implements ScenarioTester
         return new TestWithSetupResult($setup, $integerResult, $teardown);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip, TestResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeBackgroundTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeBackgroundTester.php
@@ -38,12 +38,12 @@ final class RuntimeBackgroundTester implements BackgroundTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(Environment $env, FeatureNode $feature, $skip): TestResult
+    public function test(Environment $env, FeatureNode $feature, bool $skip): TestResult
     {
         $background = $feature->getBackground();
 
@@ -63,7 +63,7 @@ final class RuntimeBackgroundTester implements BackgroundTester
         return new TestResults($results);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, bool $skip, TestResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
@@ -40,12 +40,12 @@ final class RuntimeFeatureTester implements SpecificationTester
     ) {
     }
 
-    public function setUp(Environment $env, $spec, $skip): Setup
+    public function setUp(Environment $env, $spec, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(Environment $env, $spec, $skip = false): TestResult
+    public function test(Environment $env, $spec, bool $skip = false): TestResult
     {
         $results = [];
         foreach ($spec->getScenarios() as $scenario) {
@@ -63,7 +63,7 @@ final class RuntimeFeatureTester implements SpecificationTester
         return new TestResults($results);
     }
 
-    public function tearDown(Environment $env, $spec, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, $spec, bool $skip, TestResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeFeatureTester.php
@@ -40,12 +40,12 @@ final class RuntimeFeatureTester implements SpecificationTester
     ) {
     }
 
-    public function setUp(Environment $env, $spec, bool $skip): Setup
+    public function setUp(Environment $env, mixed $spec, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(Environment $env, $spec, bool $skip = false): TestResult
+    public function test(Environment $env, mixed $spec, bool $skip = false): TestResult
     {
         $results = [];
         foreach ($spec->getScenarios() as $scenario) {
@@ -63,7 +63,7 @@ final class RuntimeFeatureTester implements SpecificationTester
         return new TestResults($results);
     }
 
-    public function tearDown(Environment $env, $spec, bool $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, mixed $spec, bool $skip, TestResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeOutlineTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeOutlineTester.php
@@ -39,12 +39,12 @@ final class RuntimeOutlineTester implements OutlineTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip = false): TestResult
+    public function test(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip = false): TestResult
     {
         $results = [];
         foreach ($outline->getExamples() as $example) {
@@ -60,7 +60,7 @@ final class RuntimeOutlineTester implements OutlineTester
         return new TestResults($results);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, OutlineNode $outline, bool $skip, TestResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
@@ -41,12 +41,12 @@ final class RuntimeScenarioTester implements ScenarioTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip = false): TestResult
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip = false): TestResult
     {
         $results = [];
 
@@ -62,7 +62,7 @@ final class RuntimeScenarioTester implements ScenarioTester
         return new TestResults($results);
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip, TestResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -47,12 +47,12 @@ final class RuntimeStepTester implements StepTester
     ) {
     }
 
-    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip): Setup
+    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip = false): StepResult
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, bool $skip = false): StepResult
     {
         try {
             $search = $this->searchDefinition($env, $feature, $step);
@@ -64,7 +64,7 @@ final class RuntimeStepTester implements StepTester
         return $result;
     }
 
-    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result): Teardown
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, bool $skip, StepResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Behat/Tester/ScenarioTester.php
+++ b/src/Behat/Behat/Tester/ScenarioTester.php
@@ -26,28 +26,16 @@ interface ScenarioTester
 {
     /**
      * Sets up example for a test.
-     *
-     * @param bool     $skip
-     *
-     * @return Setup
      */
-    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip);
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): Setup;
 
     /**
      * Tests example.
-     *
-     * @param bool     $skip
-     *
-     * @return TestResult
      */
-    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip);
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip): TestResult;
 
     /**
      * Tears down example after a test.
-     *
-     * @param bool     $skip
-     *
-     * @return Teardown
      */
-    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result);
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, bool $skip, TestResult $result): Teardown;
 }

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -69,7 +69,7 @@ final class TesterExtension extends BaseExtension
         parent::__construct($this->processor);
     }
 
-    public function configure(ArrayNodeDefinition $builder)
+    public function configure(ArrayNodeDefinition $builder): void
     {
         parent::configure($builder);
 
@@ -85,7 +85,7 @@ final class TesterExtension extends BaseExtension
         ;
     }
 
-    public function load(ContainerBuilder $container, array $config)
+    public function load(ContainerBuilder $container, array $config): void
     {
         parent::load($container, $config);
 

--- a/src/Behat/Behat/Tester/StepTester.php
+++ b/src/Behat/Behat/Tester/StepTester.php
@@ -26,28 +26,16 @@ interface StepTester
 {
     /**
      * Sets up step for a test.
-     *
-     * @param bool     $skip
-     *
-     * @return Setup
      */
-    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip);
+    public function setUp(Environment $env, FeatureNode $feature, StepNode $step, bool $skip): Setup;
 
     /**
      * Tests step.
-     *
-     * @param bool     $skip
-     *
-     * @return StepResult
      */
-    public function test(Environment $env, FeatureNode $feature, StepNode $step, $skip);
+    public function test(Environment $env, FeatureNode $feature, StepNode $step, bool $skip): StepResult;
 
     /**
      * Tears down step after a test.
-     *
-     * @param bool     $skip
-     *
-     * @return Teardown
      */
-    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result);
+    public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, bool $skip, StepResult $result): Teardown;
 }

--- a/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
+++ b/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
@@ -41,7 +41,7 @@ final class DefinitionArgumentsTransformer implements CallFilter
         return $call instanceof DefinitionCall;
     }
 
-    public function filterCall(Call $call)
+    public function filterCall(Call $call): Call
     {
         if (!$call instanceof DefinitionCall) {
             throw new UnsupportedCallException(sprintf(

--- a/src/Behat/Behat/Transformation/RegexGenerator.php
+++ b/src/Behat/Behat/Transformation/RegexGenerator.php
@@ -19,12 +19,6 @@ interface RegexGenerator
 {
     /**
      * Generates regular expression using provided parameters.
-     *
-     * @param string $suiteName
-     * @param string $pattern
-     * @param string $language
-     *
-     * @return string
      */
-    public function generateRegex($suiteName, $pattern, $language);
+    public function generateRegex(string $suiteName, string $pattern, string $language): string;
 }

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -61,15 +61,15 @@ final class TransformationExtension implements Extension
         return 'transformations';
     }
 
-    public function initialize(ExtensionManager $extensionManager)
+    public function initialize(ExtensionManager $extensionManager): void
     {
     }
 
-    public function configure(ArrayNodeDefinition $builder)
+    public function configure(ArrayNodeDefinition $builder): void
     {
     }
 
-    public function load(ContainerBuilder $container, array $config)
+    public function load(ContainerBuilder $container, array $config): void
     {
         $this->loadDefinitionArgumentsTransformer($container);
         $this->loadDefaultTransformers($container);

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -56,7 +56,7 @@ final class TransformationExtension implements Extension
         $this->processor = $processor ?: new ServiceProcessor();
     }
 
-    public function getConfigKey()
+    public function getConfigKey(): string
     {
         return 'transformations';
     }

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -41,5 +41,5 @@ interface SimpleArgumentTransformation extends Transformation
     /**
      * Transforms argument value using transformation and returns a new one.
      */
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): void;
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed;
 }

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -41,5 +41,5 @@ interface SimpleArgumentTransformation extends Transformation
     /**
      * Transforms argument value using transformation and returns a new one.
      */
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue);
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): void;
 }

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -25,33 +25,21 @@ interface SimpleArgumentTransformation extends Transformation
 {
     /**
      * Checks if transformation supports given pattern.
-     *
-     * @param string           $pattern
-     *
-     * @return bool
      */
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method);
+    public static function supportsPatternAndMethod(string $pattern, ReflectionMethod $method): bool;
 
     /**
      * Returns transformation priority.
-     *
-     * @return int
      */
-    public function getPriority();
+    public function getPriority(): int;
 
     /**
      * Checks if transformation supports argument.
-     *
-     * @param int|string $argumentIndex
-     *
-     * @return bool
      */
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue);
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool;
 
     /**
      * Transforms argument value using transformation and returns a new one.
-     *
-     * @param int|string $argumentIndex
      */
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue);
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue);
 }

--- a/src/Behat/Behat/Transformation/Transformation.php
+++ b/src/Behat/Behat/Transformation/Transformation.php
@@ -23,8 +23,6 @@ interface Transformation extends Callee
 {
     /**
      * Represents transformation as a string.
-     *
-     * @return string
      */
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -60,7 +60,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
             || $this->pattern === 'table:*';
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -30,7 +30,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
 {
     public const PATTERN_REGEX = '/^table\:(?:\*|[[:print:]]+)$/u';
 
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
+    public static function supportsPatternAndMethod(string $pattern, ReflectionMethod $method): bool
     {
         return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
@@ -50,7 +50,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -60,7 +60,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
             || $this->pattern === 'table:*';
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -32,7 +32,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
 
     public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
     {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
+        return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
 
     /**
@@ -50,7 +50,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue)
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -69,7 +69,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
         return $parameterClass === $returnClass;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -33,7 +33,7 @@ use Stringable;
  */
 final class ReturnTypeTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
+    public static function supportsPatternAndMethod(string $pattern, ReflectionMethod $method): bool
     {
         $returnClass = self::getReturnClass($method);
 
@@ -56,7 +56,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
     {
         $returnClass = self::getReturnClass($this->getReflection());
 
@@ -69,7 +69,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
         return $parameterClass === $returnClass;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -33,7 +33,7 @@ use Stringable;
  */
 final class ReturnTypeTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method)
+    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
     {
         $returnClass = self::getReturnClass($method);
 
@@ -56,7 +56,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue)
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
     {
         $returnClass = self::getReturnClass($this->getReflection());
 

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -31,7 +31,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
 {
     public const PATTERN_REGEX = '/^rowtable\:[[:print:]]+$/u';
 
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
+    public static function supportsPatternAndMethod(string $pattern, ReflectionMethod $method): bool
     {
         return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
@@ -51,7 +51,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -76,7 +76,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
         return false;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -76,7 +76,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
         return false;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -33,7 +33,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
 
     public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
     {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
+        return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
 
     /**
@@ -51,7 +51,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue)
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;

--- a/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
@@ -23,7 +23,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
 {
     public const PATTERN_REGEX = '/^column\:[[:print:]]+$/u';
 
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
+    public static function supportsPatternAndMethod(string $pattern, ReflectionMethod $method): bool
     {
         return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
@@ -38,7 +38,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
 
     public function supportsDefinitionAndArgument(
         DefinitionCall $definitionCall,
-        $argumentIndex,
+        int|string $argumentIndex,
         $argumentArgumentValue,
     ): bool {
         // The argument passed initially will be a TableNode but if a column transformation
@@ -79,7 +79,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
     public function transformArgument(
         CallCenter $callCenter,
         DefinitionCall $definitionCall,
-        $argumentIndex,
+        int|string $argumentIndex,
         $argumentValue,
     ): array {
         $columnNames = explode(',', substr($this->pattern, 7));

--- a/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
@@ -25,7 +25,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
 
     public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
     {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
+        return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
 
     public function __construct(

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -32,7 +32,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
 
     public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
     {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
+        return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
 
     /**
@@ -50,7 +50,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue)
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -30,7 +30,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
 {
     public const PATTERN_REGEX = '/^row\:[[:print:]]+$/u';
 
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
+    public static function supportsPatternAndMethod(string $pattern, ReflectionMethod $method): bool
     {
         return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
@@ -50,7 +50,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -62,7 +62,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
     /**
      * @return list<mixed>
      */
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): array
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): array
     {
         $rows = [];
         foreach ($argumentValue as $row) {

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
@@ -57,7 +57,7 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
             && $this->returnTransformation->supportsDefinitionAndArgument($definitionCall, $argumentIndex, $argumentArgumentValue);
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
@@ -30,7 +30,7 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
     private readonly TokenNameTransformation $tokenTransformation;
     private readonly ReturnTypeTransformation $returnTransformation;
 
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
+    public static function supportsPatternAndMethod(string $pattern, ReflectionMethod $method): bool
     {
         return TokenNameTransformation::supportsPatternAndMethod($pattern, $method)
             && ReturnTypeTransformation::supportsPatternAndMethod('', $method);
@@ -51,13 +51,13 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
     {
         return $this->tokenTransformation->supportsDefinitionAndArgument($definitionCall, $argumentIndex, $argumentArgumentValue)
             && $this->returnTransformation->supportsDefinitionAndArgument($definitionCall, $argumentIndex, $argumentArgumentValue);
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -31,7 +31,7 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
 
     public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
     {
-        return 1 === preg_match(self::PATTERN_REGEX, $pattern);
+        return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
 
     /**

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -54,7 +54,7 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
         return ':' . $argumentIndex === $this->pattern;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -29,7 +29,7 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
 {
     public const PATTERN_REGEX = '/^\:\w+$/';
 
-    public static function supportsPatternAndMethod($pattern, ReflectionMethod $method): bool
+    public static function supportsPatternAndMethod(string $pattern, ReflectionMethod $method): bool
     {
         return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
@@ -49,12 +49,12 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
     {
         return ':' . $argumentIndex === $this->pattern;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -29,5 +29,5 @@ interface ArgumentTransformer
     /**
      * Transforms argument value using transformation and returns a new one.
      */
-    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): void;
+    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed;
 }

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -29,5 +29,5 @@ interface ArgumentTransformer
     /**
      * Transforms argument value using transformation and returns a new one.
      */
-    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue);
+    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): void;
 }

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -23,17 +23,11 @@ interface ArgumentTransformer
 {
     /**
      * Checks if transformer supports argument.
-     *
-     * @param int|string $argumentIndex
-     *
-     * @return bool
      */
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue);
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): bool;
 
     /**
      * Transforms argument value using transformation and returns a new one.
-     *
-     * @param int|string $argumentIndex
      */
-    public function transformArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue);
+    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue);
 }

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -60,7 +60,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
     public function generateRegex(string $suiteName, string $pattern, string $language): string
     {
         $translatedPattern = $this->translator->trans($pattern, [], $suiteName, $language);
-        if ($pattern == $translatedPattern) {
+        if ($pattern === $translatedPattern) {
             return $this->patternTransformer->transformPatternToRegex($pattern);
         }
 

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -44,7 +44,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
         return count($this->repository->getEnvironmentTransformations($definitionCall->getEnvironment())) > 0;
     }
 
-    public function transformArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    public function transformArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
     {
         $environment = $definitionCall->getEnvironment();
         [$simpleTransformations, $normalTransformations] = $this->splitSimpleAndNormalTransformations(

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -57,7 +57,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
         return $newValue;
     }
 
-    public function generateRegex($suiteName, $pattern, $language)
+    public function generateRegex($suiteName, $pattern, $language): string
     {
         $translatedPattern = $this->translator->trans($pattern, [], $suiteName, $language);
         if ($pattern == $translatedPattern) {

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -39,12 +39,12 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
     ) {
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): bool
     {
         return count($this->repository->getEnvironmentTransformations($definitionCall->getEnvironment())) > 0;
     }
 
-    public function transformArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue): mixed
+    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
     {
         $environment = $definitionCall->getEnvironment();
         [$simpleTransformations, $normalTransformations] = $this->splitSimpleAndNormalTransformations(
@@ -57,7 +57,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
         return $newValue;
     }
 
-    public function generateRegex($suiteName, $pattern, $language): string
+    public function generateRegex(string $suiteName, string $pattern, string $language): string
     {
         $translatedPattern = $this->translator->trans($pattern, [], $suiteName, $language);
         if ($pattern == $translatedPattern) {

--- a/src/Behat/Testwork/Argument/ArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/ArgumentOrganiser.php
@@ -26,5 +26,5 @@ interface ArgumentOrganiser
      *
      * @return mixed[]
      */
-    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments);
+    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments): array;
 }

--- a/src/Behat/Testwork/Argument/ConstructorArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/ConstructorArgumentOrganiser.php
@@ -30,7 +30,7 @@ final class ConstructorArgumentOrganiser implements ArgumentOrganiser
     ) {
     }
 
-    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments)
+    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments): array
     {
         if (!$function instanceof ReflectionMethod) {
             throw new UnsupportedFunctionException(sprintf(

--- a/src/Behat/Testwork/Argument/PregMatchArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/PregMatchArgumentOrganiser.php
@@ -27,7 +27,7 @@ final class PregMatchArgumentOrganiser implements ArgumentOrganiser
     ) {
     }
 
-    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments)
+    public function organiseArguments(ReflectionFunctionAbstract $function, array $arguments): array
     {
         $cleanedArguments = $this->cleanupMatchDuplicates($arguments);
 

--- a/src/Behat/Testwork/Call/Call.php
+++ b/src/Behat/Testwork/Call/Call.php
@@ -19,10 +19,8 @@ interface Call
 {
     /**
      * Returns callee.
-     *
-     * @return Callee
      */
-    public function getCallee();
+    public function getCallee(): Callee;
 
     /**
      * Returns bound callable.
@@ -33,10 +31,8 @@ interface Call
 
     /**
      * Returns call arguments.
-     *
-     * @return array
      */
-    public function getArguments();
+    public function getArguments(): array;
 
     /**
      * Returns call error reporting level.

--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -31,7 +31,7 @@ interface Callee
     /**
      * Returns callee description.
      */
-    public function getDescription(): string;
+    public function getDescription(): ?string;
 
     /**
      * Returns true if callee is a method, false otherwise.

--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -25,31 +25,23 @@ interface Callee
 {
     /**
      * Returns callee definition path.
-     *
-     * @return string
      */
-    public function getPath();
+    public function getPath(): string;
 
     /**
      * Returns callee description.
-     *
-     * @return string
      */
-    public function getDescription();
+    public function getDescription(): string;
 
     /**
      * Returns true if callee is a method, false otherwise.
-     *
-     * @return bool
      */
-    public function isAMethod();
+    public function isAMethod(): bool;
 
     /**
      * Returns true if callee is an instance (non-static) method, false otherwise.
-     *
-     * @return bool
      */
-    public function isAnInstanceMethod();
+    public function isAnInstanceMethod(): bool;
 
     /**
      * Returns callable.
@@ -60,8 +52,6 @@ interface Callee
 
     /**
      * Returns callable reflection.
-     *
-     * @return ReflectionFunctionAbstract
      */
-    public function getReflection();
+    public function getReflection(): ReflectionFunctionAbstract;
 }

--- a/src/Behat/Testwork/Call/Filter/CallFilter.php
+++ b/src/Behat/Testwork/Call/Filter/CallFilter.php
@@ -24,15 +24,11 @@ interface CallFilter
 {
     /**
      * Checks if filter supports a call.
-     *
-     * @return bool
      */
-    public function supportsCall(Call $call);
+    public function supportsCall(Call $call): bool;
 
     /**
      * Filters a call and returns a new one.
-     *
-     * @return Call
      */
-    public function filterCall(Call $call);
+    public function filterCall(Call $call): Call;
 }

--- a/src/Behat/Testwork/Call/Filter/ResultFilter.php
+++ b/src/Behat/Testwork/Call/Filter/ResultFilter.php
@@ -24,15 +24,11 @@ interface ResultFilter
 {
     /**
      * Checks if filter supports call result.
-     *
-     * @return bool
      */
-    public function supportsResult(CallResult $result);
+    public function supportsResult(CallResult $result): bool;
 
     /**
      * Filters call result and returns a new result.
-     *
-     * @return CallResult
      */
-    public function filterResult(CallResult $result);
+    public function filterResult(CallResult $result): CallResult;
 }

--- a/src/Behat/Testwork/Call/Handler/CallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/CallHandler.php
@@ -25,15 +25,11 @@ interface CallHandler
 {
     /**
      * Checks if handler supports call.
-     *
-     * @return bool
      */
-    public function supportsCall(Call $call);
+    public function supportsCall(Call $call): bool;
 
     /**
      * Handles call and returns call result.
-     *
-     * @return CallResult
      */
-    public function handleCall(Call $call);
+    public function handleCall(Call $call): CallResult;
 }

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -25,7 +25,7 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
 {
     public const PATTERN = "/^Class (?:'|\")([^'\"]+)(?:'|\") not found$/";
 
-    final public function supportsException($exception): bool
+    final public function supportsException(Throwable $exception): bool
     {
         if (!$exception instanceof Error) {
             return false;
@@ -34,7 +34,7 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
         return null !== $this->extractNonExistentClass($exception);
     }
 
-    final public function handleException($exception): Throwable
+    final public function handleException(Throwable $exception): Throwable
     {
         assert($exception instanceof Error);
         $this->handleNonExistentClass($this->extractNonExistentClass($exception));

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -12,6 +12,7 @@ namespace Behat\Testwork\Call\Handler\Exception;
 
 use Behat\Testwork\Call\Handler\ExceptionHandler;
 use Error;
+use Throwable;
 
 /**
  * Handles class not found exceptions.
@@ -24,7 +25,7 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
 {
     public const PATTERN = "/^Class (?:'|\")([^'\"]+)(?:'|\") not found$/";
 
-    final public function supportsException($exception)
+    final public function supportsException($exception): bool
     {
         if (!$exception instanceof Error) {
             return false;
@@ -33,7 +34,7 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
         return null !== $this->extractNonExistentClass($exception);
     }
 
-    final public function handleException($exception)
+    final public function handleException($exception): Throwable
     {
         assert($exception instanceof Error);
         $this->handleNonExistentClass($this->extractNonExistentClass($exception));

--- a/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
@@ -12,6 +12,7 @@ namespace Behat\Testwork\Call\Handler\Exception;
 
 use Behat\Testwork\Call\Handler\ExceptionHandler;
 use Error;
+use Throwable;
 
 /**
  * Handles method not found exceptions.
@@ -24,7 +25,7 @@ abstract class MethodNotFoundHandler implements ExceptionHandler
 {
     public const PATTERN = '/^Call to undefined method ([^:]+)::([^\)]+)\(\)$/';
 
-    final public function supportsException($exception)
+    final public function supportsException($exception): bool
     {
         if (!$exception instanceof Error) {
             return false;
@@ -33,7 +34,7 @@ abstract class MethodNotFoundHandler implements ExceptionHandler
         return null !== $this->extractNonExistentCallable($exception);
     }
 
-    final public function handleException($exception)
+    final public function handleException($exception): Throwable
     {
         assert($exception instanceof Error);
         $this->handleNonExistentMethod($this->extractNonExistentCallable($exception));

--- a/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
@@ -25,7 +25,7 @@ abstract class MethodNotFoundHandler implements ExceptionHandler
 {
     public const PATTERN = '/^Call to undefined method ([^:]+)::([^\)]+)\(\)$/';
 
-    final public function supportsException($exception): bool
+    final public function supportsException(Throwable $exception): bool
     {
         if (!$exception instanceof Error) {
             return false;
@@ -34,7 +34,7 @@ abstract class MethodNotFoundHandler implements ExceptionHandler
         return null !== $this->extractNonExistentCallable($exception);
     }
 
-    final public function handleException($exception): Throwable
+    final public function handleException(Throwable $exception): Throwable
     {
         assert($exception instanceof Error);
         $this->handleNonExistentMethod($this->extractNonExistentCallable($exception));

--- a/src/Behat/Testwork/Call/Handler/ExceptionHandler.php
+++ b/src/Behat/Testwork/Call/Handler/ExceptionHandler.php
@@ -23,19 +23,11 @@ interface ExceptionHandler
 {
     /**
      * Checks if handler supports exception.
-     *
-     * @param Throwable $exception
-     *
-     * @return bool
      */
-    public function supportsException($exception);
+    public function supportsException(Throwable $exception): bool;
 
     /**
      * Handles exception and returns new one if necessary.
-     *
-     * @param Throwable $exception
-     *
-     * @return Throwable
      */
-    public function handleException($exception);
+    public function handleException(Throwable $exception): Throwable;
 }

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -44,7 +44,7 @@ final class RuntimeCallHandler implements CallHandler
         return true;
     }
 
-    public function handleCall(Call $call)
+    public function handleCall(Call $call): CallResult
     {
         $this->startErrorAndOutputBuffering($call);
         $result = $this->executeCall($call);

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -53,7 +53,7 @@ class RuntimeCallee implements Callee
     /**
      * Returns callee description.
      */
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->description;
     }

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -52,20 +52,16 @@ class RuntimeCallee implements Callee
 
     /**
      * Returns callee description.
-     *
-     * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
     /**
      * Returns callee definition path.
-     *
-     * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
@@ -82,30 +78,24 @@ class RuntimeCallee implements Callee
 
     /**
      * Returns callable reflection.
-     *
-     * @return ReflectionFunctionAbstract
      */
-    public function getReflection()
+    public function getReflection(): ReflectionFunctionAbstract
     {
         return $this->reflection;
     }
 
     /**
      * Returns true if callee is a method, false otherwise.
-     *
-     * @return bool
      */
-    public function isAMethod()
+    public function isAMethod(): bool
     {
         return $this->reflection instanceof ReflectionMethod;
     }
 
     /**
      * Returns true if callee is an instance (non-static) method, false otherwise.
-     *
-     * @return bool
      */
-    public function isAnInstanceMethod()
+    public function isAnInstanceMethod(): bool
     {
         return $this->reflection instanceof ReflectionMethod
             && !$this->reflection->isStatic();

--- a/src/Behat/Testwork/Cli/Controller.php
+++ b/src/Behat/Testwork/Cli/Controller.php
@@ -28,7 +28,7 @@ interface Controller
     /**
      * Configures command to be executable by the controller.
      */
-    public function configure(SymfonyCommand $command);
+    public function configure(SymfonyCommand $command): void;
 
     /**
      * Executes controller.

--- a/src/Behat/Testwork/Environment/Environment.php
+++ b/src/Behat/Testwork/Environment/Environment.php
@@ -22,15 +22,11 @@ interface Environment
 {
     /**
      * Returns environment suite.
-     *
-     * @return Suite
      */
-    public function getSuite();
+    public function getSuite(): Suite;
 
     /**
      * Creates callable using provided Callee.
-     *
-     * @return callable
      */
-    public function bindCallee(Callee $callee);
+    public function bindCallee(Callee $callee): callable;
 }

--- a/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
+++ b/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
@@ -25,29 +25,21 @@ interface EnvironmentHandler
 {
     /**
      * Checks if handler supports provided suite.
-     *
-     * @return bool
      */
-    public function supportsSuite(Suite $suite);
+    public function supportsSuite(Suite $suite): bool;
 
     /**
      * Builds environment object based on provided suite.
-     *
-     * @return Environment
      */
-    public function buildEnvironment(Suite $suite);
+    public function buildEnvironment(Suite $suite): Environment;
 
     /**
      * Checks if handler supports provided environment.
-     *
-     * @return bool
      */
-    public function supportsEnvironmentAndSubject(Environment $environment, $testSubject = null);
+    public function supportsEnvironmentAndSubject(Environment $environment, $testSubject = null): bool;
 
     /**
      * Isolates provided environment.
-     *
-     * @return Environment
      */
-    public function isolateEnvironment(Environment $environment, $testSubject = null);
+    public function isolateEnvironment(Environment $environment, $testSubject = null): Environment;
 }

--- a/src/Behat/Testwork/Environment/Reader/EnvironmentReader.php
+++ b/src/Behat/Testwork/Environment/Reader/EnvironmentReader.php
@@ -25,15 +25,13 @@ interface EnvironmentReader
 {
     /**
      * Checks if reader supports an environment.
-     *
-     * @return bool
      */
-    public function supportsEnvironment(Environment $environment);
+    public function supportsEnvironment(Environment $environment): bool;
 
     /**
      * Reads callees from an environment.
      *
      * @return Callee[]
      */
-    public function readEnvironmentCallees(Environment $environment);
+    public function readEnvironmentCallees(Environment $environment): array;
 }

--- a/src/Behat/Testwork/Environment/StaticEnvironment.php
+++ b/src/Behat/Testwork/Environment/StaticEnvironment.php
@@ -33,7 +33,7 @@ class StaticEnvironment implements Environment
         return $this->suite;
     }
 
-    final public function bindCallee(Callee $callee)
+    final public function bindCallee(Callee $callee): callable
     {
         return $callee->getCallable();
     }

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSetup.php
@@ -23,8 +23,6 @@ interface AfterSetup
 {
     /**
      * Returns current test setup.
-     *
-     * @return Setup
      */
-    public function getSetup();
+    public function getSetup(): Setup;
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterTested.php
@@ -24,15 +24,11 @@ interface AfterTested
 {
     /**
      * Returns current test result.
-     *
-     * @return TestResult
      */
-    public function getTestResult();
+    public function getTestResult(): TestResult;
 
     /**
      * Returns current test teardown.
-     *
-     * @return Teardown
      */
-    public function getTeardown();
+    public function getTeardown(): Teardown;
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeTeardown.php
@@ -23,8 +23,6 @@ interface BeforeTeardown
 {
     /**
      * Returns current test result.
-     *
-     * @return TestResult
      */
-    public function getTestResult();
+    public function getTestResult(): TestResult;
 }

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -54,7 +54,7 @@ class EventDispatcherExtension implements Extension
         $this->processor = $processor ?: new ServiceProcessor();
     }
 
-    public function getConfigKey()
+    public function getConfigKey(): string
     {
         return 'events';
     }

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -59,15 +59,15 @@ class EventDispatcherExtension implements Extension
         return 'events';
     }
 
-    public function initialize(ExtensionManager $extensionManager)
+    public function initialize(ExtensionManager $extensionManager): void
     {
     }
 
-    public function configure(ArrayNodeDefinition $builder)
+    public function configure(ArrayNodeDefinition $builder): void
     {
     }
 
-    public function load(ContainerBuilder $container, array $config)
+    public function load(ContainerBuilder $container, array $config): void
     {
         $this->loadSigintController($container);
         $this->loadEventDispatcher($container);

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
@@ -42,7 +42,7 @@ final class EventDispatchingExercise implements Exercise
     ) {
     }
 
-    public function setUp(array $iterators, $skip): Setup
+    public function setUp(array $iterators, bool $skip): Setup
     {
         $event = new BeforeExerciseCompleted($iterators);
 
@@ -57,12 +57,12 @@ final class EventDispatchingExercise implements Exercise
         return $setup;
     }
 
-    public function test(array $iterators, $skip = false): TestResult
+    public function test(array $iterators, bool $skip = false): TestResult
     {
         return $this->baseExercise->test($iterators, $skip);
     }
 
-    public function tearDown(array $iterators, $skip, TestResult $result): Teardown
+    public function tearDown(array $iterators, bool $skip, TestResult $result): Teardown
     {
         $event = new BeforeExerciseTeardown($iterators, $result);
 

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php
@@ -16,6 +16,8 @@ use Behat\Testwork\EventDispatcher\Event\BeforeExerciseCompleted;
 use Behat\Testwork\EventDispatcher\Event\BeforeExerciseTeardown;
 use Behat\Testwork\Tester\Exercise;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -40,7 +42,7 @@ final class EventDispatchingExercise implements Exercise
     ) {
     }
 
-    public function setUp(array $iterators, $skip)
+    public function setUp(array $iterators, $skip): Setup
     {
         $event = new BeforeExerciseCompleted($iterators);
 
@@ -55,12 +57,12 @@ final class EventDispatchingExercise implements Exercise
         return $setup;
     }
 
-    public function test(array $iterators, $skip = false)
+    public function test(array $iterators, $skip = false): TestResult
     {
         return $this->baseExercise->test($iterators, $skip);
     }
 
-    public function tearDown(array $iterators, $skip, TestResult $result)
+    public function tearDown(array $iterators, $skip, TestResult $result): Teardown
     {
         $event = new BeforeExerciseTeardown($iterators, $result);
 

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
@@ -17,6 +17,8 @@ use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTeardown;
 use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTested;
 use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Behat\Testwork\Tester\SuiteTester;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -42,7 +44,7 @@ final class EventDispatchingSuiteTester implements SuiteTester
     ) {
     }
 
-    public function setUp(Environment $env, SpecificationIterator $iterator, $skip)
+    public function setUp(Environment $env, SpecificationIterator $iterator, $skip): Setup
     {
         $event = new BeforeSuiteTested($env, $iterator);
 
@@ -57,12 +59,12 @@ final class EventDispatchingSuiteTester implements SuiteTester
         return $setup;
     }
 
-    public function test(Environment $env, SpecificationIterator $iterator, $skip = false)
+    public function test(Environment $env, SpecificationIterator $iterator, $skip = false): TestResult
     {
         return $this->baseTester->test($env, $iterator, $skip);
     }
 
-    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
+    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result): Teardown
     {
         $event = new BeforeSuiteTeardown($env, $iterator, $result);
         $this->eventDispatcher->dispatch($event, BeforeSuiteTeardown::BEFORE_TEARDOWN);

--- a/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
+++ b/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingSuiteTester.php
@@ -44,7 +44,7 @@ final class EventDispatchingSuiteTester implements SuiteTester
     ) {
     }
 
-    public function setUp(Environment $env, SpecificationIterator $iterator, $skip): Setup
+    public function setUp(Environment $env, SpecificationIterator $iterator, bool $skip): Setup
     {
         $event = new BeforeSuiteTested($env, $iterator);
 
@@ -59,12 +59,12 @@ final class EventDispatchingSuiteTester implements SuiteTester
         return $setup;
     }
 
-    public function test(Environment $env, SpecificationIterator $iterator, $skip = false): TestResult
+    public function test(Environment $env, SpecificationIterator $iterator, bool $skip = false): TestResult
     {
         return $this->baseTester->test($env, $iterator, $skip);
     }
 
-    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, SpecificationIterator $iterator, bool $skip, TestResult $result): Teardown
     {
         $event = new BeforeSuiteTeardown($env, $iterator, $result);
         $this->eventDispatcher->dispatch($event, BeforeSuiteTeardown::BEFORE_TEARDOWN);

--- a/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/ExceptionStringer.php
@@ -26,17 +26,11 @@ interface ExceptionStringer
 {
     /**
      * Checks if stringer supports provided exception.
-     *
-     * @return bool
      */
-    public function supportsException(Exception $exception);
+    public function supportsException(Exception $exception): bool;
 
     /**
      * Strings provided exception.
-     *
-     * @param int $verbosity
-     *
-     * @return string
      */
-    public function stringException(Exception $exception, $verbosity);
+    public function stringException(Exception $exception, int $verbosity): string;
 }

--- a/src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
@@ -32,7 +32,7 @@ final class PHPUnitExceptionStringer implements ExceptionStringer
             || $exception instanceof \PHPUnit\Framework\Exception;
     }
 
-    public function stringException(Exception $exception, $verbosity): string
+    public function stringException(Exception $exception, int $verbosity): string
     {
         // PHPUnit assertion exceptions do not include detailed expected / observed info in their messages. Instead,
         // test result printers within PHPUnit are expected to format and present that information separately. The

--- a/src/Behat/Testwork/Exception/Stringer/TestworkExceptionStringer.php
+++ b/src/Behat/Testwork/Exception/Stringer/TestworkExceptionStringer.php
@@ -26,7 +26,7 @@ final class TestworkExceptionStringer implements ExceptionStringer
         return $exception instanceof TestworkException || $exception instanceof CallErrorException;
     }
 
-    public function stringException(Exception $exception, $verbosity): string
+    public function stringException(Exception $exception, int $verbosity): string
     {
         return trim($exception->getMessage());
     }

--- a/src/Behat/Testwork/Filesystem/ConsoleFilesystemLogger.php
+++ b/src/Behat/Testwork/Filesystem/ConsoleFilesystemLogger.php
@@ -30,7 +30,7 @@ final class ConsoleFilesystemLogger implements FilesystemLogger
     ) {
     }
 
-    public function directoryCreated($path, $reason): void
+    public function directoryCreated(string $path, string $reason): void
     {
         $this->output->writeln(
             sprintf(
@@ -41,7 +41,7 @@ final class ConsoleFilesystemLogger implements FilesystemLogger
         );
     }
 
-    public function fileCreated($path, $reason): void
+    public function fileCreated(string $path, string $reason): void
     {
         $this->output->writeln(
             sprintf(
@@ -52,7 +52,7 @@ final class ConsoleFilesystemLogger implements FilesystemLogger
         );
     }
 
-    public function fileUpdated($path, $reason): void
+    public function fileUpdated(string $path, string $reason): void
     {
         $this->output->writeln(
             sprintf(

--- a/src/Behat/Testwork/Filesystem/FilesystemLogger.php
+++ b/src/Behat/Testwork/Filesystem/FilesystemLogger.php
@@ -19,25 +19,16 @@ interface FilesystemLogger
 {
     /**
      * Logs directory creation.
-     *
-     * @param string $path
-     * @param string $reason
      */
-    public function directoryCreated($path, $reason);
+    public function directoryCreated(string $path, string $reason);
 
     /**
      * Logs file creation.
-     *
-     * @param string $path
-     * @param string $reason
      */
-    public function fileCreated($path, $reason);
+    public function fileCreated(string $path, string $reason);
 
     /**
      * Logs file update.
-     *
-     * @param string $path
-     * @param string $reason
      */
-    public function fileUpdated($path, $reason);
+    public function fileUpdated(string $path, string $reason);
 }

--- a/src/Behat/Testwork/Filesystem/FilesystemLogger.php
+++ b/src/Behat/Testwork/Filesystem/FilesystemLogger.php
@@ -20,15 +20,15 @@ interface FilesystemLogger
     /**
      * Logs directory creation.
      */
-    public function directoryCreated(string $path, string $reason);
+    public function directoryCreated(string $path, string $reason): void;
 
     /**
      * Logs file creation.
      */
-    public function fileCreated(string $path, string $reason);
+    public function fileCreated(string $path, string $reason): void;
 
     /**
      * Logs file update.
      */
-    public function fileUpdated(string $path, string $reason);
+    public function fileUpdated(string $path, string $reason): void;
 }

--- a/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
@@ -50,7 +50,7 @@ abstract class RuntimeFilterableHook extends RuntimeHook implements Stringable, 
         return $this->filterString;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return trim($this->getName() . ' ' . $this->getFilterString());
     }

--- a/src/Behat/Testwork/Hook/Call/RuntimeHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeHook.php
@@ -38,12 +38,12 @@ abstract class RuntimeHook extends RuntimeCallee implements Stringable, Hook
         parent::__construct($callable, $description);
     }
 
-    public function getScopeName()
+    public function getScopeName(): string
     {
         return $this->scopeName;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getName();
     }

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -38,7 +38,7 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
         $this->throwIfInstanceMethod($callable, 'Suite');
     }
 
-    public function filterMatches(HookScope $scope)
+    public function filterMatches(HookScope $scope): bool
     {
         if (!$scope instanceof SuiteScope) {
             return false;

--- a/src/Behat/Testwork/Hook/FilterableHook.php
+++ b/src/Behat/Testwork/Hook/FilterableHook.php
@@ -21,8 +21,6 @@ interface FilterableHook extends Hook
 {
     /**
      * Checks that current hook matches provided hook scope.
-     *
-     * @return bool
      */
-    public function filterMatches(HookScope $scope);
+    public function filterMatches(HookScope $scope): bool;
 }

--- a/src/Behat/Testwork/Hook/Hook.php
+++ b/src/Behat/Testwork/Hook/Hook.php
@@ -21,22 +21,16 @@ interface Hook extends Callee
 {
     /**
      * Returns hook name.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Returns hook scope name.
-     *
-     * @return string
      */
-    public function getScopeName();
+    public function getScopeName(): string;
 
     /**
      * Represents hook as a string.
-     *
-     * @return string
      */
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/Behat/Testwork/Hook/Scope/AfterSuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/AfterSuiteScope.php
@@ -12,6 +12,7 @@ namespace Behat\Testwork\Hook\Scope;
 
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Specification\SpecificationIterator;
+use Behat\Testwork\Suite\Suite;
 use Behat\Testwork\Tester\Result\TestResult;
 
 /**
@@ -40,7 +41,7 @@ final class AfterSuiteScope implements SuiteScope, AfterTestScope
         return self::AFTER;
     }
 
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }

--- a/src/Behat/Testwork/Hook/Scope/AfterTestScope.php
+++ b/src/Behat/Testwork/Hook/Scope/AfterTestScope.php
@@ -23,8 +23,6 @@ interface AfterTestScope extends HookScope
 {
     /**
      * Returns test result.
-     *
-     * @return TestResult
      */
-    public function getTestResult();
+    public function getTestResult(): TestResult;
 }

--- a/src/Behat/Testwork/Hook/Scope/BeforeSuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/BeforeSuiteScope.php
@@ -12,6 +12,7 @@ namespace Behat\Testwork\Hook\Scope;
 
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\Specification\SpecificationIterator;
+use Behat\Testwork\Suite\Suite;
 
 /**
  * Represents a scope for BeforeSuite hook.
@@ -38,7 +39,7 @@ final class BeforeSuiteScope implements SuiteScope
         return self::BEFORE;
     }
 
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }

--- a/src/Behat/Testwork/Hook/Scope/HookScope.php
+++ b/src/Behat/Testwork/Hook/Scope/HookScope.php
@@ -29,22 +29,16 @@ interface HookScope
 {
     /**
      * Returns hook scope name.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Returns hook suite.
-     *
-     * @return Suite
      */
-    public function getSuite();
+    public function getSuite(): Suite;
 
     /**
      * Returns hook environment.
-     *
-     * @return Environment
      */
-    public function getEnvironment();
+    public function getEnvironment(): Environment;
 }

--- a/src/Behat/Testwork/Hook/Scope/SuiteScope.php
+++ b/src/Behat/Testwork/Hook/Scope/SuiteScope.php
@@ -27,5 +27,5 @@ interface SuiteScope extends HookScope
      *
      * @return SpecificationIterator<mixed>
      */
-    public function getSpecificationIterator();
+    public function getSpecificationIterator(): SpecificationIterator;
 }

--- a/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
+++ b/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
@@ -41,15 +41,15 @@ class HookExtension implements Extension
         return 'hooks';
     }
 
-    public function initialize(ExtensionManager $extensionManager)
+    public function initialize(ExtensionManager $extensionManager): void
     {
     }
 
-    public function configure(ArrayNodeDefinition $builder)
+    public function configure(ArrayNodeDefinition $builder): void
     {
     }
 
-    public function load(ContainerBuilder $container, array $config)
+    public function load(ContainerBuilder $container, array $config): void
     {
         $this->loadDispatcher($container);
         $this->loadRepository($container);

--- a/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
+++ b/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
@@ -36,7 +36,7 @@ class HookExtension implements Extension
     public const DISPATCHER_ID = 'hook.dispatcher';
     public const REPOSITORY_ID = 'hook.repository';
 
-    public function getConfigKey()
+    public function getConfigKey(): string
     {
         return 'hooks';
     }

--- a/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
+++ b/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
@@ -44,7 +44,7 @@ final class HookableSuiteTester implements SuiteTester
     ) {
     }
 
-    public function setUp(Environment $env, SpecificationIterator $iterator, $skip): Setup
+    public function setUp(Environment $env, SpecificationIterator $iterator, bool $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $iterator, $skip);
 
@@ -58,12 +58,12 @@ final class HookableSuiteTester implements SuiteTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, SpecificationIterator $iterator, $skip): TestResult
+    public function test(Environment $env, SpecificationIterator $iterator, bool $skip): TestResult
     {
         return $this->baseTester->test($env, $iterator, $skip);
     }
 
-    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, SpecificationIterator $iterator, bool $skip, TestResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $iterator, $skip, $result);
 

--- a/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
+++ b/src/Behat/Testwork/Hook/Tester/HookableSuiteTester.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
 use Behat\Testwork\Hook\Tester\Setup\HookedTeardown;
 use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 use Behat\Testwork\Tester\SuiteTester;
 
 /**
@@ -42,7 +44,7 @@ final class HookableSuiteTester implements SuiteTester
     ) {
     }
 
-    public function setUp(Environment $env, SpecificationIterator $iterator, $skip)
+    public function setUp(Environment $env, SpecificationIterator $iterator, $skip): Setup
     {
         $setup = $this->baseTester->setUp($env, $iterator, $skip);
 
@@ -56,12 +58,12 @@ final class HookableSuiteTester implements SuiteTester
         return new HookedSetup($setup, $hookCallResults);
     }
 
-    public function test(Environment $env, SpecificationIterator $iterator, $skip)
+    public function test(Environment $env, SpecificationIterator $iterator, $skip): TestResult
     {
         return $this->baseTester->test($env, $iterator, $skip);
     }
 
-    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result)
+    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result): Teardown
     {
         $teardown = $this->baseTester->tearDown($env, $iterator, $skip, $result);
 

--- a/src/Behat/Testwork/Hook/Tester/Setup/HookedSetup.php
+++ b/src/Behat/Testwork/Hook/Tester/Setup/HookedSetup.php
@@ -29,7 +29,7 @@ final class HookedSetup implements Setup
     ) {
     }
 
-    public function isSuccessful()
+    public function isSuccessful(): bool
     {
         if ($this->hookCallResults->hasExceptions()) {
             return false;

--- a/src/Behat/Testwork/Hook/Tester/Setup/HookedTeardown.php
+++ b/src/Behat/Testwork/Hook/Tester/Setup/HookedTeardown.php
@@ -29,7 +29,7 @@ final class HookedTeardown implements Teardown
     ) {
     }
 
-    public function isSuccessful()
+    public function isSuccessful(): bool
     {
         if ($this->hookCallResults->hasExceptions()) {
             return false;

--- a/src/Behat/Testwork/Ordering/OrderedExercise.php
+++ b/src/Behat/Testwork/Ordering/OrderedExercise.php
@@ -50,17 +50,17 @@ final class OrderedExercise implements Exercise
         $this->orderer = new NoopOrderer();
     }
 
-    public function setUp(array $iterators, $skip): Setup
+    public function setUp(array $iterators, bool $skip): Setup
     {
         return $this->decoratedExercise->setUp($this->order($iterators), $skip);
     }
 
-    public function test(array $iterators, $skip): TestResult
+    public function test(array $iterators, bool $skip): TestResult
     {
         return $this->decoratedExercise->test($this->order($iterators), $skip);
     }
 
-    public function tearDown(array $iterators, $skip, TestResult $result): Teardown
+    public function tearDown(array $iterators, bool $skip, TestResult $result): Teardown
     {
         return $this->decoratedExercise->tearDown($this->order($iterators), $skip, $result);
     }

--- a/src/Behat/Testwork/Ordering/OrderedExercise.php
+++ b/src/Behat/Testwork/Ordering/OrderedExercise.php
@@ -15,6 +15,8 @@ use Behat\Testwork\Ordering\Orderer\Orderer;
 use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Exercise;
 use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
 
 /**
  * Exercise that is ordered according to a specified algorithm.
@@ -48,17 +50,17 @@ final class OrderedExercise implements Exercise
         $this->orderer = new NoopOrderer();
     }
 
-    public function setUp(array $iterators, $skip)
+    public function setUp(array $iterators, $skip): Setup
     {
         return $this->decoratedExercise->setUp($this->order($iterators), $skip);
     }
 
-    public function test(array $iterators, $skip)
+    public function test(array $iterators, $skip): TestResult
     {
         return $this->decoratedExercise->test($this->order($iterators), $skip);
     }
 
-    public function tearDown(array $iterators, $skip, TestResult $result)
+    public function tearDown(array $iterators, $skip, TestResult $result): Teardown
     {
         return $this->decoratedExercise->tearDown($this->order($iterators), $skip, $result);
     }

--- a/src/Behat/Testwork/Ordering/Orderer/Orderer.php
+++ b/src/Behat/Testwork/Ordering/Orderer/Orderer.php
@@ -28,10 +28,7 @@ interface Orderer
      *
      * @return SpecificationIterator<T>[]
      */
-    public function order(array $scenarioIterators);
+    public function order(array $scenarioIterators): array;
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -33,7 +33,7 @@ final class OutputController implements Controller
     ) {
     }
 
-    public function configure(Command $command)
+    public function configure(Command $command): void
     {
         $command
             ->addOption(

--- a/src/Behat/Testwork/Output/Formatter.php
+++ b/src/Behat/Testwork/Output/Formatter.php
@@ -26,36 +26,26 @@ interface Formatter extends EventSubscriberInterface
 {
     /**
      * Returns formatter name.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Returns formatter description.
-     *
-     * @return string
      */
-    public function getDescription();
+    public function getDescription(): string;
 
     /**
      * Returns formatter output printer.
-     *
-     * @return OutputPrinter
      */
-    public function getOutputPrinter();
+    public function getOutputPrinter(): OutputPrinter;
 
     /**
      * Sets formatter parameter.
-     *
-     * @param string $name
      */
-    public function setParameter($name, $value);
+    public function setParameter(string $name, $value);
 
     /**
      * Returns parameter name.
-     *
-     * @param string $name
      */
-    public function getParameter($name);
+    public function getParameter(string $name);
 }

--- a/src/Behat/Testwork/Output/Formatter.php
+++ b/src/Behat/Testwork/Output/Formatter.php
@@ -42,10 +42,10 @@ interface Formatter extends EventSubscriberInterface
     /**
      * Sets formatter parameter.
      */
-    public function setParameter(string $name, $value);
+    public function setParameter(string $name, $value): void;
 
     /**
      * Returns parameter name.
      */
-    public function getParameter(string $name);
+    public function getParameter(string $name): void;
 }

--- a/src/Behat/Testwork/Output/Formatter.php
+++ b/src/Behat/Testwork/Output/Formatter.php
@@ -47,5 +47,5 @@ interface Formatter extends EventSubscriberInterface
     /**
      * Returns parameter name.
      */
-    public function getParameter(string $name): void;
+    public function getParameter(string $name): mixed;
 }

--- a/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
@@ -35,7 +35,7 @@ final class ChainEventListener implements EventListener, Countable, IteratorAggr
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName)
+    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
     {
         foreach ($this->listeners as $listener) {
             $listener->listenEvent($formatter, $event, $eventName);

--- a/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
@@ -35,7 +35,7 @@ final class ChainEventListener implements EventListener, Countable, IteratorAggr
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         foreach ($this->listeners as $listener) {
             $listener->listenEvent($formatter, $event, $eventName);

--- a/src/Behat/Testwork/Output/Node/EventListener/EventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/EventListener.php
@@ -25,5 +25,5 @@ interface EventListener
     /**
      * Notifies listener about an event.
      */
-    public function listenEvent(Formatter $formatter, Event $event, string $eventName);
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void;
 }

--- a/src/Behat/Testwork/Output/Node/EventListener/EventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/EventListener.php
@@ -24,8 +24,6 @@ interface EventListener
 {
     /**
      * Notifies listener about an event.
-     *
-     * @param string    $eventName
      */
-    public function listenEvent(Formatter $formatter, Event $event, $eventName);
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName);
 }

--- a/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
@@ -33,7 +33,7 @@ final class FireOnlyIfFormatterParameterListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName)
+    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
     {
         if ($this->value !== $formatter->getParameter($this->name)) {
             return;

--- a/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
@@ -33,7 +33,7 @@ final class FireOnlyIfFormatterParameterListener implements EventListener
     ) {
     }
 
-    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    public function listenEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if ($this->value !== $formatter->getParameter($this->name)) {
             return;

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -62,12 +62,12 @@ final class NodeEventListeningFormatter implements Formatter
         $this->listener->listenEvent($this, $event, $eventName);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -82,7 +82,7 @@ final class NodeEventListeningFormatter implements Formatter
         $this->parameters[$name] = $value;
     }
 
-    public function getParameter($name)
+    public function getParameter($name): mixed
     {
         $value = $this->parameters[$name] ?? null;
         if ($value !== null && $name === ShowOutputOption::OPTION_NAME) {

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -77,12 +77,12 @@ final class NodeEventListeningFormatter implements Formatter
         return $this->printer;
     }
 
-    public function setParameter($name, $value): void
+    public function setParameter(string $name, $value): void
     {
         $this->parameters[$name] = $value;
     }
 
-    public function getParameter($name): mixed
+    public function getParameter(string $name): mixed
     {
         $value = $this->parameters[$name] ?? null;
         if ($value !== null && $name === ShowOutputOption::OPTION_NAME) {

--- a/src/Behat/Testwork/Output/Printer/OutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/OutputPrinter.php
@@ -44,14 +44,14 @@ interface OutputPrinter
      *
      * @param string|array $messages message or array of messages
      */
-    public function write($messages): void;
+    public function write(string|array $messages): void;
 
     /**
      * Writes newlined message(s) to output stream.
      *
      * @param string|array $messages message or array of messages
      */
-    public function writeln($messages = ''): void;
+    public function writeln(string|array $messages = ''): void;
 
     /**
      * Clear output stream, so on next write formatter will need to init (create) it again.

--- a/src/Behat/Testwork/Output/Printer/OutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/OutputPrinter.php
@@ -22,39 +22,39 @@ interface OutputPrinter
     /**
      * Sets output path.
      */
-    public function setOutputPath(string $path);
+    public function setOutputPath(string $path): void;
 
     /**
      * Sets output styles.
      */
-    public function setOutputStyles(array $styles);
+    public function setOutputStyles(array $styles): void;
 
     /**
      * Forces output to be decorated.
      */
-    public function setOutputDecorated(bool $decorated);
+    public function setOutputDecorated(bool $decorated): void;
 
     /**
      * Sets output verbosity level.
      */
-    public function setOutputVerbosity(int $level);
+    public function setOutputVerbosity(int $level): void;
 
     /**
      * Writes message(s) to output stream.
      *
      * @param string|array $messages message or array of messages
      */
-    public function write($messages);
+    public function write($messages): void;
 
     /**
      * Writes newlined message(s) to output stream.
      *
      * @param string|array $messages message or array of messages
      */
-    public function writeln($messages = '');
+    public function writeln($messages = ''): void;
 
     /**
      * Clear output stream, so on next write formatter will need to init (create) it again.
      */
-    public function flush();
+    public function flush(): void;
 }

--- a/src/Behat/Testwork/Output/Printer/OutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/OutputPrinter.php
@@ -21,10 +21,8 @@ interface OutputPrinter
 {
     /**
      * Sets output path.
-     *
-     * @param string $path
      */
-    public function setOutputPath($path);
+    public function setOutputPath(string $path);
 
     /**
      * Sets output styles.
@@ -33,17 +31,13 @@ interface OutputPrinter
 
     /**
      * Forces output to be decorated.
-     *
-     * @param bool $decorated
      */
-    public function setOutputDecorated($decorated);
+    public function setOutputDecorated(bool $decorated);
 
     /**
      * Sets output verbosity level.
-     *
-     * @param int $level
      */
-    public function setOutputVerbosity($level);
+    public function setOutputVerbosity(int $level);
 
     /**
      * Writes message(s) to output stream.

--- a/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
@@ -34,41 +34,41 @@ class StreamOutputPrinter implements OutputPrinter
         return $this->outputFactory;
     }
 
-    public function setOutputPath($path)
+    public function setOutputPath($path): void
     {
         $this->outputFactory->setOutputPath($path);
         $this->flush();
     }
 
-    public function setOutputStyles(array $styles)
+    public function setOutputStyles(array $styles): void
     {
         $this->outputFactory->setOutputStyles($styles);
         $this->flush();
     }
 
-    public function setOutputDecorated($decorated)
+    public function setOutputDecorated($decorated): void
     {
         $this->outputFactory->setOutputDecorated($decorated);
         $this->flush();
     }
 
-    public function setOutputVerbosity($level)
+    public function setOutputVerbosity($level): void
     {
         $this->outputFactory->setOutputVerbosity($level);
         $this->flush();
     }
 
-    public function write($messages)
+    public function write($messages): void
     {
         $this->getWritingStream()->write($messages, false);
     }
 
-    public function writeln($messages = '')
+    public function writeln($messages = ''): void
     {
         $this->getWritingStream()->write($messages, true);
     }
 
-    public function flush()
+    public function flush(): void
     {
         $this->output = null;
     }

--- a/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
@@ -34,7 +34,7 @@ class StreamOutputPrinter implements OutputPrinter
         return $this->outputFactory;
     }
 
-    public function setOutputPath($path): void
+    public function setOutputPath(string $path): void
     {
         $this->outputFactory->setOutputPath($path);
         $this->flush();
@@ -46,24 +46,24 @@ class StreamOutputPrinter implements OutputPrinter
         $this->flush();
     }
 
-    public function setOutputDecorated($decorated): void
+    public function setOutputDecorated(bool $decorated): void
     {
         $this->outputFactory->setOutputDecorated($decorated);
         $this->flush();
     }
 
-    public function setOutputVerbosity($level): void
+    public function setOutputVerbosity(int $level): void
     {
         $this->outputFactory->setOutputVerbosity($level);
         $this->flush();
     }
 
-    public function write($messages): void
+    public function write(string|array $messages): void
     {
         $this->getWritingStream()->write($messages, false);
     }
 
-    public function writeln($messages = ''): void
+    public function writeln(string|array $messages = ''): void
     {
         $this->getWritingStream()->write($messages, true);
     }

--- a/src/Behat/Testwork/Output/ServiceContainer/Formatter/FormatterFactory.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/Formatter/FormatterFactory.php
@@ -24,10 +24,10 @@ interface FormatterFactory
     /**
      * Builds formatter configuration.
      */
-    public function buildFormatter(ContainerBuilder $container);
+    public function buildFormatter(ContainerBuilder $container): void;
 
     /**
      * Processes formatter configuration.
      */
-    public function processFormatter(ContainerBuilder $container);
+    public function processFormatter(ContainerBuilder $container): void;
 }

--- a/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
+++ b/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
@@ -29,7 +29,7 @@ final class PathOptionsController implements Controller
     ) {
     }
 
-    public function configure(Command $command)
+    public function configure(Command $command): void
     {
         $command
             ->addOption(

--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -27,10 +27,8 @@ interface Extension
 {
     /**
      * Returns the extension config key.
-     *
-     * @return string
      */
-    public function getConfigKey();
+    public function getConfigKey(): string;
 
     /**
      * Initializes other extensions.
@@ -65,8 +63,6 @@ interface Extension
      *
      * NOTE: If your extension uses the ContainerBuilder passed to this method, your composer.json should declare
      *  a direct dependency on the version(s) of symfony/dependency-injection that you support.
-     *
-     * @return void
      */
-    public function process(ContainerBuilder $container);
+    public function process(ContainerBuilder $container): void;
 }

--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -38,7 +38,7 @@ interface Extension
      * to hook into the configuration of other extensions providing such an
      * extension point.
      */
-    public function initialize(ExtensionManager $extensionManager);
+    public function initialize(ExtensionManager $extensionManager): void;
 
     /**
      * Setups configuration for the extension.
@@ -46,7 +46,7 @@ interface Extension
      * NOTE: If your extension uses the ArrayNodeDefinition passed to this method, your composer.json should declare
      * a direct dependency on the version(s) of symfony/config that you support.
      */
-    public function configure(ArrayNodeDefinition $builder);
+    public function configure(ArrayNodeDefinition $builder): void;
 
     /**
      * Loads extension services into temporary container.
@@ -56,7 +56,7 @@ interface Extension
      *
      * @param array<string, mixed> $config
      */
-    public function load(ContainerBuilder $container, array $config);
+    public function load(ContainerBuilder $container, array $config): void;
 
     /**
      * You can modify the container here before it is dumped to PHP code.

--- a/src/Behat/Testwork/Specification/Locator/SpecificationLocator.php
+++ b/src/Behat/Testwork/Specification/Locator/SpecificationLocator.php
@@ -35,9 +35,7 @@ interface SpecificationLocator
     /**
      * Locates specifications and wraps them into iterator.
      *
-     * @param string|null $locator
-     *
      * @return SpecificationIterator<T>
      */
-    public function locateSpecifications(Suite $suite, $locator): SpecificationIterator;
+    public function locateSpecifications(Suite $suite, ?string $locator): SpecificationIterator;
 }

--- a/src/Behat/Testwork/Specification/Locator/SpecificationLocator.php
+++ b/src/Behat/Testwork/Specification/Locator/SpecificationLocator.php
@@ -30,7 +30,7 @@ interface SpecificationLocator
      *
      * @return string[]
      */
-    public function getLocatorExamples();
+    public function getLocatorExamples(): array;
 
     /**
      * Locates specifications and wraps them into iterator.
@@ -39,5 +39,5 @@ interface SpecificationLocator
      *
      * @return SpecificationIterator<T>
      */
-    public function locateSpecifications(Suite $suite, $locator);
+    public function locateSpecifications(Suite $suite, $locator): SpecificationIterator;
 }

--- a/src/Behat/Testwork/Specification/SpecificationIterator.php
+++ b/src/Behat/Testwork/Specification/SpecificationIterator.php
@@ -26,8 +26,6 @@ interface SpecificationIterator extends Iterator
 {
     /**
      * Returns suite that was used to load specifications.
-     *
-     * @return Suite
      */
-    public function getSuite();
+    public function getSuite(): Suite;
 }

--- a/src/Behat/Testwork/Suite/Generator/GenericSuiteGenerator.php
+++ b/src/Behat/Testwork/Suite/Generator/GenericSuiteGenerator.php
@@ -28,12 +28,12 @@ final class GenericSuiteGenerator implements SuiteGenerator
     ) {
     }
 
-    public function supportsTypeAndSettings($type, array $settings): bool
+    public function supportsTypeAndSettings(?string $type, array $settings): bool
     {
         return null === $type;
     }
 
-    public function generateSuite($suiteName, array $settings): Suite
+    public function generateSuite(string $suiteName, array $settings): Suite
     {
         return new GenericSuite($suiteName, $this->mergeDefaultSettings($settings));
     }

--- a/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
+++ b/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
@@ -26,17 +26,11 @@ interface SuiteGenerator
      * Checks if generator support provided suite type and settings.
      *
      * @param string|null $type
-     *
-     * @return bool
      */
-    public function supportsTypeAndSettings($type, array $settings);
+    public function supportsTypeAndSettings($type, array $settings): bool;
 
     /**
      * Generate suite with provided name and settings.
-     *
-     * @param string $suiteName
-     *
-     * @return Suite
      */
-    public function generateSuite($suiteName, array $settings);
+    public function generateSuite(string $suiteName, array $settings): Suite;
 }

--- a/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
+++ b/src/Behat/Testwork/Suite/Generator/SuiteGenerator.php
@@ -24,10 +24,8 @@ interface SuiteGenerator
 {
     /**
      * Checks if generator support provided suite type and settings.
-     *
-     * @param string|null $type
      */
-    public function supportsTypeAndSettings($type, array $settings): bool;
+    public function supportsTypeAndSettings(?string $type, array $settings): bool;
 
     /**
      * Generate suite with provided name and settings.

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -48,10 +48,8 @@ final class GenericSuite implements Suite
 
     /**
      * Checks if a setting with provided name exists.
-     *
-     * @param string $key
      */
-    public function hasSetting($key): bool
+    public function hasSetting(string $key): bool
     {
         return array_key_exists($key, $this->settings);
     }
@@ -59,11 +57,9 @@ final class GenericSuite implements Suite
     /**
      * Returns setting value by its key.
      *
-     * @param string $key
-     *
      * @throws ParameterNotFoundException If setting is not set
      */
-    public function getSetting($key): mixed
+    public function getSetting(string $key): mixed
     {
         if (!$this->hasSetting($key)) {
             throw new ParameterNotFoundException(sprintf(

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -32,10 +32,8 @@ final class GenericSuite implements Suite
 
     /**
      * Returns unique suite name.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -63,7 +63,7 @@ final class GenericSuite implements Suite
      *
      * @throws ParameterNotFoundException If setting is not set
      */
-    public function getSetting($key)
+    public function getSetting($key): mixed
     {
         if (!$this->hasSetting($key)) {
             throw new ParameterNotFoundException(sprintf(

--- a/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
+++ b/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
@@ -24,10 +24,8 @@ interface SuiteSetup
 {
     /**
      * Checks if setup supports provided suite.
-     *
-     * @return bool
      */
-    public function supportsSuite(Suite $suite);
+    public function supportsSuite(Suite $suite): bool;
 
     /**
      * Sets up provided suite.

--- a/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
+++ b/src/Behat/Testwork/Suite/Setup/SuiteSetup.php
@@ -30,5 +30,5 @@ interface SuiteSetup
     /**
      * Sets up provided suite.
      */
-    public function setupSuite(Suite $suite);
+    public function setupSuite(Suite $suite): void;
 }

--- a/src/Behat/Testwork/Suite/Suite.php
+++ b/src/Behat/Testwork/Suite/Suite.php
@@ -35,5 +35,5 @@ interface Suite
     /**
      * Returns setting value by its key.
      */
-    public function getSetting(string $key);
+    public function getSetting(string $key): void;
 }

--- a/src/Behat/Testwork/Suite/Suite.php
+++ b/src/Behat/Testwork/Suite/Suite.php
@@ -35,5 +35,5 @@ interface Suite
     /**
      * Returns setting value by its key.
      */
-    public function getSetting(string $key): void;
+    public function getSetting(string $key): mixed;
 }

--- a/src/Behat/Testwork/Suite/Suite.php
+++ b/src/Behat/Testwork/Suite/Suite.php
@@ -19,31 +19,21 @@ interface Suite
 {
     /**
      * Returns unique suite name.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Returns suite settings.
-     *
-     * @return array
      */
-    public function getSettings();
+    public function getSettings(): array;
 
     /**
      * Checks if a setting with provided name exists.
-     *
-     * @param string $key
-     *
-     * @return bool
      */
-    public function hasSetting($key);
+    public function hasSetting(string $key): bool;
 
     /**
      * Returns setting value by its key.
-     *
-     * @param string $key
      */
-    public function getSetting($key);
+    public function getSetting(string $key);
 }

--- a/src/Behat/Testwork/Suite/SuiteRepository.php
+++ b/src/Behat/Testwork/Suite/SuiteRepository.php
@@ -22,5 +22,5 @@ interface SuiteRepository
      *
      * @return Suite[]
      */
-    public function getSuites();
+    public function getSuites(): array;
 }

--- a/src/Behat/Testwork/Tester/Exercise.php
+++ b/src/Behat/Testwork/Tester/Exercise.php
@@ -28,29 +28,20 @@ interface Exercise
      * Sets up exercise for a test.
      *
      * @param SpecificationIterator<TSpec>[] $iterators
-     * @param bool                 $skip
-     *
-     * @return Setup
      */
-    public function setUp(array $iterators, $skip);
+    public function setUp(array $iterators, bool $skip): Setup;
 
     /**
      * Tests suites specifications.
      *
      * @param SpecificationIterator<TSpec>[] $iterators
-     * @param bool                 $skip
-     *
-     * @return TestResult
      */
-    public function test(array $iterators, $skip);
+    public function test(array $iterators, bool $skip): TestResult;
 
     /**
      * Tears down exercise after a test.
      *
      * @param SpecificationIterator<TSpec>[] $iterators
-     * @param bool                 $skip
-     *
-     * @return Teardown
      */
-    public function tearDown(array $iterators, $skip, TestResult $result);
+    public function tearDown(array $iterators, bool $skip, TestResult $result): Teardown;
 }

--- a/src/Behat/Testwork/Tester/Result/ExceptionResult.php
+++ b/src/Behat/Testwork/Tester/Result/ExceptionResult.php
@@ -23,10 +23,8 @@ interface ExceptionResult extends TestResult
 {
     /**
      * Checks that the test result has exception.
-     *
-     * @return bool
      */
-    public function hasException();
+    public function hasException(): bool;
 
     /**
      * Returns exception that test result has.

--- a/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
+++ b/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
@@ -29,7 +29,7 @@ final class IntegerTestResult implements TestResult
 
     public function isPassed(): bool
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED === $this->getResultCode();
     }
 
     /**

--- a/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
+++ b/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
@@ -35,7 +35,7 @@ final class IntegerTestResult implements TestResult
     /**
      * @return TestResult::*
      */
-    public function getResultCode()
+    public function getResultCode(): int
     {
         return $this->resultCode;
     }

--- a/src/Behat/Testwork/Tester/Result/Interpretation/ResultInterpretation.php
+++ b/src/Behat/Testwork/Tester/Result/Interpretation/ResultInterpretation.php
@@ -24,8 +24,6 @@ interface ResultInterpretation
 {
     /**
      * Checks if provided test result should be considered as a failure.
-     *
-     * @return bool
      */
-    public function isFailure(TestResult $result);
+    public function isFailure(TestResult $result): bool;
 }

--- a/src/Behat/Testwork/Tester/Result/TestResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestResult.php
@@ -27,15 +27,13 @@ interface TestResult
 
     /**
      * Checks that test has passed.
-     *
-     * @return bool
      */
-    public function isPassed();
+    public function isPassed(): bool;
 
     /**
      * Returns tester result code.
      *
      * @return TestResult::*|TestResults::NO_TESTS
      */
-    public function getResultCode();
+    public function getResultCode(): int;
 }

--- a/src/Behat/Testwork/Tester/Result/TestResults.php
+++ b/src/Behat/Testwork/Tester/Result/TestResults.php
@@ -45,7 +45,7 @@ final class TestResults implements TestResult, Countable, IteratorAggregate
     /**
      * @return TestResult::*|TestResults::NO_TESTS
      */
-    public function getResultCode()
+    public function getResultCode(): int
     {
         $resultCode = self::NO_TESTS;
         foreach ($this->results as $result) {

--- a/src/Behat/Testwork/Tester/Result/TestResults.php
+++ b/src/Behat/Testwork/Tester/Result/TestResults.php
@@ -39,7 +39,7 @@ final class TestResults implements TestResult, Countable, IteratorAggregate
 
     public function isPassed(): bool
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED === $this->getResultCode();
     }
 
     /**

--- a/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
@@ -34,7 +34,7 @@ final class TestWithSetupResult implements TestResult
 
     public function isPassed(): bool
     {
-        return self::PASSED == $this->getResultCode();
+        return self::PASSED === $this->getResultCode();
     }
 
     public function getResultCode(): int

--- a/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
+++ b/src/Behat/Testwork/Tester/Result/TestWithSetupResult.php
@@ -37,7 +37,7 @@ final class TestWithSetupResult implements TestResult
         return self::PASSED == $this->getResultCode();
     }
 
-    public function getResultCode()
+    public function getResultCode(): int
     {
         if (!$this->setup->isSuccessful()) {
             return self::FAILED;

--- a/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php
+++ b/src/Behat/Testwork/Tester/Runtime/RuntimeExercise.php
@@ -45,12 +45,12 @@ final class RuntimeExercise implements Exercise
     ) {
     }
 
-    public function setUp(array $iterators, $skip): Setup
+    public function setUp(array $iterators, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(array $iterators, $skip = false): TestResult
+    public function test(array $iterators, bool $skip = false): TestResult
     {
         $results = [];
         foreach (GroupedSpecificationIterator::group($iterators) as $iterator) {
@@ -68,7 +68,7 @@ final class RuntimeExercise implements Exercise
         return new TestResults($results);
     }
 
-    public function tearDown(array $iterators, $skip, TestResult $result): Teardown
+    public function tearDown(array $iterators, bool $skip, TestResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Testwork/Tester/Runtime/RuntimeSuiteTester.php
+++ b/src/Behat/Testwork/Tester/Runtime/RuntimeSuiteTester.php
@@ -44,12 +44,12 @@ final class RuntimeSuiteTester implements SuiteTester
     ) {
     }
 
-    public function setUp(Environment $env, SpecificationIterator $iterator, $skip): Setup
+    public function setUp(Environment $env, SpecificationIterator $iterator, bool $skip): Setup
     {
         return new SuccessfulSetup();
     }
 
-    public function test(Environment $env, SpecificationIterator $iterator, $skip = false): TestResult
+    public function test(Environment $env, SpecificationIterator $iterator, bool $skip = false): TestResult
     {
         $results = [];
         foreach ($iterator as $specification) {
@@ -65,7 +65,7 @@ final class RuntimeSuiteTester implements SuiteTester
         return new TestResults($results);
     }
 
-    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result): Teardown
+    public function tearDown(Environment $env, SpecificationIterator $iterator, bool $skip, TestResult $result): Teardown
     {
         return new SuccessfulTeardown();
     }

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -65,7 +65,7 @@ abstract class TesterExtension implements Extension
         $this->processor = $processor ?: new ServiceProcessor();
     }
 
-    public function getConfigKey()
+    public function getConfigKey(): string
     {
         return 'testers';
     }

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -70,11 +70,11 @@ abstract class TesterExtension implements Extension
         return 'testers';
     }
 
-    public function initialize(ExtensionManager $extensionManager)
+    public function initialize(ExtensionManager $extensionManager): void
     {
     }
 
-    public function configure(ArrayNodeDefinition $builder)
+    public function configure(ArrayNodeDefinition $builder): void
     {
         $childrenBuilder = $builder
             ->addDefaultsIfNotSet()
@@ -96,7 +96,7 @@ abstract class TesterExtension implements Extension
         ;
     }
 
-    public function load(ContainerBuilder $container, array $config)
+    public function load(ContainerBuilder $container, array $config): void
     {
         $this->loadExerciseController($container, $config['skip']);
         $this->loadStopOnFailureController($container);

--- a/src/Behat/Testwork/Tester/Setup/Setup.php
+++ b/src/Behat/Testwork/Tester/Setup/Setup.php
@@ -21,15 +21,11 @@ interface Setup
 {
     /**
      * Returns true if fixtures have been handled successfully.
-     *
-     * @return bool
      */
-    public function isSuccessful();
+    public function isSuccessful(): bool;
 
     /**
      * Checks if setup has produced any output.
-     *
-     * @return bool
      */
-    public function hasOutput();
+    public function hasOutput(): bool;
 }

--- a/src/Behat/Testwork/Tester/Setup/Teardown.php
+++ b/src/Behat/Testwork/Tester/Setup/Teardown.php
@@ -21,15 +21,11 @@ interface Teardown
 {
     /**
      * Returns true if fixtures have been handled successfully.
-     *
-     * @return bool
      */
-    public function isSuccessful();
+    public function isSuccessful(): bool;
 
     /**
      * Checks if tear down has produced any output.
-     *
-     * @return bool
      */
-    public function hasOutput();
+    public function hasOutput(): bool;
 }

--- a/src/Behat/Testwork/Tester/SpecificationTester.php
+++ b/src/Behat/Testwork/Tester/SpecificationTester.php
@@ -28,29 +28,20 @@ interface SpecificationTester
      * Sets up specification for a test.
      *
      * @param TSpec       $spec
-     * @param bool     $skip
-     *
-     * @return Setup
      */
-    public function setUp(Environment $env, $spec, $skip);
+    public function setUp(Environment $env, $spec, bool $skip): Setup;
 
     /**
      * Tests provided specification.
      *
      * @param TSpec       $spec
-     * @param bool     $skip
-     *
-     * @return TestResult
      */
-    public function test(Environment $env, $spec, $skip);
+    public function test(Environment $env, $spec, bool $skip): TestResult;
 
     /**
      * Tears down specification after a test.
      *
      * @param TSpec       $spec
-     * @param bool     $skip
-     *
-     * @return Teardown
      */
-    public function tearDown(Environment $env, $spec, $skip, TestResult $result);
+    public function tearDown(Environment $env, $spec, bool $skip, TestResult $result): Teardown;
 }

--- a/src/Behat/Testwork/Tester/SpecificationTester.php
+++ b/src/Behat/Testwork/Tester/SpecificationTester.php
@@ -29,19 +29,19 @@ interface SpecificationTester
      *
      * @param TSpec       $spec
      */
-    public function setUp(Environment $env, $spec, bool $skip): Setup;
+    public function setUp(Environment $env, mixed $spec, bool $skip): Setup;
 
     /**
      * Tests provided specification.
      *
      * @param TSpec       $spec
      */
-    public function test(Environment $env, $spec, bool $skip): TestResult;
+    public function test(Environment $env, mixed $spec, bool $skip): TestResult;
 
     /**
      * Tears down specification after a test.
      *
      * @param TSpec       $spec
      */
-    public function tearDown(Environment $env, $spec, bool $skip, TestResult $result): Teardown;
+    public function tearDown(Environment $env, mixed $spec, bool $skip, TestResult $result): Teardown;
 }

--- a/src/Behat/Testwork/Tester/SuiteTester.php
+++ b/src/Behat/Testwork/Tester/SuiteTester.php
@@ -29,29 +29,20 @@ interface SuiteTester
      * Sets up suite for a test.
      *
      * @param SpecificationIterator<TSpec> $iterator
-     * @param bool               $skip
-     *
-     * @return Setup
      */
-    public function setUp(Environment $env, SpecificationIterator $iterator, $skip);
+    public function setUp(Environment $env, SpecificationIterator $iterator, bool $skip): Setup;
 
     /**
      * Tests provided suite specifications.
      *
      * @param SpecificationIterator<TSpec> $iterator
-     * @param bool               $skip
-     *
-     * @return TestResult
      */
-    public function test(Environment $env, SpecificationIterator $iterator, $skip);
+    public function test(Environment $env, SpecificationIterator $iterator, bool $skip): TestResult;
 
     /**
      * Tears down suite after a test.
      *
      * @param SpecificationIterator<TSpec> $iterator
-     * @param bool               $skip
-     *
-     * @return Teardown
      */
-    public function tearDown(Environment $env, SpecificationIterator $iterator, $skip, TestResult $result);
+    public function tearDown(Environment $env, SpecificationIterator $iterator, bool $skip, TestResult $result): Teardown;
 }

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/ArgumentsContextAttributes.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/ArgumentsContextAttributes.php
@@ -27,7 +27,7 @@ class ArgumentsContextAttributes implements TranslatableContext
         PHPUnit\Framework\Assert::assertSame($value, $this->index);
     }
 
-    public static function getTranslationResources()
+    public static function getTranslationResources(): array
     {
         return [__DIR__ . DIRECTORY_SEPARATOR . 'i18n' . DIRECTORY_SEPARATOR . 'ru.xliff'];
     }

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/FeatureContextAttributes.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/FeatureContextAttributes.php
@@ -40,7 +40,7 @@ class FeatureContextAttributes implements TranslatableContext
         PHPUnit\Framework\Assert::assertEquals($username, $user->name);
     }
 
-    public static function getTranslationResources()
+    public static function getTranslationResources(): array
     {
         return [__DIR__ . DIRECTORY_SEPARATOR . 'i18n' . DIRECTORY_SEPARATOR . 'ru.xliff'];
     }

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/PhpContextAttributes.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/PhpContextAttributes.php
@@ -40,7 +40,7 @@ class PhpContextAttributes implements TranslatableContext
         PHPUnit\Framework\Assert::assertEquals($username, $user->name);
     }
 
-    public static function getTranslationResources()
+    public static function getTranslationResources(): array
     {
         return [__DIR__ . DIRECTORY_SEPARATOR . 'i18n' . DIRECTORY_SEPARATOR . 'ru.php'];
     }

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/YamlContextAttributes.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/YamlContextAttributes.php
@@ -40,7 +40,7 @@ class YamlContextAttributes implements TranslatableContext
         PHPUnit\Framework\Assert::assertEquals($username, $user->name);
     }
 
-    public static function getTranslationResources()
+    public static function getTranslationResources(): array
     {
         return [__DIR__ . DIRECTORY_SEPARATOR . 'i18n' . DIRECTORY_SEPARATOR . 'ru.yml'];
     }

--- a/tests/Fixtures/UnusedDefinitions/features/bootstrap/TranslatedDefinitionsContext.php
+++ b/tests/Fixtures/UnusedDefinitions/features/bootstrap/TranslatedDefinitionsContext.php
@@ -15,7 +15,7 @@ class TranslatedDefinitionsContext implements TranslatableContext
     {
     }
 
-    public static function getTranslationResources()
+    public static function getTranslationResources(): array
     {
         return [__DIR__ . DIRECTORY_SEPARATOR . 'i18n' . DIRECTORY_SEPARATOR . 'ru.xliff'];
     }


### PR DESCRIPTION
Adds strict parameter / return types to all methods that are defined in an interface. The types are applied both to the interface and to all implementations of the method.

I have used my [ingenerator/risky-rector-rules](https://github.com/ingenerator/risky-rector-rules) package to:

* generate the interface method signatures from their phpdoc, removing redundant phpdoc at the same time
* explicitly mark interface methods as `void` if they were not documented as returning anything
* add parameter types in all methods that extend / implement a parent method (if the parameter was previously untyped). This is theoretically risky if a child class was intentionally accepting a wider type than the parent, but I have not yet found anywhere that it actually causes a problem.

I have also used standard Rector rules to add method return types based on the new interface method returns, and to refactor a few `==` that are now safe to be `===` because they are comparing known types.

Along the way, I've made some manual fixes / changes to the auto-generated types where our phpdoc was wrong/incomplete.

I've left in the commits that added the extra Rector package & rules for transparency, but reverted them out at the end. The risky-rector-rules are only intended to be used for a one-time migration.

This continues #1744

After this is merged, the next step will be to run Rector's own type-declaration rules again to add types based on analysing the new method parameter / return type information.
