### PR TITLE
fix: Callee description can be null

### DIFF
--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -33,7 +33,7 @@ interface Callee
     /**
      * Returns callee description.
      *
-     * @return string
+     * @return ?string
      */
     public function getDescription();
 

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -53,7 +53,7 @@ class RuntimeCallee implements Callee
     /**
      * Returns callee description.
      *
-     * @return string
+     * @return ?string
      */
     public function getDescription()
     {


### PR DESCRIPTION
The phpdoc on Callee::getDescription was `@return string` however `RuntimeCallee` (which is the parent of most implementations) accepts a nullable description value and therefore the return type can also be null.