### PR TITLE
[4.0] refactor: Add strict types based on Rector type-declaration rules

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -25,6 +25,9 @@
         <!-- Addition of strict return types is expected throughout the 4.0 release -->
         <ignored-regex>#CHANGED: The return type of .+? changed from no type to#</ignored-regex>
 
+        <!-- Addition of strict property types is expected throughout the 4.0 release -->
+        <ignored-regex>#CHANGED: Type of property .+? changed from having no type to#</ignored-regex>
+
         <!--
         When running in the 4.x branch, the BC checker installs symfony 8, therefore reports BC breaks in symfony
         classes that we extend (since the 3.x release it compares to installed symfony 7)

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(13)
+    ->withTypeCoverageLevel(18)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(9)
+    ->withTypeCoverageLevel(13)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(32)
+    ->withTypeCoverageLevel(35)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(6)
+    ->withTypeCoverageLevel(9)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(57)
+    ->withTypeCoverageLevel(58)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(25)
+    ->withTypeCoverageLevel(32)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(21)
+    ->withTypeCoverageLevel(22)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
+    ->withTypeCoverageLevel(0)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(48)
+    ->withTypeCoverageLevel(49)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(22)
+    ->withTypeCoverageLevel(25)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,6 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(58)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(0)
+    ->withTypeCoverageLevel(6)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(56)
+    ->withTypeCoverageLevel(57)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(18)
+    ->withTypeCoverageLevel(21)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(49)
+    ->withTypeCoverageLevel(56)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(35)
+    ->withTypeCoverageLevel(48)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -124,7 +124,7 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
      *
      * @throws SuiteConfigurationException If `contexts` setting is not an array
      */
-    private function getSuiteContexts(Suite $suite): mixed
+    private function getSuiteContexts(Suite $suite): array
     {
         if (!is_array($suite->getSetting('contexts'))) {
             throw new SuiteConfigurationException(

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -124,7 +124,7 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
      *
      * @throws SuiteConfigurationException If `contexts` setting is not an array
      */
-    private function getSuiteContexts(Suite $suite)
+    private function getSuiteContexts(Suite $suite): mixed
     {
         if (!is_array($suite->getSetting('contexts'))) {
             throw new SuiteConfigurationException(

--- a/src/Behat/Behat/Context/Environment/Reader/ContextEnvironmentReader.php
+++ b/src/Behat/Behat/Context/Environment/Reader/ContextEnvironmentReader.php
@@ -68,11 +68,9 @@ final class ContextEnvironmentReader implements EnvironmentReader
     /**
      * Reads callees from a specific suite's context.
      *
-     * @param string             $contextClass
-     *
      * @return list<Callee>
      */
-    private function readContextCallees(ContextEnvironment $environment, $contextClass): array
+    private function readContextCallees(ContextEnvironment $environment, string $contextClass): array
     {
         $callees = [];
         foreach ($this->contextReaders as $loader) {

--- a/src/Behat/Behat/Context/Reader/TranslatableContextReader.php
+++ b/src/Behat/Behat/Context/Reader/TranslatableContextReader.php
@@ -53,11 +53,9 @@ final class TranslatableContextReader implements ContextReader
     /**
      * Adds translation resource.
      *
-     * @param string $path
-     *
      * @throws UnknownTranslationResourceException
      */
-    private function addTranslationResource($path, ?string $assetsId): void
+    private function addTranslationResource(string $path, ?string $assetsId): void
     {
         match ($ext = pathinfo($path, PATHINFO_EXTENSION)) {
             'yml' => $this->addTranslatorResource('yaml', $path, basename($path, '.' . $ext), $assetsId),
@@ -72,10 +70,8 @@ final class TranslatableContextReader implements ContextReader
 
     /**
      * Adds resource to translator instance.
-     *
-     * @param string $path
      */
-    private function addTranslatorResource(string $type, $path, string $language, ?string $assetsId): void
+    private function addTranslatorResource(string $type, string $path, string $language, ?string $assetsId): void
     {
         $this->translator->addResource($type, $path, $language, $assetsId);
     }

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -66,11 +66,9 @@ final class PatternTransformer
      *
      * @param string $pattern
      *
-     * @return string
-     *
      * @throws UnknownPatternException
      */
-    public function transformPatternToRegex($pattern)
+    public function transformPatternToRegex($pattern): string
     {
         if (!isset($this->patternToRegexpCache[$pattern])) {
             $this->patternToRegexpCache[$pattern] = $this->transformPatternToRegexWithSupportedPolicy($pattern);

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -46,11 +46,9 @@ final class PatternTransformer
      * @param string $type
      * @param string $stepText
      *
-     * @return Pattern
-     *
      * @throws UnsupportedPatternTypeException
      */
-    public function generatePattern($type, $stepText)
+    public function generatePattern($type, $stepText): Pattern
     {
         foreach ($this->policies as $policy) {
             if ($policy->supportsPatternType($type)) {
@@ -98,11 +96,9 @@ final class PatternTransformer
     /**
      * @param string $pattern
      *
-     * @return string
-     *
      * @throws UnknownPatternException
      */
-    private function transformPatternToRegexWithSupportedPolicy($pattern)
+    private function transformPatternToRegexWithSupportedPolicy($pattern): string
     {
         foreach ($this->policies as $policy) {
             if ($policy->supportsPattern($pattern)) {

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -44,11 +44,10 @@ final class PatternTransformer
      * Generates pattern.
      *
      * @param string $type
-     * @param string $stepText
      *
      * @throws UnsupportedPatternTypeException
      */
-    public function generatePattern($type, $stepText): Pattern
+    public function generatePattern($type, string $stepText): Pattern
     {
         foreach ($this->policies as $policy) {
             if ($policy->supportsPatternType($type)) {

--- a/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/RegexPatternPolicy.php
@@ -86,10 +86,8 @@ final class RegexPatternPolicy implements PatternPolicy
 
     /**
      * Counts regex placeholders using provided text.
-     *
-     * @param string $stepText
      */
-    private function countPlaceholders($stepText, string $stepRegex): int
+    private function countPlaceholders(string $stepText, string $stepRegex): int
     {
         preg_match('/^' . $stepRegex . '$/', $stepText, $matches);
 

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -86,10 +86,7 @@ final class TurnipPatternPolicy implements PatternPolicy
         return $this->regexCache[$pattern];
     }
 
-    /**
-     * @param string $pattern
-     */
-    private function createTransformedRegex($pattern): string
+    private function createTransformedRegex(string $pattern): string
     {
         $regex = preg_quote($pattern, '/');
 

--- a/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
@@ -46,10 +46,8 @@ final class TranslatedDefinition implements Stringable, Definition
 
     /**
      * Returns original (not translated) pattern.
-     *
-     * @return string
      */
-    public function getOriginalPattern()
+    public function getOriginalPattern(): string
     {
         return $this->definition->getPattern();
     }

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
@@ -63,10 +63,8 @@ final class AfterStepSetup extends StepTested implements AfterSetup
 
     /**
      * Checks if step call, setup or teardown produced any output (stdOut or exception).
-     *
-     * @return bool
      */
-    public function hasOutput()
+    public function hasOutput(): bool
     {
         return $this->setup->hasOutput();
     }

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
@@ -83,10 +83,8 @@ final class AfterStepTested extends StepTested implements AfterTested
 
     /**
      * Checks if step teardown has output.
-     *
-     * @return bool
      */
-    private function teardownHasOutput()
+    private function teardownHasOutput(): bool
     {
         return $this->teardown->hasOutput();
     }

--- a/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Behat/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -45,7 +45,7 @@ final class EventDispatcherExtension extends BaseExtension
     /**
      * Loads event-dispatching background tester.
      */
-    protected function loadEventDispatchingBackgroundTester(ContainerBuilder $container)
+    protected function loadEventDispatchingBackgroundTester(ContainerBuilder $container): void
     {
         $definition = new Definition(EventDispatchingBackgroundTester::class, [
             new Reference(TesterExtension::BACKGROUND_TESTER_ID),
@@ -58,7 +58,7 @@ final class EventDispatcherExtension extends BaseExtension
     /**
      * Loads event-dispatching feature tester.
      */
-    protected function loadEventDispatchingFeatureTester(ContainerBuilder $container)
+    protected function loadEventDispatchingFeatureTester(ContainerBuilder $container): void
     {
         $definition = new Definition(EventDispatchingFeatureTester::class, [
             new Reference(TesterExtension::SPECIFICATION_TESTER_ID),
@@ -71,7 +71,7 @@ final class EventDispatcherExtension extends BaseExtension
     /**
      * Loads event-dispatching outline tester.
      */
-    protected function loadEventDispatchingOutlineTester(ContainerBuilder $container)
+    protected function loadEventDispatchingOutlineTester(ContainerBuilder $container): void
     {
         $definition = new Definition(EventDispatchingOutlineTester::class, [
             new Reference(TesterExtension::OUTLINE_TESTER_ID),
@@ -84,7 +84,7 @@ final class EventDispatcherExtension extends BaseExtension
     /**
      * Loads event-dispatching scenario tester.
      */
-    protected function loadEventDispatchingScenarioTester(ContainerBuilder $container)
+    protected function loadEventDispatchingScenarioTester(ContainerBuilder $container): void
     {
         $definition = new Definition(EventDispatchingScenarioTester::class, [
             new Reference(TesterExtension::SCENARIO_TESTER_ID),
@@ -101,7 +101,7 @@ final class EventDispatcherExtension extends BaseExtension
     /**
      * Loads event-dispatching example tester.
      */
-    protected function loadEventDispatchingExampleTester(ContainerBuilder $container)
+    protected function loadEventDispatchingExampleTester(ContainerBuilder $container): void
     {
         $definition = new Definition(EventDispatchingScenarioTester::class, [
             new Reference(TesterExtension::EXAMPLE_TESTER_ID),
@@ -118,7 +118,7 @@ final class EventDispatcherExtension extends BaseExtension
     /**
      * Loads event-dispatching step tester.
      */
-    protected function loadEventDispatchingStepTester(ContainerBuilder $container)
+    protected function loadEventDispatchingStepTester(ContainerBuilder $container): void
     {
         $definition = new Definition(EventDispatchingStepTester::class, [
             new Reference(TesterExtension::STEP_TESTER_ID),

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -83,7 +83,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
      *
      * @throws SuiteConfigurationException If `paths` setting is not an array
      */
-    private function getSuitePaths(Suite $suite): mixed
+    private function getSuitePaths(Suite $suite): array
     {
         if (!is_array($suite->getSetting('paths'))) {
             throw new SuiteConfigurationException(

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -83,7 +83,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
      *
      * @throws SuiteConfigurationException If `paths` setting is not an array
      */
-    private function getSuitePaths(Suite $suite)
+    private function getSuitePaths(Suite $suite): mixed
     {
         if (!is_array($suite->getSetting('paths'))) {
             throw new SuiteConfigurationException(

--- a/src/Behat/Behat/Output/Node/EventListener/AST/OutlineListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/OutlineListener.php
@@ -97,10 +97,8 @@ final class OutlineListener implements EventListener
 
     /**
      * Prints example footer on example AFTER event.
-     *
-     * @param string    $eventName
      */
-    private function printExampleFooterOnAfterExampleEvent(Formatter $formatter, Event $event, $eventName): void
+    private function printExampleFooterOnAfterExampleEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if (!$event instanceof AfterScenarioTested || ExampleTested::AFTER !== $eventName) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/OutlineTableListener.php
@@ -117,10 +117,8 @@ final class OutlineTableListener implements EventListener
 
     /**
      * Removes outline from the ivar on outline AFTER event.
-     *
-     * @param string $eventName
      */
-    private function forgetOutlineOnAfterOutlineEvent($eventName): void
+    private function forgetOutlineOnAfterOutlineEvent(string $eventName): void
     {
         if (OutlineTested::AFTER !== $eventName) {
             return;
@@ -131,10 +129,8 @@ final class OutlineTableListener implements EventListener
 
     /**
      * Prints outline header (if has not been printed yet) on example AFTER event.
-     *
-     * @param string    $eventName
      */
-    private function printHeaderOnAfterExampleEvent(Formatter $formatter, Event $event, $eventName): void
+    private function printHeaderOnAfterExampleEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if (!$event instanceof AfterScenarioTested || ExampleTested::AFTER !== $eventName) {
             return;
@@ -153,10 +149,8 @@ final class OutlineTableListener implements EventListener
 
     /**
      * Prints example row on example AFTER event.
-     *
-     * @param string    $eventName
      */
-    private function printExampleRowOnAfterExampleEvent(Formatter $formatter, Event $event, $eventName): void
+    private function printExampleRowOnAfterExampleEvent(Formatter $formatter, Event $event, string $eventName): void
     {
         if (!$event instanceof AfterScenarioTested || ExampleTested::AFTER !== $eventName) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
@@ -59,10 +59,8 @@ final class StepListener implements EventListener
 
     /**
      * Removes scenario from the ivar on scenario/background/example AFTER event.
-     *
-     * @param string $eventName
      */
-    private function forgetScenarioOnAfterEvent($eventName): void
+    private function forgetScenarioOnAfterEvent(string $eventName): void
     {
         if (!in_array($eventName, [ScenarioTested::AFTER, ExampleTested::AFTER])) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
@@ -60,10 +60,8 @@ final class FirstBackgroundFiresFirstListener implements EventListener
 
     /**
      * Flushes state if the event is the BEFORE feature.
-     *
-     * @param string $eventName
      */
-    private function flushStatesIfBeginningOfTheFeature($eventName): void
+    private function flushStatesIfBeginningOfTheFeature(string $eventName): void
     {
         if (FeatureTested::BEFORE !== $eventName) {
             return;
@@ -74,10 +72,8 @@ final class FirstBackgroundFiresFirstListener implements EventListener
 
     /**
      * Marks first background printed.
-     *
-     * @param string $eventName
      */
-    private function markFirstBackgroundPrintedAfterBackground($eventName): void
+    private function markFirstBackgroundPrintedAfterBackground(string $eventName): void
     {
         if (BackgroundTested::AFTER !== $eventName) {
             return;
@@ -102,10 +98,8 @@ final class FirstBackgroundFiresFirstListener implements EventListener
 
     /**
      * Fires delayed events on AFTER background event.
-     *
-     * @param string    $eventName
      */
-    private function fireDelayedEventsOnAfterBackground(Formatter $formatter, $eventName): void
+    private function fireDelayedEventsOnAfterBackground(Formatter $formatter, string $eventName): void
     {
         if (BackgroundTested::AFTER !== $eventName) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
@@ -59,10 +59,8 @@ final class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Flushes state if the event is the BEFORE feature.
-     *
-     * @param string $eventName
      */
-    private function flushStatesIfBeginningOfTheFeature($eventName): void
+    private function flushStatesIfBeginningOfTheFeature(string $eventName): void
     {
         if (FeatureTested::BEFORE !== $eventName) {
             return;
@@ -74,10 +72,8 @@ final class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Marks beginning or end of the background.
-     *
-     * @param string $eventName
      */
-    private function markBeginningOrEndOfTheBackground($eventName): void
+    private function markBeginningOrEndOfTheBackground(string $eventName): void
     {
         if (BackgroundTested::BEFORE === $eventName) {
             $this->inBackground = true;
@@ -90,10 +86,8 @@ final class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Marks first background printed.
-     *
-     * @param string $eventName
      */
-    private function markFirstBackgroundPrintedAfterBackground($eventName): void
+    private function markFirstBackgroundPrintedAfterBackground(string $eventName): void
     {
         if (BackgroundTested::AFTER !== $eventName) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/JUnit/JUnitOutlineStoreListener.php
@@ -38,7 +38,7 @@ final class JUnitOutlineStoreListener implements EventListener
         $this->printFooterOnAfterSuiteTestedEvent($formatter, $event);
     }
 
-    private function printHeaderOnBeforeSuiteTestedEvent(Formatter $formatter, Event $event)
+    private function printHeaderOnBeforeSuiteTestedEvent(Formatter $formatter, Event $event): void
     {
         if (!$event instanceof BeforeSuiteTested) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StatisticsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StatisticsListener.php
@@ -41,10 +41,8 @@ final class StatisticsListener implements EventListener
 
     /**
      * Starts timer on exercise BEFORE event.
-     *
-     * @param string $eventName
      */
-    private function startTimerOnBeforeExercise($eventName): void
+    private function startTimerOnBeforeExercise(string $eventName): void
     {
         if (ExerciseCompleted::BEFORE !== $eventName) {
             return;
@@ -55,10 +53,8 @@ final class StatisticsListener implements EventListener
 
     /**
      * Prints statistics on after exercise event.
-     *
-     * @param string    $eventName
      */
-    private function printStatisticsOnAfterExerciseEvent(Formatter $formatter, $eventName): void
+    private function printStatisticsOnAfterExerciseEvent(Formatter $formatter, string $eventName): void
     {
         if (ExerciseCompleted::AFTER !== $eventName) {
             return;

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
@@ -70,10 +70,8 @@ final class StepStatsListener implements EventListener
 
     /**
      * Removes current feature file path from the ivar on feature AFTER event.
-     *
-     * @param string $eventName
      */
-    private function forgetCurrentFeaturePathOnAfterFeatureEvent($eventName): void
+    private function forgetCurrentFeaturePathOnAfterFeatureEvent(string $eventName): void
     {
         if (FeatureTested::AFTER !== $eventName) {
             return;
@@ -95,7 +93,7 @@ final class StepStatsListener implements EventListener
         $this->scenarioPath = sprintf('%s:%s', $this->currentFeaturePath, $event->getScenario()->getLine());
     }
 
-    private function forgetScenarioOnAfterFeatureEvent($eventName): void
+    private function forgetScenarioOnAfterFeatureEvent(string $eventName): void
     {
         if (ScenarioTested::AFTER !== $eventName) {
             return;

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
@@ -92,7 +92,7 @@ final class ProgressStepPrinter implements StepPrinter
 
         $printer->writeln("\n" . $result->getStepDefinition()->getPath() . ':');
         $callResult = $result->getCallResult();
-        $pad = (fn ($line): string => sprintf(
+        $pad = (fn (string $line): string => sprintf(
             '  | {+stdout}%s{-stdout}',
             $line
         ));

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -419,7 +419,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Creates root listener definition.
      */
-    private function rearrangeBackgroundEvents($listener): Definition
+    private function rearrangeBackgroundEvents(Reference $listener): Definition
     {
         return new Definition(FirstBackgroundFiresFirstListener::class, [
             new Definition(OnlyFirstBackgroundFiresListener::class, [
@@ -431,11 +431,9 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Creates contextual proxy listener.
      *
-     * @param string       $beforeEventName
-     * @param string       $afterEventName
      * @param Definition[] $listeners
      */
-    private function proxySiblingEvents($beforeEventName, $afterEventName, array $listeners): Definition
+    private function proxySiblingEvents(string $beforeEventName, string $afterEventName, array $listeners): Definition
     {
         return new Definition(
             FireOnlySiblingsListener::class,
@@ -449,10 +447,8 @@ final class PrettyFormatterFactory implements FormatterFactory
 
     /**
      * Creates contextual proxy listener.
-     *
-     * @param string $name
      */
-    private function proxyEventsIfParameterIsSet($name, $value, Definition $listener): Definition
+    private function proxyEventsIfParameterIsSet(string $name, bool $value, Definition $listener): Definition
     {
         return new Definition(
             FireOnlyIfFormatterParameterListener::class,

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -408,10 +408,8 @@ final class PrettyFormatterFactory implements FormatterFactory
 
     /**
      * Creates output printer definition.
-     *
-     * @return Definition
      */
-    private function createOutputPrinterDefinition()
+    private function createOutputPrinterDefinition(): Definition
     {
         return new Definition(StreamOutputPrinter::class, [
             new Definition(ConsoleOutputFactory::class),
@@ -420,10 +418,8 @@ final class PrettyFormatterFactory implements FormatterFactory
 
     /**
      * Creates root listener definition.
-     *
-     * @return Definition
      */
-    private function rearrangeBackgroundEvents($listener)
+    private function rearrangeBackgroundEvents($listener): Definition
     {
         return new Definition(FirstBackgroundFiresFirstListener::class, [
             new Definition(OnlyFirstBackgroundFiresListener::class, [
@@ -438,10 +434,8 @@ final class PrettyFormatterFactory implements FormatterFactory
      * @param string       $beforeEventName
      * @param string       $afterEventName
      * @param Definition[] $listeners
-     *
-     * @return Definition
      */
-    private function proxySiblingEvents($beforeEventName, $afterEventName, array $listeners)
+    private function proxySiblingEvents($beforeEventName, $afterEventName, array $listeners): Definition
     {
         return new Definition(
             FireOnlySiblingsListener::class,
@@ -457,10 +451,8 @@ final class PrettyFormatterFactory implements FormatterFactory
      * Creates contextual proxy listener.
      *
      * @param string $name
-     *
-     * @return Definition
      */
-    private function proxyEventsIfParameterIsSet($name, $value, Definition $listener)
+    private function proxyEventsIfParameterIsSet($name, $value, Definition $listener): Definition
     {
         return new Definition(
             FireOnlyIfFormatterParameterListener::class,

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/PrettyFormatterFactory.php
@@ -110,7 +110,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads pretty formatter node event listener.
      */
-    private function loadRootNodeListener(ContainerBuilder $container)
+    private function loadRootNodeListener(ContainerBuilder $container): void
     {
         $definition = new Definition(ChainEventListener::class, [
             [
@@ -187,7 +187,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads formatter itself.
      */
-    private function loadFormatter(ContainerBuilder $container)
+    private function loadFormatter(ContainerBuilder $container): void
     {
         $definition = new Definition(TotalStatistics::class);
         $container->setDefinition('output.pretty.statistics', $definition);
@@ -230,7 +230,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads feature, scenario and step printers.
      */
-    private function loadCorePrinters(ContainerBuilder $container)
+    private function loadCorePrinters(ContainerBuilder $container): void
     {
         $definition = new Definition(PrettyFeaturePrinter::class);
         $container->setDefinition('output.node.printer.pretty.feature', $definition);
@@ -266,7 +266,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads table outline printer.
      */
-    private function loadTableOutlinePrinter(ContainerBuilder $container)
+    private function loadTableOutlinePrinter(ContainerBuilder $container): void
     {
         $definition = new Definition(PrettyOutlineTablePrinter::class, [
             new Reference('output.node.printer.pretty.scenario'),
@@ -286,7 +286,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads expanded outline printer.
      */
-    private function loadExpandedOutlinePrinter(ContainerBuilder $container)
+    private function loadExpandedOutlinePrinter(ContainerBuilder $container): void
     {
         $definition = new Definition(PrettyOutlinePrinter::class, [
             new Reference('output.node.printer.pretty.scenario'),
@@ -313,7 +313,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads hook printers.
      */
-    private function loadHookPrinters(ContainerBuilder $container)
+    private function loadHookPrinters(ContainerBuilder $container): void
     {
         $definition = new Definition(PrettySetupPrinter::class, [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
@@ -365,7 +365,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads statistics printer.
      */
-    private function loadStatisticsPrinter(ContainerBuilder $container)
+    private function loadStatisticsPrinter(ContainerBuilder $container): void
     {
         $definition = new Definition(CounterPrinter::class, [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
@@ -391,7 +391,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Loads printer helpers.
      */
-    private function loadPrinterHelpers(ContainerBuilder $container)
+    private function loadPrinterHelpers(ContainerBuilder $container): void
     {
         $definition = new Definition(WidthCalculator::class);
         $container->setDefinition('output.node.printer.pretty.width_calculator', $definition);
@@ -463,7 +463,7 @@ final class PrettyFormatterFactory implements FormatterFactory
     /**
      * Processes all registered pretty formatter node listener wrappers.
      */
-    private function processListenerWrappers(ContainerBuilder $container)
+    private function processListenerWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::ROOT_LISTENER_ID, self::ROOT_LISTENER_WRAPPER_TAG);
     }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -80,7 +80,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Loads progress formatter node event listener.
      */
-    private function loadRootNodeListener(ContainerBuilder $container)
+    private function loadRootNodeListener(ContainerBuilder $container): void
     {
         $definition = new Definition(StepListener::class, [
             new Reference('output.node.printer.progress.step'),
@@ -91,7 +91,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Loads feature, scenario and step printers.
      */
-    private function loadCorePrinters(ContainerBuilder $container)
+    private function loadCorePrinters(ContainerBuilder $container): void
     {
         $definition = new Definition(CounterPrinter::class, [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
@@ -122,7 +122,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Loads printer helpers.
      */
-    private function loadPrinterHelpers(ContainerBuilder $container)
+    private function loadPrinterHelpers(ContainerBuilder $container): void
     {
         $definition = new Definition(ResultToStringConverter::class);
         $container->setDefinition(self::RESULT_TO_STRING_CONVERTER_ID, $definition);
@@ -131,7 +131,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Loads formatter itself.
      */
-    private function loadFormatter(ContainerBuilder $container)
+    private function loadFormatter(ContainerBuilder $container): void
     {
         $definition = new Definition(TotalStatistics::class);
         $container->setDefinition('output.progress.statistics', $definition);
@@ -182,7 +182,7 @@ final class ProgressFormatterFactory implements FormatterFactory
     /**
      * Processes all registered pretty formatter node listener wrappers.
      */
-    private function processListenerWrappers(ContainerBuilder $container)
+    private function processListenerWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::ROOT_LISTENER_ID, self::ROOT_LISTENER_WRAPPER_TAG);
     }

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -171,10 +171,8 @@ final class ProgressFormatterFactory implements FormatterFactory
 
     /**
      * Creates output printer definition.
-     *
-     * @return Definition
      */
-    private function createOutputPrinterDefinition()
+    private function createOutputPrinterDefinition(): Definition
     {
         return new Definition(StreamOutputPrinter::class, [
             new Definition(ConsoleOutputFactory::class),

--- a/src/Behat/Behat/Snippet/AggregateSnippet.php
+++ b/src/Behat/Behat/Snippet/AggregateSnippet.php
@@ -63,7 +63,7 @@ final class AggregateSnippet
     {
         return array_unique(
             array_map(
-                fn (Snippet $snippet) => $snippet->getStep(),
+                fn (Snippet $snippet): StepNode => $snippet->getStep(),
                 $this->snippets
             ),
             SORT_REGULAR
@@ -79,7 +79,7 @@ final class AggregateSnippet
     {
         return array_unique(
             array_map(
-                fn (Snippet $snippet) => $snippet->getTarget(),
+                fn (Snippet $snippet): string => $snippet->getTarget(),
                 $this->snippets
             )
         );

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -80,7 +80,7 @@ final class SnippetExtension implements Extension
         $this->processAppenders($container);
     }
 
-    private function loadController(ContainerBuilder $container)
+    private function loadController(ContainerBuilder $container): void
     {
         $definition = new Definition(ConsoleSnippetPrinter::class, [
             new Reference(CliExtension::OUTPUT_ID),
@@ -98,19 +98,19 @@ final class SnippetExtension implements Extension
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.snippet', $definition);
     }
 
-    private function loadRegistry(ContainerBuilder $container)
+    private function loadRegistry(ContainerBuilder $container): void
     {
         $definition = new Definition(SnippetRegistry::class);
         $container->setDefinition(self::REGISTRY_ID, $definition);
     }
 
-    private function loadWriter(ContainerBuilder $container)
+    private function loadWriter(ContainerBuilder $container): void
     {
         $definition = new Definition(SnippetWriter::class);
         $container->setDefinition(self::WRITER_ID, $definition);
     }
 
-    private function processGenerators(ContainerBuilder $container)
+    private function processGenerators(ContainerBuilder $container): void
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::GENERATOR_TAG);
         $definition = $container->getDefinition(self::REGISTRY_ID);
@@ -120,7 +120,7 @@ final class SnippetExtension implements Extension
         }
     }
 
-    private function processAppenders(ContainerBuilder $container)
+    private function processAppenders(ContainerBuilder $container): void
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::APPENDER_TAG);
         $definition = $container->getDefinition(self::WRITER_ID);

--- a/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeScenarioTester.php
@@ -69,10 +69,8 @@ final class RuntimeScenarioTester implements ScenarioTester
 
     /**
      * Tests background of the provided feature against provided environment.
-     *
-     * @param bool     $skip
      */
-    private function testBackground(Environment $env, FeatureNode $feature, $skip): TestWithSetupResult
+    private function testBackground(Environment $env, FeatureNode $feature, bool $skip): TestWithSetupResult
     {
         $setup = $this->backgroundTester->setUp($env, $feature, $skip);
         $skipSetup = !$setup->isSuccessful() || $skip;

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -81,10 +81,8 @@ final class RuntimeStepTester implements StepTester
 
     /**
      * Tests found definition.
-     *
-     * @param bool      $skip
      */
-    private function testDefinition(Environment $env, FeatureNode $feature, StepNode $step, SearchResult $search, $skip): StepResult
+    private function testDefinition(Environment $env, FeatureNode $feature, StepNode $step, SearchResult $search, bool $skip): StepResult
     {
         if (!$search->hasMatch()) {
             return new UndefinedStepResult();

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -107,7 +107,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Loads specification tester.
      */
-    protected function loadSpecificationTester(ContainerBuilder $container)
+    protected function loadSpecificationTester(ContainerBuilder $container): void
     {
         $definition = new Definition(RuntimeFeatureTester::class, [
             new Reference(self::SCENARIO_TESTER_ID),
@@ -124,7 +124,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Loads scenario tester.
      */
-    protected function loadScenarioTester(ContainerBuilder $container)
+    protected function loadScenarioTester(ContainerBuilder $container): void
     {
         $definition = new Definition(StepContainerTester::class, [
             new Reference(self::STEP_TESTER_ID),
@@ -152,7 +152,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Loads outline tester.
      */
-    protected function loadOutlineTester(ContainerBuilder $container)
+    protected function loadOutlineTester(ContainerBuilder $container): void
     {
         $definition = new Definition(RuntimeOutlineTester::class, [
             new Reference(self::EXAMPLE_TESTER_ID),
@@ -165,7 +165,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Loads example tester.
      */
-    protected function loadExampleTester(ContainerBuilder $container)
+    protected function loadExampleTester(ContainerBuilder $container): void
     {
         $definition = new Definition(StepContainerTester::class, [
             new Reference(self::STEP_TESTER_ID),
@@ -193,7 +193,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Loads background tester.
      */
-    protected function loadBackgroundTester(ContainerBuilder $container)
+    protected function loadBackgroundTester(ContainerBuilder $container): void
     {
         $definition = new Definition(StepContainerTester::class, [
             new Reference(self::STEP_TESTER_ID),
@@ -209,7 +209,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Loads step tester.
      */
-    protected function loadStepTester(ContainerBuilder $container)
+    protected function loadStepTester(ContainerBuilder $container): void
     {
         $definition = new Definition(RuntimeStepTester::class, [
             new Reference(DefinitionExtension::FINDER_ID),
@@ -223,7 +223,7 @@ final class TesterExtension extends BaseExtension
      *
      * @param string|null $cachePath
      */
-    protected function loadRerunController(ContainerBuilder $container, $cachePath)
+    protected function loadRerunController(ContainerBuilder $container, $cachePath): void
     {
         $definition = new Definition(RerunController::class, [
             new Reference(EventDispatcherExtension::DISPATCHER_ID),
@@ -238,7 +238,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Loads pending exception stringer.
      */
-    protected function loadPendingExceptionStringer(ContainerBuilder $container)
+    protected function loadPendingExceptionStringer(ContainerBuilder $container): void
     {
         $definition = new Definition(PendingExceptionStringer::class);
         $definition->addTag(ExceptionExtension::STRINGER_TAG);
@@ -248,7 +248,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Processes all registered scenario tester wrappers.
      */
-    protected function processScenarioTesterWrappers(ContainerBuilder $container)
+    protected function processScenarioTesterWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::SCENARIO_TESTER_ID, self::SCENARIO_TESTER_WRAPPER_TAG);
     }
@@ -256,7 +256,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Processes all registered outline tester wrappers.
      */
-    protected function processOutlineTesterWrappers(ContainerBuilder $container)
+    protected function processOutlineTesterWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::OUTLINE_TESTER_ID, self::OUTLINE_TESTER_WRAPPER_TAG);
     }
@@ -264,7 +264,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Processes all registered example tester wrappers.
      */
-    protected function processExampleTesterWrappers(ContainerBuilder $container)
+    protected function processExampleTesterWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::EXAMPLE_TESTER_ID, self::EXAMPLE_TESTER_WRAPPER_TAG);
     }
@@ -272,7 +272,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Processes all registered background tester wrappers.
      */
-    protected function processBackgroundTesterWrappers(ContainerBuilder $container)
+    protected function processBackgroundTesterWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::BACKGROUND_TESTER_ID, self::BACKGROUND_TESTER_WRAPPER_TAG);
     }
@@ -280,7 +280,7 @@ final class TesterExtension extends BaseExtension
     /**
      * Processes all registered step tester wrappers.
      */
-    protected function processStepTesterWrappers(ContainerBuilder $container)
+    protected function processStepTesterWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::STEP_TESTER_ID, self::STEP_TESTER_WRAPPER_TAG);
     }

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -85,7 +85,7 @@ final class TransformationExtension implements Extension
     /**
      * Loads definition arguments transformer.
      */
-    private function loadDefinitionArgumentsTransformer(ContainerBuilder $container)
+    private function loadDefinitionArgumentsTransformer(ContainerBuilder $container): void
     {
         $definition = new Definition(DefinitionArgumentsTransformer::class);
         $definition->addTag(CallExtension::CALL_FILTER_TAG, ['priority' => 200]);
@@ -95,7 +95,7 @@ final class TransformationExtension implements Extension
     /**
      * Loads default transformers.
      */
-    private function loadDefaultTransformers(ContainerBuilder $container)
+    private function loadDefaultTransformers(ContainerBuilder $container): void
     {
         $definition = new Definition(RepositoryArgumentTransformer::class, [
             new Reference(self::REPOSITORY_ID),
@@ -122,7 +122,7 @@ final class TransformationExtension implements Extension
     /**
      * Loads transformations repository.
      */
-    private function loadRepository(ContainerBuilder $container)
+    private function loadRepository(ContainerBuilder $container): void
     {
         $definition = new Definition(TransformationRepository::class, [
             new Reference(EnvironmentExtension::MANAGER_ID),
@@ -133,7 +133,7 @@ final class TransformationExtension implements Extension
     /**
      * Processes all available argument transformers.
      */
-    private function processArgumentsTransformers(ContainerBuilder $container)
+    private function processArgumentsTransformers(ContainerBuilder $container): void
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::ARGUMENT_TRANSFORMER_TAG);
         $definition = $container->getDefinition(self::DEFINITION_ARGUMENT_TRANSFORMER_ID);

--- a/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
@@ -100,7 +100,7 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
         return 'PatternTransform ' . $this->pattern;
     }
 
-    private function match($regexPattern, $argumentValue, &$match): bool
+    private function match(string $regexPattern, $argumentValue, &$match): bool
     {
         if (is_string($argumentValue) && preg_match($regexPattern, $argumentValue, $match)) {
             // take arguments from capture groups if there are some

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -115,11 +115,9 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
     /**
      * Attempts to get definition parameter using its index (parameter position or name).
      *
-     * @param string|int $argumentIndex
-     *
      * @return string|null
      */
-    private function getParameterClassNameByIndex(DefinitionCall $definitionCall, $argumentIndex)
+    private function getParameterClassNameByIndex(DefinitionCall $definitionCall, int|string $argumentIndex)
     {
         $parameters = array_filter(
             array_filter(
@@ -149,11 +147,9 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
     /**
      * Returns appropriate closure for filtering parameter by index.
      *
-     * @param string|int $index
-     *
      * @return Closure
      */
-    private function hasIndex($index)
+    private function hasIndex(int|string $index)
     {
         return is_string($index) ? $this->hasName($index) : $this->hasPosition($index);
     }
@@ -171,11 +167,9 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
     /**
      * Returns closure to filter parameter by position.
      *
-     * @param int $index
-     *
      * @return Closure
      */
-    private function hasPosition($index)
+    private function hasPosition(int $index)
     {
         return fn (ReflectionParameter $parameter): bool => $index === $parameter->getPosition();
     }

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -71,9 +71,8 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      * Apply simple argument transformations in priority order.
      *
      * @param SimpleArgumentTransformation[] $transformations
-     * @param int|string                     $index
      */
-    private function applySimpleTransformations(array $transformations, DefinitionCall $definitionCall, $index, $value)
+    private function applySimpleTransformations(array $transformations, DefinitionCall $definitionCall, int|string $index, $value)
     {
         usort($transformations, fn (SimpleArgumentTransformation $t1, SimpleArgumentTransformation $t2): int => $t2->getPriority() <=> $t1->getPriority());
 
@@ -89,9 +88,8 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      * Apply normal (non-simple) argument transformations.
      *
      * @param Transformation[] $transformations
-     * @param int|string       $index
      */
-    private function applyNormalTransformations(array $transformations, DefinitionCall $definitionCall, $index, $value)
+    private function applyNormalTransformations(array $transformations, DefinitionCall $definitionCall, int|string $index, $value)
     {
         $newValue = $value;
         foreach ($transformations as $transformation) {
@@ -103,10 +101,8 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
 
     /**
      * Transforms argument value using registered transformers.
-     *
-     * @param int|string $index
      */
-    private function transform(DefinitionCall $definitionCall, Transformation $transformation, $index, $value)
+    private function transform(DefinitionCall $definitionCall, Transformation $transformation, int|string $index, $value)
     {
         if (is_object($value) && !$value instanceof ArgumentInterface) {
             return $value;

--- a/src/Behat/Testwork/Call/CallCenter.php
+++ b/src/Behat/Testwork/Call/CallCenter.php
@@ -110,11 +110,9 @@ final class CallCenter
     /**
      * Handles call using registered call handlers.
      *
-     * @return CallResult
-     *
      * @throws CallHandlingException If call handlers didn't produce call result
      */
-    private function handleCall(Call $call)
+    private function handleCall(Call $call): CallResult
     {
         foreach ($this->callHandlers as $handler) {
             if (!$handler->supportsCall($call)) {

--- a/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
+++ b/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
@@ -47,7 +47,7 @@ class EnvironmentCall implements Call
         return $this->callee;
     }
 
-    final public function getBoundCallable()
+    final public function getBoundCallable(): callable
     {
         return $this->environment->bindCallee($this->callee);
     }

--- a/src/Behat/Testwork/Environment/EnvironmentManager.php
+++ b/src/Behat/Testwork/Environment/EnvironmentManager.php
@@ -52,11 +52,9 @@ final class EnvironmentManager
     /**
      * Builds new environment for provided test suite.
      *
-     * @return Environment
-     *
      * @throws EnvironmentBuildException
      */
-    public function buildEnvironment(Suite $suite)
+    public function buildEnvironment(Suite $suite): Environment
     {
         foreach ($this->handlers as $handler) {
             if ($handler->supportsSuite($suite)) {
@@ -73,11 +71,9 @@ final class EnvironmentManager
     /**
      * Creates new isolated test environment using built one.
      *
-     * @return Environment
-     *
      * @throws EnvironmentIsolationException If appropriate environment handler is not found
      */
-    public function isolateEnvironment(Environment $environment, $testSubject = null)
+    public function isolateEnvironment(Environment $environment, $testSubject = null): Environment
     {
         foreach ($this->handlers as $handler) {
             if ($handler->supportsEnvironmentAndSubject($environment, $testSubject)) {

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -41,10 +41,7 @@ class EventDispatcherExtension implements Extension
      */
     public const SUBSCRIBER_TAG = 'event_dispatcher.subscriber';
 
-    /**
-     * @var ServiceProcessor
-     */
-    protected $processor;
+    protected ServiceProcessor $processor;
 
     /**
      * Initializes extension.

--- a/src/Behat/Testwork/Ordering/OrderedExercise.php
+++ b/src/Behat/Testwork/Ordering/OrderedExercise.php
@@ -39,7 +39,7 @@ final class OrderedExercise implements Exercise
     /**
      * @var SpecificationIterator<TSpec>[]|null
      */
-    private $ordered;
+    private ?array $ordered = null;
 
     /**
      * @param Exercise<TSpec> $decoratedExercise
@@ -78,7 +78,7 @@ final class OrderedExercise implements Exercise
      *
      * @return SpecificationIterator<TSpec>[]
      */
-    private function order(array $iterators)
+    private function order(array $iterators): array
     {
         if (!$this->ordered || $this->unordered != $iterators) {
             $this->unordered = $iterators;

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -75,7 +75,7 @@ final class OutputController implements Controller
     /**
      * Configures formatters based on container, input and output configurations.
      */
-    private function configureFormatters(array $formats, InputInterface $input, OutputInterface $output)
+    private function configureFormatters(array $formats, InputInterface $input, OutputInterface $output): void
     {
         $this->enableFormatters($formats);
         $this->setFormattersParameters($input, $output);
@@ -84,7 +84,7 @@ final class OutputController implements Controller
     /**
      * Enables formatters.
      */
-    private function enableFormatters(array $formats)
+    private function enableFormatters(array $formats): void
     {
         if (count($formats)) {
             $this->manager->disableAllFormatters();
@@ -97,7 +97,7 @@ final class OutputController implements Controller
     /**
      * Sets formatters parameters based on input & output.
      */
-    private function setFormattersParameters(InputInterface $input, OutputInterface $output)
+    private function setFormattersParameters(InputInterface $input, OutputInterface $output): void
     {
         $this->manager->setFormattersParameter('output_decorate', $output->isDecorated());
 

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -61,7 +61,7 @@ final class OutputController implements Controller
             );
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): null
     {
         $formats = $input->getOption('format');
         $outputs = $input->getOption('out');

--- a/src/Behat/Testwork/Output/OutputManager.php
+++ b/src/Behat/Testwork/Output/OutputManager.php
@@ -128,9 +128,8 @@ final class OutputManager
      * Sets provided parameter to said formatter.
      *
      * @param string $formatter
-     * @param string $parameterName
      */
-    public function setFormatterParameter($formatter, $parameterName, $parameterValue): void
+    public function setFormatterParameter($formatter, string $parameterName, $parameterValue): void
     {
         $formatter = $this->getFormatter($formatter);
         $printer = $formatter->getOutputPrinter();
@@ -171,10 +170,8 @@ final class OutputManager
 
     /**
      * Sets provided parameter to all registered formatters.
-     *
-     * @param string $parameterName
      */
-    public function setFormattersParameter($parameterName, $parameterValue): void
+    public function setFormattersParameter(string $parameterName, $parameterValue): void
     {
         foreach (array_keys($this->formatters) as $formatter) {
             $this->setFormatterParameter($formatter, $parameterName, $parameterValue);

--- a/src/Behat/Testwork/Output/OutputManager.php
+++ b/src/Behat/Testwork/Output/OutputManager.php
@@ -47,10 +47,8 @@ final class OutputManager
 
     /**
      * Checks if formatter is registered.
-     *
-     * @param string $name
      */
-    public function isFormatterRegistered($name): bool
+    public function isFormatterRegistered(string $name): bool
     {
         return isset($this->formatters[$name]);
     }

--- a/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
@@ -26,10 +26,8 @@ class ConsoleOutputFactory extends OutputFactory
 {
     /**
      * Creates output formatter that is used to create a stream.
-     *
-     * @return OutputFormatter
      */
-    protected function createOutputFormatter()
+    protected function createOutputFormatter(): OutputFormatter
     {
         return new OutputFormatter();
     }
@@ -72,7 +70,7 @@ class ConsoleOutputFactory extends OutputFactory
         return $stream;
     }
 
-    public function createOutput($stream = null)
+    public function createOutput($stream = null): StreamOutput
     {
         $stream = $stream ?: $this->createOutputStream();
         $format = $this->createOutputFormatter();

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -25,7 +25,7 @@ final class FilesystemOutputFactory extends OutputFactory
 {
     private $fileName;
 
-    public function setFileName($fileName)
+    public function setFileName($fileName): void
     {
         $this->fileName = $fileName;
     }
@@ -33,7 +33,7 @@ final class FilesystemOutputFactory extends OutputFactory
     /**
      * Configure output stream parameters.
      */
-    private function configureOutputStream(OutputInterface $output)
+    private function configureOutputStream(OutputInterface $output): void
     {
         $verbosity = $this->getOutputVerbosity() ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL;
         $output->setVerbosity($verbosity);

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -39,7 +39,7 @@ final class FilesystemOutputFactory extends OutputFactory
         $output->setVerbosity($verbosity);
     }
 
-    public function createOutput($stream = null)
+    public function createOutput($stream = null): StreamOutput
     {
         if ($this->getOutputPath() === null) {
             throw new MissingOutputPathException(

--- a/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
@@ -37,7 +37,7 @@ abstract class OutputFactory
      *
      * @param string $path
      */
-    public function setOutputPath($path)
+    public function setOutputPath($path): void
     {
         $this->outputPath = $path;
     }
@@ -55,7 +55,7 @@ abstract class OutputFactory
     /**
      * Sets output styles.
      */
-    public function setOutputStyles(array $styles)
+    public function setOutputStyles(array $styles): void
     {
         $this->outputStyles = $styles;
     }
@@ -73,7 +73,7 @@ abstract class OutputFactory
     /**
      * Forces output to be decorated.
      */
-    public function setOutputDecorated(?bool $decorated)
+    public function setOutputDecorated(?bool $decorated): void
     {
         $this->outputDecorated = $decorated;
     }
@@ -93,7 +93,7 @@ abstract class OutputFactory
      *
      * @param int $level
      */
-    public function setOutputVerbosity($level)
+    public function setOutputVerbosity($level): void
     {
         $this->verbosityLevel = intval($level);
     }

--- a/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
@@ -26,10 +26,7 @@ class StreamOutputPrinter implements OutputPrinter
     ) {
     }
 
-    /**
-     * @return OutputFactory
-     */
-    protected function getOutputFactory()
+    protected function getOutputFactory(): OutputFactory
     {
         return $this->outputFactory;
     }

--- a/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
+++ b/src/Behat/Testwork/PathOptions/Cli/PathOptionsController.php
@@ -47,7 +47,7 @@ final class PathOptionsController implements Controller
         ;
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): null
     {
         $printAbsolutePaths = $input->getOption('print-absolute-paths');
         $editorUrl = $input->getOption('editor-url');

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -75,11 +75,9 @@ final class ExtensionManager
     /**
      * Returns specific extension by its name.
      *
-     * @param string $key
-     *
      * @return Extension|null
      */
-    public function getExtension($key)
+    public function getExtension(string $key)
     {
         return $this->extensions[$key] ?? null;
     }

--- a/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
+++ b/src/Behat/Testwork/Suite/ServiceContainer/SuiteExtension.php
@@ -77,7 +77,7 @@ final class SuiteExtension implements Extension
             ->prototype('array')
                 ->beforeNormalization()
                     ->ifTrue(fn ($suite): bool => is_array($suite) && count($suite))
-                    ->then(function ($suite) {
+                    ->then(function (array $suite): array {
                         $suite['settings'] ??= [];
 
                         foreach ($suite as $key => $val) {

--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -142,7 +142,7 @@ final class ExerciseController implements Controller
      *
      * @return Suite[]
      */
-    private function getAvailableSuites()
+    private function getAvailableSuites(): array
     {
         return $this->suiteRepository->getSuites();
     }

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -148,7 +148,7 @@ abstract class TesterExtension implements Extension
     /**
      * Loads stop on failure handler.
      */
-    private function loadStopOnFailureHandler(ContainerBuilder $container, ?bool $stopOnFailure)
+    private function loadStopOnFailureHandler(ContainerBuilder $container, ?bool $stopOnFailure): void
     {
         $definition = new Definition(StopOnFailureHandler::class, [
             new Reference(EventDispatcherExtension::DISPATCHER_ID),


### PR DESCRIPTION
Continues #1744 to add more strict types based on Rector's type declaration rules.

This includes:

* Types that Rector could detect in the 3.x branch (including `void` methods) but that we skipped because they would have caused a BC break.
* Types that Rector can detect now that we have strict types on our interfaces in 4.x (e.g. a method that returns the result of calling an interface that now has a strict type).

As usual, I have committed each type coverage level separately to aid review.