### PR TITLE
fix: Type hinting / safety of TableColumnTransformation

### DIFF
--- a/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
@@ -16,6 +16,7 @@ use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
+use InvalidArgumentException;
 use ReflectionMethod;
 use Stringable;
 
@@ -44,7 +45,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
         // The argument passed initially will be a TableNode but if a column transformation
         // has already been applied then this will have been transformed into an array already,
         // so we need to accept both possibilities
-        if (!$argumentArgumentValue instanceof TableNode && !is_array($argumentArgumentValue)) {
+        if (!$this->isSupportedArgumentValueType($argumentArgumentValue)) {
             return false;
         }
 
@@ -73,15 +74,24 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
         return true;
     }
 
-    /**
-     * @param TableNode|array $argumentValue
-     */
+    private function isSupportedArgumentValueType(mixed $argumentArgumentValue): bool
+    {
+        return $argumentArgumentValue instanceof TableNode || is_array($argumentArgumentValue);
+    }
+
     public function transformArgument(
         CallCenter $callCenter,
         DefinitionCall $definitionCall,
         $argumentIndex,
         $argumentValue,
     ): array {
+        if (!$this->isSupportedArgumentValueType($argumentValue)) {
+            throw new InvalidArgumentException(sprintf(
+                __METHOD__ . ' called with an unsupported argument type. Expected an array or a TableNode, got "%s".',
+                get_debug_type($argumentValue)
+            ));
+        }
+
         $columnNames = explode(',', substr($this->pattern, 7));
         $rows = [];
         foreach ($argumentValue as $row) {


### PR DESCRIPTION
The phpdoc declared that `$argumentValue` would be either a `TableNode` or an `array`.

However, this is not compatible with the parent interface, where the argumentValue is effectively `mixed`.

In our own / expected usage, the caller should first call `supportsDefinitionAndArgument` to check that the argument is suitable for this transformation.

So in practice within Behat we can only receive a `TableNode|array` but in theory another caller could pass something different.

We cannot convert this into a strict parameter type in 4.0 because of the parent type compatibility issue. Instead, we should narrow the type at runtime to enforce that the caller has checked (or knows) that the argumentValue is supported.

We can safely do this in 3.x without a BC break.