### PR TITLE
[4.0] refactor: Add remaining auto-generated strict types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "composer-runtime-api": "^2.2",
         "behat/gherkin": "^4.15.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
+        "ingenerator/risky-rector-rules": "^1.1",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "composer-runtime-api": "^2.2",
         "behat/gherkin": "^4.15.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
-        "ingenerator/risky-rector-rules": "dev-main@dev",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer-runtime-api": "^2.2",
         "behat/gherkin": "^4.15.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
-        "ingenerator/risky-rector-rules": "^1.1",
+        "ingenerator/risky-rector-rules": "dev-main@dev",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",

--- a/rector.php
+++ b/rector.php
@@ -13,9 +13,11 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-    ->withPreparedSets(codeQuality: true)
+    ->withPreparedSets(
+        codeQuality: true,
+        typeDeclarations: true,
+    )
     ->withPhpSets(php82: true)
-//    ->withTypeCoverageLevel(66)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -1,6 +1,8 @@
 <?php
 
 declare(strict_types=1);
+
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddPropertyTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
@@ -12,9 +14,9 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-    ->withPreparedSets(codeQuality: true)
-    ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(49)
+//    ->withPreparedSets(codeQuality: true)
+//    ->withPhpSets(php82: true)
+//    ->withTypeCoverageLevel(66)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,
@@ -24,4 +26,7 @@ return RectorConfig::configure()
     ->withImportNames(
         removeUnusedImports: true,
     )
+    ->withRules([
+        AddPropertyTypeFromPhpDocRector::class,
+    ])
 ;

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
+    ->withTypeCoverageLevel(0)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -8,6 +8,7 @@ use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRect
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
 
@@ -36,5 +37,6 @@ return RectorConfig::configure()
         AddReturnTypeFromPhpDocRector::class,
         AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
         AddParamTypeBasedOnParentClassMethodRector::class,
+        ReadOnlyPropertyRector::class,
     ])
 ;

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(13)
+    ->withTypeCoverageLevel(49)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -1,8 +1,6 @@
 <?php
 
 declare(strict_types=1);
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
@@ -14,17 +12,13 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-//    ->withPreparedSets(codeQuality: true)
-//    ->withPhpSets(php82: true)
+    ->withPreparedSets(codeQuality: true)
+    ->withPhpSets(php82: true)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,
         // DI setFactory does not support closures
         ArrayToFirstClassCallableRector::class => [__DIR__ . '/src/Behat/Testwork/Deprecation/ServiceContainer/DeprecationExtension.php'],
-    ])
-    ->withRules([
-        AddParamTypeFromPhpDocRector::class,
-        AddReturnTypeFromPhpDocRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/rector.php
+++ b/rector.php
@@ -2,10 +2,15 @@
 
 declare(strict_types=1);
 
+use Ingenerator\RiskyRectorRules\AddStrictTypes\AddParamTypeBasedOnParentClassMethodRector;
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddMethodTypeConfig;
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -13,11 +18,11 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-    ->withPreparedSets(
-        codeQuality: true,
-        typeDeclarations: true,
-    )
-    ->withPhpSets(php82: true)
+//    ->withPreparedSets(
+//        codeQuality: true,
+//        typeDeclarations: true,
+//    )
+//    ->withPhpSets(php82: true)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,
@@ -27,4 +32,10 @@ return RectorConfig::configure()
     ->withImportNames(
         removeUnusedImports: true,
     )
+    ->withConfiguredRule(AddParamTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
+    ->withConfiguredRule(AddReturnTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
+    ->withRules([
+        AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
+        AddParamTypeBasedOnParentClassMethodRector::class,
+    ])
 ;

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(codeQuality: true)
     ->withPhpSets(php82: true)
-    ->withTypeCoverageLevel(0)
+    ->withTypeCoverageLevel(13)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -1,6 +1,8 @@
 <?php
 
 declare(strict_types=1);
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
@@ -12,13 +14,17 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-    ->withPreparedSets(codeQuality: true)
-    ->withPhpSets(php82: true)
+//    ->withPreparedSets(codeQuality: true)
+//    ->withPhpSets(php82: true)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,
         // DI setFactory does not support closures
         ArrayToFirstClassCallableRector::class => [__DIR__ . '/src/Behat/Testwork/Deprecation/ServiceContainer/DeprecationExtension.php'],
+    ])
+    ->withRules([
+        AddParamTypeFromPhpDocRector::class,
+        AddReturnTypeFromPhpDocRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/rector.php
+++ b/rector.php
@@ -1,16 +1,10 @@
 <?php
 
 declare(strict_types=1);
-
-use Ingenerator\RiskyRectorRules\AddStrictTypes\AddParamTypeBasedOnParentClassMethodRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
-use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -32,11 +26,4 @@ return RectorConfig::configure()
     ->withImportNames(
         removeUnusedImports: true,
     )
-    ->withRules([
-        AddParamTypeFromPhpDocRector::class,
-        AddReturnTypeFromPhpDocRector::class,
-        AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
-        AddParamTypeBasedOnParentClassMethodRector::class,
-        ReadOnlyPropertyRector::class,
-    ])
 ;

--- a/rector.php
+++ b/rector.php
@@ -18,11 +18,11 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-//    ->withPreparedSets(
-//        codeQuality: true,
-//        typeDeclarations: true,
-//    )
-//    ->withPhpSets(php82: true)
+    ->withPreparedSets(
+        codeQuality: true,
+        typeDeclarations: true,
+    )
+    ->withPhpSets(php82: true)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddPropertyTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
@@ -14,8 +13,8 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-//    ->withPreparedSets(codeQuality: true)
-//    ->withPhpSets(php82: true)
+    ->withPreparedSets(codeQuality: true)
+    ->withPhpSets(php82: true)
 //    ->withTypeCoverageLevel(66)
     ->withSkip([
         StringableForToStringRector::class,
@@ -26,7 +25,4 @@ return RectorConfig::configure()
     ->withImportNames(
         removeUnusedImports: true,
     )
-    ->withRules([
-        AddPropertyTypeFromPhpDocRector::class,
-    ])
 ;

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Ingenerator\RiskyRectorRules\AddStrictTypes\AddParamTypeBasedOnParentClassMethodRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddMethodTypeConfig;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
@@ -18,11 +17,11 @@ return RectorConfig::configure()
         __DIR__ . '/src',
     ])
     ->withRootFiles()
-    ->withPreparedSets(
-        codeQuality: true,
-        typeDeclarations: true,
-    )
-    ->withPhpSets(php82: true)
+//    ->withPreparedSets(
+//        codeQuality: true,
+//        typeDeclarations: true,
+//    )
+//    ->withPhpSets(php82: true)
     ->withSkip([
         StringableForToStringRector::class,
         ReadOnlyClassRector::class,
@@ -32,9 +31,9 @@ return RectorConfig::configure()
     ->withImportNames(
         removeUnusedImports: true,
     )
-    ->withConfiguredRule(AddParamTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
-    ->withConfiguredRule(AddReturnTypeFromPhpDocRector::class, [AddMethodTypeConfig::INTERFACES_ONLY => true])
     ->withRules([
+        AddParamTypeFromPhpDocRector::class,
+        AddReturnTypeFromPhpDocRector::class,
         AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
         AddParamTypeBasedOnParentClassMethodRector::class,
     ])

--- a/src/Behat/Behat/ApplicationFactory.php
+++ b/src/Behat/Behat/ApplicationFactory.php
@@ -55,7 +55,7 @@ final class ApplicationFactory extends BaseFactory
         return 'behat';
     }
 
-    protected function getVersion()
+    protected function getVersion(): string
     {
         // Get the currently installed behat version from composer's runtime API
         return InstalledVersions::getVersion('behat/behat');

--- a/src/Behat/Behat/Context/ContextFactory.php
+++ b/src/Behat/Behat/Context/ContextFactory.php
@@ -63,10 +63,8 @@ final class ContextFactory
      *
      * @param class-string<Context> $class
      * @param ArgumentResolver[] $singleUseResolvers
-     *
-     * @return Context
      */
-    public function createContext($class, array $arguments = [], array $singleUseResolvers = [])
+    public function createContext(string $class, array $arguments = [], array $singleUseResolvers = []): Context
     {
         $reflection = new ReflectionClass($class);
         $resolvers = array_merge($singleUseResolvers, $this->argumentResolvers);
@@ -84,7 +82,7 @@ final class ContextFactory
      *
      * @return mixed[]
      */
-    private function resolveArguments(ReflectionClass $reflection, array $arguments, array $resolvers)
+    private function resolveArguments(ReflectionClass $reflection, array $arguments, array $resolvers): array
     {
         $newArguments = $arguments;
 

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -142,12 +142,8 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
 
     /**
      * Resolves class using registered class resolvers.
-     *
-     * @param string $class
-     *
-     * @return string
      */
-    private function resolveClass($class)
+    private function resolveClass(string $class): string
     {
         foreach ($this->classResolvers as $resolver) {
             if ($resolver->supportsClass($class)) {

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -98,7 +98,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
      *
      * @throws ContextNotFoundException If context is not in the environment
      */
-    public function getContext($class)
+    public function getContext(string $class): Context
     {
         if (!$this->hasContextClass($class)) {
             throw new ContextNotFoundException(sprintf(

--- a/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/UninitializedContextEnvironment.php
@@ -39,7 +39,7 @@ final class UninitializedContextEnvironment extends StaticEnvironment implements
      * @throws ContextNotFoundException   If class does not exist
      * @throws WrongContextClassException if class does not implement Context interface
      */
-    public function registerContextClass($contextClass, ?array $arguments = null): void
+    public function registerContextClass(string $contextClass, ?array $arguments = null): void
     {
         if (!class_exists($contextClass)) {
             throw new ContextNotFoundException(sprintf(

--- a/src/Behat/Behat/Context/Exception/ContextNotFoundException.php
+++ b/src/Behat/Behat/Context/Exception/ContextNotFoundException.php
@@ -24,7 +24,7 @@ final class ContextNotFoundException extends InvalidArgumentException implements
      */
     public function __construct(
         string $message,
-        private string $class,
+        private readonly string $class,
     ) {
         parent::__construct($message);
     }

--- a/src/Behat/Behat/Context/Exception/ContextNotFoundException.php
+++ b/src/Behat/Behat/Context/Exception/ContextNotFoundException.php
@@ -21,23 +21,18 @@ final class ContextNotFoundException extends InvalidArgumentException implements
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
-     * @param string $class
      */
     public function __construct(
-        $message,
-        private $class,
+        string $message,
+        private string $class,
     ) {
         parent::__construct($message);
     }
 
     /**
      * Returns not found classname.
-     *
-     * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }

--- a/src/Behat/Behat/Context/Exception/UnknownTranslationResourceException.php
+++ b/src/Behat/Behat/Context/Exception/UnknownTranslationResourceException.php
@@ -24,7 +24,7 @@ final class UnknownTranslationResourceException extends InvalidArgumentException
      */
     public function __construct(
         string $message,
-        private string $resource,
+        private readonly string $resource,
     ) {
         parent::__construct($message);
     }

--- a/src/Behat/Behat/Context/Exception/UnknownTranslationResourceException.php
+++ b/src/Behat/Behat/Context/Exception/UnknownTranslationResourceException.php
@@ -21,23 +21,18 @@ final class UnknownTranslationResourceException extends InvalidArgumentException
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
-     * @param string $resource
      */
     public function __construct(
-        $message,
-        private $resource,
+        string $message,
+        private string $resource,
     ) {
         parent::__construct($message);
     }
 
     /**
      * Returns unsupported resource.
-     *
-     * @return string
      */
-    public function getResource()
+    public function getResource(): string
     {
         return $this->resource;
     }

--- a/src/Behat/Behat/Context/Snippet/Generator/AggregateContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/AggregateContextIdentifier.php
@@ -33,7 +33,7 @@ final class AggregateContextIdentifier implements TargetContextIdentifier
     ) {
     }
 
-    public function guessTargetContextClass(ContextEnvironment $environment)
+    public function guessTargetContextClass(ContextEnvironment $environment): ?string
     {
         foreach ($this->identifiers as $identifier) {
             $contextClass = $identifier->guessTargetContextClass($environment);

--- a/src/Behat/Behat/Context/Snippet/Generator/CachedContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/CachedContextIdentifier.php
@@ -29,7 +29,7 @@ final class CachedContextIdentifier implements TargetContextIdentifier
     ) {
     }
 
-    public function guessTargetContextClass(ContextEnvironment $environment)
+    public function guessTargetContextClass(ContextEnvironment $environment): ?string
     {
         $suiteKey = $environment->getSuite()->getName();
 

--- a/src/Behat/Behat/Context/Snippet/Generator/TargetContextIdentifier.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/TargetContextIdentifier.php
@@ -21,8 +21,6 @@ interface TargetContextIdentifier
 {
     /**
      * Attempts to guess the target context class from the environment.
-     *
-     * @return string|null
      */
-    public function guessTargetContextClass(ContextEnvironment $environment);
+    public function guessTargetContextClass(ContextEnvironment $environment): ?string;
 }

--- a/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
+++ b/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
@@ -157,10 +157,8 @@ final class SuiteWithContextsSetup implements SuiteSetup
 
     /**
      * Generates class using registered class generators.
-     *
-     * @return string|null
      */
-    private function generateClass(Suite $suite, string $class)
+    private function generateClass(Suite $suite, string $class): ?string
     {
         $content = null;
         foreach ($this->classGenerators as $generator) {

--- a/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
+++ b/src/Behat/Behat/Context/Suite/Setup/SuiteWithContextsSetup.php
@@ -87,7 +87,7 @@ final class SuiteWithContextsSetup implements SuiteSetup
      *
      * @throws SuiteConfigurationException If `contexts` setting is not an array
      */
-    private function getSuiteContexts(Suite $suite)
+    private function getSuiteContexts(Suite $suite): array
     {
         $contexts = $suite->getSetting('contexts');
 
@@ -119,10 +119,8 @@ final class SuiteWithContextsSetup implements SuiteSetup
 
     /**
      * Creates context class file in the filesystem.
-     *
-     * @param string $content
      */
-    private function createContextFile(string $path, $content): void
+    private function createContextFile(string $path, string $content): void
     {
         file_put_contents($path, $content);
 
@@ -134,11 +132,9 @@ final class SuiteWithContextsSetup implements SuiteSetup
     /**
      * Finds file to store a class.
      *
-     * @param string $class
-     *
      * @throws ContextNotFoundException If class file could not be determined
      */
-    private function findClassFile($class): string
+    private function findClassFile(string $class): string
     {
         [$classpath, $classname] = $this->findClasspathAndClass($class);
         $classpath .= str_replace('_', DIRECTORY_SEPARATOR, $classname) . '.php';
@@ -162,11 +158,9 @@ final class SuiteWithContextsSetup implements SuiteSetup
     /**
      * Generates class using registered class generators.
      *
-     * @param string $class
-     *
      * @return string|null
      */
-    private function generateClass(Suite $suite, $class)
+    private function generateClass(Suite $suite, string $class)
     {
         $content = null;
         foreach ($this->classGenerators as $generator) {
@@ -191,11 +185,9 @@ final class SuiteWithContextsSetup implements SuiteSetup
     /**
      * Finds classpath and classname from class.
      *
-     * @param string $class
-     *
      * @return array{?string, string}
      */
-    private function findClasspathAndClass($class): array
+    private function findClasspathAndClass(string $class): array
     {
         if (false !== $pos = strrpos($class, '\\')) {
             // namespaced class name

--- a/src/Behat/Behat/Definition/Call/DefinitionCall.php
+++ b/src/Behat/Behat/Definition/Call/DefinitionCall.php
@@ -27,8 +27,6 @@ final class DefinitionCall extends EnvironmentCall
 {
     /**
      * Initializes definition call.
-     *
-     * @param int|null $errorReportingLevel
      */
     public function __construct(
         Environment $environment,
@@ -36,7 +34,7 @@ final class DefinitionCall extends EnvironmentCall
         private readonly StepNode $step,
         Definition $definition,
         array $arguments,
-        $errorReportingLevel = null,
+        ?int $errorReportingLevel = null,
     ) {
         parent::__construct($environment, $definition, $arguments, $errorReportingLevel);
     }

--- a/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
+++ b/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
@@ -28,14 +28,11 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Stringable, De
     /**
      * Initializes definition.
      *
-     * @param string      $type
-     * @param string      $pattern
-     *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private $type,
-        private $pattern,
+        private string $type,
+        private string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
+++ b/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
@@ -31,8 +31,8 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Stringable, De
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private string $type,
-        private string $pattern,
+        private readonly string $type,
+        private readonly string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Definition/Cli/AvailableDefinitionsController.php
+++ b/src/Behat/Behat/Definition/Cli/AvailableDefinitionsController.php
@@ -68,10 +68,8 @@ final class AvailableDefinitionsController implements Controller
 
     /**
      * Returns definition printer for provided option argument.
-     *
-     * @param string $argument
      */
-    private function getDefinitionPrinter($argument): ConsoleDefinitionListPrinter|ConsoleDefinitionInformationPrinter
+    private function getDefinitionPrinter(string $argument): ConsoleDefinitionListPrinter|ConsoleDefinitionInformationPrinter
     {
         if ('l' === $argument) {
             return $this->listPrinter;

--- a/src/Behat/Behat/Definition/DefinitionFinder.php
+++ b/src/Behat/Behat/Definition/DefinitionFinder.php
@@ -37,10 +37,8 @@ final class DefinitionFinder
 
     /**
      * Searches definition for a provided step in a provided environment.
-     *
-     * @return SearchResult
      */
-    public function findDefinition(Environment $environment, FeatureNode $feature, StepNode $step)
+    public function findDefinition(Environment $environment, FeatureNode $feature, StepNode $step): SearchResult
     {
         foreach ($this->engines as $engine) {
             $result = $engine->searchDefinition($environment, $feature, $step);

--- a/src/Behat/Behat/Definition/Exception/AmbiguousMatchException.php
+++ b/src/Behat/Behat/Definition/Exception/AmbiguousMatchException.php
@@ -29,7 +29,7 @@ final class AmbiguousMatchException extends RuntimeException implements SearchEx
      * @param string       $text    step description
      * @param Definition[] $matches ambiguous matches (array of Definition's)
      */
-    public function __construct($text, array $matches)
+    public function __construct(string $text, array $matches)
     {
         $message = sprintf('Ambiguous match of "%s":', $text);
         foreach ($matches as $definition) {

--- a/src/Behat/Behat/Definition/Exception/UnsupportedPatternTypeException.php
+++ b/src/Behat/Behat/Definition/Exception/UnsupportedPatternTypeException.php
@@ -21,23 +21,18 @@ final class UnsupportedPatternTypeException extends InvalidArgumentException imp
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
-     * @param string $type
      */
     public function __construct(
-        $message,
-        private $type,
+        string $message,
+        private string $type,
     ) {
         parent::__construct($message);
     }
 
     /**
      * Returns pattern type that caused exception.
-     *
-     * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }

--- a/src/Behat/Behat/Definition/Exception/UnsupportedPatternTypeException.php
+++ b/src/Behat/Behat/Definition/Exception/UnsupportedPatternTypeException.php
@@ -24,7 +24,7 @@ final class UnsupportedPatternTypeException extends InvalidArgumentException imp
      */
     public function __construct(
         string $message,
-        private string $type,
+        private readonly string $type,
     ) {
         parent::__construct($message);
     }

--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -43,11 +43,9 @@ final class PatternTransformer
     /**
      * Generates pattern.
      *
-     * @param string|null $type
-     *
      * @throws UnsupportedPatternTypeException
      */
-    public function generatePattern($type, string $stepText): Pattern
+    public function generatePattern(?string $type, string $stepText): Pattern
     {
         foreach ($this->policies as $policy) {
             if ($policy->supportsPatternType($type)) {
@@ -61,11 +59,9 @@ final class PatternTransformer
     /**
      * Transforms pattern string to regex.
      *
-     * @param string $pattern
-     *
      * @throws UnknownPatternException
      */
-    public function transformPatternToRegex($pattern): string
+    public function transformPatternToRegex(string $pattern): string
     {
         if (!isset($this->patternToRegexpCache[$pattern])) {
             $this->patternToRegexpCache[$pattern] = $this->transformPatternToRegexWithSupportedPolicy($pattern);
@@ -93,11 +89,9 @@ final class PatternTransformer
     }
 
     /**
-     * @param string $pattern
-     *
      * @throws UnknownPatternException
      */
-    private function transformPatternToRegexWithSupportedPolicy($pattern): string
+    private function transformPatternToRegexWithSupportedPolicy(string $pattern): string
     {
         foreach ($this->policies as $policy) {
             if ($policy->supportsPattern($pattern)) {

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
@@ -27,10 +27,8 @@ final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter
 
     /**
      * Sets search criterion.
-     *
-     * @param string $criterion
      */
-    public function setSearchCriterion($criterion): void
+    public function setSearchCriterion(string $criterion): void
     {
         $this->searchCriterion = $criterion;
     }

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionInformationPrinter.php
@@ -20,10 +20,7 @@ use Behat\Testwork\Suite\Suite;
  */
 final class ConsoleDefinitionInformationPrinter extends ConsoleDefinitionPrinter implements UnusedDefinitionPrinter
 {
-    /**
-     * @var string|null
-     */
-    private $searchCriterion;
+    private ?string $searchCriterion = null;
 
     /**
      * Sets search criterion.

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
@@ -69,10 +69,8 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
 
     /**
      * Translates definition using translator.
-     *
-     * @return Definition
      */
-    final protected function translateDefinition(Suite $suite, Definition $definition)
+    final protected function translateDefinition(Suite $suite, Definition $definition): Definition
     {
         return $this->translator->translateDefinition($suite, $definition);
     }
@@ -87,7 +85,7 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
      *
      * @return bool true if verbosity is set to VERBOSITY_VERBOSE, false otherwise
      */
-    final protected function isVerbose()
+    final protected function isVerbose(): bool
     {
         return $this->output->isVerbose();
     }

--- a/src/Behat/Behat/Definition/Search/SearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/SearchEngine.php
@@ -29,8 +29,6 @@ interface SearchEngine
 {
     /**
      * Searches for a step definition.
-     *
-     * @return SearchResult|null
      */
-    public function searchDefinition(Environment $environment, FeatureNode $feature, StepNode $step);
+    public function searchDefinition(Environment $environment, FeatureNode $feature, StepNode $step): ?SearchResult;
 }

--- a/src/Behat/Behat/Definition/SearchResult.php
+++ b/src/Behat/Behat/Definition/SearchResult.php
@@ -19,12 +19,10 @@ final class SearchResult
 {
     /**
      * Registers search match.
-     *
-     * @param string|null $matchedText
      */
     public function __construct(
         private readonly ?Definition $definition = null,
-        private $matchedText = null,
+        private ?string $matchedText = null,
         private readonly ?array $arguments = null,
     ) {
     }
@@ -47,10 +45,8 @@ final class SearchResult
 
     /**
      * Returns matched text.
-     *
-     * @return string|null
      */
-    public function getMatchedText()
+    public function getMatchedText(): ?string
     {
         return $this->matchedText;
     }

--- a/src/Behat/Behat/Definition/SearchResult.php
+++ b/src/Behat/Behat/Definition/SearchResult.php
@@ -22,7 +22,7 @@ final class SearchResult
      */
     public function __construct(
         private readonly ?Definition $definition = null,
-        private ?string $matchedText = null,
+        private readonly ?string $matchedText = null,
         private readonly ?array $arguments = null,
     ) {
     }

--- a/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
@@ -26,8 +26,8 @@ final class TranslatedDefinition implements Stringable, Definition
      */
     public function __construct(
         private readonly Definition $definition,
-        private string $translatedPattern,
-        private string $language,
+        private readonly string $translatedPattern,
+        private readonly string $language,
     ) {
     }
 

--- a/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
@@ -23,14 +23,11 @@ final class TranslatedDefinition implements Stringable, Definition
 {
     /**
      * Initialises translated definition.
-     *
-     * @param string     $translatedPattern
-     * @param string     $language
      */
     public function __construct(
         private readonly Definition $definition,
-        private $translatedPattern,
-        private $language,
+        private string $translatedPattern,
+        private string $language,
     ) {
     }
 
@@ -54,10 +51,8 @@ final class TranslatedDefinition implements Stringable, Definition
 
     /**
      * Returns language definition was translated to.
-     *
-     * @return string
      */
-    public function getLanguage()
+    public function getLanguage(): string
     {
         return $this->language;
     }
@@ -82,7 +77,7 @@ final class TranslatedDefinition implements Stringable, Definition
         return $this->definition->isAnInstanceMethod();
     }
 
-    public function getCallable()
+    public function getCallable(): callable|array
     {
         return $this->definition->getCallable();
     }

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
@@ -99,10 +99,8 @@ final class AfterStepTested extends StepTested implements AfterTested
 
     /**
      * Checks if result is executed and call result has produced exception or stdOut.
-     *
-     * @return bool
      */
-    private function resultCallHasOutput()
+    private function resultCallHasOutput(): bool
     {
         if (!$this->result instanceof ExecutedStepResult) {
             return false;

--- a/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
@@ -30,10 +30,8 @@ abstract class BackgroundTested extends LifecycleEvent implements ScenarioLikeTe
 
     /**
      * Returns background node.
-     *
-     * @return BackgroundNode
      */
-    abstract public function getBackground();
+    abstract public function getBackground(): BackgroundNode;
 
     /**
      * Returns node.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
@@ -82,10 +82,8 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
 
     /**
      * Checks if result is executed and call result has produced exception or stdOut.
-     *
-     * @return bool
      */
-    private function resultCallHasOutput()
+    private function resultCallHasOutput(): bool
     {
         if (!$this->result instanceof ExecutedStepResult) {
             return false;

--- a/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
@@ -30,10 +30,8 @@ abstract class FeatureTested extends LifecycleEvent implements GherkinNodeTested
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    abstract public function getFeature();
+    abstract public function getFeature(): FeatureNode;
 
     /**
      * Returns node.

--- a/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
@@ -31,17 +31,13 @@ abstract class OutlineTested extends LifecycleEvent implements GherkinNodeTested
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    abstract public function getFeature();
+    abstract public function getFeature(): FeatureNode;
 
     /**
      * Returns outline node.
-     *
-     * @return OutlineNode
      */
-    abstract public function getOutline();
+    abstract public function getOutline(): OutlineNode;
 
     /**
      * Returns node.

--- a/src/Behat/Behat/EventDispatcher/Event/StepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/StepTested.php
@@ -31,17 +31,13 @@ abstract class StepTested extends LifecycleEvent implements GherkinNodeTested
 
     /**
      * Returns feature.
-     *
-     * @return FeatureNode
      */
-    abstract public function getFeature();
+    abstract public function getFeature(): FeatureNode;
 
     /**
      * Returns step node.
-     *
-     * @return StepNode
      */
-    abstract public function getStep();
+    abstract public function getStep(): StepNode;
 
     final public function getNode(): NodeInterface
     {

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
@@ -36,10 +36,10 @@ final class EventDispatchingScenarioTester implements ScenarioTester
     public function __construct(
         private readonly ScenarioTester $baseTester,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private string $beforeEventName,
-        private string $afterSetupEventName,
-        private string $beforeTeardownEventName,
-        private string $afterEventName,
+        private readonly string $beforeEventName,
+        private readonly string $afterSetupEventName,
+        private readonly string $beforeTeardownEventName,
+        private readonly string $afterEventName,
     ) {
     }
 

--- a/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
+++ b/src/Behat/Behat/EventDispatcher/Tester/EventDispatchingScenarioTester.php
@@ -32,19 +32,14 @@ final class EventDispatchingScenarioTester implements ScenarioTester
 {
     /**
      * Initializes tester.
-     *
-     * @param string                   $beforeEventName
-     * @param string                   $afterSetupEventName
-     * @param string                   $beforeTeardownEventName
-     * @param string                   $afterEventName
      */
     public function __construct(
         private readonly ScenarioTester $baseTester,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private $beforeEventName,
-        private $afterSetupEventName,
-        private $beforeTeardownEventName,
-        private $afterEventName,
+        private string $beforeEventName,
+        private string $afterSetupEventName,
+        private string $beforeTeardownEventName,
+        private string $afterEventName,
     ) {
     }
 

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -194,10 +194,8 @@ final class GherkinExtension implements Extension
 
     /**
      * Loads gherkin loaders.
-     *
-     * @param string           $cachePath
      */
-    private function loadDefaultLoaders(ContainerBuilder $container, $cachePath): void
+    private function loadDefaultLoaders(ContainerBuilder $container, string $cachePath): void
     {
         $definition = new Definition(GherkinFileLoader::class, [
             new Reference('gherkin.parser'),
@@ -318,11 +316,9 @@ final class GherkinExtension implements Extension
     /**
      * Creates filter definition of provided type.
      *
-     * @param string $filterString
-     *
      * @throws ExtensionException If filter type is not recognised
      */
-    private function createFilterDefinition(string $type, $filterString): Definition
+    private function createFilterDefinition(string $type, string $filterString): Definition
     {
         if ('role' === $type) {
             return new Definition(RoleFilter::class, [$filterString]);

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -201,7 +201,7 @@ final class GherkinExtension implements Extension
             new Reference('gherkin.parser'),
         ]);
 
-        if ($cachePath) {
+        if ($cachePath !== '') {
             $cacheDefinition = new Definition(FileCache::class, [$cachePath]);
         } else {
             $cacheDefinition = new Definition(MemoryCache::class);

--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -42,7 +42,7 @@ final class LazyFeatureIterator implements SpecificationIterator
     /**
      * @var list<FeatureNode>
      */
-    private $features = [];
+    private array $features = [];
     private ?FeatureNode $currentFeature = null;
 
     /**

--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -114,11 +114,9 @@ final class LazyFeatureIterator implements SpecificationIterator
     /**
      * Creates filter of provided type.
      *
-     * @param string $filterString
-     *
      * @throws SuiteConfigurationException If filter type is not recognised
      */
-    private function createFilter(string $type, $filterString, Suite $suite): FeatureFilterInterface
+    private function createFilter(string $type, string $filterString, Suite $suite): FeatureFilterInterface
     {
         if ('role' === $type) {
             return new RoleFilter($filterString);
@@ -160,11 +158,9 @@ final class LazyFeatureIterator implements SpecificationIterator
     /**
      * Parses feature at path.
      *
-     * @param string $path
-     *
      * @return FeatureNode[]
      */
-    private function parseFeature($path)
+    private function parseFeature(string $path): array
     {
         return $this->gherkin->load($path, $this->filters);
     }

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -140,10 +140,6 @@ final class FilesystemFeatureLocator implements SpecificationLocator
             return realpath($path);
         }
 
-        if (null === $this->basePath) {
-            return false;
-        }
-
         if (is_file($this->basePath . DIRECTORY_SEPARATOR . $path)
             || is_dir($this->basePath . DIRECTORY_SEPARATOR . $path)
         ) {

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -37,7 +37,7 @@ final class FilesystemFeatureLocator implements SpecificationLocator
      */
     public function __construct(
         private readonly Gherkin $gherkin,
-        private string $basePath,
+        private readonly string $basePath,
     ) {
     }
 

--- a/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
+++ b/src/Behat/Behat/Gherkin/Specification/Locator/FilesystemFeatureLocator.php
@@ -34,12 +34,10 @@ final class FilesystemFeatureLocator implements SpecificationLocator
 {
     /**
      * Initializes loader.
-     *
-     * @param string  $basePath
      */
     public function __construct(
         private readonly Gherkin $gherkin,
-        private $basePath,
+        private string $basePath,
     ) {
     }
 

--- a/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
+++ b/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
@@ -23,11 +23,9 @@ final class SuiteWithPathsSetup implements SuiteSetup
 {
     /**
      * Initializes setup.
-     *
-     * @param string                $basePath
      */
     public function __construct(
-        private $basePath,
+        private string $basePath,
         private readonly ?FilesystemLogger $logger = null,
     ) {
     }

--- a/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
+++ b/src/Behat/Behat/Gherkin/Suite/Setup/SuiteWithPathsSetup.php
@@ -25,7 +25,7 @@ final class SuiteWithPathsSetup implements SuiteSetup
      * Initializes setup.
      */
     public function __construct(
-        private string $basePath,
+        private readonly string $basePath,
         private readonly ?FilesystemLogger $logger = null,
     ) {
     }

--- a/src/Behat/Behat/HelperContainer/ArgumentAutowirer.php
+++ b/src/Behat/Behat/HelperContainer/ArgumentAutowirer.php
@@ -54,12 +54,8 @@ final class ArgumentAutowirer
      * Checks if given argument is wireable.
      *
      * Argument is wireable if it was not previously set and it has a class type-hint.
-     *
-     * @param int $index
-     *
-     * @return bool
      */
-    private function isArgumentWireable(array $arguments, $index, ReflectionParameter $parameter)
+    private function isArgumentWireable(array $arguments, int $index, ReflectionParameter $parameter): bool
     {
         if (isset($arguments[$index]) || array_key_exists($index, $arguments)) {
             return false;

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -137,11 +137,9 @@ final class BuiltInServiceContainer implements PsrContainerInterface
     /**
      * Checks if factory method exists.
      *
-     * @param string          $methodName
-     *
      * @throws WrongServicesConfigurationException
      */
-    private function assertFactoryMethodExists(ReflectionClass $class, $methodName): void
+    private function assertFactoryMethodExists(ReflectionClass $class, string $methodName): void
     {
         if (!$class->hasMethod($methodName)) {
             throw new WrongServicesConfigurationException(sprintf(

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -23,10 +23,7 @@ use ReflectionMethod;
  */
 final class BuiltInServiceContainer implements PsrContainerInterface
 {
-    /**
-     * @var array
-     */
-    private $instances;
+    private array $instances;
 
     /**
      * Initialises container using provided service configuration.

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -60,7 +60,8 @@ final class BuiltInServiceContainer implements PsrContainerInterface
         $reflection = new ReflectionClass($schema['class']);
         $arguments = $schema['arguments'];
 
-        if ($factoryMethod = $this->getAndValidateFactoryMethod($reflection, $schema)) {
+        $factoryMethod = $this->getAndValidateFactoryMethod($reflection, $schema);
+        if ($factoryMethod instanceof ReflectionMethod) {
             return $factoryMethod->invokeArgs(null, $arguments);
         }
 

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -70,11 +70,9 @@ final class BuiltInServiceContainer implements PsrContainerInterface
     /**
      * Gets and validates a service configuration for a service with given ID.
      *
-     * @return array|string
-     *
      * @throws WrongServicesConfigurationException
      */
-    private function getAndValidateServiceSchema(string $id)
+    private function getAndValidateServiceSchema(string $id): array|string
     {
         $schema = $this->schema[$id];
 
@@ -114,10 +112,8 @@ final class BuiltInServiceContainer implements PsrContainerInterface
 
     /**
      * Gets and validates a factory method.
-     *
-     * @return ReflectionMethod|null
      */
-    private function getAndValidateFactoryMethod(ReflectionClass $reflection, array $schema)
+    private function getAndValidateFactoryMethod(ReflectionClass $reflection, array $schema): ?ReflectionMethod
     {
         if (!isset($schema['factory_method'])) {
             return null;

--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -56,8 +56,6 @@ final class ServicesResolver implements CallFilter
     /**
      * Gets container from the call.
      *
-     * @return ContainerInterface|null
-     *
      * @throws UnsupportedCallException if given call is not EnvironmentCall or environment is not ServiceContainerEnvironment
      */
     private function getContainer(Call $call): ?ContainerInterface

--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -60,7 +60,7 @@ final class ServicesResolver implements CallFilter
      *
      * @throws UnsupportedCallException if given call is not EnvironmentCall or environment is not ServiceContainerEnvironment
      */
-    private function getContainer(Call $call)
+    private function getContainer(Call $call): ?ContainerInterface
     {
         if (!$call instanceof EnvironmentCall) {
             throw new UnsupportedCallException(sprintf(

--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -43,7 +43,8 @@ final class ServicesResolver implements CallFilter
      */
     public function filterCall(Call $call): Call
     {
-        if ($container = $this->getContainer($call)) {
+        $container = $this->getContainer($call);
+        if ($container instanceof ContainerInterface) {
             $autowirer = new ArgumentAutowirer($container);
             $newArguments = $autowirer->autowireArguments($call->getCallee()->getReflection(), $call->getArguments());
 

--- a/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
+++ b/src/Behat/Behat/HelperContainer/Environment/ServiceContainerEnvironment.php
@@ -29,8 +29,6 @@ interface ServiceContainerEnvironment extends Environment
 
     /**
      * Returns environment service container if set.
-     *
-     * @return ContainerInterface|null
      */
-    public function getServiceContainer();
+    public function getServiceContainer(): ?ContainerInterface;
 }

--- a/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
@@ -22,23 +22,18 @@ final class ServiceNotFoundException extends InvalidArgumentException implements
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
-     * @param string $serviceId
      */
     public function __construct(
-        $message,
-        private $serviceId,
+        string $message,
+        private string $serviceId,
     ) {
         parent::__construct($message);
     }
 
     /**
      * Returns service ID that caused exception.
-     *
-     * @return string
      */
-    public function getServiceId()
+    public function getServiceId(): string
     {
         return $this->serviceId;
     }

--- a/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/ServiceNotFoundException.php
@@ -25,7 +25,7 @@ final class ServiceNotFoundException extends InvalidArgumentException implements
      */
     public function __construct(
         string $message,
-        private string $serviceId,
+        private readonly string $serviceId,
     ) {
         parent::__construct($message);
     }

--- a/src/Behat/Behat/HelperContainer/Exception/UnsupportedCallException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/UnsupportedCallException.php
@@ -22,11 +22,9 @@ final class UnsupportedCallException extends InvalidArgumentException implements
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
      */
     public function __construct(
-        $message,
+        string $message,
         private readonly Call $call,
     ) {
         parent::__construct($message);

--- a/src/Behat/Behat/Hook/Call/AfterFeature.php
+++ b/src/Behat/Behat/Hook/Call/AfterFeature.php
@@ -25,11 +25,9 @@ final class AfterFeature extends RuntimeFeatureHook
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct(FeatureScope::AFTER, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/AfterScenario.php
+++ b/src/Behat/Behat/Hook/Call/AfterScenario.php
@@ -25,11 +25,9 @@ final class AfterScenario extends RuntimeScenarioHook
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct(ScenarioScope::AFTER, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/AfterStep.php
+++ b/src/Behat/Behat/Hook/Call/AfterStep.php
@@ -25,11 +25,9 @@ final class AfterStep extends RuntimeStepHook
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct(StepScope::AFTER, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/BeforeFeature.php
+++ b/src/Behat/Behat/Hook/Call/BeforeFeature.php
@@ -25,11 +25,9 @@ final class BeforeFeature extends RuntimeFeatureHook
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct(FeatureScope::BEFORE, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/BeforeScenario.php
+++ b/src/Behat/Behat/Hook/Call/BeforeScenario.php
@@ -25,11 +25,9 @@ final class BeforeScenario extends RuntimeScenarioHook
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct(ScenarioScope::BEFORE, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/BeforeStep.php
+++ b/src/Behat/Behat/Hook/Call/BeforeStep.php
@@ -25,11 +25,9 @@ final class BeforeStep extends RuntimeStepHook
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct(StepScope::BEFORE, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -28,12 +28,11 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
     /**
      * Initializes hook.
      *
-     * @param string|null                          $filterString
      * @param callable|array{class-string, string} $callable
      *
      * @throws BadCallbackException If callback is method, but not a static one
      */
-    public function __construct(string $scopeName, $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(string $scopeName, ?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct($scopeName, $filterString, $callable, $description);
 

--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -28,13 +28,12 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
     /**
      * Initializes hook.
      *
-     * @param string                               $scopeName
      * @param string|null                          $filterString
      * @param callable|array{class-string, string} $callable
      *
      * @throws BadCallbackException If callback is method, but not a static one
      */
-    public function __construct($scopeName, $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(string $scopeName, $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct($scopeName, $filterString, $callable, $description);
 
@@ -54,12 +53,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
         return $this->isMatch($scope->getFeature(), $filterString);
     }
 
-    /**
-     * @param string      $filterString
-     *
-     * @return bool
-     */
-    private function isMatch(FeatureNode $feature, $filterString)
+    private function isMatch(FeatureNode $feature, string $filterString): bool
     {
         if (str_contains($filterString, '@')) {
             return $this->isMatchTagFilter($feature, $filterString);
@@ -74,10 +68,8 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
 
     /**
      * Checks if feature matches tag filter.
-     *
-     * @return bool
      */
-    private function isMatchTagFilter(FeatureNode $feature, string $filterString)
+    private function isMatchTagFilter(FeatureNode $feature, string $filterString): bool
     {
         $filter = new TagFilter($filterString);
 
@@ -86,12 +78,8 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
 
     /**
      * Checks if feature matches name filter.
-     *
-     * @param string      $filterString
-     *
-     * @return bool
      */
-    private function isMatchNameFilter(FeatureNode $feature, $filterString)
+    private function isMatchNameFilter(FeatureNode $feature, string $filterString): bool
     {
         $filter = new NameFilter($filterString);
 

--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -59,7 +59,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
             return $this->isMatchTagFilter($feature, $filterString);
         }
 
-        if (!empty($filterString)) {
+        if ($filterString !== '') {
             return $this->isMatchNameFilter($feature, $filterString);
         }
 

--- a/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
@@ -47,7 +47,7 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
             return $this->isMatchTagFilter($feature, $scenario, $filterString);
         }
 
-        if (!empty($filterString)) {
+        if ($filterString !== '') {
             return $this->isMatchNameFilter($scenario, $filterString);
         }
 

--- a/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeScenarioHook.php
@@ -40,12 +40,8 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
 
     /**
      * Checks if nodes match filter.
-     *
-     * @param string            $filterString
-     *
-     * @return bool
      */
-    protected function isMatch(FeatureNode $feature, ScenarioInterface $scenario, $filterString)
+    protected function isMatch(FeatureNode $feature, ScenarioInterface $scenario, string $filterString): bool
     {
         if (str_contains($filterString, '@')) {
             return $this->isMatchTagFilter($feature, $scenario, $filterString);
@@ -60,12 +56,8 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
 
     /**
      * Checks if node match tag filter.
-     *
-     * @param string            $filterString
-     *
-     * @return bool
      */
-    protected function isMatchTagFilter(FeatureNode $feature, ScenarioInterface $scenario, $filterString)
+    protected function isMatchTagFilter(FeatureNode $feature, ScenarioInterface $scenario, string $filterString): bool
     {
         $filter = new TagFilter($filterString);
 
@@ -74,12 +66,8 @@ abstract class RuntimeScenarioHook extends RuntimeFilterableHook
 
     /**
      * Checks if scenario matches name filter.
-     *
-     * @param string            $filterString
-     *
-     * @return bool
      */
-    protected function isMatchNameFilter(ScenarioInterface $scenario, $filterString)
+    protected function isMatchNameFilter(ScenarioInterface $scenario, string $filterString): bool
     {
         $filter = new NameFilter($filterString);
 

--- a/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
@@ -33,7 +33,7 @@ abstract class RuntimeStepHook extends RuntimeFilterableHook
             return true;
         }
 
-        if (!empty($filterString)) {
+        if ($filterString !== '') {
             $filter = new NameFilter($filterString);
 
             if ($filter->isFeatureMatch($scope->getFeature())) {

--- a/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeStepHook.php
@@ -48,10 +48,8 @@ abstract class RuntimeStepHook extends RuntimeFilterableHook
 
     /**
      * Checks if Feature matches specified filter.
-     *
-     * @param string   $filterString
      */
-    private function isStepMatch(StepNode $step, $filterString): bool
+    private function isStepMatch(StepNode $step, string $filterString): bool
     {
         if ('/' === $filterString[0]) {
             return 1 === preg_match($filterString, $step->getText());

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
@@ -28,13 +28,10 @@ final class FireOnlySiblingsListener implements EventListener
 
     /**
      * Initializes listener.
-     *
-     * @param string        $beforeEventName
-     * @param string        $afterEventName
      */
     public function __construct(
-        private $beforeEventName,
-        private $afterEventName,
+        private string $beforeEventName,
+        private string $afterEventName,
         private readonly EventListener $descendant,
     ) {
     }

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FireOnlySiblingsListener.php
@@ -30,8 +30,8 @@ final class FireOnlySiblingsListener implements EventListener
      * Initializes listener.
      */
     public function __construct(
-        private string $beforeEventName,
-        private string $afterEventName,
+        private readonly string $beforeEventName,
+        private readonly string $afterEventName,
         private readonly EventListener $descendant,
     ) {
     }

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/FirstBackgroundFiresFirstListener.php
@@ -84,10 +84,8 @@ final class FirstBackgroundFiresFirstListener implements EventListener
 
     /**
      * Checks if provided event should be postponed until background is printed.
-     *
-     * @return bool
      */
-    private function isEventDelayedUntilFirstBackgroundPrinted(Event $event)
+    private function isEventDelayedUntilFirstBackgroundPrinted(Event $event): bool
     {
         if (!$event instanceof ScenarioTested && !$event instanceof OutlineTested && !$event instanceof ExampleTested) {
             return false;

--- a/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Flow/OnlyFirstBackgroundFiresListener.php
@@ -98,10 +98,8 @@ final class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Checks if provided event is skippable.
-     *
-     * @return bool
      */
-    private function isSkippableEvent(Event $event)
+    private function isSkippableEvent(Event $event): bool
     {
         if (!$this->firstBackgroundEnded) {
             return false;
@@ -112,10 +110,8 @@ final class OnlyFirstBackgroundFiresListener implements EventListener
 
     /**
      * Checks if provided event is a non-failing step in consequent background.
-     *
-     * @return bool
      */
-    private function isNonFailingConsequentBackgroundStep(Event $event)
+    private function isNonFailingConsequentBackgroundStep(Event $event): bool
     {
         if (!$this->inBackground) {
             return false;

--- a/src/Behat/Behat/Output/Node/Printer/Helper/ResultToStringConverter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/ResultToStringConverter.php
@@ -29,10 +29,8 @@ final class ResultToStringConverter
 
     /**
      * Converts provided result code to a string.
-     *
-     * @param int $resultCode
      */
-    public function convertResultCodeToString($resultCode): string
+    public function convertResultCodeToString(int $resultCode): string
     {
         return match ($resultCode) {
             TestResult::SKIPPED => 'skipped',

--- a/src/Behat/Behat/Output/Node/Printer/Helper/StepTextPainter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/StepTextPainter.php
@@ -33,12 +33,8 @@ final class StepTextPainter
 
     /**
      * Colorizes step text arguments according to definition.
-     *
-     * @param string     $text
-     *
-     * @return string
      */
-    public function paintText($text, Definition $definition, TestResult $result)
+    public function paintText(string $text, Definition $definition, TestResult $result): string
     {
         $regex = $this->patternTransformer->transformPatternToRegex($definition->getPattern());
         $style = $this->resultConverter->convertResultToString($result);

--- a/src/Behat/Behat/Output/Node/Printer/Helper/WidthCalculator.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/WidthCalculator.php
@@ -23,13 +23,8 @@ final class WidthCalculator
 {
     /**
      * Calculates scenario width.
-     *
-     * @param int $indentation
-     * @param int $subIndentation
-     *
-     * @return int
      */
-    public function calculateScenarioWidth(Scenario $scenario, $indentation, $subIndentation)
+    public function calculateScenarioWidth(Scenario $scenario, int $indentation, int $subIndentation): int
     {
         $length = $this->calculateScenarioHeaderWidth($scenario, $indentation);
 
@@ -43,13 +38,8 @@ final class WidthCalculator
 
     /**
      * Calculates outline examples width.
-     *
-     * @param int $indentation
-     * @param int $subIndentation
-     *
-     * @return int
      */
-    public function calculateExampleWidth(ExampleNode $example, $indentation, $subIndentation)
+    public function calculateExampleWidth(ExampleNode $example, int $indentation, int $subIndentation): int
     {
         $length = $this->calculateScenarioHeaderWidth($example, $indentation);
 
@@ -63,10 +53,8 @@ final class WidthCalculator
 
     /**
      * Calculates scenario header width.
-     *
-     * @param int $indentation
      */
-    public function calculateScenarioHeaderWidth(Scenario $scenario, $indentation): int
+    public function calculateScenarioHeaderWidth(Scenario $scenario, int $indentation): int
     {
         $indentText = str_repeat(' ', intval($indentation));
 
@@ -83,10 +71,8 @@ final class WidthCalculator
 
     /**
      * Calculates step width.
-     *
-     * @param int $indentation
      */
-    public function calculateStepWidth(StepNode $step, $indentation): int
+    public function calculateStepWidth(StepNode $step, int $indentation): int
     {
         $indentText = str_repeat(' ', intval($indentation));
 

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -155,7 +155,7 @@ final class ListPrinter
             $printer->writeln(implode("\n", $stdOutString));
         }
 
-        if ($hookStat->getError()) {
+        if ($hookStat->getError() !== '') {
             $exceptionString = implode("\n", array_map($pad, explode("\n", $hookStat->getError())));
             $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $exceptionString, $style));
         }

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -50,12 +50,10 @@ final class ListPrinter
     /**
      * Prints scenarios list.
      *
-     * @param string         $intro
-     * @param int            $resultCode
      * @param ScenarioStat[] $scenarioStats
      * @param StepStatV2[]     $stepStats
      */
-    public function printScenariosList(OutputPrinter $printer, $intro, $resultCode, array $scenarioStats, ?array $stepStats = null): void
+    public function printScenariosList(OutputPrinter $printer, string $intro, int $resultCode, array $scenarioStats, ?array $stepStats = null): void
     {
         if (!count($scenarioStats)) {
             return;
@@ -79,14 +77,12 @@ final class ListPrinter
     /**
      * Prints step list.
      *
-     * @param string     $intro
-     * @param int        $resultCode
      * @param StepStatV2[] $stepStats
      */
     public function printStepList(
         OutputPrinter $printer,
-        $intro,
-        $resultCode,
+        string $intro,
+        int $resultCode,
         array $stepStats,
         ?ShowOutputOption $showOutput = ShowOutputOption::InSummary,
     ): void {

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExamplePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExamplePrinter.php
@@ -31,12 +31,10 @@ final class PrettyExamplePrinter implements ExamplePrinter
 
     /**
      * Initializes printer.
-     *
-     * @param int $indentation
      */
     public function __construct(
         private readonly PrettyPathPrinter $pathPrinter,
-        $indentation = 6,
+        int $indentation = 6,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
     }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExamplePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExamplePrinter.php
@@ -24,7 +24,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyExamplePrinter implements ExamplePrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
 
     /**
      * Initializes printer.

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExamplePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExamplePrinter.php
@@ -24,10 +24,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyExamplePrinter implements ExamplePrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
 
     /**
      * Initializes printer.

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
@@ -32,10 +32,7 @@ use Behat\Testwork\Tester\Result\TestResults;
  */
 final class PrettyExampleRowPrinter implements ExampleRowPrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
@@ -40,16 +40,13 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param int $indentation
-     * @param int $subIndentation
      */
     public function __construct(
         private readonly ResultToStringConverter $resultConverter,
         private readonly ExceptionPresenter $exceptionPresenter,
         private readonly TranslatorInterface $translator,
-        $indentation = 6,
-        $subIndentation = 2,
+        int $indentation = 6,
+        int $subIndentation = 2,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
@@ -32,7 +32,7 @@ use Behat\Testwork\Tester\Result\TestResults;
  */
 final class PrettyExampleRowPrinter implements ExampleRowPrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
@@ -31,11 +31,8 @@ final class PrettyFeaturePrinter implements FeaturePrinter
 
     /**
      * Initializes printer.
-     *
-     * @param int $indentation
-     * @param int $subIndentation
      */
-    public function __construct($indentation = 0, $subIndentation = 2)
+    public function __construct(int $indentation = 0, int $subIndentation = 2)
     {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyFeaturePrinter implements FeaturePrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
@@ -23,10 +23,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyFeaturePrinter implements FeaturePrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlinePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlinePrinter.php
@@ -36,16 +36,12 @@ final class PrettyOutlinePrinter implements OutlinePrinter
     private $indentText;
     private readonly string $subIndentText;
 
-    /**
-     * @param int $indentation
-     * @param int $subIndentation
-     */
     public function __construct(
         private readonly ScenarioPrinter $scenarioPrinter,
         private readonly StepPrinter $stepPrinter,
         private readonly ResultToStringConverter $resultConverter,
-        $indentation = 4,
-        $subIndentation = 2,
+        int $indentation = 4,
+        int $subIndentation = 2,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlinePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlinePrinter.php
@@ -30,10 +30,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyOutlinePrinter implements OutlinePrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
     private readonly string $subIndentText;
 
     public function __construct(

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlinePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlinePrinter.php
@@ -30,7 +30,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyOutlinePrinter implements OutlinePrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
     private readonly string $subIndentText;
 
     public function __construct(

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlineTablePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlineTablePrinter.php
@@ -30,10 +30,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyOutlineTablePrinter implements OutlineTablePrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlineTablePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlineTablePrinter.php
@@ -38,16 +38,13 @@ final class PrettyOutlineTablePrinter implements OutlineTablePrinter
 
     /**
      * Initializes printer.
-     *
-     * @param int $indentation
-     * @param int $subIndentation
      */
     public function __construct(
         private readonly ScenarioPrinter $scenarioPrinter,
         private readonly StepPrinter $stepPrinter,
         private readonly ResultToStringConverter $resultConverter,
-        $indentation = 4,
-        $subIndentation = 2,
+        int $indentation = 4,
+        int $subIndentation = 2,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlineTablePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyOutlineTablePrinter.php
@@ -30,7 +30,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyOutlineTablePrinter implements OutlineTablePrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyPathPrinter.php
@@ -42,10 +42,8 @@ final class PrettyPathPrinter
 
     /**
      * Prints scenario path comment.
-     *
-     * @param int $indentation
      */
-    public function printScenarioPath(Formatter $formatter, FeatureNode $feature, Scenario $scenario, $indentation): void
+    public function printScenarioPath(Formatter $formatter, FeatureNode $feature, Scenario $scenario, int $indentation): void
     {
         $printer = $formatter->getOutputPrinter();
 
@@ -65,15 +63,13 @@ final class PrettyPathPrinter
 
     /**
      * Prints step path comment.
-     *
-     * @param int $indentation
      */
     public function printStepPath(
         Formatter $formatter,
         Scenario $scenario,
         StepNode $step,
         StepResult $result,
-        $indentation,
+        int $indentation,
     ): void {
         $printer = $formatter->getOutputPrinter();
 
@@ -91,10 +87,8 @@ final class PrettyPathPrinter
 
     /**
      * Prints defined step path.
-     *
-     * @param int $scenarioWidth
      */
-    private function printDefinedStepPath(OutputPrinter $printer, DefinedStepResult $result, $scenarioWidth, int $stepWidth): void
+    private function printDefinedStepPath(OutputPrinter $printer, DefinedStepResult $result, int $scenarioWidth, int $stepWidth): void
     {
         $path = $result->getStepDefinition()->getPath();
         $spacing = str_repeat(' ', max(0, $scenarioWidth - $stepWidth));

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -25,10 +25,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyScenarioPrinter implements ScenarioPrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -82,10 +82,8 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
 
     /**
      * Prints scenario title (first line of long title).
-     *
-     * @param string|null   $longTitle
      */
-    private function printTitle(OutputPrinter $printer, $longTitle): void
+    private function printTitle(OutputPrinter $printer, ?string $longTitle): void
     {
         $description = explode("\n", $longTitle ?? '');
         $title = array_shift($description);
@@ -97,10 +95,8 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
 
     /**
      * Prints scenario description (other lines of long title).
-     *
-     * @param string|null   $longTitle
      */
-    private function printDescription(OutputPrinter $printer, $longTitle): void
+    private function printDescription(OutputPrinter $printer, ?string $longTitle): void
     {
         $lines = explode("\n", $longTitle ?? '');
         array_shift($lines);

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -25,7 +25,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyScenarioPrinter implements ScenarioPrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -33,14 +33,11 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param int $indentation
-     * @param int $subIndentation
      */
     public function __construct(
         private readonly PrettyPathPrinter $pathPrinter,
-        $indentation = 2,
-        $subIndentation = 2,
+        int $indentation = 2,
+        int $subIndentation = 2,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));
@@ -80,10 +77,8 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
 
     /**
      * Prints scenario keyword.
-     *
-     * @param string        $keyword
      */
-    private function printKeyword(OutputPrinter $printer, $keyword): void
+    private function printKeyword(OutputPrinter $printer, string $keyword): void
     {
         $printer->write(sprintf('%s{+keyword}%s:{-keyword}', $this->indentText, $keyword));
     }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
@@ -30,7 +30,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  */
 final class PrettySetupPrinter implements SetupPrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
 
     /**
      * Initializes printer.

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
@@ -30,10 +30,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  */
 final class PrettySetupPrinter implements SetupPrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
 
     /**
      * Initializes printer.

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
@@ -42,8 +42,8 @@ final class PrettySetupPrinter implements SetupPrinter
         private readonly ResultToStringConverter $resultConverter,
         private readonly ExceptionPresenter $exceptionPresenter,
         int $indentation = 0,
-        private bool $newlineBefore = false,
-        private bool $newlineAfter = false,
+        private readonly bool $newlineBefore = false,
+        private readonly bool $newlineAfter = false,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
     }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
@@ -37,17 +37,13 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param int  $indentation
-     * @param bool $newlineBefore
-     * @param bool $newlineAfter
      */
     public function __construct(
         private readonly ResultToStringConverter $resultConverter,
         private readonly ExceptionPresenter $exceptionPresenter,
-        $indentation = 0,
-        private $newlineBefore = false,
-        private $newlineAfter = false,
+        int $indentation = 0,
+        private bool $newlineBefore = false,
+        private bool $newlineAfter = false,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
     }
@@ -134,10 +130,8 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Prints hook call output (if has some).
-     *
-     * @param string        $indentText
      */
-    private function printHookCallStdOut(OutputPrinter $printer, CallResult $callResult, $indentText): void
+    private function printHookCallStdOut(OutputPrinter $printer, CallResult $callResult, string $indentText): void
     {
         if (!$callResult->hasStdOut()) {
             return;
@@ -155,10 +149,8 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Prints hook call exception (if has some).
-     *
-     * @param string        $indentText
      */
-    private function printHookCallException(OutputPrinter $printer, CallResult $callResult, $indentText): void
+    private function printHookCallException(OutputPrinter $printer, CallResult $callResult, string $indentText): void
     {
         if (!$callResult->hasException()) {
             return;

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -40,16 +40,13 @@ final class PrettySkippedStepPrinter implements StepPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param int $indentation
-     * @param int $subIndentation
      */
     public function __construct(
         private readonly StepTextPainter $textPainter,
         private readonly ResultToStringConverter $resultConverter,
         private readonly PrettyPathPrinter $pathPrinter,
-        $indentation = 4,
-        $subIndentation = 2,
+        int $indentation = 4,
+        int $subIndentation = 2,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));
@@ -64,11 +61,8 @@ final class PrettySkippedStepPrinter implements StepPrinter
 
     /**
      * Prints step text.
-     *
-     * @param string        $stepType
-     * @param string        $stepText
      */
-    private function printText(OutputPrinter $printer, $stepType, $stepText, StepResult $result): void
+    private function printText(OutputPrinter $printer, string $stepType, string $stepText, StepResult $result): void
     {
         $style = $this->resultConverter->convertResultCodeToString(TestResult::SKIPPED);
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -32,7 +32,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettySkippedStepPrinter implements StepPrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -32,10 +32,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettySkippedStepPrinter implements StepPrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -36,7 +36,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyStepPrinter implements StepPrinter
 {
-    private string $indentText;
+    private readonly string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -44,17 +44,14 @@ final class PrettyStepPrinter implements StepPrinter
 
     /**
      * Initializes printer.
-     *
-     * @param int $indentation
-     * @param int $subIndentation
      */
     public function __construct(
         private readonly StepTextPainter $textPainter,
         private readonly ResultToStringConverter $resultConverter,
         private readonly PrettyPathPrinter $pathPrinter,
         private readonly ExceptionPresenter $exceptionPresenter,
-        $indentation = 4,
-        $subIndentation = 2,
+        int $indentation = 4,
+        int $subIndentation = 2,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));
@@ -83,11 +80,8 @@ final class PrettyStepPrinter implements StepPrinter
 
     /**
      * Prints step text.
-     *
-     * @param string        $stepType
-     * @param string        $stepText
      */
-    private function printText(OutputPrinter $printer, $stepType, $stepText, StepResult $result): void
+    private function printText(OutputPrinter $printer, string $stepType, string $stepText, StepResult $result): void
     {
         if ($result instanceof DefinedStepResult && $result->getStepDefinition()) {
             $definition = $result->getStepDefinition();

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -36,10 +36,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class PrettyStepPrinter implements StepPrinter
 {
-    /**
-     * @var string
-     */
-    private $indentText;
+    private string $indentText;
     private readonly string $subIndentText;
 
     /**

--- a/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
+++ b/src/Behat/Behat/Output/Printer/Formatter/ConsoleFormatter.php
@@ -48,7 +48,7 @@ final class ConsoleFormatter extends BaseOutputFormatter
      *
      * @return string The replaced style
      */
-    private function replaceStyle(array $match)
+    private function replaceStyle(array $match): string
     {
         if (!$this->isDecorated()) {
             return $match[2];

--- a/src/Behat/Behat/Output/Statistics/HookStat.php
+++ b/src/Behat/Behat/Output/Statistics/HookStat.php
@@ -30,8 +30,8 @@ final class HookStat
      * @param string|null $stdOut
      */
     public function __construct(
-        private string $name,
-        private string $path,
+        private readonly string $name,
+        private readonly string $path,
         private $error = null,
         private $stdOut = null,
     ) {

--- a/src/Behat/Behat/Output/Statistics/HookStat.php
+++ b/src/Behat/Behat/Output/Statistics/HookStat.php
@@ -26,14 +26,12 @@ final class HookStat
     /**
      * Initializes hook stat.
      *
-     * @param string      $name
-     * @param string      $path
      * @param string|null $error
      * @param string|null $stdOut
      */
     public function __construct(
-        private $name,
-        private $path,
+        private string $name,
+        private string $path,
         private $error = null,
         private $stdOut = null,
     ) {
@@ -66,20 +64,16 @@ final class HookStat
 
     /**
      * Returns hook exception.
-     *
-     * @return string
      */
-    public function getError()
+    public function getError(): string
     {
         return $this->error;
     }
 
     /**
      * Returns hook path.
-     *
-     * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }

--- a/src/Behat/Behat/Output/Statistics/HookStat.php
+++ b/src/Behat/Behat/Output/Statistics/HookStat.php
@@ -25,15 +25,12 @@ final class HookStat
 
     /**
      * Initializes hook stat.
-     *
-     * @param string|null $error
-     * @param string|null $stdOut
      */
     public function __construct(
         private readonly string $name,
         private readonly string $path,
-        private $error = null,
-        private $stdOut = null,
+        private ?string $error = null,
+        private ?string $stdOut = null,
     ) {
     }
 
@@ -54,10 +51,8 @@ final class HookStat
 
     /**
      * Returns hook standard output (if has some).
-     *
-     * @return string|null
      */
-    public function getStdOut()
+    public function getStdOut(): ?string
     {
         return $this->stdOut;
     }

--- a/src/Behat/Behat/Output/Statistics/HookStat.php
+++ b/src/Behat/Behat/Output/Statistics/HookStat.php
@@ -42,7 +42,7 @@ final class HookStat
         $this->scope = $scope;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Behat/Behat/Output/Statistics/HookStat.php
+++ b/src/Behat/Behat/Output/Statistics/HookStat.php
@@ -29,8 +29,8 @@ final class HookStat
     public function __construct(
         private readonly string $name,
         private readonly string $path,
-        private ?string $error = null,
-        private ?string $stdOut = null,
+        private readonly ?string $error = null,
+        private readonly ?string $stdOut = null,
     ) {
     }
 

--- a/src/Behat/Behat/Snippet/Exception/EnvironmentSnippetGenerationException.php
+++ b/src/Behat/Behat/Snippet/Exception/EnvironmentSnippetGenerationException.php
@@ -22,11 +22,9 @@ final class EnvironmentSnippetGenerationException extends RuntimeException imple
 {
     /**
      * Initializes exception.
-     *
-     * @param string      $message
      */
     public function __construct(
-        $message,
+        string $message,
         private readonly Environment $environment,
     ) {
         parent::__construct($message);

--- a/src/Behat/Behat/Snippet/SnippetRegistry.php
+++ b/src/Behat/Behat/Snippet/SnippetRegistry.php
@@ -112,7 +112,7 @@ final class SnippetRegistry implements SnippetRepository
                 continue;
             }
 
-            if (!$snippet) {
+            if (!$snippet instanceof Snippet) {
                 continue;
             }
 

--- a/src/Behat/Behat/Snippet/SnippetRegistry.php
+++ b/src/Behat/Behat/Snippet/SnippetRegistry.php
@@ -134,10 +134,7 @@ final class SnippetRegistry implements SnippetRepository
         $this->snippetsGenerated = true;
     }
 
-    /**
-     * @return Snippet|null
-     */
-    private function generateSnippet(Environment $environment, StepNode $step)
+    private function generateSnippet(Environment $environment, StepNode $step): ?Snippet
     {
         foreach ($this->generators as $generator) {
             if ($generator->supportsEnvironmentAndStep($environment, $step)) {

--- a/src/Behat/Behat/Tester/Cli/RerunController.php
+++ b/src/Behat/Behat/Tester/Cli/RerunController.php
@@ -38,14 +38,12 @@ final class RerunController implements Controller
 
     /**
      * Initializes controller.
-     *
-     * @param string|null $cachePath
      */
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ResultInterpreter $resultInterpreter,
         private readonly string $basepath,
-        $cachePath,
+        ?string $cachePath,
     ) {
         $this->cachePath = null !== $cachePath ? rtrim($cachePath, DIRECTORY_SEPARATOR) : null;
     }

--- a/src/Behat/Behat/Tester/Exception/FeatureHasNoBackgroundException.php
+++ b/src/Behat/Behat/Tester/Exception/FeatureHasNoBackgroundException.php
@@ -23,11 +23,9 @@ final class FeatureHasNoBackgroundException extends RuntimeException implements 
 {
     /**
      * Initializes exception.
-     *
-     * @param string      $message
      */
     public function __construct(
-        $message,
+        string $message,
         private readonly FeatureNode $feature,
     ) {
         parent::__construct($message);

--- a/src/Behat/Behat/Tester/Exception/PendingException.php
+++ b/src/Behat/Behat/Tester/Exception/PendingException.php
@@ -22,10 +22,8 @@ final class PendingException extends RuntimeException implements TesterException
 {
     /**
      * Initializes pending exception.
-     *
-     * @param string $text
      */
-    public function __construct($text = 'TODO: write pending definition')
+    public function __construct(string $text = 'TODO: write pending definition')
     {
         parent::__construct($text);
     }

--- a/src/Behat/Behat/Tester/Result/DefinedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/DefinedStepResult.php
@@ -23,8 +23,6 @@ interface DefinedStepResult extends StepResult
 {
     /**
      * Returns found step definition.
-     *
-     * @return Definition|null
      */
-    public function getStepDefinition();
+    public function getStepDefinition(): ?Definition;
 }

--- a/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
+++ b/src/Behat/Behat/Tester/Runtime/RuntimeStepTester.php
@@ -71,10 +71,8 @@ final class RuntimeStepTester implements StepTester
 
     /**
      * Searches for a definition.
-     *
-     * @return SearchResult
      */
-    private function searchDefinition(Environment $env, FeatureNode $feature, StepNode $step)
+    private function searchDefinition(Environment $env, FeatureNode $feature, StepNode $step): SearchResult
     {
         return $this->definitionFinder->findDefinition($env, $feature, $step);
     }

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -220,10 +220,8 @@ final class TesterExtension extends BaseExtension
 
     /**
      * Loads rerun controller.
-     *
-     * @param string|null $cachePath
      */
-    protected function loadRerunController(ContainerBuilder $container, $cachePath): void
+    protected function loadRerunController(ContainerBuilder $container, ?string $cachePath): void
     {
         $definition = new Definition(RerunController::class, [
             new Reference(EventDispatcherExtension::DISPATCHER_ID),

--- a/src/Behat/Behat/Tester/StepContainerTester.php
+++ b/src/Behat/Behat/Tester/StepContainerTester.php
@@ -35,11 +35,9 @@ final class StepContainerTester
     /**
      * Tests container.
      *
-     * @param bool                $skip
-     *
      * @return list<TestResult>
      */
-    public function test(Environment $env, FeatureNode $feature, StepContainerInterface $container, $skip): array
+    public function test(Environment $env, FeatureNode $feature, StepContainerInterface $container, bool $skip): array
     {
         $results = [];
         foreach ($container->getSteps() as $step) {

--- a/src/Behat/Behat/Transformation/Exception/UnsupportedCallException.php
+++ b/src/Behat/Behat/Transformation/Exception/UnsupportedCallException.php
@@ -22,11 +22,9 @@ final class UnsupportedCallException extends InvalidArgumentException implements
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
      */
     public function __construct(
-        $message,
+        string $message,
         private readonly Call $call,
     ) {
         parent::__construct($message);

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -38,12 +38,10 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
     /**
      * Initializes transformation.
      *
-     * @param string      $pattern
-     *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private $pattern,
+        private string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -41,7 +41,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private string $pattern,
+        private readonly string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
@@ -34,7 +34,7 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private string $pattern,
+        private readonly string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
@@ -31,12 +31,10 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
     /**
      * Initializes transformation.
      *
-     * @param string      $pattern
-     *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private $pattern,
+        private string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -47,11 +47,9 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
     /**
      * Initializes transformation.
      *
-     * @param string      $pattern
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($pattern, callable|array $callable, ?string $description = null)
+    public function __construct(string $pattern, callable|array $callable, ?string $description = null)
     {
         parent::__construct($callable, $description);
     }
@@ -146,30 +144,24 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
 
     /**
      * Returns appropriate closure for filtering parameter by index.
-     *
-     * @return Closure
      */
-    private function hasIndex(int|string $index)
+    private function hasIndex(int|string $index): Closure
     {
         return is_string($index) ? $this->hasName($index) : $this->hasPosition($index);
     }
 
     /**
      * Returns closure to filter parameter by name.
-     *
-     * @return Closure
      */
-    private function hasName(string $index)
+    private function hasName(string $index): Closure
     {
         return fn (ReflectionParameter $parameter): bool => $index === $parameter->getName();
     }
 
     /**
      * Returns closure to filter parameter by position.
-     *
-     * @return Closure
      */
-    private function hasPosition(int $index)
+    private function hasPosition(int $index): Closure
     {
         return fn (ReflectionParameter $parameter): bool => $index === $parameter->getPosition();
     }

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -112,10 +112,8 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
 
     /**
      * Attempts to get definition parameter using its index (parameter position or name).
-     *
-     * @return string|null
      */
-    private function getParameterClassNameByIndex(DefinitionCall $definitionCall, int|string $argumentIndex)
+    private function getParameterClassNameByIndex(DefinitionCall $definitionCall, int|string $argumentIndex): ?string
     {
         $parameters = array_filter(
             array_filter(

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -42,7 +42,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private string $pattern,
+        private readonly string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -39,12 +39,10 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
     /**
      * Initializes transformation.
      *
-     * @param string      $pattern
-     *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private $pattern,
+        private string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -41,7 +41,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private string $pattern,
+        private readonly string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -38,12 +38,10 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
     /**
      * Initializes transformation.
      *
-     * @param string      $pattern
-     *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private $pattern,
+        private string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
@@ -39,11 +39,9 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
     /**
      * Initializes transformation.
      *
-     * @param string      $pattern
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($pattern, callable|array $callable, ?string $description = null)
+    public function __construct(string $pattern, callable|array $callable, ?string $description = null)
     {
         $this->tokenTransformation = new TokenNameTransformation($pattern, $callable, $description);
         $this->returnTransformation = new ReturnTypeTransformation('', $callable, $description);

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -37,12 +37,10 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
     /**
      * Initializes transformation.
      *
-     * @param string      $pattern
-     *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private $pattern,
+        private string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -40,7 +40,7 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private string $pattern,
+        private readonly string $pattern,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Hook/AfterFeature.php
+++ b/src/Behat/Hook/AfterFeature.php
@@ -22,11 +22,9 @@ final class AfterFeature implements Hook
 {
     /**
      * @api
-     *
-     * @param string|null $filterString
      */
     public function __construct(
-        public $filterString = null,
+        public ?string $filterString = null,
     ) {
     }
 

--- a/src/Behat/Hook/AfterScenario.php
+++ b/src/Behat/Hook/AfterScenario.php
@@ -22,11 +22,9 @@ final class AfterScenario implements Hook
 {
     /**
      * @api
-     *
-     * @param string|null $filterString
      */
     public function __construct(
-        public $filterString = null,
+        public ?string $filterString = null,
     ) {
     }
 

--- a/src/Behat/Hook/AfterStep.php
+++ b/src/Behat/Hook/AfterStep.php
@@ -22,11 +22,9 @@ final class AfterStep implements Hook
 {
     /**
      * @api
-     *
-     * @param string|null $filterString
      */
     public function __construct(
-        public $filterString = null,
+        public ?string $filterString = null,
     ) {
     }
 

--- a/src/Behat/Hook/AfterSuite.php
+++ b/src/Behat/Hook/AfterSuite.php
@@ -22,11 +22,9 @@ final class AfterSuite implements Hook
 {
     /**
      * @api
-     *
-     * @param string|null $filterString
      */
     public function __construct(
-        public $filterString = null,
+        public ?string $filterString = null,
     ) {
     }
 

--- a/src/Behat/Hook/BeforeFeature.php
+++ b/src/Behat/Hook/BeforeFeature.php
@@ -21,12 +21,10 @@ use Attribute;
 final class BeforeFeature implements Hook
 {
     /**
-     * @param string|null $filterString
-     *
      * @api
      */
     public function __construct(
-        public $filterString = null,
+        public ?string $filterString = null,
     ) {
     }
 

--- a/src/Behat/Hook/BeforeScenario.php
+++ b/src/Behat/Hook/BeforeScenario.php
@@ -21,12 +21,10 @@ use Attribute;
 final class BeforeScenario implements Hook
 {
     /**
-     * @param string|null $filterString
-     *
      * @api
      */
     public function __construct(
-        public $filterString = null,
+        public ?string $filterString = null,
     ) {
     }
 

--- a/src/Behat/Hook/BeforeStep.php
+++ b/src/Behat/Hook/BeforeStep.php
@@ -21,12 +21,10 @@ use Attribute;
 final class BeforeStep implements Hook
 {
     /**
-     * @param string|null $filterString
-     *
      * @api
      */
     public function __construct(
-        public $filterString = null,
+        public ?string $filterString = null,
     ) {
     }
 

--- a/src/Behat/Hook/BeforeSuite.php
+++ b/src/Behat/Hook/BeforeSuite.php
@@ -21,12 +21,10 @@ use Attribute;
 final class BeforeSuite implements Hook
 {
     /**
-     * @param string|null $filterString
-     *
      * @api
      */
     public function __construct(
-        public $filterString = null,
+        public ?string $filterString = null,
     ) {
     }
 

--- a/src/Behat/Step/Given.php
+++ b/src/Behat/Step/Given.php
@@ -21,12 +21,10 @@ use Attribute;
 final class Given implements Definition
 {
     /**
-     * @param string|null $pattern
-     *
      * @api
      */
     public function __construct(
-        public $pattern = null,
+        public ?string $pattern = null,
     ) {
     }
 

--- a/src/Behat/Step/Then.php
+++ b/src/Behat/Step/Then.php
@@ -21,12 +21,10 @@ use Attribute;
 final class Then implements Definition
 {
     /**
-     * @param string|null $pattern
-     *
      * @api
      */
     public function __construct(
-        public $pattern = null,
+        public ?string $pattern = null,
     ) {
     }
 

--- a/src/Behat/Step/When.php
+++ b/src/Behat/Step/When.php
@@ -21,12 +21,10 @@ use Attribute;
 final class When implements Definition
 {
     /**
-     * @param string|null $pattern
-     *
      * @api
      */
     public function __construct(
-        public $pattern = null,
+        public ?string $pattern = null,
     ) {
     }
 

--- a/src/Behat/Testwork/ApplicationFactory.php
+++ b/src/Behat/Testwork/ApplicationFactory.php
@@ -48,10 +48,8 @@ abstract class ApplicationFactory
 
     /**
      * Returns user config path.
-     *
-     * @return string|null
      */
-    abstract protected function getConfigPath();
+    abstract protected function getConfigPath(): ?string;
 
     /**
      * Creates application instance.

--- a/src/Behat/Testwork/ApplicationFactory.php
+++ b/src/Behat/Testwork/ApplicationFactory.php
@@ -26,31 +26,25 @@ abstract class ApplicationFactory
 {
     /**
      * Returns application name.
-     *
-     * @return string
      */
-    abstract protected function getName();
+    abstract protected function getName(): string;
 
     /**
      * Returns current application version.
-     *
-     * @return string
      */
-    abstract protected function getVersion();
+    abstract protected function getVersion(): string;
 
     /**
      * Returns list of extensions enabled by default.
      *
      * @return Extension[]
      */
-    abstract protected function getDefaultExtensions();
+    abstract protected function getDefaultExtensions(): array;
 
     /**
      * Returns the name of configuration environment variable.
-     *
-     * @return string
      */
-    abstract protected function getEnvironmentVariableName();
+    abstract protected function getEnvironmentVariableName(): string;
 
     /**
      * Returns user config path.
@@ -61,10 +55,8 @@ abstract class ApplicationFactory
 
     /**
      * Creates application instance.
-     *
-     * @return Application
      */
-    public function createApplication()
+    public function createApplication(): Application
     {
         $configurationLoader = $this->createConfigurationLoader();
         $extensionManager = $this->createExtensionManager();
@@ -74,20 +66,16 @@ abstract class ApplicationFactory
 
     /**
      * Creates configuration loader.
-     *
-     * @return ConfigurationLoader
      */
-    protected function createConfigurationLoader()
+    protected function createConfigurationLoader(): ConfigurationLoader
     {
         return new ConfigurationLoader($this->getEnvironmentVariableName(), $this->getConfigPath());
     }
 
     /**
      * Creates extension manager.
-     *
-     * @return ExtensionManager
      */
-    protected function createExtensionManager()
+    protected function createExtensionManager(): ExtensionManager
     {
         return new ExtensionManager($this->getDefaultExtensions());
     }

--- a/src/Behat/Testwork/Argument/Validator.php
+++ b/src/Behat/Testwork/Argument/Validator.php
@@ -38,10 +38,8 @@ final class Validator
 
     /**
      * Validates given argument.
-     *
-     * @param int $parameterIndex
      */
-    private function validateArgument(ReflectionParameter $parameter, $parameterIndex, array $givenArguments): void
+    private function validateArgument(ReflectionParameter $parameter, int $parameterIndex, array $givenArguments): void
     {
         if ($parameter->isDefaultValueAvailable()) {
             return;

--- a/src/Behat/Testwork/Call/Call.php
+++ b/src/Behat/Testwork/Call/Call.php
@@ -36,8 +36,6 @@ interface Call
 
     /**
      * Returns call error reporting level.
-     *
-     * @return int|null
      */
-    public function getErrorReportingLevel();
+    public function getErrorReportingLevel(): ?int;
 }

--- a/src/Behat/Testwork/Call/CallCenter.php
+++ b/src/Behat/Testwork/Call/CallCenter.php
@@ -77,10 +77,8 @@ final class CallCenter
 
     /**
      * Handles call and its result using registered filters and handlers.
-     *
-     * @return CallResult
      */
-    public function makeCall(Call $call)
+    public function makeCall(Call $call): CallResult
     {
         try {
             return $this->filterResult($this->handleCall($this->filterCall($call)));
@@ -91,10 +89,8 @@ final class CallCenter
 
     /**
      * Filters call using registered filters and returns a filtered one.
-     *
-     * @return Call
      */
-    private function filterCall(Call $call)
+    private function filterCall(Call $call): Call
     {
         foreach ($this->callFilters as $filter) {
             if (!$filter->supportsCall($call)) {
@@ -130,10 +126,8 @@ final class CallCenter
 
     /**
      * Filters call result using registered filters and returns a filtered one.
-     *
-     * @return CallResult
      */
-    private function filterResult(CallResult $result)
+    private function filterResult(CallResult $result): CallResult
     {
         foreach ($this->resultFilters as $filter) {
             if (!$filter->supportsResult($result)) {

--- a/src/Behat/Testwork/Call/CallResult.php
+++ b/src/Behat/Testwork/Call/CallResult.php
@@ -26,7 +26,7 @@ final class CallResult
         private readonly Call $call,
         private $return,
         private readonly ?Exception $exception = null,
-        private ?string $stdOut = null,
+        private readonly ?string $stdOut = null,
     ) {
     }
 

--- a/src/Behat/Testwork/Call/CallResult.php
+++ b/src/Behat/Testwork/Call/CallResult.php
@@ -21,14 +21,12 @@ final class CallResult
 {
     /**
      * Initializes call result.
-     *
-     * @param string|null $stdOut
      */
     public function __construct(
         private readonly Call $call,
         private $return,
         private readonly ?Exception $exception = null,
-        private $stdOut = null,
+        private ?string $stdOut = null,
     ) {
     }
 
@@ -77,10 +75,8 @@ final class CallResult
 
     /**
      * Returns stdOut produced by call (if any).
-     *
-     * @return string|null
      */
-    public function getStdOut()
+    public function getStdOut(): ?string
     {
         return $this->stdOut;
     }

--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -48,7 +48,7 @@ interface Callee
      *
      * @phpstan-return TBehatCallable
      */
-    public function getCallable();
+    public function getCallable(): callable|array;
 
     /**
      * Returns callable reflection.

--- a/src/Behat/Testwork/Call/Exception/BadCallbackException.php
+++ b/src/Behat/Testwork/Call/Exception/BadCallbackException.php
@@ -27,10 +27,9 @@ final class BadCallbackException extends InvalidArgumentException implements Cal
     /**
      * Initializes exception.
      *
-     * @param string   $message
      * @param callable $callable
      */
-    public function __construct($message, $callable)
+    public function __construct(string $message, $callable)
     {
         $this->callable = $callable;
 

--- a/src/Behat/Testwork/Call/Exception/CallErrorException.php
+++ b/src/Behat/Testwork/Call/Exception/CallErrorException.php
@@ -38,7 +38,7 @@ final class CallErrorException extends ErrorException
      * @param string $file    error file
      * @param int    $line    error line
      */
-    public function __construct($level, $message, $file, $line)
+    public function __construct(int $level, string $message, string $file, int $line)
     {
         // E_STRICT is deprecated since PHP 8.4.
         if (defined('E_STRICT') && $level === @E_STRICT) {

--- a/src/Behat/Testwork/Call/Exception/CallHandlingException.php
+++ b/src/Behat/Testwork/Call/Exception/CallHandlingException.php
@@ -22,11 +22,9 @@ final class CallHandlingException extends RuntimeException implements CallExcept
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
      */
     public function __construct(
-        $message,
+        string $message,
         private readonly Call $call,
     ) {
         parent::__construct($message);

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -44,10 +44,8 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
 
     /**
      * Override to handle non-existent class name.
-     *
-     * @param string $class
      */
-    abstract public function handleNonExistentClass($class);
+    abstract public function handleNonExistentClass(string $class);
 
     /**
      * Extracts missing class name from the exception.

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -30,11 +30,9 @@ final class RuntimeCallHandler implements CallHandler
 
     /**
      * Initializes executor.
-     *
-     * @param int $errorReportingLevel
      */
     public function __construct(
-        private $errorReportingLevel = E_ALL,
+        private int $errorReportingLevel = E_ALL,
     ) {
         $this->validator = new Validator();
     }
@@ -58,14 +56,9 @@ final class RuntimeCallHandler implements CallHandler
      *
      * @see set_error_handler()
      *
-     * @param int    $level
-     * @param string $message
-     * @param string $file
-     * @param int    $line
-     *
      * @throws CallErrorException
      */
-    public function handleError($level, $message, $file, $line): bool
+    public function handleError(int $level, string $message, string $file, int $line): bool
     {
         if ($this->errorLevelIsNotReportable($level)) {
             return false;
@@ -133,10 +126,8 @@ final class RuntimeCallHandler implements CallHandler
 
     /**
      * Checks if provided error level is not reportable.
-     *
-     * @param int $level
      */
-    private function errorLevelIsNotReportable($level): bool
+    private function errorLevelIsNotReportable(int $level): bool
     {
         return !(error_reporting() & $level);
     }

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -32,7 +32,7 @@ final class RuntimeCallHandler implements CallHandler
      * Initializes executor.
      */
     public function __construct(
-        private int $errorReportingLevel = E_ALL,
+        private readonly int $errorReportingLevel = E_ALL,
     ) {
         $this->validator = new Validator();
     }

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -71,7 +71,7 @@ class RuntimeCallee implements Callee
      *
      * @return TBehatCallable
      */
-    public function getCallable()
+    public function getCallable(): callable|array
     {
         return $this->callable;
     }

--- a/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
+++ b/src/Behat/Testwork/Call/ServiceContainer/CallExtension.php
@@ -94,10 +94,8 @@ final class CallExtension implements Extension
 
     /**
      * Loads prebuilt call handlers.
-     *
-     * @param int $errorReporting
      */
-    private function loadCallHandlers(ContainerBuilder $container, $errorReporting): void
+    private function loadCallHandlers(ContainerBuilder $container, int $errorReporting): void
     {
         $definition = new Definition(RuntimeCallHandler::class, [$errorReporting]);
         $definition->addTag(self::CALL_HANDLER_TAG, ['priority' => 50]);

--- a/src/Behat/Testwork/Cli/Application.php
+++ b/src/Behat/Testwork/Cli/Application.php
@@ -177,10 +177,8 @@ final class Application extends BaseApplication
 
     /**
      * Returns base path.
-     *
-     * @return string
      */
-    private function getBasePath()
+    private function getBasePath(): string
     {
         if ($configPath = $this->configurationLoader->getConfigurationFilePath()) {
             return realpath(dirname($configPath));

--- a/src/Behat/Testwork/Cli/Controller.php
+++ b/src/Behat/Testwork/Cli/Controller.php
@@ -32,8 +32,6 @@ interface Controller
 
     /**
      * Executes controller.
-     *
-     * @return int|null
      */
-    public function execute(InputInterface $input, OutputInterface $output);
+    public function execute(InputInterface $input, OutputInterface $output): ?int;
 }

--- a/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
+++ b/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
@@ -57,7 +57,7 @@ class EnvironmentCall implements Call
         return $this->arguments;
     }
 
-    final public function getErrorReportingLevel()
+    final public function getErrorReportingLevel(): ?int
     {
         return $this->errorReportingLevel;
     }

--- a/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
+++ b/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
@@ -23,14 +23,12 @@ class EnvironmentCall implements Call
 {
     /**
      * Initializes call.
-     *
-     * @param int|null $errorReportingLevel
      */
     public function __construct(
         private readonly Environment $environment,
         private readonly Callee $callee,
         private readonly array $arguments,
-        private $errorReportingLevel = null,
+        private ?int $errorReportingLevel = null,
     ) {
     }
 

--- a/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
+++ b/src/Behat/Testwork/Environment/Call/EnvironmentCall.php
@@ -28,7 +28,7 @@ class EnvironmentCall implements Call
         private readonly Environment $environment,
         private readonly Callee $callee,
         private readonly array $arguments,
-        private ?int $errorReportingLevel = null,
+        private readonly ?int $errorReportingLevel = null,
     ) {
     }
 

--- a/src/Behat/Testwork/Environment/Exception/EnvironmentBuildException.php
+++ b/src/Behat/Testwork/Environment/Exception/EnvironmentBuildException.php
@@ -22,11 +22,9 @@ final class EnvironmentBuildException extends RuntimeException implements Enviro
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
      */
     public function __construct(
-        $message,
+        string $message,
         private readonly Suite $suite,
     ) {
         parent::__construct($message);

--- a/src/Behat/Testwork/Environment/Exception/EnvironmentIsolationException.php
+++ b/src/Behat/Testwork/Environment/Exception/EnvironmentIsolationException.php
@@ -22,11 +22,9 @@ final class EnvironmentIsolationException extends RuntimeException implements En
 {
     /**
      * Initializes exception.
-     *
-     * @param string      $message
      */
     public function __construct(
-        $message,
+        string $message,
         private readonly Environment $environment,
         private $subject = null,
     ) {

--- a/src/Behat/Testwork/Environment/Exception/EnvironmentReadException.php
+++ b/src/Behat/Testwork/Environment/Exception/EnvironmentReadException.php
@@ -22,11 +22,9 @@ final class EnvironmentReadException extends RuntimeException implements Environ
 {
     /**
      * Initializes exception.
-     *
-     * @param string      $message
      */
     public function __construct(
-        $message,
+        string $message,
         private readonly Environment $environment,
     ) {
         parent::__construct($message);

--- a/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
@@ -32,5 +32,5 @@ abstract class ExerciseCompleted extends Event
      *
      * @return SpecificationIterator<mixed>[]
      */
-    abstract public function getSpecificationIterators();
+    abstract public function getSpecificationIterators(): array;
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/LifecycleEvent.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/LifecycleEvent.php
@@ -33,20 +33,16 @@ abstract class LifecycleEvent extends Event
 
     /**
      * Returns suite in which this event was fired.
-     *
-     * @return Suite
      */
-    public function getSuite()
+    public function getSuite(): Suite
     {
         return $this->environment->getSuite();
     }
 
     /**
      * Returns environment in which this event was fired.
-     *
-     * @return Environment
      */
-    public function getEnvironment()
+    public function getEnvironment(): Environment
     {
         return $this->environment;
     }

--- a/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
@@ -31,5 +31,5 @@ abstract class SuiteTested extends LifecycleEvent
      *
      * @return SpecificationIterator<mixed>
      */
-    abstract public function getSpecificationIterator();
+    abstract public function getSpecificationIterator(): SpecificationIterator;
 }

--- a/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
+++ b/src/Behat/Testwork/Exception/ServiceContainer/ExceptionExtension.php
@@ -94,10 +94,8 @@ final class ExceptionExtension implements Extension
 
     /**
      * Loads exception presenter.
-     *
-     * @param int $verbosity
      */
-    private function loadPresenter(ContainerBuilder $container, $verbosity): void
+    private function loadPresenter(ContainerBuilder $container, int $verbosity): void
     {
         $definition = new Definition(ExceptionPresenter::class, [
             $verbosity,

--- a/src/Behat/Testwork/Filesystem/ConsoleFilesystemLogger.php
+++ b/src/Behat/Testwork/Filesystem/ConsoleFilesystemLogger.php
@@ -21,11 +21,9 @@ final class ConsoleFilesystemLogger implements FilesystemLogger
 {
     /**
      * Initializes logger.
-     *
-     * @param string          $basePath
      */
     public function __construct(
-        private $basePath,
+        private string $basePath,
         private readonly OutputInterface $output,
     ) {
     }

--- a/src/Behat/Testwork/Filesystem/ConsoleFilesystemLogger.php
+++ b/src/Behat/Testwork/Filesystem/ConsoleFilesystemLogger.php
@@ -23,7 +23,7 @@ final class ConsoleFilesystemLogger implements FilesystemLogger
      * Initializes logger.
      */
     public function __construct(
-        private string $basePath,
+        private readonly string $basePath,
         private readonly OutputInterface $output,
     ) {
     }

--- a/src/Behat/Testwork/Hook/Call/AfterSuite.php
+++ b/src/Behat/Testwork/Hook/Call/AfterSuite.php
@@ -25,11 +25,9 @@ final class AfterSuite extends RuntimeSuiteHook
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct(SuiteScope::AFTER, $filterString, $callable, $description);
     }

--- a/src/Behat/Testwork/Hook/Call/BeforeSuite.php
+++ b/src/Behat/Testwork/Hook/Call/BeforeSuite.php
@@ -25,11 +25,9 @@ final class BeforeSuite extends RuntimeSuiteHook
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
-    public function __construct($filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct(SuiteScope::BEFORE, $filterString, $callable, $description);
     }

--- a/src/Behat/Testwork/Hook/Call/HookCall.php
+++ b/src/Behat/Testwork/Hook/Call/HookCall.php
@@ -25,10 +25,8 @@ final class HookCall extends EnvironmentCall
 
     /**
      * Initializes hook call.
-     *
-     * @param int|null $errorReportingLevel
      */
-    public function __construct(HookScope $scope, Hook $hook, $errorReportingLevel = null)
+    public function __construct(HookScope $scope, Hook $hook, ?int $errorReportingLevel = null)
     {
         parent::__construct($scope->getEnvironment(), $hook, [$scope], $errorReportingLevel);
 

--- a/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
@@ -30,7 +30,7 @@ abstract class RuntimeFilterableHook extends RuntimeHook implements Stringable, 
      */
     public function __construct(
         string $scopeName,
-        private ?string $filterString,
+        private readonly ?string $filterString,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
@@ -26,13 +26,12 @@ abstract class RuntimeFilterableHook extends RuntimeHook implements Stringable, 
     /**
      * Initializes hook.
      *
-     * @param string      $scopeName
      * @param string|null $filterString
      *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        $scopeName,
+        string $scopeName,
         private $filterString,
         callable|array $callable,
         ?string $description = null,

--- a/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
@@ -26,13 +26,11 @@ abstract class RuntimeFilterableHook extends RuntimeHook implements Stringable, 
     /**
      * Initializes hook.
      *
-     * @param string|null $filterString
-     *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         string $scopeName,
-        private $filterString,
+        private ?string $filterString,
         callable|array $callable,
         ?string $description = null,
     ) {
@@ -41,10 +39,8 @@ abstract class RuntimeFilterableHook extends RuntimeHook implements Stringable, 
 
     /**
      * Returns hook filter string (if has one).
-     *
-     * @return string|null
      */
-    public function getFilterString()
+    public function getFilterString(): ?string
     {
         return $this->filterString;
     }

--- a/src/Behat/Testwork/Hook/Call/RuntimeHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeHook.php
@@ -29,7 +29,7 @@ abstract class RuntimeHook extends RuntimeCallee implements Stringable, Hook
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private string $scopeName,
+        private readonly string $scopeName,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Testwork/Hook/Call/RuntimeHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeHook.php
@@ -26,12 +26,10 @@ abstract class RuntimeHook extends RuntimeCallee implements Stringable, Hook
     /**
      * Initializes hook.
      *
-     * @param string      $scopeName
-     *
      * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        private $scopeName,
+        private string $scopeName,
         callable|array $callable,
         ?string $description = null,
     ) {

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -25,12 +25,11 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
     /**
      * Initializes hook.
      *
-     * @param string|null                          $filterString
      * @param callable|array{class-string, string} $callable
      *
      * @throws BadCallbackException If callback is method, but not a static one
      */
-    public function __construct(string $scopeName, $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(string $scopeName, ?string $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct($scopeName, $filterString, $callable, $description);
 

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -25,13 +25,12 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
     /**
      * Initializes hook.
      *
-     * @param string                               $scopeName
      * @param string|null                          $filterString
      * @param callable|array{class-string, string} $callable
      *
      * @throws BadCallbackException If callback is method, but not a static one
      */
-    public function __construct($scopeName, $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(string $scopeName, $filterString, callable|array $callable, ?string $description = null)
     {
         parent::__construct($scopeName, $filterString, $callable, $description);
 
@@ -56,10 +55,8 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
 
     /**
      * Checks if Feature matches specified filter.
-     *
-     * @param string $filterString
      */
-    private function isSuiteMatch(Suite $suite, $filterString): bool
+    private function isSuiteMatch(Suite $suite, string $filterString): bool
     {
         if ('/' === $filterString[0]) {
             return 1 === preg_match($filterString, $suite->getName());

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -45,7 +45,7 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
             return true;
         }
 
-        if (!empty($filterString)) {
+        if ($filterString !== '') {
             return $this->isSuiteMatch($scope->getSuite(), $filterString);
         }
 

--- a/src/Behat/Testwork/Hook/HookDispatcher.php
+++ b/src/Behat/Testwork/Hook/HookDispatcher.php
@@ -47,10 +47,8 @@ final class HookDispatcher
 
     /**
      * Dispatches single event hook.
-     *
-     * @return CallResult
      */
-    private function dispatchHook(HookScope $scope, Hook $hook)
+    private function dispatchHook(HookScope $scope, Hook $hook): CallResult
     {
         return $this->callCenter->makeCall(new HookCall($scope, $hook));
     }

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -110,12 +110,8 @@ final class OutputController implements Controller
 
     /**
      * Locates output path from relative one.
-     *
-     * @param string $path
-     *
-     * @return string
      */
-    private function locateOutputPath($path)
+    private function locateOutputPath(string $path): string
     {
         if ($this->isAbsolutePath($path)) {
             return $path;
@@ -163,10 +159,8 @@ final class OutputController implements Controller
 
     /**
      * Checks if provided output identifier represents standard output.
-     *
-     * @param string $outputId
      */
-    private function isStandardOutput($outputId): bool
+    private function isStandardOutput(string $outputId): bool
     {
         return 'std' === $outputId || 'null' === $outputId || 'false' === $outputId;
     }
@@ -176,7 +170,7 @@ final class OutputController implements Controller
      *
      * @param string $file A file path
      */
-    private function isAbsolutePath($file): bool
+    private function isAbsolutePath(string $file): bool
     {
         return $file[0] == '/' || $file[0] == '\\'
             || (
@@ -208,10 +202,8 @@ final class OutputController implements Controller
 
     /**
      * Loads JSON settings as formatter parameters.
-     *
-     * @param string $jsonSettings
      */
-    private function loadJsonSettings($jsonSettings): void
+    private function loadJsonSettings(string $jsonSettings): void
     {
         $settings = @json_decode($jsonSettings, true);
 

--- a/src/Behat/Testwork/Output/Exception/BadOutputPathException.php
+++ b/src/Behat/Testwork/Output/Exception/BadOutputPathException.php
@@ -24,7 +24,7 @@ final class BadOutputPathException extends InvalidArgumentException implements P
      */
     public function __construct(
         string $message,
-        private string $path,
+        private readonly string $path,
     ) {
         parent::__construct($message);
     }

--- a/src/Behat/Testwork/Output/Exception/BadOutputPathException.php
+++ b/src/Behat/Testwork/Output/Exception/BadOutputPathException.php
@@ -21,23 +21,18 @@ final class BadOutputPathException extends InvalidArgumentException implements P
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
-     * @param string $path
      */
     public function __construct(
-        $message,
-        private $path,
+        string $message,
+        private string $path,
     ) {
         parent::__construct($message);
     }
 
     /**
      * Returns exception causing path.
-     *
-     * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }

--- a/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
+++ b/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
@@ -24,7 +24,7 @@ final class FormatterNotFoundException extends InvalidArgumentException implemen
      */
     public function __construct(
         string $message,
-        private string $name,
+        private readonly string $name,
     ) {
         parent::__construct($message);
     }

--- a/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
+++ b/src/Behat/Testwork/Output/Exception/FormatterNotFoundException.php
@@ -21,23 +21,18 @@ final class FormatterNotFoundException extends InvalidArgumentException implemen
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
-     * @param string $name
      */
     public function __construct(
-        $message,
-        private $name,
+        string $message,
+        private string $name,
     ) {
         parent::__construct($message);
     }
 
     /**
      * Returns formatter name.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
@@ -25,7 +25,7 @@ final class FireOnlyIfFormatterParameterListener implements EventListener
      * Initializes listener.
      */
     public function __construct(
-        private string $name,
+        private readonly string $name,
         private $value,
         private readonly EventListener $descendant,
     ) {

--- a/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
@@ -23,11 +23,9 @@ final class FireOnlyIfFormatterParameterListener implements EventListener
 {
     /**
      * Initializes listener.
-     *
-     * @param string        $name
      */
     public function __construct(
-        private $name,
+        private string $name,
         private $value,
         private readonly EventListener $descendant,
     ) {

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -25,13 +25,10 @@ final class NodeEventListeningFormatter implements Formatter
 {
     /**
      * Initializes formatter.
-     *
-     * @param string        $name
-     * @param string        $description
      */
     public function __construct(
-        private $name,
-        private $description,
+        private string $name,
+        private string $description,
         private array $parameters,
         private readonly OutputPrinter $printer,
         private readonly EventListener $listener,

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -27,8 +27,8 @@ final class NodeEventListeningFormatter implements Formatter
      * Initializes formatter.
      */
     public function __construct(
-        private string $name,
-        private string $description,
+        private readonly string $name,
+        private readonly string $description,
         private array $parameters,
         private readonly OutputPrinter $printer,
         private readonly EventListener $listener,

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -47,10 +47,8 @@ final class NodeEventListeningFormatter implements Formatter
 
     /**
      * Proxies event to the listener.
-     *
-     * @param string|null $eventName
      */
-    public function listenEvent(Event $event, $eventName = null): void
+    public function listenEvent(Event $event, ?string $eventName = null): void
     {
         if (null === $eventName) {
             $eventName = method_exists($event, 'getName') ? $event->getName() : $event::class;

--- a/src/Behat/Testwork/Output/OutputManager.php
+++ b/src/Behat/Testwork/Output/OutputManager.php
@@ -56,13 +56,9 @@ final class OutputManager
     /**
      * Returns formatter by name provided.
      *
-     * @param string $name
-     *
-     * @return Formatter
-     *
      * @throws FormatterNotFoundException
      */
-    public function getFormatter($name)
+    public function getFormatter(string $name): Formatter
     {
         if (!$this->isFormatterRegistered($name)) {
             throw new FormatterNotFoundException(sprintf(
@@ -87,10 +83,8 @@ final class OutputManager
 
     /**
      * Enable formatter by name provided.
-     *
-     * @param string $formatter
      */
-    public function enableFormatter($formatter): void
+    public function enableFormatter(string $formatter): void
     {
         if (!$this->isFormatterRegistered($formatter) && class_exists($formatter)) {
             $formatterInstance = new $formatter();
@@ -106,10 +100,8 @@ final class OutputManager
 
     /**
      * Disable formatter by name provided.
-     *
-     * @param string $formatter
      */
-    public function disableFormatter($formatter): void
+    public function disableFormatter(string $formatter): void
     {
         $this->eventDispatcher->removeSubscriber($this->getFormatter($formatter));
     }
@@ -124,10 +116,8 @@ final class OutputManager
 
     /**
      * Sets provided parameter to said formatter.
-     *
-     * @param string $formatter
      */
-    public function setFormatterParameter($formatter, string $parameterName, $parameterValue): void
+    public function setFormatterParameter(string $formatter, string $parameterName, $parameterValue): void
     {
         $formatter = $this->getFormatter($formatter);
         $printer = $formatter->getOutputPrinter();
@@ -156,10 +146,8 @@ final class OutputManager
 
     /**
      * Sets provided formatter parameters.
-     *
-     * @param string $formatter
      */
-    public function setFormatterParameters($formatter, array $parameters): void
+    public function setFormatterParameters(string $formatter, array $parameters): void
     {
         foreach ($parameters as $key => $val) {
             $this->setFormatterParameter($formatter, $key, $val);

--- a/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
@@ -37,8 +37,12 @@ class ConsoleOutputFactory extends OutputFactory
      */
     protected function configureOutputStream(OutputInterface $output)
     {
-        $verbosity = $this->getOutputVerbosity() ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL;
-        $output->setVerbosity($verbosity);
+        $output->setVerbosity(
+            match ($this->getOutputVerbosity()) {
+                0 => OutputInterface::VERBOSITY_NORMAL,
+                default => OutputInterface::VERBOSITY_VERBOSE,
+            }
+        );
 
         if (null !== $this->isOutputDecorated()) {
             $output->getFormatter()->setDecorated($this->isOutputDecorated());

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -35,8 +35,12 @@ final class FilesystemOutputFactory extends OutputFactory
      */
     private function configureOutputStream(OutputInterface $output): void
     {
-        $verbosity = $this->getOutputVerbosity() ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL;
-        $output->setVerbosity($verbosity);
+        $output->setVerbosity(
+            match ($this->getOutputVerbosity()) {
+                0 => OutputInterface::VERBOSITY_NORMAL,
+                default => OutputInterface::VERBOSITY_VERBOSE,
+            }
+        );
     }
 
     public function createOutput($stream = null): StreamOutput

--- a/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
@@ -34,10 +34,8 @@ abstract class OutputFactory
 
     /**
      * Sets output path.
-     *
-     * @param string $path
      */
-    public function setOutputPath($path): void
+    public function setOutputPath(string $path): void
     {
         $this->outputPath = $path;
     }
@@ -62,10 +60,8 @@ abstract class OutputFactory
 
     /**
      * Returns output styles.
-     *
-     * @return array
      */
-    public function getOutputStyles()
+    public function getOutputStyles(): array
     {
         return $this->outputStyles;
     }
@@ -90,28 +86,22 @@ abstract class OutputFactory
 
     /**
      * Sets output verbosity level.
-     *
-     * @param int $level
      */
-    public function setOutputVerbosity($level): void
+    public function setOutputVerbosity(int $level): void
     {
         $this->verbosityLevel = intval($level);
     }
 
     /**
      * Returns output verbosity level.
-     *
-     * @return int
      */
-    public function getOutputVerbosity()
+    public function getOutputVerbosity(): int
     {
         return $this->verbosityLevel;
     }
 
     /**
      * Returns a new output stream.
-     *
-     * @return OutputInterface
      */
-    abstract public function createOutput();
+    abstract public function createOutput(): OutputInterface;
 }

--- a/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
@@ -23,10 +23,7 @@ abstract class OutputFactory
     public const VERBOSITY_VERY_VERBOSE = 3;
     public const VERBOSITY_DEBUG = 4;
 
-    /**
-     * @var string|null
-     */
-    private $outputPath;
+    private ?string $outputPath = null;
     private array $outputStyles = [];
 
     private ?bool $outputDecorated = null;

--- a/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/OutputFactory.php
@@ -39,10 +39,8 @@ abstract class OutputFactory
 
     /**
      * Returns output path.
-     *
-     * @return string|null
      */
-    public function getOutputPath()
+    public function getOutputPath(): ?string
     {
         return $this->outputPath;
     }
@@ -73,10 +71,8 @@ abstract class OutputFactory
 
     /**
      * Returns output decoration status.
-     *
-     * @return bool|null
      */
-    public function isOutputDecorated()
+    public function isOutputDecorated(): ?bool
     {
         return $this->outputDecorated;
     }

--- a/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/JUnitOutputPrinter.php
@@ -108,11 +108,8 @@ final class JUnitOutputPrinter extends StreamOutputPrinter
 
     /**
      * Add a testcase child element.
-     *
-     * @param string $nodeName
-     * @param string $nodeValue
      */
-    public function addTestcaseChild($nodeName, array $nodeAttributes = [], $nodeValue = null): void
+    public function addTestcaseChild(string $nodeName, array $nodeAttributes = [], ?string $nodeValue = null): void
     {
         $childNode = $this->domDocument->createElement($nodeName, $nodeValue ?? '');
         $this->currentTestcase->appendChild($childNode);

--- a/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
+++ b/src/Behat/Testwork/Output/Printer/StreamOutputPrinter.php
@@ -72,10 +72,8 @@ class StreamOutputPrinter implements OutputPrinter
 
     /**
      * Returns output instance, prepared to write.
-     *
-     * @return OutputInterface
      */
-    final protected function getWritingStream()
+    final protected function getWritingStream(): OutputInterface
     {
         if (!$this->output instanceof OutputInterface) {
             $this->output = $this->outputFactory->createOutput();

--- a/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
@@ -47,7 +47,7 @@ final class OutputExtension implements Extension
      * @param FormatterFactory[] $factories
      */
     public function __construct(
-        private string $defaultFormatter,
+        private readonly string $defaultFormatter,
         private array $factories,
         ?ServiceProcessor $processor = null,
     ) {

--- a/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
+++ b/src/Behat/Testwork/Output/ServiceContainer/OutputExtension.php
@@ -44,11 +44,10 @@ final class OutputExtension implements Extension
     /**
      * Initializes extension.
      *
-     * @param string                $defaultFormatter
      * @param FormatterFactory[] $factories
      */
     public function __construct(
-        private $defaultFormatter,
+        private string $defaultFormatter,
         private array $factories,
         ?ServiceProcessor $processor = null,
     ) {

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -37,47 +37,39 @@ final class ConfigurationLoader
      * @param string|null $configurationPath       Configuration file path
      */
     public function __construct(
-        private $environmentVariable = null,
-        private $configurationPath = null,
+        private ?string $environmentVariable = null,
+        private ?string $configurationPath = null,
     ) {
     }
 
     /**
      * Sets environment variable name.
-     *
-     * @param string|null $variable
      */
-    public function setEnvironmentVariableName($variable): void
+    public function setEnvironmentVariableName(?string $variable): void
     {
         $this->environmentVariable = $variable;
     }
 
     /**
      * Returns environment variable name.
-     *
-     * @return string|null
      */
-    public function getEnvironmentVariableName()
+    public function getEnvironmentVariableName(): ?string
     {
         return $this->environmentVariable;
     }
 
     /**
      * Sets configuration file path.
-     *
-     * @param string|null $path
      */
-    public function setConfigurationFilePath($path): void
+    public function setConfigurationFilePath(?string $path): void
     {
         $this->configurationPath = $path;
     }
 
     /**
      * Returns configuration file path.
-     *
-     * @return string|null
      */
-    public function getConfigurationFilePath()
+    public function getConfigurationFilePath(): ?string
     {
         return $this->configurationPath;
     }

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -94,7 +94,7 @@ final class ConfigurationLoader
      *
      * @throws ConfigurationLoadingException
      */
-    public function loadConfiguration($profile = 'default'): array
+    public function loadConfiguration(string $profile = 'default'): array
     {
         $this->profileFound = false;
 
@@ -122,10 +122,8 @@ final class ConfigurationLoader
 
     /**
      * Returns array with configuration debug information.
-     *
-     * @return array
      */
-    public function debugInformation()
+    public function debugInformation(): array
     {
         return $this->debugInformation;
     }
@@ -176,7 +174,7 @@ final class ConfigurationLoader
      *
      * @phpstan-impure
      */
-    private function loadFileConfiguration($configPath, $profile): array
+    private function loadFileConfiguration(string $configPath, string $profile): array
     {
         if (!is_file($configPath) || !is_readable($configPath)) {
             throw new ConfigurationLoadingException(sprintf('Configuration file `%s` not found.', $configPath));
@@ -215,10 +213,8 @@ final class ConfigurationLoader
 
     /**
      * Loads configs for provided config and profile.
-     *
-     * @param string $profile
      */
-    private function loadConfigs(string $basePath, array $config, $profile): array
+    private function loadConfigs(string $basePath, array $config, string $profile): array
     {
         $configs = [];
 
@@ -280,11 +276,9 @@ final class ConfigurationLoader
     /**
      * Parses import.
      *
-     * @param string $path
-     *
      * @throws ConfigurationLoadingException If import file not found
      */
-    private function parseImport(string $basePath, $path, string $profile): array
+    private function parseImport(string $basePath, string $path, string $profile): array
     {
         if (!file_exists($path) && file_exists($basePath . DIRECTORY_SEPARATOR . $path)) {
             $path = $basePath . DIRECTORY_SEPARATOR . $path;

--- a/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/Configuration/ConfigurationLoader.php
@@ -24,10 +24,7 @@ use function str_ends_with;
 final class ConfigurationLoader
 {
     private ?bool $profileFound = null;
-    /**
-     * @var array
-     */
-    private $debugInformation = [
+    private array $debugInformation = [
         'environment_variable_name' => 'none',
         'environment_variable_content' => 'none',
         'configuration_file_path' => 'none',

--- a/src/Behat/Testwork/ServiceContainer/ContainerLoader.php
+++ b/src/Behat/Testwork/ServiceContainer/ContainerLoader.php
@@ -116,7 +116,8 @@ final class ContainerLoader
 
         // Load activated extensions
         foreach ($config as $extensionConfigKey => $extensionConfig) {
-            if (null === $extension = $this->extensionManager->getExtension($extensionConfigKey)) {
+            $extension = $this->extensionManager->getExtension($extensionConfigKey);
+            if (!$extension instanceof Extension) {
                 throw new ExtensionException(
                     sprintf('None of the activated extensions use `%s` config section.', $extensionConfigKey),
                     $extensionConfigKey

--- a/src/Behat/Testwork/ServiceContainer/Exception/ExtensionException.php
+++ b/src/Behat/Testwork/ServiceContainer/Exception/ExtensionException.php
@@ -21,23 +21,18 @@ class ExtensionException extends RuntimeException implements ServiceContainerExc
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
-     * @param string $extensionName
      */
     public function __construct(
-        $message,
-        private $extensionName,
+        string $message,
+        private string $extensionName,
     ) {
         parent::__construct($message);
     }
 
     /**
      * Returns name of the extension that caused exception.
-     *
-     * @return string
      */
-    public function getExtensionName()
+    public function getExtensionName(): string
     {
         return $this->extensionName;
     }

--- a/src/Behat/Testwork/ServiceContainer/Exception/ExtensionException.php
+++ b/src/Behat/Testwork/ServiceContainer/Exception/ExtensionException.php
@@ -24,7 +24,7 @@ class ExtensionException extends RuntimeException implements ServiceContainerExc
      */
     public function __construct(
         string $message,
-        private string $extensionName,
+        private readonly string $extensionName,
     ) {
         parent::__construct($message);
     }

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -39,7 +39,7 @@ final class ExtensionManager
      */
     public function __construct(
         array $extensions,
-        private $extensionsPath = null,
+        private ?string $extensionsPath = null,
     ) {
         foreach ($extensions as $extension) {
             $this->extensions[$extension->getConfigKey()] = $extension;
@@ -48,10 +48,8 @@ final class ExtensionManager
 
     /**
      * Sets path to directory in which manager will try to find extension files.
-     *
-     * @param string|null $path
      */
-    public function setExtensionsPath($path): void
+    public function setExtensionsPath(?string $path): void
     {
         $this->extensionsPath = $path;
     }
@@ -72,10 +70,8 @@ final class ExtensionManager
 
     /**
      * Returns specific extension by its name.
-     *
-     * @return Extension|null
      */
-    public function getExtension(string $key)
+    public function getExtension(string $key): ?Extension
     {
         return $this->extensions[$key] ?? null;
     }

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -60,10 +60,8 @@ final class ExtensionManager
      * Activate extension by its locator.
      *
      * @param string $locator phar file name, php file name, class name
-     *
-     * @return Extension
      */
-    public function activateExtension(string $locator)
+    public function activateExtension(string $locator): Extension
     {
         $extension = $this->initialize($locator);
 

--- a/src/Behat/Testwork/ServiceContainer/ServiceProcessor.php
+++ b/src/Behat/Testwork/ServiceContainer/ServiceProcessor.php
@@ -51,7 +51,7 @@ final class ServiceProcessor
      * @param string           $target     The id of the service being decorated
      * @param string           $wrapperTag The tag used by wrappers
      */
-    public function processWrapperServices(ContainerBuilder $container, $target, string $wrapperTag): void
+    public function processWrapperServices(ContainerBuilder $container, string $target, string $wrapperTag): void
     {
         $references = $this->findAndSortTaggedServices($container, $wrapperTag);
 

--- a/src/Behat/Testwork/Specification/SpecificationArrayIterator.php
+++ b/src/Behat/Testwork/Specification/SpecificationArrayIterator.php
@@ -35,7 +35,7 @@ final class SpecificationArrayIterator extends ArrayIterator implements Specific
      */
     public function __construct(
         private readonly Suite $suite,
-        $specifications = [],
+        array $specifications = [],
     ) {
         parent::__construct($specifications);
     }

--- a/src/Behat/Testwork/Suite/Exception/ParameterNotFoundException.php
+++ b/src/Behat/Testwork/Suite/Exception/ParameterNotFoundException.php
@@ -19,25 +19,19 @@ final class ParameterNotFoundException extends SuiteException
 {
     /**
      * Initializes exception.
-     *
-     * @param string $message
-     * @param string $name
-     * @param string $parameter
      */
     public function __construct(
-        $message,
-        $name,
-        private $parameter,
+        string $message,
+        string $name,
+        private string $parameter,
     ) {
         parent::__construct($message, $name);
     }
 
     /**
      * Returns parameter that caused exception.
-     *
-     * @return string
      */
-    public function getParameter()
+    public function getParameter(): string
     {
         return $this->parameter;
     }

--- a/src/Behat/Testwork/Suite/Exception/ParameterNotFoundException.php
+++ b/src/Behat/Testwork/Suite/Exception/ParameterNotFoundException.php
@@ -23,7 +23,7 @@ final class ParameterNotFoundException extends SuiteException
     public function __construct(
         string $message,
         string $name,
-        private string $parameter,
+        private readonly string $parameter,
     ) {
         parent::__construct($message, $name);
     }

--- a/src/Behat/Testwork/Suite/Exception/SuiteException.php
+++ b/src/Behat/Testwork/Suite/Exception/SuiteException.php
@@ -23,13 +23,10 @@ class SuiteException extends InvalidArgumentException implements TestworkExcepti
 {
     /**
      * Initializes exception.
-     *
-     * @param string         $message
-     * @param string         $name
      */
     public function __construct(
-        $message,
-        private $name,
+        string $message,
+        private string $name,
         ?Exception $previous = null,
     ) {
         parent::__construct($message, 0, $previous);
@@ -37,10 +34,8 @@ class SuiteException extends InvalidArgumentException implements TestworkExcepti
 
     /**
      * Returns name of the suite that caused exception.
-     *
-     * @return string
      */
-    public function getSuiteName()
+    public function getSuiteName(): string
     {
         return $this->name;
     }

--- a/src/Behat/Testwork/Suite/Exception/SuiteException.php
+++ b/src/Behat/Testwork/Suite/Exception/SuiteException.php
@@ -26,7 +26,7 @@ class SuiteException extends InvalidArgumentException implements TestworkExcepti
      */
     public function __construct(
         string $message,
-        private string $name,
+        private readonly string $name,
         ?Exception $previous = null,
     ) {
         parent::__construct($message, 0, $previous);

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -21,11 +21,9 @@ final class GenericSuite implements Suite
 {
     /**
      * Initializes suite.
-     *
-     * @param string $name
      */
     public function __construct(
-        private $name,
+        private string $name,
         private array $settings,
     ) {
     }

--- a/src/Behat/Testwork/Suite/GenericSuite.php
+++ b/src/Behat/Testwork/Suite/GenericSuite.php
@@ -23,7 +23,7 @@ final class GenericSuite implements Suite
      * Initializes suite.
      */
     public function __construct(
-        private string $name,
+        private readonly string $name,
         private array $settings,
     ) {
     }

--- a/src/Behat/Testwork/Suite/SuiteRegistry.php
+++ b/src/Behat/Testwork/Suite/SuiteRegistry.php
@@ -45,12 +45,9 @@ final class SuiteRegistry implements SuiteRepository
     /**
      * Registers suite using provided name, type & parameters.
      *
-     * @param string $name
-     * @param string|null $type
-     *
      * @throws SuiteConfigurationException
      */
-    public function registerSuiteConfiguration($name, $type, array $settings): void
+    public function registerSuiteConfiguration(string $name, ?string $type, array $settings): void
     {
         if (isset($this->suiteConfigurations[$name])) {
             throw new SuiteConfigurationException(sprintf(

--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -43,7 +43,7 @@ final class ExerciseController implements Controller
         private readonly SpecificationFinder $specificationFinder,
         private readonly Exercise $exercise,
         private readonly ResultInterpreter $resultInterpreter,
-        private bool $skip = false,
+        private readonly bool $skip = false,
     ) {
     }
 

--- a/src/Behat/Testwork/Tester/Cli/ExerciseController.php
+++ b/src/Behat/Testwork/Tester/Cli/ExerciseController.php
@@ -37,15 +37,13 @@ final class ExerciseController implements Controller
 {
     /**
      * Initializes controller.
-     *
-     * @param bool             $skip
      */
     public function __construct(
         private readonly SuiteRepository $suiteRepository,
         private readonly SpecificationFinder $specificationFinder,
         private readonly Exercise $exercise,
         private readonly ResultInterpreter $resultInterpreter,
-        private $skip = false,
+        private bool $skip = false,
     ) {
     }
 

--- a/src/Behat/Testwork/Tester/Cli/StrictController.php
+++ b/src/Behat/Testwork/Tester/Cli/StrictController.php
@@ -27,12 +27,10 @@ final class StrictController implements Controller
 {
     /**
      * Initializes controller.
-     *
-     * @param bool           $strict
      */
     public function __construct(
         private readonly ResultInterpreter $resultInterpreter,
-        private $strict = false,
+        private bool $strict = false,
     ) {
     }
 

--- a/src/Behat/Testwork/Tester/Cli/StrictController.php
+++ b/src/Behat/Testwork/Tester/Cli/StrictController.php
@@ -30,7 +30,7 @@ final class StrictController implements Controller
      */
     public function __construct(
         private readonly ResultInterpreter $resultInterpreter,
-        private bool $strict = false,
+        private readonly bool $strict = false,
     ) {
     }
 

--- a/src/Behat/Testwork/Tester/Exception/WrongPathsException.php
+++ b/src/Behat/Testwork/Tester/Exception/WrongPathsException.php
@@ -27,11 +27,10 @@ final class WrongPathsException extends RuntimeException implements TesterExcept
     /**
      * Initializes exception.
      *
-     * @param string $message
      * @param string|list<string> $paths
      */
     public function __construct(
-        $message,
+        string $message,
         string|array $paths,
     ) {
         parent::__construct($message);

--- a/src/Behat/Testwork/Tester/Result/ExceptionResult.php
+++ b/src/Behat/Testwork/Tester/Result/ExceptionResult.php
@@ -28,8 +28,6 @@ interface ExceptionResult extends TestResult
 
     /**
      * Returns exception that test result has.
-     *
-     * @return Throwable|null
      */
-    public function getException();
+    public function getException(): ?Throwable;
 }

--- a/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
+++ b/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
@@ -23,7 +23,7 @@ final class IntegerTestResult implements TestResult
      * @param TestResult::* $resultCode
      */
     public function __construct(
-        private int $resultCode,
+        private readonly int $resultCode,
     ) {
     }
 

--- a/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
+++ b/src/Behat/Testwork/Tester/Result/IntegerTestResult.php
@@ -23,7 +23,7 @@ final class IntegerTestResult implements TestResult
      * @param TestResult::* $resultCode
      */
     public function __construct(
-        private $resultCode,
+        private int $resultCode,
     ) {
     }
 

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -118,10 +118,8 @@ abstract class TesterExtension implements Extension
 
     /**
      * Loads exercise cli controllers.
-     *
-     * @param bool          $skip
      */
-    protected function loadExerciseController(ContainerBuilder $container, $skip = false)
+    protected function loadExerciseController(ContainerBuilder $container, bool $skip = false)
     {
         $definition = new Definition(ExerciseController::class, [
             new Reference(SuiteExtension::REGISTRY_ID),
@@ -163,10 +161,8 @@ abstract class TesterExtension implements Extension
 
     /**
      * Loads exercise cli controllers.
-     *
-     * @param bool          $strict
      */
-    protected function loadStrictController(ContainerBuilder $container, $strict = false)
+    protected function loadStrictController(ContainerBuilder $container, bool $strict = false)
     {
         $definition = new Definition(StrictController::class, [
             new Reference(self::RESULT_INTERPRETER_ID),

--- a/src/Behat/Testwork/Translator/ServiceContainer/TranslatorExtension.php
+++ b/src/Behat/Testwork/Translator/ServiceContainer/TranslatorExtension.php
@@ -77,11 +77,8 @@ final class TranslatorExtension implements Extension
 
     /**
      * Loads translator service.
-     *
-     * @param string           $locale
-     * @param string           $fallbackLocale
      */
-    private function loadTranslator(ContainerBuilder $container, $locale, $fallbackLocale): void
+    private function loadTranslator(ContainerBuilder $container, string $locale, string $fallbackLocale): void
     {
         $definition = new Definition(Translator::class, [$locale]);
         $container->setDefinition(self::TRANSLATOR_ID, $definition);


### PR DESCRIPTION
This temporarily reintroduces ingenerator/risky-rector-rules to convert the remaining phpdoc parameter, return and property types into strict types.

First, I generated strict types for all objects -`@param` and `@return` types, then types that Rector could now infer automatically, then finally any `@var` types. Then I ran Rector again which generated some changes, including making the newly-typed properties readonly.

While reviewing that first pass, I realised that #1820 had missed some interface `@param` and `@return` where they had union types. This was because my ingenerator/risky-rector-rules didn't support converting union types to strict types.

I've fixed that, so the second half of this branch follows the same sequence of commits - interface methods, class methods, Rector's type declaration rules, phpdoc `@var` - for the union-types that were missed in the first pass.

I think this PR gets us as far as we can go with generating/converting strict types for #1744. 

The next step will be to review any remaining methods / properties with missing types and add them manually.