### PR TITLE
fix: Incorrect not-null string phpdoc typehints

### DIFF
--- a/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
+++ b/src/Behat/Behat/Definition/Pattern/PatternTransformer.php
@@ -43,7 +43,7 @@ final class PatternTransformer
     /**
      * Generates pattern.
      *
-     * @param string $type
+     * @param string|null $type
      * @param string $stepText
      *
      * @return Pattern

--- a/src/Behat/Testwork/Suite/SuiteRegistry.php
+++ b/src/Behat/Testwork/Suite/SuiteRegistry.php
@@ -46,7 +46,7 @@ final class SuiteRegistry implements SuiteRepository
      * Registers suite using provided name, type & parameters.
      *
      * @param string $name
-     * @param string $type
+     * @param string|null $type
      *
      * @throws SuiteConfigurationException
      */


### PR DESCRIPTION
In both of these methods the phpdoc specifies that `$type` will/must always be a `string`. 

In practice it is very often null, and Behat correctly treats that as the 'default' case. The internal methods that are called all accept `string|null` and therefore so should the public method.