### PR TITLE
fix: Always populate language in `TranslatedDefinition`

### DIFF
--- a/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
+++ b/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
@@ -50,7 +50,7 @@ final class DefinitionTranslator
         }
 
         if ($pattern != $translatedPattern) {
-            return new TranslatedDefinition($definition, $translatedPattern, $language);
+            return new TranslatedDefinition($definition, $translatedPattern, $language ?? $this->getLocale());
         }
 
         return $definition;


### PR DESCRIPTION
If no language was passed to `DefinitionTranslator` (which accepts a null language) then it will use the default locale.

Previously we were then passing that null through to the resultant `TranslatedDefinition`. 

But the phpdoc for that class expects that the `$language` will always be `string` - both on the property itself and on the getter.

It seems more logical to pass in the language that was actually used (e.g. the default locale) to the DTO that carries the translation, rather than allowing the object to accept / carry a `null` language.