### PR TITLE
ci: Ignore PHPUnit security advisory related PHP Ini Argument injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,11 @@
 
     "bin": ["bin/behat"],
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "ignore": {
+                "PKSA-5jz8-6tcw-pbk4": "PHPunit is a dev dependency, we don't set custom .ini values in our PHPUnit config, and we only run CI of trusted PRs in ephemeral environments."
+            }
+        }
     }
 }


### PR DESCRIPTION
Composer install fails due to a security advisory on PHPUnit 9.6.34 [PKSA-5jz8-6tcw-pbk4](https://github.com/advisories/GHSA-qrr6-mg7r-m243)

That advisory relates to the potential for an attacker with write access to phpunit.xml or a php.ini file, or the ability to run `phpunit -d name=value` to inject arbitrary php.ini values that could lead to unexpected file access or remote code execution.

PHPUnit 9 is in life support, so this issue is only fixed from PHPUnit 12.5.22 or 13.1.6.

In our case:

* We do not currently set any ini file directives in phpunit.xml.
* We do not run PRs from untrusted contributors without approval.
* Our CI runs in ephemeral GitHub Actions runners with no security-relevant filesystem or execution context. Our only Actions Secret is in the `release` job.

So we meet all the acceptable workarounds documented in the SA, and our exposure in CI is relatively limited.

In theory this could be a vector on local developer environments, but if an attacker has write and/or execute access to the local environment there are many easier ways to exploit that. Therefore, I don't consider this a significant vulnerability at this point.