### PR TITLE
[4.0] refactor: Add remaining strict types and improve runtime type checking

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -235,5 +235,8 @@
         <ignored-regex>#REMOVED: Method Behat\\Testwork\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#loadEventDispatchingSuiteTester\(\) was removed#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Testwork\\EventDispatcher\\ServiceContainer\\EventDispatcherExtension\#processSubscribers\(\) was removed#</ignored-regex>
 
+        <!-- WrongContainerClassException might not now return a class name (this is not a public API class) -->
+        <ignored-regex>#CHANGED: The return type of Behat\\Behat\\HelperContainer\\Exception\\WrongContainerClassException\#getClass\(\) changed from string to the non-covariant string\|null#</ignored-regex>
+
     </baseline>
 </roave-bc-check>

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - src
     ignoreErrors:
@@ -11,3 +11,7 @@ parameters:
             identifier: constructor.unusedParameter
             paths:
                 - src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+        -
+            identifier: missingType.iterableValue
+        -
+            identifier: missingType.generics

--- a/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
+++ b/src/Behat/Behat/Context/Environment/Handler/ContextEnvironmentHandler.php
@@ -71,12 +71,12 @@ final class ContextEnvironmentHandler implements EnvironmentHandler
         return $environment;
     }
 
-    public function supportsEnvironmentAndSubject(Environment $environment, $testSubject = null): bool
+    public function supportsEnvironmentAndSubject(Environment $environment, mixed $testSubject = null): bool
     {
         return $environment instanceof UninitializedContextEnvironment;
     }
 
-    public function isolateEnvironment(Environment $environment, $testSubject = null): InitializedContextEnvironment
+    public function isolateEnvironment(Environment $environment, mixed $testSubject = null): InitializedContextEnvironment
     {
         if (!$environment instanceof UninitializedContextEnvironment) {
             throw new EnvironmentIsolationException(sprintf(

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -17,6 +17,7 @@ use Behat\Behat\HelperContainer\Environment\ServiceContainerEnvironment;
 use Behat\Testwork\Call\Callee;
 use Behat\Testwork\Suite\Suite;
 use Psr\Container\ContainerInterface;
+use UnexpectedValueException;
 
 /**
  * Context environment based on a list of instantiated context objects.
@@ -119,8 +120,18 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
     {
         $callable = $callee->getCallable();
 
-        if ($callee->isAnInstanceMethod() && is_array($callable)) {
-            return [$this->getContext($callable[0]), $callable[1]];
+        if ($callee->isAnInstanceMethod() && is_array($callable) && count($callable) === 2 && is_string($callable[0])) {
+            $contextClass = $callable[0];
+            if (!is_a($contextClass, Context::class, true)) {
+                throw new UnexpectedValueException(
+                    sprintf(
+                        'Expected a native callable or a reference to a `Context` method (got reference to `%s`).',
+                        $contextClass
+                    )
+                );
+            }
+
+            return [$this->getContext($contextClass), $callable[1]];
         }
 
         return $callable;

--- a/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
+++ b/src/Behat/Behat/Definition/Pattern/Policy/TurnipPatternPolicy.php
@@ -111,7 +111,10 @@ final class TurnipPatternPolicy implements PatternPolicy
         );
     }
 
-    private function replaceTokenWithRegexCaptureGroup($tokenMatch): string
+    /**
+     * @param list<string> $tokenMatch
+     */
+    private function replaceTokenWithRegexCaptureGroup(array $tokenMatch): string
     {
         if (strlen((string) $tokenMatch[1]) > 32) {
             throw new InvalidPatternException(

--- a/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
+++ b/src/Behat/Behat/Definition/Printer/ConsoleDefinitionPrinter.php
@@ -43,7 +43,7 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
     /**
      * Writes text to the console.
      */
-    final protected function write(string|iterable $text, bool $lineBreakBefore = false)
+    final protected function write(string|iterable $text, bool $lineBreakBefore = false): void
     {
         if ($lineBreakBefore) {
             $this->output->writeln('');
@@ -52,7 +52,7 @@ abstract class ConsoleDefinitionPrinter implements DefinitionPrinter
         $this->output->writeln('');
     }
 
-    final protected function getDefinitionType(Definition $definition, $onlyOne = false)
+    final protected function getDefinitionType(Definition $definition, bool $onlyOne = false): string
     {
         $this->keywords->setLanguage($this->translator->getLocale());
 

--- a/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
+++ b/src/Behat/Behat/Definition/Translator/DefinitionTranslator.php
@@ -61,7 +61,7 @@ final class DefinitionTranslator
         return $this->translator->trans($infoText, $parameters, 'output');
     }
 
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->translator->getLocale();
     }

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolver.php
@@ -48,7 +48,7 @@ final class ServicesResolver implements ArgumentResolver
      *
      * @throws ContainerExceptionInterface
      */
-    private function resolveArgument($value)
+    private function resolveArgument(mixed $value): mixed
     {
         if (is_string($value) && 0 === mb_strpos($value, '@')) {
             return $this->container->get(mb_substr($value, 1));

--- a/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
+++ b/src/Behat/Behat/HelperContainer/Argument/ServicesResolverFactory.php
@@ -65,7 +65,7 @@ final class ServicesResolverFactory implements ArgumentResolverFactory
      *
      * @throws WrongServicesConfigurationException
      */
-    private function createContainer($settings)
+    private function createContainer(mixed $settings): ContainerInterface
     {
         if (is_string($settings)) {
             return $this->createContainerFromString($settings);
@@ -85,7 +85,7 @@ final class ServicesResolverFactory implements ArgumentResolverFactory
      *
      * @throws WrongServicesConfigurationException
      */
-    private function createContainerFromString(string $settings)
+    private function createContainerFromString(string $settings): ContainerInterface
     {
         if (0 === mb_strpos($settings, '@')) {
             return $this->loadContainerFromContainer(mb_substr($settings, 1));
@@ -107,7 +107,7 @@ final class ServicesResolverFactory implements ArgumentResolverFactory
      *
      * @throws WrongServicesConfigurationException
      */
-    private function loadContainerFromContainer(string $name): object
+    private function loadContainerFromContainer(string $name): ContainerInterface
     {
         $services = $this->container->findTaggedServiceIds(HelperContainerExtension::HELPER_CONTAINER_TAG);
 
@@ -117,21 +117,30 @@ final class ServicesResolverFactory implements ArgumentResolverFactory
             );
         }
 
-        return $this->container->get($name);
+        return $this->ensureValidContainer(
+            $this->container->get($name),
+            sprintf('service `%s`', $name)
+        );
     }
 
     /**
      * Creates container from string-based class spec.
      */
-    private function createContainerFromClassSpec(string $classSpec)
+    private function createContainerFromClassSpec(string $classSpec): ContainerInterface
     {
         $constructor = explode('::', $classSpec);
 
         if (2 === count($constructor)) {
-            return call_user_func($constructor);
+            return $this->ensureValidContainer(
+                call_user_func($constructor),
+                $classSpec
+            );
         }
 
-        return new $constructor[0]();
+        return $this->ensureValidContainer(
+            new $constructor[0](),
+            $classSpec
+        );
     }
 
     /**
@@ -141,22 +150,27 @@ final class ServicesResolverFactory implements ArgumentResolverFactory
      *
      * @throws WrongContainerClassException
      */
-    private function createResolvers($container, bool $autowire): array
+    private function createResolvers(ContainerInterface $container, bool $autowire): array
     {
-        if (!$container instanceof ContainerInterface) {
-            throw new WrongContainerClassException(
-                sprintf(
-                    'Service container is expected to implement `Psr\Container\ContainerInterface`, but `%s` does not.',
-                    $container::class
-                ),
-                $container::class
-            );
-        }
-
         if ($autowire) {
             return [new ServicesResolver($container), new AutowiringResolver($container)];
         }
 
         return [new ServicesResolver($container)];
+    }
+
+    private function ensureValidContainer(mixed $container, string $source): ContainerInterface
+    {
+        if ($container instanceof ContainerInterface) {
+            return $container;
+        }
+
+        throw new WrongContainerClassException(
+            sprintf(
+                'Expected `%s` to provide an implementation of %s, but it does not (got %s)',
+                $source, ContainerInterface::class, get_debug_type($container)
+            ),
+            is_object($container) ? $container::class : null
+        );
     }
 }

--- a/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
+++ b/src/Behat/Behat/HelperContainer/BuiltInServiceContainer.php
@@ -23,6 +23,9 @@ use ReflectionMethod;
  */
 final class BuiltInServiceContainer implements PsrContainerInterface
 {
+    /**
+     * @var array<string, object>
+     */
     private array $instances;
 
     /**
@@ -38,7 +41,7 @@ final class BuiltInServiceContainer implements PsrContainerInterface
         return array_key_exists($id, $this->schema);
     }
 
-    public function get(string $id)
+    public function get(string $id): object
     {
         if (!$this->has($id)) {
             throw new ServiceNotFoundException(
@@ -53,7 +56,7 @@ final class BuiltInServiceContainer implements PsrContainerInterface
     /**
      * Creates an instance of given service.
      */
-    private function createInstance(string $id)
+    private function createInstance(string $id): object
     {
         $schema = $this->getAndValidateServiceSchema($id);
 
@@ -73,7 +76,7 @@ final class BuiltInServiceContainer implements PsrContainerInterface
      *
      * @throws WrongServicesConfigurationException
      */
-    private function getAndValidateServiceSchema(string $id): array|string
+    private function getAndValidateServiceSchema(string $id): array
     {
         $schema = $this->schema[$id];
 

--- a/src/Behat/Behat/HelperContainer/Exception/WrongContainerClassException.php
+++ b/src/Behat/Behat/HelperContainer/Exception/WrongContainerClassException.php
@@ -13,7 +13,7 @@ namespace Behat\Behat\HelperContainer\Exception;
 use InvalidArgumentException;
 
 /**
- * Represents an exception when provided class exists, but is not an acceptable as a container.
+ * Represents an exception when the configured container is not acceptable as a container.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
@@ -21,15 +21,15 @@ final class WrongContainerClassException extends InvalidArgumentException implem
 {
     public function __construct(
         string $message,
-        private readonly string $class,
+        private readonly ?string $class,
     ) {
         parent::__construct($message);
     }
 
     /**
-     * Returns not found classname.
+     * Returns class name of the object that was created, if any.
      */
-    public function getClass(): string
+    public function getClass(): ?string
     {
         return $this->class;
     }

--- a/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
+++ b/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
@@ -79,7 +79,7 @@ final class DefinitionArgumentsTransformer implements CallFilter
     /**
      * Transforms call argument using registered transformers.
      */
-    private function transformArgument(DefinitionCall $definitionCall, int|string $index, $value)
+    private function transformArgument(DefinitionCall $definitionCall, int|string $index, mixed $value): mixed
     {
         foreach ($this->argumentTransformers as $transformer) {
             if (!$transformer->supportsDefinitionAndArgument($definitionCall, $index, $value)) {

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -36,10 +36,10 @@ interface SimpleArgumentTransformation extends Transformation
     /**
      * Checks if transformation supports argument.
      */
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool;
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool;
 
     /**
      * Transforms argument value using transformation and returns a new one.
      */
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed;
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed;
 }

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -48,7 +48,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -58,7 +58,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
             || $this->pattern === 'table:*';
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
@@ -18,6 +18,7 @@ use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use Exception;
 use Stringable;
+use UnexpectedValueException;
 
 /**
  * Pattern-based transformation.
@@ -55,7 +56,7 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
             $definitionCall->getFeature()->getLanguage()
         );
 
-        return $this->match($regex, $argumentValue, $match);
+        return $this->match($regex, $argumentValue) !== false;
     }
 
     /**
@@ -75,7 +76,15 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
             $definitionCall->getFeature()->getLanguage()
         );
 
-        $this->match($regex, $argumentValue, $arguments);
+        $arguments = $this->match($regex, $argumentValue);
+
+        if ($arguments === false) {
+            // This should never happen, as supportsDefinitionAndArgument() should have been called first and would have
+            // returned false if the argument does not match the regex.
+            throw new UnexpectedValueException(
+                __METHOD__.' was called with an unsupported argument - was supportsDefinitionAndArgument() called first?'
+            );
+        }
 
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),
@@ -98,7 +107,10 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
         return 'PatternTransform ' . $this->pattern;
     }
 
-    private function match(string $regexPattern, mixed $argumentValue, &$match): bool
+    /**
+     * @return list<string>|false
+     */
+    private function match(string $regexPattern, mixed $argumentValue): array|false
     {
         if (is_string($argumentValue) && preg_match($regexPattern, $argumentValue, $match)) {
             // take arguments from capture groups if there are some
@@ -106,7 +118,7 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
                 $match = array_slice($match, 1);
             }
 
-            return true;
+            return $match;
         }
 
         return false;

--- a/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
@@ -47,7 +47,7 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
     public function supportsDefinitionAndArgument(
         RegexGenerator $regexGenerator,
         DefinitionCall $definitionCall,
-        $argumentValue,
+        mixed $argumentValue,
     ): bool {
         $regex = $regexGenerator->generateRegex(
             $definitionCall->getEnvironment()->getSuite()->getName(),
@@ -67,8 +67,8 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
         RegexGenerator $regexGenerator,
         CallCenter $callCenter,
         DefinitionCall $definitionCall,
-        $argumentValue,
-    ) {
+        mixed $argumentValue,
+    ): mixed {
         $regex = $regexGenerator->generateRegex(
             $definitionCall->getEnvironment()->getSuite()->getName(),
             $this->pattern,
@@ -98,7 +98,7 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
         return 'PatternTransform ' . $this->pattern;
     }
 
-    private function match(string $regexPattern, $argumentValue, &$match): bool
+    private function match(string $regexPattern, mixed $argumentValue, &$match): bool
     {
         if (is_string($argumentValue) && preg_match($regexPattern, $argumentValue, $match)) {
             // take arguments from capture groups if there are some

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -54,7 +54,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         $returnClass = self::getReturnClass($this->getReflection());
 
@@ -67,7 +67,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
         return $parameterClass === $returnClass;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -49,7 +49,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -74,7 +74,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
         return false;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
@@ -40,7 +40,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
     public function supportsDefinitionAndArgument(
         DefinitionCall $definitionCall,
         int|string $argumentIndex,
-        $argumentArgumentValue,
+        mixed $argumentArgumentValue,
     ): bool {
         // The argument passed initially will be a TableNode but if a column transformation
         // has already been applied then this will have been transformed into an array already,
@@ -83,7 +83,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
         CallCenter $callCenter,
         DefinitionCall $definitionCall,
         int|string $argumentIndex,
-        $argumentValue,
+        mixed $argumentValue,
     ): array {
         if (!$this->isSupportedArgumentValueType($argumentValue)) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -48,7 +48,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -60,7 +60,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
     /**
      * @return list<mixed>
      */
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): array
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): array
     {
         $rows = [];
         foreach ($argumentValue as $row) {

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
@@ -49,13 +49,13 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         return $this->tokenTransformation->supportsDefinitionAndArgument($definitionCall, $argumentIndex, $argumentArgumentValue)
             && $this->returnTransformation->supportsDefinitionAndArgument($definitionCall, $argumentIndex, $argumentArgumentValue);
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -47,12 +47,12 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         return ':' . $argumentIndex === $this->pattern;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
+    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
     {
         $call = new TransformationCall(
             $definitionCall->getEnvironment(),

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -24,10 +24,10 @@ interface ArgumentTransformer
     /**
      * Checks if transformer supports argument.
      */
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): bool;
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): bool;
 
     /**
      * Transforms argument value using transformation and returns a new one.
      */
-    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed;
+    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed;
 }

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -39,12 +39,12 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
     ) {
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): bool
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): bool
     {
         return count($this->repository->getEnvironmentTransformations($definitionCall->getEnvironment())) > 0;
     }
 
-    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, $argumentValue): mixed
+    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
     {
         $environment = $definitionCall->getEnvironment();
         [$simpleTransformations, $normalTransformations] = $this->splitSimpleAndNormalTransformations(

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -72,7 +72,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      *
      * @param SimpleArgumentTransformation[] $transformations
      */
-    private function applySimpleTransformations(array $transformations, DefinitionCall $definitionCall, int|string $index, $value)
+    private function applySimpleTransformations(array $transformations, DefinitionCall $definitionCall, int|string $index, mixed $value): mixed
     {
         usort($transformations, fn (SimpleArgumentTransformation $t1, SimpleArgumentTransformation $t2): int => $t2->getPriority() <=> $t1->getPriority());
 
@@ -89,7 +89,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      *
      * @param Transformation[] $transformations
      */
-    private function applyNormalTransformations(array $transformations, DefinitionCall $definitionCall, int|string $index, $value)
+    private function applyNormalTransformations(array $transformations, DefinitionCall $definitionCall, int|string $index, mixed $value): mixed
     {
         $newValue = $value;
         foreach ($transformations as $transformation) {
@@ -102,7 +102,7 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
     /**
      * Transforms argument value using registered transformers.
      */
-    private function transform(DefinitionCall $definitionCall, Transformation $transformation, int|string $index, $value)
+    private function transform(DefinitionCall $definitionCall, Transformation $transformation, int|string $index, mixed $value): mixed
     {
         if (is_object($value) && !$value instanceof ArgumentInterface) {
             return $value;

--- a/src/Behat/Config/Formatter/JSONFormatter.php
+++ b/src/Behat/Config/Formatter/JSONFormatter.php
@@ -28,7 +28,7 @@ final class JSONFormatter extends Formatter
      */
     public function __construct(
         bool $timer = true,
-        ...$baseOptions,
+        mixed ...$baseOptions,
     ) {
         $settings = [
             self::TIMER_SETTING => $timer,

--- a/src/Behat/Config/Formatter/JUnitFormatter.php
+++ b/src/Behat/Config/Formatter/JUnitFormatter.php
@@ -20,7 +20,7 @@ final class JUnitFormatter extends Formatter
      */
     public function __construct(
         bool $timer = true,
-        ...$baseOptions,
+        mixed ...$baseOptions,
     ) {
         $settings = [
             self::TIMER_SETTING => $timer,

--- a/src/Behat/Config/Formatter/PrettyFormatter.php
+++ b/src/Behat/Config/Formatter/PrettyFormatter.php
@@ -40,7 +40,7 @@ final class PrettyFormatter extends Formatter
         ShowOutputOption $showOutput = ShowOutputOption::Yes,
         bool $shortSummary = true,
         bool $printSkippedSteps = true,
-        ...$baseOptions,
+        mixed ...$baseOptions,
     ) {
         $settings = [
             self::TIMER_SETTING => $timer,

--- a/src/Behat/Config/Formatter/ProgressFormatter.php
+++ b/src/Behat/Config/Formatter/ProgressFormatter.php
@@ -27,7 +27,7 @@ final class ProgressFormatter extends Formatter
         bool $timer = true,
         ShowOutputOption $showOutput = ShowOutputOption::InSummary,
         bool $shortSummary = false,
-        ...$baseOptions,
+        mixed ...$baseOptions,
     ) {
         $settings = [
             self::TIMER_SETTING => $timer,

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -142,7 +142,7 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
      *
      * @param  list<ReflectionParameter> $parameters
      */
-    private function isParameterTypehintedInArgumentList(array $parameters, $value): bool
+    private function isParameterTypehintedInArgumentList(array $parameters, mixed $value): bool
     {
         if (!is_object($value)) {
             return false;

--- a/src/Behat/Testwork/Call/CallResult.php
+++ b/src/Behat/Testwork/Call/CallResult.php
@@ -24,7 +24,7 @@ final class CallResult
      */
     public function __construct(
         private readonly Call $call,
-        private $return,
+        private readonly mixed $return,
         private readonly ?Exception $exception = null,
         private readonly ?string $stdOut = null,
     ) {
@@ -41,7 +41,7 @@ final class CallResult
     /**
      * Returns call return value.
      */
-    public function getReturn()
+    public function getReturn(): mixed
     {
         return $this->return;
     }

--- a/src/Behat/Testwork/Call/Exception/CallErrorException.php
+++ b/src/Behat/Testwork/Call/Exception/CallErrorException.php
@@ -19,7 +19,7 @@ use ErrorException;
  */
 final class CallErrorException extends ErrorException
 {
-    private $levels = [
+    private const LEVELS = [
         E_WARNING => 'Warning',
         E_NOTICE => 'Notice',
         E_DEPRECATED => 'Deprecated',
@@ -42,13 +42,15 @@ final class CallErrorException extends ErrorException
     {
         // E_STRICT is deprecated since PHP 8.4.
         if (defined('E_STRICT') && $level === @E_STRICT) {
-            $this->levels[@E_STRICT] = 'Runtime Notice';
+            $levelName = 'Runtime Notice';
+        } else {
+            $levelName = self::LEVELS[$level] ?? $level;
         }
 
         parent::__construct(
             sprintf(
                 '%s: %s in %s line %d',
-                $this->levels[$level] ?? $level,
+                $levelName,
                 $message,
                 $file,
                 $line

--- a/src/Behat/Testwork/Call/Exception/CallErrorException.php
+++ b/src/Behat/Testwork/Call/Exception/CallErrorException.php
@@ -40,17 +40,10 @@ final class CallErrorException extends ErrorException
      */
     public function __construct(int $level, string $message, string $file, int $line)
     {
-        // E_STRICT is deprecated since PHP 8.4.
-        if (defined('E_STRICT') && $level === @E_STRICT) {
-            $levelName = 'Runtime Notice';
-        } else {
-            $levelName = self::LEVELS[$level] ?? $level;
-        }
-
         parent::__construct(
             sprintf(
                 '%s: %s in %s line %d',
-                $levelName,
+                self::LEVELS[$level] ?? $level,
                 $message,
                 $file,
                 $line

--- a/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/ClassNotFoundHandler.php
@@ -45,7 +45,7 @@ abstract class ClassNotFoundHandler implements ExceptionHandler
     /**
      * Override to handle non-existent class name.
      */
-    abstract public function handleNonExistentClass(string $class);
+    abstract public function handleNonExistentClass(string $class): void;
 
     /**
      * Extracts missing class name from the exception.

--- a/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
+++ b/src/Behat/Testwork/Call/Handler/Exception/MethodNotFoundHandler.php
@@ -45,7 +45,7 @@ abstract class MethodNotFoundHandler implements ExceptionHandler
     /**
      * Override to handle non-existent method.
      */
-    abstract public function handleNonExistentMethod(array $callable);
+    abstract public function handleNonExistentMethod(array $callable): void;
 
     /**
      * Extract callable from exception.

--- a/src/Behat/Testwork/Environment/EnvironmentManager.php
+++ b/src/Behat/Testwork/Environment/EnvironmentManager.php
@@ -73,7 +73,7 @@ final class EnvironmentManager
      *
      * @throws EnvironmentIsolationException If appropriate environment handler is not found
      */
-    public function isolateEnvironment(Environment $environment, $testSubject = null): Environment
+    public function isolateEnvironment(Environment $environment, mixed $testSubject = null): Environment
     {
         foreach ($this->handlers as $handler) {
             if ($handler->supportsEnvironmentAndSubject($environment, $testSubject)) {

--- a/src/Behat/Testwork/Environment/Exception/EnvironmentIsolationException.php
+++ b/src/Behat/Testwork/Environment/Exception/EnvironmentIsolationException.php
@@ -26,7 +26,7 @@ final class EnvironmentIsolationException extends RuntimeException implements En
     public function __construct(
         string $message,
         private readonly Environment $environment,
-        private $subject = null,
+        private readonly mixed $subject = null,
     ) {
         parent::__construct($message);
     }
@@ -42,7 +42,7 @@ final class EnvironmentIsolationException extends RuntimeException implements En
     /**
      * Returns test subject that caused exception.
      */
-    public function getSubject()
+    public function getSubject(): mixed
     {
         return $this->subject;
     }

--- a/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
+++ b/src/Behat/Testwork/Environment/Handler/EnvironmentHandler.php
@@ -36,10 +36,10 @@ interface EnvironmentHandler
     /**
      * Checks if handler supports provided environment.
      */
-    public function supportsEnvironmentAndSubject(Environment $environment, $testSubject = null): bool;
+    public function supportsEnvironmentAndSubject(Environment $environment, mixed $testSubject = null): bool;
 
     /**
      * Isolates provided environment.
      */
-    public function isolateEnvironment(Environment $environment, $testSubject = null): Environment;
+    public function isolateEnvironment(Environment $environment, mixed $testSubject = null): Environment;
 }

--- a/src/Behat/Testwork/Environment/Handler/StaticEnvironmentHandler.php
+++ b/src/Behat/Testwork/Environment/Handler/StaticEnvironmentHandler.php
@@ -31,12 +31,12 @@ final class StaticEnvironmentHandler implements EnvironmentHandler
         return new StaticEnvironment($suite);
     }
 
-    public function supportsEnvironmentAndSubject(Environment $environment, $testSubject = null): bool
+    public function supportsEnvironmentAndSubject(Environment $environment, mixed $testSubject = null): bool
     {
         return $environment instanceof StaticEnvironment;
     }
 
-    public function isolateEnvironment(Environment $environment, $testSubject = null): Environment
+    public function isolateEnvironment(Environment $environment, mixed $testSubject = null): Environment
     {
         return $environment;
     }

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -80,7 +80,7 @@ class EventDispatcherExtension implements Extension
     /**
      * Loads sigint controller.
      */
-    protected function loadSigintController(ContainerBuilder $container)
+    protected function loadSigintController(ContainerBuilder $container): void
     {
         $definition = new Definition(SigintController::class, [
             new Reference(EventDispatcherExtension::DISPATCHER_ID),
@@ -92,7 +92,7 @@ class EventDispatcherExtension implements Extension
     /**
      * Loads event dispatcher.
      */
-    protected function loadEventDispatcher(ContainerBuilder $container)
+    protected function loadEventDispatcher(ContainerBuilder $container): void
     {
         $definition = new Definition(TestworkEventDispatcher::class);
         $container->setDefinition(self::DISPATCHER_ID, $definition);
@@ -101,7 +101,7 @@ class EventDispatcherExtension implements Extension
     /**
      * Loads event-dispatching exercise.
      */
-    protected function loadEventDispatchingExercise(ContainerBuilder $container)
+    protected function loadEventDispatchingExercise(ContainerBuilder $container): void
     {
         $definition = new Definition(EventDispatchingExercise::class, [
             new Reference(TesterExtension::EXERCISE_ID),
@@ -114,7 +114,7 @@ class EventDispatcherExtension implements Extension
     /**
      * Loads event-dispatching suite tester.
      */
-    protected function loadEventDispatchingSuiteTester(ContainerBuilder $container)
+    protected function loadEventDispatchingSuiteTester(ContainerBuilder $container): void
     {
         $definition = new Definition(EventDispatchingSuiteTester::class, [
             new Reference(TesterExtension::SUITE_TESTER_ID),
@@ -127,7 +127,7 @@ class EventDispatcherExtension implements Extension
     /**
      * Registers all available event subscribers.
      */
-    protected function processSubscribers(ContainerBuilder $container)
+    protected function processSubscribers(ContainerBuilder $container): void
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::SUBSCRIBER_TAG);
         $definition = $container->getDefinition(self::DISPATCHER_ID);

--- a/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
+++ b/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
@@ -63,7 +63,7 @@ class HookExtension implements Extension
     /**
      * Loads hook dispatcher.
      */
-    protected function loadDispatcher(ContainerBuilder $container)
+    protected function loadDispatcher(ContainerBuilder $container): void
     {
         $definition = new Definition(HookDispatcher::class, [
             new Reference(self::REPOSITORY_ID),
@@ -75,7 +75,7 @@ class HookExtension implements Extension
     /**
      * Loads hook repository.
      */
-    protected function loadRepository(ContainerBuilder $container)
+    protected function loadRepository(ContainerBuilder $container): void
     {
         $definition = new Definition(HookRepository::class, [
             new Reference(EnvironmentExtension::MANAGER_ID),
@@ -86,7 +86,7 @@ class HookExtension implements Extension
     /**
      * Loads hookable testers.
      */
-    protected function loadHookableTesters(ContainerBuilder $container)
+    protected function loadHookableTesters(ContainerBuilder $container): void
     {
         $definition = new Definition(HookableSuiteTester::class, [
             new Reference(TesterExtension::SUITE_TESTER_ID),

--- a/src/Behat/Testwork/Output/Formatter.php
+++ b/src/Behat/Testwork/Output/Formatter.php
@@ -42,7 +42,7 @@ interface Formatter extends EventSubscriberInterface
     /**
      * Sets formatter parameter.
      */
-    public function setParameter(string $name, $value): void;
+    public function setParameter(string $name, mixed $value): void;
 
     /**
      * Returns parameter name.

--- a/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/Flow/FireOnlyIfFormatterParameterListener.php
@@ -26,7 +26,7 @@ final class FireOnlyIfFormatterParameterListener implements EventListener
      */
     public function __construct(
         private readonly string $name,
-        private $value,
+        private readonly mixed $value,
         private readonly EventListener $descendant,
     ) {
     }

--- a/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
+++ b/src/Behat/Testwork/Output/NodeEventListeningFormatter.php
@@ -72,7 +72,7 @@ final class NodeEventListeningFormatter implements Formatter
         return $this->printer;
     }
 
-    public function setParameter(string $name, $value): void
+    public function setParameter(string $name, mixed $value): void
     {
         $this->parameters[$name] = $value;
     }

--- a/src/Behat/Testwork/Output/OutputManager.php
+++ b/src/Behat/Testwork/Output/OutputManager.php
@@ -117,7 +117,7 @@ final class OutputManager
     /**
      * Sets provided parameter to said formatter.
      */
-    public function setFormatterParameter(string $formatter, string $parameterName, $parameterValue): void
+    public function setFormatterParameter(string $formatter, string $parameterName, mixed $parameterValue): void
     {
         $formatter = $this->getFormatter($formatter);
         $printer = $formatter->getOutputPrinter();
@@ -157,7 +157,7 @@ final class OutputManager
     /**
      * Sets provided parameter to all registered formatters.
      */
-    public function setFormattersParameter(string $parameterName, $parameterValue): void
+    public function setFormattersParameter(string $parameterName, mixed $parameterValue): void
     {
         foreach (array_keys($this->formatters) as $formatter) {
             $this->setFormatterParameter($formatter, $parameterName, $parameterValue);

--- a/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
@@ -58,7 +58,7 @@ class ConsoleOutputFactory extends OutputFactory
      *
      * @throws BadOutputPathException
      */
-    protected function createOutputStream()
+    protected function createOutputStream(): mixed
     {
         if (null === $this->getOutputPath()) {
             $stream = fopen('php://stdout', 'w');
@@ -74,7 +74,10 @@ class ConsoleOutputFactory extends OutputFactory
         return $stream;
     }
 
-    public function createOutput($stream = null): StreamOutput
+    /**
+     * @param resource|null $stream
+     */
+    public function createOutput(mixed $stream = null): StreamOutput
     {
         $stream = $stream ?: $this->createOutputStream();
         $format = $this->createOutputFormatter();

--- a/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
@@ -35,7 +35,7 @@ class ConsoleOutputFactory extends OutputFactory
     /**
      * Configure output stream parameters.
      */
-    protected function configureOutputStream(OutputInterface $output)
+    protected function configureOutputStream(OutputInterface $output): void
     {
         $output->setVerbosity(
             match ($this->getOutputVerbosity()) {

--- a/src/Behat/Testwork/Output/Printer/Factory/FileOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FileOutputFactory.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 final class FileOutputFactory extends OutputFactory
 {
-    public function createOutput($stream = null): OutputInterface
+    public function createOutput(): OutputInterface
     {
         if ($this->getOutputPath() === null) {
             throw new MissingOutputPathException(

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -43,7 +43,7 @@ final class FilesystemOutputFactory extends OutputFactory
         );
     }
 
-    public function createOutput($stream = null): StreamOutput
+    public function createOutput(): StreamOutput
     {
         if ($this->getOutputPath() === null) {
             throw new MissingOutputPathException(

--- a/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/FilesystemOutputFactory.php
@@ -23,9 +23,9 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 final class FilesystemOutputFactory extends OutputFactory
 {
-    private $fileName;
+    private ?string $fileName = null;
 
-    public function setFileName($fileName): void
+    public function setFileName(?string $fileName): void
     {
         $this->fileName = $fileName;
     }

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -119,7 +119,7 @@ abstract class TesterExtension implements Extension
     /**
      * Loads exercise cli controllers.
      */
-    protected function loadExerciseController(ContainerBuilder $container, bool $skip = false)
+    protected function loadExerciseController(ContainerBuilder $container, bool $skip = false): void
     {
         $definition = new Definition(ExerciseController::class, [
             new Reference(SuiteExtension::REGISTRY_ID),
@@ -162,7 +162,7 @@ abstract class TesterExtension implements Extension
     /**
      * Loads exercise cli controllers.
      */
-    protected function loadStrictController(ContainerBuilder $container, bool $strict = false)
+    protected function loadStrictController(ContainerBuilder $container, bool $strict = false): void
     {
         $definition = new Definition(StrictController::class, [
             new Reference(self::RESULT_INTERPRETER_ID),
@@ -175,7 +175,7 @@ abstract class TesterExtension implements Extension
     /**
      * Loads result interpreter controller.
      */
-    protected function loadResultInterpreter(ContainerBuilder $container)
+    protected function loadResultInterpreter(ContainerBuilder $container): void
     {
         $definition = new Definition(ResultInterpreter::class);
         $container->setDefinition(self::RESULT_INTERPRETER_ID, $definition);
@@ -188,7 +188,7 @@ abstract class TesterExtension implements Extension
     /**
      * Loads exercise tester.
      */
-    protected function loadExercise(ContainerBuilder $container)
+    protected function loadExercise(ContainerBuilder $container): void
     {
         $definition = new Definition(RuntimeExercise::class, [
             new Reference(EnvironmentExtension::MANAGER_ID),
@@ -200,7 +200,7 @@ abstract class TesterExtension implements Extension
     /**
      * Loads suite tester.
      */
-    protected function loadSuiteTester(ContainerBuilder $container)
+    protected function loadSuiteTester(ContainerBuilder $container): void
     {
         $definition = new Definition(RuntimeSuiteTester::class, [
             new Reference(self::SPECIFICATION_TESTER_ID),
@@ -211,12 +211,12 @@ abstract class TesterExtension implements Extension
     /**
      * Loads specification tester.
      */
-    abstract protected function loadSpecificationTester(ContainerBuilder $container);
+    abstract protected function loadSpecificationTester(ContainerBuilder $container): void;
 
     /**
      * Processes all registered exercise wrappers.
      */
-    protected function processExerciseWrappers(ContainerBuilder $container)
+    protected function processExerciseWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::EXERCISE_ID, self::EXERCISE_WRAPPER_TAG);
     }
@@ -224,7 +224,7 @@ abstract class TesterExtension implements Extension
     /**
      * Processes all registered suite tester wrappers.
      */
-    protected function processSuiteTesterWrappers(ContainerBuilder $container)
+    protected function processSuiteTesterWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::SUITE_TESTER_ID, self::SUITE_TESTER_WRAPPER_TAG);
     }
@@ -232,7 +232,7 @@ abstract class TesterExtension implements Extension
     /**
      * Processes all registered specification tester wrappers.
      */
-    protected function processSpecificationTesterWrappers(ContainerBuilder $container)
+    protected function processSpecificationTesterWrappers(ContainerBuilder $container): void
     {
         $this->processor->processWrapperServices($container, self::SPECIFICATION_TESTER_ID, self::SPECIFICATION_TESTER_WRAPPER_TAG);
     }
@@ -240,7 +240,7 @@ abstract class TesterExtension implements Extension
     /**
      * Processes all registered result interpretations.
      */
-    protected function processResultInterpretations(ContainerBuilder $container)
+    protected function processResultInterpretations(ContainerBuilder $container): void
     {
         $references = $this->processor->findAndSortTaggedServices($container, self::RESULT_INTERPRETATION_TAG);
         $definition = $container->getDefinition(self::RESULT_INTERPRETER_ID);


### PR DESCRIPTION
This PR adds strict types for all remaining properties, method parameters and returns. 

I have ensured that is true by bumping our PHPStan to level 6 (ignoring errors about array shapes and generics, which are not relevant to our PHP native strict typehints).

As a result, I have also included a few internal refactorings:

* To be stricter about asserting at runtime that our code is being used as expected / with the expected types
* Where there is a more efficient / neater implementation that works better with strict types.

I've explained these changes in the individual commit messages.

None of these should affect any users or extension authors, as they do not touch our public API. The runtime type checks I've added only enforce that parameters match those that the phpdoc previously specified.

This completes #1744