### PR TITLE
refactor: Add runtime deprecations for ScenarioLikeTested interface

### DIFF
--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\Event\AfterSetup;
 use Behat\Testwork\Tester\Setup\Setup;
@@ -52,6 +53,8 @@ final class AfterBackgroundSetup extends BackgroundTested implements AfterSetup
      */
     public function getScenario(): BackgroundNode
     {
+        DeprecationCollector::trigger(__METHOD__.' is deprecated - use getBackground() instead. This method and the ScenarioLikeInterface will be removed in 4.0');
+
         return $this->background;
     }
 

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\Event\AfterTested;
 use Behat\Testwork\Tester\Result\TestResult;
@@ -54,6 +55,8 @@ final class AfterBackgroundTested extends BackgroundTested implements AfterTeste
      */
     public function getScenario(): BackgroundNode
     {
+        DeprecationCollector::trigger(__METHOD__.' is deprecated - use getBackground() instead. This method and the ScenarioLikeTested interface will be removed in 4.0');
+
         return $this->background;
     }
 

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\Event\BeforeTeardown;
 use Behat\Testwork\Tester\Result\TestResult;
@@ -52,6 +53,8 @@ final class BeforeBackgroundTeardown extends BackgroundTested implements BeforeT
      */
     public function getScenario(): BackgroundNode
     {
+        DeprecationCollector::trigger(__METHOD__.' is deprecated - use getBackground() instead. This method and the ScenarioLikeInterface will be removed in 4.0');
+
         return $this->background;
     }
 

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Behat\Testwork\Environment\Environment;
 use Behat\Testwork\EventDispatcher\Event\BeforeTested;
 
@@ -50,6 +51,8 @@ final class BeforeBackgroundTested extends BackgroundTested implements BeforeTes
      */
     public function getScenario(): BackgroundNode
     {
+        DeprecationCollector::trigger(__METHOD__.' is deprecated - use getBackground() instead. This method and the ScenarioLikeInterface will be removed in 4.0');
+
         return $this->background;
     }
 

--- a/src/Behat/Behat/EventDispatcher/Event/ScenarioLikeTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ScenarioLikeTested.php
@@ -17,6 +17,8 @@ use Behat\Gherkin\Node\ScenarioLikeInterface;
  * Represents an event of scenario-like structure (Scenario, Background, Example).
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @deprecated This will be removed in 4.0, in favour of separate inheritance chains for `ScenarioTested` and `BackgroundTested` events
  */
 interface ScenarioLikeTested extends GherkinNodeTested
 {

--- a/src/Behat/Behat/Output/Node/EventListener/AST/ScenarioNodeListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/ScenarioNodeListener.php
@@ -10,9 +10,12 @@
 
 namespace Behat\Behat\Output\Node\EventListener\AST;
 
+use Behat\Behat\EventDispatcher\Event\BackgroundTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioLikeTested;
+use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Behat\Output\Node\Printer\ScenarioPrinter;
 use Behat\Behat\Output\Node\Printer\SetupPrinter;
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Behat\Testwork\Event\Event;
 use Behat\Testwork\EventDispatcher\Event\AfterSetup;
 use Behat\Testwork\EventDispatcher\Event\AfterTested;
@@ -40,6 +43,13 @@ final class ScenarioNodeListener implements EventListener
             return;
         }
 
+        if (!$event instanceof BackgroundTested && !$event instanceof ScenarioTested) {
+            DeprecationCollector::trigger(sprintf(
+                '%s implements the ScenarioLikeTested interface which is deprecated and will be removed in 4.0.',
+                $event::class
+            ));
+        }
+
         $this->printHeaderOnBeforeEvent($formatter, $event, $eventName);
         $this->printFooterOnAfterEvent($formatter, $event, $eventName);
     }
@@ -57,7 +67,11 @@ final class ScenarioNodeListener implements EventListener
             $this->setupPrinter->printSetup($formatter, $event->getSetup());
         }
 
-        $this->scenarioPrinter->printHeader($formatter, $event->getFeature(), $event->getScenario());
+        $this->scenarioPrinter->printHeader(
+            $formatter,
+            $event->getFeature(),
+            $event instanceof BackgroundTested ? $event->getBackground() : $event->getScenario(),
+        );
     }
 
     /**

--- a/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/StepListener.php
@@ -12,12 +12,14 @@ namespace Behat\Behat\Output\Node\EventListener\AST;
 
 use Behat\Behat\EventDispatcher\Event\AfterStepSetup;
 use Behat\Behat\EventDispatcher\Event\AfterStepTested;
+use Behat\Behat\EventDispatcher\Event\BackgroundTested;
 use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioLikeTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Behat\Output\Node\Printer\SetupPrinter;
 use Behat\Behat\Output\Node\Printer\StepPrinter;
 use Behat\Gherkin\Node\ScenarioLikeInterface;
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Behat\Testwork\Event\Event;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Node\EventListener\EventListener;
@@ -29,7 +31,7 @@ use Behat\Testwork\Output\Node\EventListener\EventListener;
  */
 final class StepListener implements EventListener
 {
-    private ?ScenarioLikeInterface $scenario = null;
+    private ?ScenarioLikeInterface $scenarioOrBackground = null;
 
     public function __construct(
         private readonly StepPrinter $stepPrinter,
@@ -54,7 +56,14 @@ final class StepListener implements EventListener
             return;
         }
 
-        $this->scenario = $event->getScenario();
+        if (!$event instanceof BackgroundTested && !$event instanceof ScenarioTested) {
+            DeprecationCollector::trigger(sprintf(
+                '%s implements the ScenarioLikeTested interface which is deprecated and will be removed in 4.0.',
+                $event::class
+            ));
+        }
+
+        $this->scenarioOrBackground = $event instanceof BackgroundTested ? $event->getBackground() : $event->getScenario();
     }
 
     /**
@@ -68,7 +77,7 @@ final class StepListener implements EventListener
             return;
         }
 
-        $this->scenario = null;
+        $this->scenarioOrBackground = null;
     }
 
     private function printStepSetupOnBeforeEvent(Formatter $formatter, Event $event): void
@@ -91,7 +100,7 @@ final class StepListener implements EventListener
             return;
         }
 
-        $this->stepPrinter->printStep($formatter, $this->scenario, $event->getStep(), $event->getTestResult());
+        $this->stepPrinter->printStep($formatter, $this->scenarioOrBackground, $event->getStep(), $event->getTestResult());
 
         if ($this->setupPrinter instanceof SetupPrinter) {
             $this->setupPrinter->printTeardown($formatter, $event->getTeardown());


### PR DESCRIPTION
There are three places this could affect users:

* If they are calling `instanceof ScenarioLikeTested`. There's nothing we can do to detect / warn about this other than marking the interface `@deprecated` for their IDE / CI tooling.

* If they are creating and dispatching custom events that implement `ScenarioLikeTested` but *do not* extend either `ScenarioTested` or `BackgroundTested`. We can detect these at the point we handle the event.

* If they are calling `getScenario` instead of `getBackground` on any of the `BackgroundTested` event family.

I have refactored so that our own code only calls `getBackground` on a background node. Any remaining calls to `getScenario` will trigger a deprecation.