### PR TITLE
ci: Fail on Behat deprecations in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 .github export-ignore
 .php-cs-fixer.dist.php export-ignore
 AGENTS.md export-ignore
-behat.yml.dist
+behat.dist.php export-ignore
 box.json export-ignore
 CONTRIBUTING.md export-ignore
 phpstan.dist.neon export-ignore

--- a/behat.dist.php
+++ b/behat.dist.php
@@ -1,0 +1,11 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\GherkinOptions;
+use Behat\Config\Profile;
+use Behat\Gherkin\GherkinCompatibilityMode;
+
+return (new Config())
+    ->withProfile((new Profile('default'))
+        ->withGherkinOptions((new GherkinOptions())
+            ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32)));

--- a/behat.dist.php
+++ b/behat.dist.php
@@ -3,9 +3,15 @@
 use Behat\Config\Config;
 use Behat\Config\GherkinOptions;
 use Behat\Config\Profile;
+use Behat\Config\TesterOptions;
 use Behat\Gherkin\GherkinCompatibilityMode;
 
 return (new Config())
     ->withProfile((new Profile('default'))
-        ->withGherkinOptions((new GherkinOptions())
-            ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32)));
+            ->withGherkinOptions((new GherkinOptions())
+                    ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32),
+            )
+        ->withTesterOptions((new TesterOptions())
+            ->withFailOnBehatDeprecations()
+        )
+    );

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,3 +1,0 @@
-default:
-  gherkin:
-    compatibility: gherkin-32


### PR DESCRIPTION
We should not be using any deprecated code within Behat itself.

Obviously we might do inside our own features (e.g. to prove that deprecations are reported) but these are controlled by their own Behat config within the test fixture.

Therefore, the outer Behat process that runs the features can safely fail on any Behat deprecation.

In theory this could be configured in behat.yml, but I think it's clearer (and future proof) to take the opportunity to convert to using PHP config for our own Behat run.