### PR TITLE
Use Traversable as iterator aggregate return type

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -238,5 +238,10 @@
         <!-- WrongContainerClassException might not now return a class name (this is not a public API class) -->
         <ignored-regex>#CHANGED: The return type of Behat\\Behat\\HelperContainer\\Exception\\WrongContainerClassException\#getClass\(\) changed from string to the non-covariant string\|null#</ignored-regex>
 
+        <!-- use Traversable as return type in IteratorAggregate instead of leaking the iterator implementation used to our public API. Intended BC break in 4.0 -->
+        <ignored-regex>#CHANGED: The return type of Behat\\Testwork\\Call\\CallResults\#getIterator\(\) changed from ArrayIterator to the non-covariant Traversable#</ignored-regex>
+        <ignored-regex>#CHANGED: The return type of Behat\\Testwork\\Tester\\Result\\TestResults\#getIterator\(\) changed from ArrayIterator to the non-covariant Traversable#</ignored-regex>
+        <ignored-regex>#CHANGED: The return type of Behat\\Testwork\\Output\\Node\\EventListener\\ChainEventListener\#getIterator\(\) changed from ArrayIterator to the non-covariant Traversable#</ignored-regex>
+        <ignored-regex>#CHANGED: The return type of Behat\\Testwork\\Output\\Node\\EventListener\\ChainEventListener\#getIterator\(\) changed from ArrayIterator to Traversable#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/src/Behat/Testwork/Call/CallResults.php
+++ b/src/Behat/Testwork/Call/CallResults.php
@@ -13,6 +13,7 @@ namespace Behat\Testwork\Call;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * Aggregates multiple call results into a collection and provides an informational API on top of that.
@@ -89,7 +90,7 @@ final class CallResults implements Countable, IteratorAggregate
     /**
      * Returns collection iterator.
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->results);
     }

--- a/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
+++ b/src/Behat/Testwork/Output/Node/EventListener/ChainEventListener.php
@@ -15,6 +15,7 @@ use Behat\Testwork\Event\Event;
 use Behat\Testwork\Output\Formatter;
 use Countable;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * Used to compose formatter event listeners.
@@ -47,7 +48,7 @@ final class ChainEventListener implements EventListener, Countable, IteratorAggr
         return count($this->listeners);
     }
 
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->listeners);
     }

--- a/src/Behat/Testwork/Tester/Result/TestResults.php
+++ b/src/Behat/Testwork/Tester/Result/TestResults.php
@@ -13,6 +13,7 @@ namespace Behat\Testwork\Tester\Result;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * Aggregates multiple test results into a collection and provides informational API on top of that.
@@ -60,7 +61,7 @@ final class TestResults implements TestResult, Countable, IteratorAggregate
         return count($this->results);
     }
 
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->results);
     }


### PR DESCRIPTION
Rector inferred a return type based on the implementation of the method. However, I don't think we should guarantee the kind of iterator being returned, to reduce the BC surface of those classes.

Refs #1744