### PR TITLE
Add generic types for CallResult

### DIFF
--- a/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
+++ b/src/Behat/Behat/HelperContainer/Call/Filter/ServicesResolver.php
@@ -83,6 +83,12 @@ final class ServicesResolver implements CallFilter
     /**
      * Repackages old calls with new arguments, but only if two differ.
      *
+     * @template T of Call
+     *
+     * @param T $call
+     *
+     * @return T
+     *
      * @throws UnsupportedCallException if given call is not DefinitionCall or TransformationCall
      */
     private function repackageCallIfNewArguments(Call $call, array $arguments): Call
@@ -97,9 +103,15 @@ final class ServicesResolver implements CallFilter
     /**
      * Repackages old calls with new arguments.
      *
+     * @template T of Call
+     *
+     * @param T $call
+     *
+     * @return T
+     *
      * @throws UnsupportedCallException
      */
-    private function repackageCallWithNewArguments(Call $call, array $newArguments): DefinitionCall|TransformationCall
+    private function repackageCallWithNewArguments(Call $call, array $newArguments): Call
     {
         if ($call instanceof DefinitionCall) {
             return $this->repackageDefinitionCall($call, $newArguments);

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/HookStatsListener.php
@@ -86,11 +86,12 @@ final class HookStatsListener implements EventListener
 
     /**
      * Captures hook call result.
+     *
+     * @param CallResult<HookCall> $hookCallResult
      */
     private function captureHookStat(CallResult $hookCallResult): void
     {
         $call = $hookCallResult->getCall();
-        assert($call instanceof HookCall);
         $callee = $call->getCallee();
         $scope = $call->getScope();
         $path = $callee->getPath();

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONSetupPrinter.php
@@ -18,6 +18,8 @@ use Behat\Testwork\Call\CallResults;
 use Behat\Testwork\Exception\ExceptionPresenter;
 use Behat\Testwork\Hook\Call\AfterSuite;
 use Behat\Testwork\Hook\Call\BeforeSuite;
+use Behat\Testwork\Hook\Call\HookCall;
+use Behat\Testwork\Hook\Call\RuntimeHook;
 use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
 use Behat\Testwork\Hook\Tester\Setup\HookedTeardown;
 use Behat\Testwork\Output\Formatter;
@@ -46,6 +48,9 @@ final class JSONSetupPrinter implements SetupPrinter
         }
     }
 
+    /**
+     * @param CallResults<HookCall> $results
+     */
     private function handleHookCalls(Formatter $formatter, CallResults $results, string $messageType): void
     {
         foreach ($results as $hookCallResult) {
@@ -56,6 +61,7 @@ final class JSONSetupPrinter implements SetupPrinter
                 assert($outputPrinter instanceof JSONOutputPrinter);
 
                 $callee = $call->getCallee();
+                \assert($callee instanceof RuntimeHook);
                 $message = $callee->getName();
                 if ($scope instanceof StepScope) {
                     $message .= ': ' . $scope->getStep()->getKeyword() . ' ' . $scope->getStep()->getText();

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
@@ -6,6 +6,8 @@ use Behat\Behat\Hook\Scope\StepScope;
 use Behat\Behat\Output\Node\Printer\SetupPrinter;
 use Behat\Testwork\Call\CallResults;
 use Behat\Testwork\Exception\ExceptionPresenter;
+use Behat\Testwork\Hook\Call\HookCall;
+use Behat\Testwork\Hook\Call\RuntimeHook;
 use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
 use Behat\Testwork\Hook\Tester\Setup\HookedTeardown;
 use Behat\Testwork\Output\Formatter;
@@ -37,6 +39,9 @@ final class JUnitSetupPrinter implements SetupPrinter
         }
     }
 
+    /**
+     * @param CallResults<HookCall> $results
+     */
     private function handleHookCalls(Formatter $formatter, CallResults $results, string $messageType): void
     {
         foreach ($results as $hookCallResult) {
@@ -47,6 +52,7 @@ final class JUnitSetupPrinter implements SetupPrinter
                 assert($outputPrinter instanceof JUnitOutputPrinter);
 
                 $callee = $call->getCallee();
+                \assert($callee instanceof RuntimeHook);
                 $message = $callee->getName();
                 if ($scope instanceof StepScope) {
                     $message .= ': ' . $scope->getStep()->getKeyword() . ' ' . $scope->getStep()->getText();

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySetupPrinter.php
@@ -14,6 +14,7 @@ use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
 use Behat\Behat\Output\Node\Printer\SetupPrinter;
 use Behat\Testwork\Call\CallResult;
 use Behat\Testwork\Exception\ExceptionPresenter;
+use Behat\Testwork\Hook\Call\HookCall;
 use Behat\Testwork\Hook\Call\RuntimeHook;
 use Behat\Testwork\Hook\Tester\Setup\HookedSetup;
 use Behat\Testwork\Hook\Tester\Setup\HookedTeardown;
@@ -69,6 +70,8 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Prints setup hook call result.
+     *
+     * @param CallResult<HookCall> $callResult
      */
     private function printSetupHookCallResult(OutputPrinter $printer, CallResult $callResult): void
     {
@@ -98,6 +101,8 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Prints teardown hook call result.
+     *
+     * @param CallResult<HookCall> $callResult
      */
     private function printTeardownHookCallResult(OutputPrinter $printer, CallResult $callResult): void
     {
@@ -127,6 +132,8 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Prints hook call output (if has some).
+     *
+     * @param CallResult<HookCall> $callResult
      */
     private function printHookCallStdOut(OutputPrinter $printer, CallResult $callResult, string $indentText): void
     {
@@ -146,6 +153,8 @@ final class PrettySetupPrinter implements SetupPrinter
 
     /**
      * Prints hook call exception (if has some).
+     *
+     * @param CallResult<HookCall> $callResult
      */
     private function printHookCallException(OutputPrinter $printer, CallResult $callResult, string $indentText): void
     {

--- a/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Tester\Result;
 
+use Behat\Behat\Definition\Call\DefinitionCall;
 use Behat\Behat\Definition\Definition;
 use Behat\Behat\Definition\SearchResult;
 use Behat\Behat\Tester\Exception\PendingException;
@@ -28,6 +29,8 @@ final class ExecutedStepResult implements StepResult, DefinedStepResult, Excepti
 {
     /**
      * Initialize test result.
+     *
+     * @param CallResult<DefinitionCall> $callResult
      */
     public function __construct(
         private readonly SearchResult $searchResult,
@@ -45,6 +48,8 @@ final class ExecutedStepResult implements StepResult, DefinedStepResult, Excepti
 
     /**
      * Returns definition call result or null if no call were made.
+     *
+     * @return CallResult<DefinitionCall>
      */
     public function getCallResult(): CallResult
     {

--- a/src/Behat/Testwork/Call/CallCenter.php
+++ b/src/Behat/Testwork/Call/CallCenter.php
@@ -77,6 +77,12 @@ final class CallCenter
 
     /**
      * Handles call and its result using registered filters and handlers.
+     *
+     * @template T of Call
+     *
+     * @param T $call
+     *
+     * @return CallResult<T>
      */
     public function makeCall(Call $call): CallResult
     {
@@ -89,6 +95,12 @@ final class CallCenter
 
     /**
      * Filters call using registered filters and returns a filtered one.
+     *
+     * @template T of Call
+     *
+     * @param T $call
+     *
+     * @return T
      */
     private function filterCall(Call $call): Call
     {
@@ -105,6 +117,12 @@ final class CallCenter
 
     /**
      * Handles call using registered call handlers.
+     *
+     * @template T of Call
+     *
+     * @param T $call
+     *
+     * @return CallResult<T>
      *
      * @throws CallHandlingException If call handlers didn't produce call result
      */
@@ -126,6 +144,12 @@ final class CallCenter
 
     /**
      * Filters call result using registered filters and returns a filtered one.
+     *
+     * @template T of Call
+     *
+     * @param CallResult<T> $result
+     *
+     * @return CallResult<T>
      */
     private function filterResult(CallResult $result): CallResult
     {

--- a/src/Behat/Testwork/Call/CallResult.php
+++ b/src/Behat/Testwork/Call/CallResult.php
@@ -16,11 +16,15 @@ use Exception;
  * Represents result of the call.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @template-covariant T of Call
  */
 final class CallResult
 {
     /**
      * Initializes call result.
+     *
+     * @param T $call
      */
     public function __construct(
         private readonly Call $call,
@@ -32,6 +36,8 @@ final class CallResult
 
     /**
      * Returns call.
+     *
+     * @return T
      */
     public function getCall(): Call
     {

--- a/src/Behat/Testwork/Call/CallResults.php
+++ b/src/Behat/Testwork/Call/CallResults.php
@@ -19,14 +19,16 @@ use IteratorAggregate;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @implements IteratorAggregate<int, CallResult>
+ * @template T of Call
+ *
+ * @implements IteratorAggregate<int, CallResult<T>>
  */
 final class CallResults implements Countable, IteratorAggregate
 {
     /**
      * Initializes call results collection.
      *
-     * @param CallResult[] $results
+     * @param CallResult<T>[] $results
      */
     public function __construct(
         private readonly array $results = [],
@@ -35,6 +37,13 @@ final class CallResults implements Countable, IteratorAggregate
 
     /**
      * Merges results from provided collection into the current one.
+     *
+     * @template U of Call
+     *
+     * @param CallResults<U> $first
+     * @param CallResults<U> $second
+     *
+     * @return CallResults<U>
      */
     public static function merge(CallResults $first, CallResults $second): self
     {
@@ -88,7 +97,7 @@ final class CallResults implements Countable, IteratorAggregate
     /**
      * Returns call results array.
      *
-     * @return CallResult[]
+     * @return CallResult<T>[]
      */
     public function toArray(): array
     {

--- a/src/Behat/Testwork/Call/Filter/CallFilter.php
+++ b/src/Behat/Testwork/Call/Filter/CallFilter.php
@@ -29,6 +29,12 @@ interface CallFilter
 
     /**
      * Filters a call and returns a new one.
+     *
+     * @template T of Call
+     *
+     * @param T $call
+     *
+     * @return T
      */
     public function filterCall(Call $call): Call;
 }

--- a/src/Behat/Testwork/Call/Filter/ResultFilter.php
+++ b/src/Behat/Testwork/Call/Filter/ResultFilter.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\Call\Filter;
 
+use Behat\Testwork\Call\Call;
 use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\CallResult;
 
@@ -24,11 +25,19 @@ interface ResultFilter
 {
     /**
      * Checks if filter supports call result.
+     *
+     * @param CallResult<Call> $result
      */
     public function supportsResult(CallResult $result): bool;
 
     /**
      * Filters call result and returns a new result.
+     *
+     * @template T of Call
+     *
+     * @param CallResult<T> $result
+     *
+     * @return CallResult<T>
      */
     public function filterResult(CallResult $result): CallResult;
 }

--- a/src/Behat/Testwork/Call/Handler/CallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/CallHandler.php
@@ -30,6 +30,12 @@ interface CallHandler
 
     /**
      * Handles call and returns call result.
+     *
+     * @template T of Call
+     *
+     * @param T $call
+     *
+     * @return CallResult<T>
      */
     public function handleCall(Call $call): CallResult;
 }

--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -69,6 +69,12 @@ final class RuntimeCallHandler implements CallHandler
 
     /**
      * Executes single call.
+     *
+     * @template T of Call
+     *
+     * @param T $call
+     *
+     * @return CallResult<T>
      */
     private function executeCall(Call $call): CallResult
     {

--- a/src/Behat/Testwork/Hook/HookDispatcher.php
+++ b/src/Behat/Testwork/Hook/HookDispatcher.php
@@ -34,6 +34,8 @@ final class HookDispatcher
 
     /**
      * Dispatches hooks for a specified event.
+     *
+     * @return CallResults<HookCall>
      */
     public function dispatchScopeHooks(HookScope $scope): CallResults
     {
@@ -47,6 +49,8 @@ final class HookDispatcher
 
     /**
      * Dispatches single event hook.
+     *
+     * @return CallResult<HookCall>
      */
     private function dispatchHook(HookScope $scope, Hook $hook): CallResult
     {

--- a/src/Behat/Testwork/Hook/Tester/Setup/HookedSetup.php
+++ b/src/Behat/Testwork/Hook/Tester/Setup/HookedSetup.php
@@ -11,6 +11,7 @@
 namespace Behat\Testwork\Hook\Tester\Setup;
 
 use Behat\Testwork\Call\CallResults;
+use Behat\Testwork\Hook\Call\HookCall;
 use Behat\Testwork\Tester\Setup\Setup;
 
 /**
@@ -22,6 +23,8 @@ final class HookedSetup implements Setup
 {
     /**
      * Initializes setup.
+     *
+     * @param CallResults<HookCall> $hookCallResults
      */
     public function __construct(
         private readonly Setup $setup,
@@ -45,6 +48,8 @@ final class HookedSetup implements Setup
 
     /**
      * Returns hook call results.
+     *
+     * @return CallResults<HookCall>
      */
     public function getHookCallResults(): CallResults
     {

--- a/src/Behat/Testwork/Hook/Tester/Setup/HookedTeardown.php
+++ b/src/Behat/Testwork/Hook/Tester/Setup/HookedTeardown.php
@@ -11,6 +11,7 @@
 namespace Behat\Testwork\Hook\Tester\Setup;
 
 use Behat\Testwork\Call\CallResults;
+use Behat\Testwork\Hook\Call\HookCall;
 use Behat\Testwork\Tester\Setup\Teardown;
 
 /**
@@ -22,6 +23,8 @@ final class HookedTeardown implements Teardown
 {
     /**
      * Initializes setup.
+     *
+     * @param CallResults<HookCall> $hookCallResults
      */
     public function __construct(
         private readonly Teardown $teardown,
@@ -45,6 +48,8 @@ final class HookedTeardown implements Teardown
 
     /**
      * Returns hook call results.
+     *
+     * @return CallResults<HookCall>
      */
     public function getHookCallResults(): CallResults
     {


### PR DESCRIPTION
This allows documenting that the HookedSetup and HookedTeardown classes are dealing with call results for HookCall, not for arbitrary calls.