### PR TITLE
Feature/symfony8 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,12 @@ jobs:
             composer-mode: update
             symfony-version: '6.4'
 
-          - php: 8.3
+          - php: 8.4
+            os: ubuntu-latest
+            composer-mode: update
+            symfony-version: '8.0'
+
+          - php: 8.5
             os: ubuntu-latest
             composer-mode: update
             symfony-version: '8.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,11 @@ jobs:
             composer-mode: update
             symfony-version: '6.4'
 
+          - php: 8.3
+            os: ubuntu-latest
+            composer-mode: update
+            symfony-version: '8.0'
+
     steps:
       - uses: actions/checkout@v4
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",
-        "symfony/dependency-injection": "^8.0",
+        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/translation": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",
-        "symfony/config": "^5.4 || ^6.4 || ^7.0",
-        "symfony/console": "^5.4.9 || ^6.4 || ^7.0",
-        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
-        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
-        "symfony/translation": "^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0"
+        "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/console": "^5.4.9 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^8.0",
+        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/translation": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
 
     "require-dev": {
@@ -36,9 +36,9 @@
         "phpunit/phpunit": "^9.6",
         "rector/rector": "2.3.9",
         "sebastian/diff": "^4.0",
-        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/polyfill-php84": "^1.31",
-        "symfony/process": "^5.4 || ^6.4 || ^7.0"
+        "symfony/process": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
 
     "suggest": {

--- a/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
+++ b/src/Behat/Behat/Snippet/ServiceContainer/SnippetExtension.php
@@ -74,7 +74,7 @@ class SnippetExtension implements Extension
         $this->loadWriter($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processGenerators($container);
         $this->processAppenders($container);

--- a/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Behat/Tester/ServiceContainer/TesterExtension.php
@@ -93,7 +93,7 @@ class TesterExtension extends BaseExtension
         $this->loadPendingExceptionStringer($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         parent::process($container);
 

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -79,7 +79,7 @@ class TransformationExtension implements Extension
         $this->loadRepository($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processArgumentsTransformers($container);
     }

--- a/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
+++ b/src/Behat/Testwork/EventDispatcher/ServiceContainer/EventDispatcherExtension.php
@@ -75,7 +75,7 @@ class EventDispatcherExtension implements Extension
         $this->loadEventDispatchingSuiteTester($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processSubscribers($container);
     }

--- a/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
+++ b/src/Behat/Testwork/Hook/ServiceContainer/HookExtension.php
@@ -56,7 +56,7 @@ class HookExtension implements Extension
         $this->loadHookableTesters($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
     }
 

--- a/src/Behat/Testwork/ServiceContainer/Extension.php
+++ b/src/Behat/Testwork/ServiceContainer/Extension.php
@@ -66,8 +66,6 @@ interface Extension extends CompilerPassInterface
      *
      * NOTE: If your extension uses the ContainerBuilder passed to this method, your composer.json should declare
      *  a direct dependency on the version(s) of symfony/dependency-injection that you support.
-     *
-     * @return void
      */
-    public function process(ContainerBuilder $container);
+    public function process(ContainerBuilder $container): void;
 }

--- a/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
+++ b/src/Behat/Testwork/Tester/ServiceContainer/TesterExtension.php
@@ -106,7 +106,7 @@ abstract class TesterExtension implements Extension
         $this->loadSpecificationTester($container);
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->processExerciseWrappers($container);
         $this->processSuiteTesterWrappers($container);


### PR DESCRIPTION
Symfony 8 has been released 6 months ago and Behat is only compliant with symfony component from versions 5 to 7.
If Behat is added in dev require of a symfony project, the project is locked in 7.

This commit allow symfony 8 in composer require and fix some Symfony Components' interfaces implementations.

Tests are green localy