### PR TITLE
feat: Support GHERKIN_32 parsing mode in pretty formatter

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -14,5 +14,11 @@
         <ignored-regex>#CHANGED: The return type of Behat\\Testwork\\Environment\\Call\\EnvironmentCall\#getEnvironment\(\) changed#</ignored-regex>
         <ignored-regex>#CHANGED: The return type of Behat\\Testwork\\Environment\\Call\\EnvironmentCall\#getCallee\(\) changed#</ignored-regex>
         <ignored-regex>#CHANGED: The return type of Behat\\Testwork\\Environment\\Call\\EnvironmentCall\#getArguments\(\) changed#</ignored-regex>
+
+        <!-- The default indentation has changed to produce the same output in most cases as previous versions.
+             We officially don't support configuring this, if end-users are creating an instance with a different
+             indentation then output may change slightly but we don't guarantee human-readable output will be identical
+             between versions anyway. -->
+        <ignored-regex>#CHANGED: Default parameter value for parameter \$subIndentation of Behat\\Behat\\Output\\Node\\Printer\\Pretty\\PrettyScenarioPrinter\#__construct\(\) changed from 2 to 4#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -467,7 +467,12 @@ EOL;
         }
 
         throw new UnexpectedValueException(
-            'Expected previous command to ' . strtoupper($success) . ' but got exit code ' . $this->getExitCode()
+            sprintf(
+                "Expected previous command to %s but got exit code %d with output:\n%s",
+                strtoupper($success),
+                $this->getExitCode(),
+                $this->getOutput()
+            )
         );
     }
 

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -274,12 +274,24 @@ Feature: Pretty Formatter
             When I subtract 15
             Then I must have 10       # FeatureContext::iMustHave()
 
+          @with-examples
+          Scenario Outline: Cases that dynamically check the calculator # features/gherkin-parity.feature:30
+              using inputs from the sets of tables
+            When I add <input>                                          # FeatureContext::iAdd()
+            Then I must have <expect>                                   # FeatureContext::iMustHave()
+
+            Examples:
+              | input | expect |
+              | 3     | 28     |
+              | 4     | 29     |
+              | 180   | 205    |
+
         --- Failed scenarios:
 
             features/gherkin-parity.feature:20 (on line 22)
 
-        3 scenarios (1 passed, 1 failed, 1 undefined)
-        9 steps (6 passed, 1 failed, 1 undefined, 1 skipped)
+        6 scenarios (4 passed, 1 failed, 1 undefined)
+        18 steps (15 passed, 1 failed, 1 undefined, 1 skipped)
         """
 
     Examples:

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -250,7 +250,7 @@ Feature: Pretty Formatter
         @gherkin-parity
         Feature: Parity with basic feature file
           In order to see that the pretty formatter can handle different gherkin modes
-          As a developer
+            As a developer
           I need to see an example with basic Gherkin syntax
 
           Background:               # features/gherkin-parity.feature:7

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -253,26 +253,30 @@ Feature: Pretty Formatter
             As a developer
           I need to see an example with basic Gherkin syntax
 
-          Background:               # features/gherkin-parity.feature:7
-            Given I have entered 25 # FeatureContext::iHaveEntered()
+          Background: That sets up the calculator # features/gherkin-parity.feature:7
+              to have a starting number
+             for every scenario
+            Given I have entered 25               # FeatureContext::iHaveEntered()
 
-          Scenario: Simple passing scenario # features/gherkin-parity.feature:11
+          Scenario: Simple passing scenario # features/gherkin-parity.feature:14
+              describing what happens when
+               numbers are correctly added.
             When I add 2                    # FeatureContext::iAdd()
             Then I must have 27             # FeatureContext::iMustHave()
 
-          Scenario: Simple failing scenario # features/gherkin-parity.feature:15
+          Scenario: Simple failing scenario # features/gherkin-parity.feature:20
             When I add 3                    # FeatureContext::iAdd()
             Then I must have 30             # FeatureContext::iMustHave()
               Failed asserting that 28 matches expected '30'.
 
           @wip @new
-          Scenario: With unknown step # features/gherkin-parity.feature:20
+          Scenario: With unknown step # features/gherkin-parity.feature:25
             When I subtract 15
             Then I must have 10       # FeatureContext::iMustHave()
 
         --- Failed scenarios:
 
-            features/gherkin-parity.feature:15 (on line 17)
+            features/gherkin-parity.feature:20 (on line 22)
 
         3 scenarios (1 passed, 1 failed, 1 undefined)
         9 steps (6 passed, 1 failed, 1 undefined, 1 skipped)

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -238,3 +238,47 @@ Feature: Pretty Formatter
       4 scenarios (2 passed, 2 failed)
       8 steps (6 passed, 2 failed)
       """
+
+  Scenario Outline: Consistent output between Gherkin parser compatibility modes
+      When I run behat with the following additional options:
+        | option       | value |
+        | --profile       | gherkin-parity-<compatibility_mode> |
+        | --no-snippets |                                     |
+
+      Then it should fail with:
+        """
+        @gherkin-parity
+        Feature: Parity with basic feature file
+          In order to see that the pretty formatter can handle different gherkin modes
+          As a developer
+          I need to see an example with basic Gherkin syntax
+
+          Background:               # features/gherkin-parity.feature:7
+            Given I have entered 25 # FeatureContext::iHaveEntered()
+
+          Scenario: Simple passing scenario # features/gherkin-parity.feature:11
+            When I add 2                    # FeatureContext::iAdd()
+            Then I must have 27             # FeatureContext::iMustHave()
+
+          Scenario: Simple failing scenario # features/gherkin-parity.feature:15
+            When I add 3                    # FeatureContext::iAdd()
+            Then I must have 30             # FeatureContext::iMustHave()
+              Failed asserting that 28 matches expected '30'.
+
+          @wip @new
+          Scenario: With unknown step # features/gherkin-parity.feature:20
+            When I subtract 15
+            Then I must have 10       # FeatureContext::iMustHave()
+
+        --- Failed scenarios:
+
+            features/gherkin-parity.feature:15 (on line 17)
+
+        3 scenarios (1 passed, 1 failed, 1 undefined)
+        9 steps (6 passed, 1 failed, 1 undefined, 1 skipped)
+        """
+
+    Examples:
+      | compatibility_mode |
+      | legacy             |
+      | gherkin-32         |

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -79,14 +79,14 @@ Feature: Pretty Formatter
           Given I have entered 10 # FeatureContextMultiline::iHaveEntered()
 
         Scenario: Adding some interesting # features/WorldMultiline.feature:9
-                  value
+            value
           Then I must have 10             # FeatureContextMultiline::iMustHave()
           And I add the value 6           # FeatureContextMultiline::iAddOrSubtract()
           Then I must have 16             # FeatureContextMultiline::iMustHave()
 
         Scenario: Subtracting        # features/WorldMultiline.feature:15
-                  some
-                  value
+            some
+            value
           Then I must have 10        # FeatureContextMultiline::iMustHave()
           And I subtract the value 6 # FeatureContextMultiline::iAddOrSubtract()
           Then I must have 4         # FeatureContextMultiline::iMustHave()
@@ -144,21 +144,21 @@ Feature: Pretty Formatter
         I want, that "World" flushes between scenarios
 
         Background: Some background # features/WorldMultilineBackgroundScenario.feature:6
-          title
-            with
-          multiple lines
+            title
+              with
+            multiple lines
           Given I have entered 10
 
         Scenario: Undefined   # features/WorldMultilineBackgroundScenario.feature:13
-                  scenario or
-                  whatever
+            scenario or
+            whatever
           Then I must have 10
           And Something new
           Then I must have 10
 
         Scenario Outline: Passed & Failed # features/WorldMultilineBackgroundScenario.feature:20
-          steps and other interesting stuff
-          he-he-he
+            steps and other interesting stuff
+            he-he-he
           Given I must have 10
           When I add <value>
           Then I must have <result>
@@ -255,7 +255,7 @@ Feature: Pretty Formatter
 
           Background: That sets up the calculator # features/gherkin-parity.feature:7
               to have a starting number
-             for every scenario
+              for every scenario
             Given I have entered 25               # FeatureContext::iHaveEntered()
 
           Scenario: Simple passing scenario # features/gherkin-parity.feature:14

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyDescriptionPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyDescriptionPrinter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Behat\Behat\Output\Node\Printer\Pretty;
+
+use Behat\Testwork\Output\Printer\OutputPrinter;
+
+final class PrettyDescriptionPrinter
+{
+    public function printDescription(OutputPrinter $printer, string $description, string $subIndentText): void
+    {
+        if ('' === $description) {
+            return;
+        }
+
+        // Leading whitespace is handled differently in different parsing modes:
+        // - In gherkin-32, nothing is trimmed and the text exactly matches the feature file.
+        // - In legacy, the parser removes {keywordIndent + 2} spaces from the start of every line.
+        //
+        // For consistent output between modes, we need to:
+        // * Find the indentation of the first line (if any).
+        // * Then un-indent every line by up to that amount.
+        // * Then re-indent by our desired indentation.
+        //
+        // The trade-off is that the output might not match the exact indentation within the source feature file if:
+        // - the block is indented differently to the expected {2 spaces more than the keyword / title line}.
+        // - there are lines that are indented *less* than the first line of the block.
+        //
+        // I think these are acceptable trade-offs for the sake of consistent output (our past behaviour didn't
+        // guarantee that it would match the feature file either).
+        $lines = explode("\n", $description);
+        $internalIndent = strlen(preg_match('/^( +)/', $lines[0], $matches) ? $matches[0] : '');
+
+        foreach (explode("\n", $description) as $descriptionLine) {
+            $descriptionLine = preg_replace('/^ {0,'.$internalIndent.'}/', '', $descriptionLine);
+            $printer->writeln(sprintf('%s%s', $subIndentText, $descriptionLine));
+        }
+    }
+}

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
@@ -93,7 +93,19 @@ final class PrettyFeaturePrinter implements FeaturePrinter
             return;
         }
 
+        // Leading whitespace is handled differently in different parsing modes:
+        // - In gherkin-32, nothing is trimmed and the text exactly matches the feature file.
+        // - In legacy, the parser removes {keywordIndent + 2} spaces from the start of every line.
+        //
+        // For consistent output between modes, we need to find the indentation of the first line (if any). Then
+        // un-indent every line by that amount, then re-indent by our desired indentation.
+        //
+        // The trade-off is that the output might not match the exact indentation within the source feature file.
+        $lines = explode("\n", $feature->getDescription());
+        $internalIndent = preg_match('/^\s*/', $lines[0], $matches) ? $matches[0] : '';
+
         foreach (explode("\n", $feature->getDescription()) as $descriptionLine) {
+            $descriptionLine = preg_replace('/^'.$internalIndent.'/', '', $descriptionLine);
             $printer->writeln(sprintf('%s%s', $this->subIndentText, $descriptionLine));
         }
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyFeaturePrinter.php
@@ -28,6 +28,7 @@ final class PrettyFeaturePrinter implements FeaturePrinter
      */
     private $indentText;
     private readonly string $subIndentText;
+    private readonly PrettyDescriptionPrinter $descriptionPrinter;
 
     /**
      * Initializes printer.
@@ -39,6 +40,7 @@ final class PrettyFeaturePrinter implements FeaturePrinter
     {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));
+        $this->descriptionPrinter = new PrettyDescriptionPrinter();
     }
 
     public function printHeader(Formatter $formatter, FeatureNode $feature): void
@@ -46,7 +48,8 @@ final class PrettyFeaturePrinter implements FeaturePrinter
         $this->printTags($formatter->getOutputPrinter(), $feature->getTags());
 
         $this->printTitle($formatter->getOutputPrinter(), $feature);
-        $this->printDescription($formatter->getOutputPrinter(), $feature);
+        $this->descriptionPrinter->printDescription($formatter->getOutputPrinter(), $feature->getDescription() ?? '', $this->subIndentText);
+        $formatter->getOutputPrinter()->writeln();
     }
 
     public function printFooter(Formatter $formatter, TestResult $result): void
@@ -77,36 +80,6 @@ final class PrettyFeaturePrinter implements FeaturePrinter
 
         if ($title = $feature->getTitle()) {
             $printer->write(sprintf(' %s', $title));
-        }
-
-        $printer->writeln();
-    }
-
-    /**
-     * Prints feature description using provided printer.
-     */
-    private function printDescription(OutputPrinter $printer, FeatureNode $feature): void
-    {
-        if (!$feature->getDescription()) {
-            $printer->writeln();
-
-            return;
-        }
-
-        // Leading whitespace is handled differently in different parsing modes:
-        // - In gherkin-32, nothing is trimmed and the text exactly matches the feature file.
-        // - In legacy, the parser removes {keywordIndent + 2} spaces from the start of every line.
-        //
-        // For consistent output between modes, we need to find the indentation of the first line (if any). Then
-        // un-indent every line by that amount, then re-indent by our desired indentation.
-        //
-        // The trade-off is that the output might not match the exact indentation within the source feature file.
-        $lines = explode("\n", $feature->getDescription());
-        $internalIndent = preg_match('/^\s*/', $lines[0], $matches) ? $matches[0] : '';
-
-        foreach (explode("\n", $feature->getDescription()) as $descriptionLine) {
-            $descriptionLine = preg_replace('/^'.$internalIndent.'/', '', $descriptionLine);
-            $printer->writeln(sprintf('%s%s', $this->subIndentText, $descriptionLine));
         }
 
         $printer->writeln();

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -11,6 +11,7 @@
 namespace Behat\Behat\Output\Node\Printer\Pretty;
 
 use Behat\Behat\Output\Node\Printer\ScenarioPrinter;
+use Behat\Gherkin\Node\DescribableNodeInterface;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioLikeInterface as Scenario;
 use Behat\Gherkin\Node\TaggedNodeInterface;
@@ -30,6 +31,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
      */
     private $indentText;
     private readonly string $subIndentText;
+    private readonly PrettyDescriptionPrinter $descriptionPrinter;
 
     /**
      * Initializes printer.
@@ -44,6 +46,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));
+        $this->descriptionPrinter = new PrettyDescriptionPrinter();
     }
 
     public function printHeader(Formatter $formatter, FeatureNode $feature, Scenario $scenario): void
@@ -52,10 +55,40 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
             $this->printTags($formatter->getOutputPrinter(), $scenario->getTags());
         }
 
+        ['title' => $title, 'description' => $description] = $this->getTitleAndDescription($scenario);
+
         $this->printKeyword($formatter->getOutputPrinter(), $scenario->getKeyword());
-        $this->printTitle($formatter->getOutputPrinter(), $scenario->getTitle());
+        $this->printTitle($formatter->getOutputPrinter(), $title ?? '');
         $this->pathPrinter->printScenarioPath($formatter, $feature, $scenario, mb_strlen($this->indentText, 'utf8'));
-        $this->printDescription($formatter->getOutputPrinter(), $scenario->getTitle());
+        $this->descriptionPrinter->printDescription($formatter->getOutputPrinter(), $description ?? '', $this->subIndentText);
+    }
+
+    /**
+     * @return array{title: ?string, description: ?string}
+     */
+    private function getTitleAndDescription(Scenario $scenario): array
+    {
+        if ($scenario instanceof DescribableNodeInterface && $scenario->getDescription()) {
+            // All ScenarioLikeInterface defined by behat/gherkin are also DescribableNodeInterface
+            // but we can't guarantee that's true if the node has come from third-party code.
+            //
+            // If it does match this interface and was parsed in gherkin-32 mode the description
+            // will be in the description property and the title is guaranteed to be a single line.
+            return [
+                'title' => $scenario->getTitle(),
+                'description' => $scenario->getDescription(),
+            ];
+        }
+
+        // Could have been parsed in gherkin-32 mode with no description, or in legacy mode with a multi-line title
+        // either way the title is the first line (if any) and the description is the rest.
+        $lines = explode("\n", (string) $scenario->getTitle());
+        $title = array_shift($lines);
+
+        return [
+            'title' => $title,
+            'description' => $lines === [] ? null : implode("\n", $lines),
+        ];
     }
 
     public function printFooter(Formatter $formatter, TestResult $result): void
@@ -89,32 +122,12 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
     }
 
     /**
-     * Prints scenario title (first line of long title).
-     *
-     * @param string|null   $longTitle
+     * Prints scenario title.
      */
-    private function printTitle(OutputPrinter $printer, $longTitle): void
+    private function printTitle(OutputPrinter $printer, string $title): void
     {
-        $description = explode("\n", $longTitle ?? '');
-        $title = array_shift($description);
-
         if ('' !== $title) {
             $printer->write(sprintf(' %s', $title));
-        }
-    }
-
-    /**
-     * Prints scenario description (other lines of long title).
-     *
-     * @param string|null   $longTitle
-     */
-    private function printDescription(OutputPrinter $printer, $longTitle): void
-    {
-        $lines = explode("\n", $longTitle ?? '');
-        array_shift($lines);
-
-        foreach ($lines as $line) {
-            $printer->writeln(sprintf('%s%s', $this->subIndentText, $line));
         }
     }
 

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyScenarioPrinter.php
@@ -42,7 +42,7 @@ final class PrettyScenarioPrinter implements ScenarioPrinter
     public function __construct(
         private readonly PrettyPathPrinter $pathPrinter,
         $indentation = 2,
-        $subIndentation = 2,
+        $subIndentation = 4,
     ) {
         $this->indentText = str_repeat(' ', intval($indentation));
         $this->subIndentText = $this->indentText . str_repeat(' ', intval($subIndentation));

--- a/tests/Fixtures/PrettyFormat/behat.php
+++ b/tests/Fixtures/PrettyFormat/behat.php
@@ -3,8 +3,11 @@
 declare(strict_types=1);
 
 use Behat\Config\Config;
+use Behat\Config\Filter\TagFilter;
+use Behat\Config\GherkinOptions;
 use Behat\Config\Profile;
 use Behat\Config\Suite;
+use Behat\Gherkin\GherkinCompatibilityMode;
 
 $defaultProfile = (new Profile('default'))
     ->withSuite(
@@ -48,6 +51,24 @@ $lsProfile = (new Profile('ls'))
     )
 ;
 
+$parityLegacyProfile = (new Profile('gherkin-parity-legacy'))
+    ->withSuite(
+        (new Suite('default'))
+            ->withContexts('FeatureContext'),
+    )
+    ->withGherkinOptions(
+        (new GherkinOptions())
+            ->withFilter(new TagFilter('@gherkin-parity'))
+            ->withCompatibilityMode(GherkinCompatibilityMode::LEGACY),
+    );
+
+$parityGherkin32Profile = (new Profile('gherkin-parity-gherkin-32', $parityLegacyProfile->toArray()))
+    ->withGherkinOptions(
+        (new GherkinOptions())
+            ->withFilter(new TagFilter('@gherkin-parity'))
+            ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32),
+    );
+
 return (new Config())
     ->withProfile($defaultProfile)
     ->withProfile($multilineProfile)
@@ -55,4 +76,6 @@ return (new Config())
     ->withProfile($backgroundFailingProfile)
     ->withProfile($multipleExamplesProfile)
     ->withProfile($lsProfile)
+    ->withProfile($parityLegacyProfile)
+    ->withProfile($parityGherkin32Profile)
 ;

--- a/tests/Fixtures/PrettyFormat/features/WorldMultilineBackgroundScenario.feature
+++ b/tests/Fixtures/PrettyFormat/features/WorldMultilineBackgroundScenario.feature
@@ -19,7 +19,7 @@ Feature: World consistency
 
 Scenario Outline: Passed & Failed
 steps and other interesting stuff
-  he-he-he
+he-he-he
 
     Given I must have 10
     When I add <value>

--- a/tests/Fixtures/PrettyFormat/features/gherkin-parity.feature
+++ b/tests/Fixtures/PrettyFormat/features/gherkin-parity.feature
@@ -1,8 +1,8 @@
 @gherkin-parity
 Feature: Parity with basic feature file
   In order to see that the pretty formatter can handle different gherkin modes
-  As a developer
-  I need to see an example with basic Gherkin syntax
+    As a developer
+I need to see an example with basic Gherkin syntax
 
   Background:
     Given I have entered 25

--- a/tests/Fixtures/PrettyFormat/features/gherkin-parity.feature
+++ b/tests/Fixtures/PrettyFormat/features/gherkin-parity.feature
@@ -1,0 +1,22 @@
+@gherkin-parity
+Feature: Parity with basic feature file
+  In order to see that the pretty formatter can handle different gherkin modes
+  As a developer
+  I need to see an example with basic Gherkin syntax
+
+  Background:
+    Given I have entered 25
+
+
+  Scenario: Simple passing scenario
+    When  I add 2
+    Then  I must have 27
+
+  Scenario: Simple failing scenario
+    When  I add 3
+    Then  I must have 30
+
+  @wip @new
+  Scenario: With unknown step
+    When  I subtract 15
+    Then  I must have 10

--- a/tests/Fixtures/PrettyFormat/features/gherkin-parity.feature
+++ b/tests/Fixtures/PrettyFormat/features/gherkin-parity.feature
@@ -4,11 +4,16 @@ Feature: Parity with basic feature file
     As a developer
 I need to see an example with basic Gherkin syntax
 
-  Background:
+  Background: That sets up the calculator
+      to have a starting number
+     for every scenario
+
     Given I have entered 25
 
 
   Scenario: Simple passing scenario
+      describing what happens when
+       numbers are correctly added.
     When  I add 2
     Then  I must have 27
 

--- a/tests/Fixtures/PrettyFormat/features/gherkin-parity.feature
+++ b/tests/Fixtures/PrettyFormat/features/gherkin-parity.feature
@@ -25,3 +25,23 @@ I need to see an example with basic Gherkin syntax
   Scenario: With unknown step
     When  I subtract 15
     Then  I must have 10
+
+  @with-examples
+  Scenario Outline: Cases that dynamically check the calculator
+      using inputs from the sets of tables
+
+      When I add <input>
+      Then   I must have <expect>
+
+      @simple
+      Examples: First set
+        with a description
+        | input | expect |
+        | 3     | 28     |
+        | 4     | 29     |
+
+      @big
+      Examples: Some more examples
+         that cover bigger numbers
+         | input | expect |
+         | 180   | 205    |


### PR DESCRIPTION
Ensures our pretty formatter can properly / consistently render features that were parsed in the newer `GHERKIN_32` compatibility mode.

Two changes in parser behaviour are particularly relevant.

#### Separate `title` and `description` properties

Anything that can take a description (scenarios, outlines, examples tables etc) is parsed with a one-line `title` and possibly a multi-line `description` as separate properties. 

In `LEGACY` parser mode, the entire text appears in `title` (which may or may not contain linebreaks).

#### Whitespace / indentation not trimmed inside the `description`

Only the start and end of the `description` are trimmed - `LEGACY` mode also attempted to left-trim each line to match the indentation of the keyword.

With a feature file like:

```
    Scenario: Do something
      Because I would like
      to prove that it works.
```

* `GHERKIN_32` mode gives `{"title": "Do something", "description": "Because I would like\n    to prove that it works"}`.
* `LEGACY` mode gives `{"title": "Do something\n  Because I would like\n  to prove that it works"}`.

---

Currently, the pretty formatter **does not** guarantee to render lines with the same indentation as the feature file. Instead it attempts to render with a "normalised" indentation style.  This is because `behat/gherkin` nodes do not contain any information about their original indentation.

In theory the indentation for different types of line can be configured by constructor arguments to e.g. `PrettyFeaturePrinter` and `PrettyScenarioPrinter` - however we don't expose these in our service container configuration.

In practice, the current output of the pretty formatter sometimes matches some feature files - but there are a lot of edge cases and variations if the feature file is indented in unusual ways.

We do not generally expect end-users to be relying on the exact output of the pretty formatter - it should be safe to assume that most build tooling would use one of the machine-readable formats.

However, our own feature suite extensively asserts the output of the pretty formatter (either because we're asserting what the formatter does, or because it is the most readable way to show expected behaviour).

Therefore:
* It seems more important that the output of the pretty formatter for "normally formatted" feature files is consistent regardless of which `GherkinCompatibilityMode` is configured. This avoids us having to modify feature files where the specified behaviour hasn't actually changed.
* Ideally the output of the pretty formatter for "normally formatted" feature files will match previous Behat versions.
* It seems acceptable to slightly change whitespace in pretty output for "unusually formatted" feature files - both between parser modes and/or between Behat versions.

This PR modifies the formatter on that basis, and also normalises the formatting of a couple of our feature files where the indentation isn't relevant to the behaviour that's being specified.

Fixes #1646 