### PR TITLE
test: Prove JUnit scenario description handling in gherkin compat modes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=8.2 <8.6",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.2",
-        "behat/gherkin": "^4.15.0",
+        "behat/gherkin": "^4.16.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=8.2 <8.6",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.2",
-        "behat/gherkin": "^4.16.0",
+        "behat/gherkin": "^4.16.1",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -76,10 +76,11 @@ Feature: JUnit Formatter
       """
     And the file "logs/multiple_features.xml" should be a valid document according to "junit.xsd"
 
-  Scenario: Confirm multiline scenario titles are printed correctly
+  Scenario: Confirm multiline scenario titles are printed correctly in legacy gherkin mode
     When I run behat with the following additional options:
-      | option  | value            |
-      | --suite | multiline_titles |
+      | option    | value                  |
+      | --suite   | multiline_titles       |
+      | --profile | legacy-gherkin-parsing |
     Then it should pass with no output
     And the "logs/multiline_titles.xml" file xml should be like:
       """
@@ -88,6 +89,25 @@ Feature: JUnit Formatter
         <testsuite name="Use multiline titles" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
           <testcase name="Adding some interesting value" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature" line="13"/>
           <testcase name="Adding another value" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature" line="20"/>
+        </testsuite>
+      </testsuites>
+      """
+    And the file "logs/multiline_titles.xml" should be a valid document according to "junit.xsd"
+
+  Scenario: Confirm multiline scenario titles do NOT include the description in gherkin-32 parsing mode
+    # Our test examples are slightly contrived compared to a likely title / description in an actual feature
+    When I run behat with the following additional options:
+      | option    | value              |
+      | --suite   | multiline_titles   |
+      | --profile | gherkin-32-parsing |
+    Then it should pass with no output
+    And the "logs/multiline_titles.xml" file xml should be like:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="multiline_titles">
+        <testsuite name="Use multiline titles" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature" tests="2" skipped="0" failures="0" errors="0" time="-IGNORE-VALUE-">
+          <testcase name="Adding some interesting" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature" line="13"/>
+          <testcase name="Adding" classname="Use multiline titles" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiline_titles.feature" line="20"/>
         </testsuite>
       </testsuites>
       """

--- a/tests/Fixtures/TestReportFormat/behat.php
+++ b/tests/Fixtures/TestReportFormat/behat.php
@@ -3,6 +3,7 @@
 use Behat\Config\Config;
 use Behat\Config\Profile;
 use Behat\Config\Suite;
+use Behat\Gherkin\GherkinCompatibilityMode;
 
 return (new Config())
     ->withProfile(
@@ -44,4 +45,10 @@ return (new Config())
                 'features/abort_on_php_error.feature'
             )
         )
+    )
+    ->withProfile((new Profile('gherkin-32-parsing'))
+        ->withGherkinOptions((new Behat\Config\GherkinOptions())->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32))
+    )
+    ->withProfile((new Profile('legacy-gherkin-parsing'))
+        ->withGherkinOptions((new Behat\Config\GherkinOptions())->withCompatibilityMode(GherkinCompatibilityMode::LEGACY))
     );


### PR DESCRIPTION
Historically, the `name` attribute in the JUnit file has been the full Scenario "multi-line title" e.g. the name and the description.

In GherkinCompatibilityMode::LEGACY we will keep this behaviour, to avoid any BC break for external systems which may depend on the testcase name being the same over time.

In GherkinCompatibilityMode::GHERKIN_32, the attribute **only** contains the Scenario title e.g. the first line of the scenario. This is what's already happening because the description isn't included in `getTitle` any more.

In most cases, JUnit output is used for summary output on CI systems and for tracking pass/fail trends over time. IMO these will usually benefit from having a short and fairly stable testcase name, so excluding the description here is probably an improvement.

If required we could in future add an option to the JUnit formatter to control whether the description should be included.