### PR TITLE
fix: Only print ` ` between Step keyword & text if correct for language

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=8.2 <8.6",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.2",
-        "behat/gherkin": "^4.16.1",
+        "behat/gherkin": "^4.17.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
@@ -115,7 +115,7 @@ final class StepStatsListener implements EventListener
 
         $result = $event->getTestResult();
         $step = $event->getStep();
-        $text = sprintf('%s %s', $step->getKeyword(), $step->getText());
+        $text = $step->getFullText();
         $exception = $this->getStepException($result);
 
         $path = $this->getStepPath($event, $exception);

--- a/src/Behat/Behat/Output/Node/Printer/Helper/WidthCalculator.php
+++ b/src/Behat/Behat/Output/Node/Printer/Helper/WidthCalculator.php
@@ -90,7 +90,7 @@ final class WidthCalculator
     {
         $indentText = str_repeat(' ', intval($indentation));
 
-        $text = sprintf('%s%s %s', $indentText, $step->getKeyword(), $step->getText());
+        $text = sprintf('%s%s', $indentText, $step->getFullText());
 
         return mb_strlen($text, 'utf8');
     }

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONSetupPrinter.php
@@ -58,7 +58,7 @@ final class JSONSetupPrinter implements SetupPrinter
                 $callee = $call->getCallee();
                 $message = $callee->getName();
                 if ($scope instanceof StepScope) {
-                    $message .= ': ' . $scope->getStep()->getKeyword() . ' ' . $scope->getStep()->getText();
+                    $message .= ': ' . $scope->getStep()->getFullText();
                 }
                 $message .= ': ' . $this->exceptionPresenter->presentException(
                     $hookCallResult->getException(),

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONStepPrinter.php
@@ -36,7 +36,7 @@ final class JSONStepPrinter implements StepPrinter
         $outputPrinter = $formatter->getOutputPrinter();
         assert($outputPrinter instanceof JSONOutputPrinter);
 
-        $message = $step->getKeyword() . ' ' . $step->getText();
+        $message = $step->getFullText();
 
         if ($result instanceof ExceptionResult && $result->hasException()) {
             $message .= ': ' . $this->exceptionPresenter->presentException(

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitSetupPrinter.php
@@ -49,7 +49,7 @@ class JUnitSetupPrinter implements SetupPrinter
                 $callee = $call->getCallee();
                 $message = $callee->getName();
                 if ($scope instanceof StepScope) {
-                    $message .= ': ' . $scope->getStep()->getKeyword() . ' ' . $scope->getStep()->getText();
+                    $message .= ': ' . $scope->getStep()->getFullText();
                 }
                 $message .= ': ' . $this->exceptionPresenter->presentException(
                     $hookCallResult->getException(),

--- a/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JUnit/JUnitStepPrinter.php
@@ -41,7 +41,7 @@ class JUnitStepPrinter implements StepPrinter
         /** @var JUnitOutputPrinter $outputPrinter */
         $outputPrinter = $formatter->getOutputPrinter();
 
-        $message = $step->getKeyword() . ' ' . $step->getText();
+        $message = $step->getFullText();
 
         if ($result instanceof ExceptionResult && $result->hasException()) {
             $message .= ': ' . $this->exceptionPresenter->presentException(

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
@@ -127,7 +127,7 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
         if ($event instanceof AfterStepTested) {
             $title = $this->translator->trans('failed_step_title', [], 'output');
             $step = $event->getStep();
-            $printer->writeln(sprintf('{+%s}%s%s %s %s{-%s}', $style, $this->subIndentText, $title, $step->getKeyword(), $step->getText(), $style));
+            $printer->writeln(sprintf('{+%s}%s%s %s{-%s}', $style, $this->subIndentText, $title, $step->getFullText(), $style));
         }
 
         $text = $this->exceptionPresenter->presentException($result->getException());

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -73,9 +73,11 @@ final class PrettySkippedStepPrinter implements StepPrinter
 
         if ($result instanceof DefinedStepResult && $result->getStepDefinition()) {
             $definition = $result->getStepDefinition();
-            // We only paint the step text, but we render it as part of the full text (e.g. with the keyword prefix)
-            // The step text is always at the end, so use preg_replace to guarantee that we never modify the keyword
-            // even the edge case that it contains the step text (e.g. in languages with logograms).
+            // We render the full text, but should only paint the step text - the keyword should not be modified.
+            // It's theoretically possible (e.g. in languages with logograms) that the keyword contains the step text
+            // so we can't just str_replace.
+            // Instead, use a substring to extract the prefix by excluding the last {length of step text} chars.
+            // We can then prepend that to the painted step text to get the final value.
             $stepText = $this->textPainter->paintText(
                 $step->getText(),
                 $definition,

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -25,6 +25,8 @@ use Behat\Testwork\Output\Printer\OutputPrinter;
 use Behat\Testwork\Tester\Result\IntegerTestResult;
 use Behat\Testwork\Tester\Result\TestResult;
 
+use function strlen;
+
 /**
  * Prints steps as skipped.
  *
@@ -79,7 +81,8 @@ final class PrettySkippedStepPrinter implements StepPrinter
                 $definition,
                 new IntegerTestResult(TestResult::SKIPPED)
             );
-            $fullStepText = preg_replace('/'.preg_quote($step->getText(), '/').'$/', $stepText, $step->getFullText());
+            $prefix = substr($step->getFullText(), 0, -strlen($step->getText()));
+            $fullStepText = $prefix . $stepText;
         } else {
             $fullStepText = $step->getFullText();
         }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettySkippedStepPrinter.php
@@ -57,31 +57,34 @@ final class PrettySkippedStepPrinter implements StepPrinter
 
     public function printStep(Formatter $formatter, Scenario $scenario, StepNode $step, StepResult $result): void
     {
-        $this->printText($formatter->getOutputPrinter(), $step->getKeyword(), $step->getText(), $result);
+        $this->printText($formatter->getOutputPrinter(), $step, $result);
         $this->pathPrinter->printStepPath($formatter, $scenario, $step, $result, mb_strlen($this->indentText, 'utf8'));
         $this->printArguments($formatter, $step->getArguments());
     }
 
     /**
      * Prints step text.
-     *
-     * @param string        $stepType
-     * @param string        $stepText
      */
-    private function printText(OutputPrinter $printer, $stepType, $stepText, StepResult $result): void
+    private function printText(OutputPrinter $printer, StepNode $step, StepResult $result): void
     {
         $style = $this->resultConverter->convertResultCodeToString(TestResult::SKIPPED);
 
         if ($result instanceof DefinedStepResult && $result->getStepDefinition()) {
             $definition = $result->getStepDefinition();
+            // We only paint the step text, but we render it as part of the full text (e.g. with the keyword prefix)
+            // The step text is always at the end, so use preg_replace to guarantee that we never modify the keyword
+            // even the edge case that it contains the step text (e.g. in languages with logograms).
             $stepText = $this->textPainter->paintText(
-                $stepText,
+                $step->getText(),
                 $definition,
                 new IntegerTestResult(TestResult::SKIPPED)
             );
+            $fullStepText = preg_replace('/'.preg_quote($step->getText(), '/').'$/', $stepText, $step->getFullText());
+        } else {
+            $fullStepText = $step->getFullText();
         }
 
-        $printer->write(sprintf('%s{+%s}%s %s{-%s}', $this->indentText, $style, $stepType, $stepText, $style));
+        $printer->write(sprintf('%s{+%s}%s{-%s}', $this->indentText, $style, $fullStepText, $style));
     }
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -29,6 +29,8 @@ use Behat\Testwork\Output\Printer\OutputPrinter;
 use Behat\Testwork\Tester\Result\ExceptionResult;
 use Behat\Testwork\Tester\Result\TestResult;
 
+use function strlen;
+
 /**
  * Prints step.
  *
@@ -92,7 +94,8 @@ final class PrettyStepPrinter implements StepPrinter
             // The step text is always at the end, so use preg_replace to guarantee that we never modify the keyword
             // even the edge case that it contains the step text (e.g. in languages with logograms).
             $stepText = $this->textPainter->paintText($step->getText(), $definition, $result);
-            $fullStepText = preg_replace('/'.preg_quote($step->getText(), '/').'$/', $stepText, $step->getFullText());
+            $prefix = substr($step->getFullText(), 0, -strlen($step->getText()));
+            $fullStepText = $prefix . $stepText;
         } else {
             $fullStepText = $step->getFullText();
         }

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -90,9 +90,11 @@ final class PrettyStepPrinter implements StepPrinter
     {
         if ($result instanceof DefinedStepResult && $result->getStepDefinition()) {
             $definition = $result->getStepDefinition();
-            // We only paint the step text, but we render it as part of the full text (e.g. with the keyword prefix)
-            // The step text is always at the end, so use preg_replace to guarantee that we never modify the keyword
-            // even the edge case that it contains the step text (e.g. in languages with logograms).
+            // We render the full text, but should only paint the step text - the keyword should not be modified.
+            // It's theoretically possible (e.g. in languages with logograms) that the keyword contains the step text
+            // so we can't just str_replace.
+            // Instead, use a substring to extract the prefix by excluding the last {length of step text} chars.
+            // We can then prepend that to the painted step text to get the final value.
             $stepText = $this->textPainter->paintText($step->getText(), $definition, $result);
             $prefix = substr($step->getFullText(), 0, -strlen($step->getText()));
             $fullStepText = $prefix . $stepText;

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -70,7 +70,7 @@ final class PrettyStepPrinter implements StepPrinter
             }
         }
 
-        $this->printText($formatter->getOutputPrinter(), $step->getKeyword(), $step->getText(), $result);
+        $this->printText($formatter->getOutputPrinter(), $step, $result);
         $this->pathPrinter->printStepPath($formatter, $scenario, $step, $result, mb_strlen($this->indentText, 'utf8'));
         $this->printArguments($formatter, $step->getArguments(), $result);
         $showOutput = $formatter->getParameter(ShowOutputOption::OPTION_NAME);
@@ -83,19 +83,22 @@ final class PrettyStepPrinter implements StepPrinter
 
     /**
      * Prints step text.
-     *
-     * @param string        $stepType
-     * @param string        $stepText
      */
-    private function printText(OutputPrinter $printer, $stepType, $stepText, StepResult $result): void
+    private function printText(OutputPrinter $printer, StepNode $step, StepResult $result): void
     {
         if ($result instanceof DefinedStepResult && $result->getStepDefinition()) {
             $definition = $result->getStepDefinition();
-            $stepText = $this->textPainter->paintText($stepText, $definition, $result);
+            // We only paint the step text, but we render it as part of the full text (e.g. with the keyword prefix)
+            // The step text is always at the end, so use preg_replace to guarantee that we never modify the keyword
+            // even the edge case that it contains the step text (e.g. in languages with logograms).
+            $stepText = $this->textPainter->paintText($step->getText(), $definition, $result);
+            $fullStepText = preg_replace('/'.preg_quote($step->getText(), '/').'$/', $stepText, $step->getFullText());
+        } else {
+            $fullStepText = $step->getFullText();
         }
 
         $style = $this->resultConverter->convertResultToString($result);
-        $printer->write(sprintf('%s{+%s}%s %s{-%s}', $this->indentText, $style, $stepType, $stepText, $style));
+        $printer->write(sprintf('%s{+%s}%s{-%s}', $this->indentText, $style, $fullStepText, $style));
     }
 
     /**

--- a/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
+++ b/src/Behat/Behat/Snippet/Printer/ConsoleSnippetPrinter.php
@@ -77,7 +77,7 @@ class ConsoleSnippetPrinter implements SnippetPrinter
         $this->output->writeln('--- ' . $message . PHP_EOL);
 
         foreach ($steps as $step) {
-            $this->output->writeln(sprintf('    <snippet_undefined>%s %s</snippet_undefined>', $step->getKeyword(), $step->getText()));
+            $this->output->writeln(sprintf('    <snippet_undefined>%s</snippet_undefined>', $step->getFullText()));
         }
 
         $this->output->writeln('');


### PR DESCRIPTION
Historically, our formatters always printed a space after the keyword of
a step (e.g. `Given I have 20 apples`). This is correct for the majority
of languages, but not all.

For example:
* Languages like Japanese never have spaces after keywords
* Languages like French may not have a space depending on the keyword
  e.g. `Et qu'` when the step begins with a vowel.

The gherkin parser understood this distinction, but this was not
previously exposed to us.

This commit uses the new `$step->getFullText()` everywhere that we print
the keyword and text, rather than concatenating the separate keyword and
text properties.

This will slightly change the formatter output for steps in languages
with no separating space - but to what it should always have been.

This will be consistent across all Gherkin parsing modes.
