### PR TITLE
fix: JSON formatter should support `GHERKIN_32` mode

### DIFF
--- a/features/json_format.feature
+++ b/features/json_format.feature
@@ -229,11 +229,12 @@ Feature: JSON Formatter
       """
     And the file "multiple_features.json" should be a valid document according to the json schema "schema.json"
 
-  Scenario: Confirm multiline scenario titles are printed correctly
+  Scenario: Confirm multiline scenario titles are printed correctly in legacy parsing mode
     When I run behat with the following additional options:
-      | option  | value                 |
-      | --suite | multiline_titles .    |
-      | --out   | multiline_titles.json |
+      | option    | value                  |
+      | --suite   | multiline_titles .     |
+      | --out     | multiline_titles.json  |
+      | --profile | legacy-gherkin-parsing |
     Then it should pass with no output
     And the "multiline_titles.json" file json should be like:
       """
@@ -273,6 +274,67 @@ Feature: JSON Formatter
                               },
                               {
                                   "name": "Adding another value",
+                                  "time": -IGNORE-VALUE-,
+                                  "status": "passed",
+                                  "file": "features-DIRECTORY-SEPARATOR-multiline_titles.feature",
+                                  "line": 20
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ]
+      }
+      """
+    And the file "multiline_titles.json" should be a valid document according to the json schema "schema.json"
+
+  Scenario: Confirm multiline scenario titles are printed correctly in gherkin-32 parsing mode
+    When I run behat with the following additional options:
+      | option    | value                 |
+      | --suite   | multiline_titles .    |
+      | --out     | multiline_titles.json |
+      | --profile | gherkin-32-parsing    |
+    Then it should pass with no output
+    And the "multiline_titles.json" file json should be like:
+      """
+      {
+          "tests": 2,
+          "skipped": 0,
+          "failed": 0,
+          "pending": 0,
+          "undefined": 0,
+          "time": -IGNORE-VALUE-,
+          "suites": [
+              {
+                  "name": "multiline_titles",
+                  "tests": 2,
+                  "skipped": 0,
+                  "failed": 0,
+                  "pending": 0,
+                  "undefined": 0,
+                  "time": -IGNORE-VALUE-,
+                  "features": [
+                      {
+                          "name": "Use multiline titles",
+                          "file": "features-DIRECTORY-SEPARATOR-multiline_titles.feature",
+                          "tests": 2,
+                          "skipped": 0,
+                          "failed": 0,
+                          "pending": 0,
+                          "undefined": 0,
+                          "time": -IGNORE-VALUE-,
+                          "scenarios": [
+                              {
+                                  "name": "Adding some interesting",
+                                  "description": "value",
+                                  "time": -IGNORE-VALUE-,
+                                  "status": "passed",
+                                  "file": "features-DIRECTORY-SEPARATOR-multiline_titles.feature",
+                                  "line": 13
+                              },
+                              {
+                                  "name": "Adding",
+                                  "description": "another\nvalue",
                                   "time": -IGNORE-VALUE-,
                                   "status": "passed",
                                   "file": "features-DIRECTORY-SEPARATOR-multiline_titles.feature",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -95,6 +95,7 @@
             "required": ["name", "status", "file", "line"],
             "properties": {
                 "name": { "type": "string" },
+                "description": { "type": "string" },
                 "time": { "$ref": "#/$defs/DurationSeconds" },
                 "status": {
                     "type": "string",

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONScenarioPrinter.php
@@ -13,6 +13,7 @@ namespace Behat\Behat\Output\Node\Printer\JSON;
 use Behat\Behat\Output\Node\EventListener\JSON\JSONDurationListener;
 use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
 use Behat\Behat\Output\Node\Printer\ScenarioPrinter;
+use Behat\Gherkin\Node\DescribableNodeInterface;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\NamedScenarioInterface;
 use Behat\Gherkin\Node\ScenarioLikeInterface;
@@ -50,11 +51,14 @@ final class JSONScenarioPrinter implements ScenarioPrinter
     {
         $scenario = $this->currentScenario;
         assert($scenario instanceof NamedScenarioInterface);
-        $name = implode(' ', array_map(fn ($l): string => trim((string) $l), explode("\n", $scenario->getName() ?? '')));
+        ['name' => $name, 'description' => $description] = $this->getNameAndDescription($scenario);
 
         $scenarioAttributes = [
             'name' => $name,
         ];
+        if ($description !== null) {
+            $scenarioAttributes['description'] = $description;
+        }
 
         if ($formatter->getParameter('timer')) {
             $scenarioAttributes['time'] = (float) $this->durationListener->getDuration($scenario);
@@ -74,5 +78,42 @@ final class JSONScenarioPrinter implements ScenarioPrinter
         assert($outputPrinter instanceof JSONOutputPrinter);
 
         $outputPrinter->addCurrentScenarioAttributes($scenarioAttributes, true);
+    }
+
+    /**
+     * @return array{name: ?string, description: ?string}
+     */
+    private function getNameAndDescription(NamedScenarioInterface $scenario): array
+    {
+        if ($scenario instanceof DescribableNodeInterface && $scenario->getDescription()) {
+            // All ScenarioLikeInterface defined by behat/gherkin are also DescribableNodeInterface
+            // but we can't guarantee that's true if the node has come from third-party code.
+            //
+            // If it does match this interface and was parsed in gherkin-32 mode the description
+            // will be in the description property and the title is guaranteed to be a single line.
+            //
+            // Remove any internal padding from the description as this may not always be consistent and is of no real
+            // use to the user.
+            return [
+                'name' => $scenario->getName(),
+                'description' => implode("\n", array_map(trim(...), explode("\n", $scenario->getDescription()))),
+            ];
+        }
+
+        if (!str_contains((string) $scenario->getName(), "\n")) {
+            // It was parsed in gherkin-32 mode with no description, or in legacy mode with a single-line name/title
+            // Either way the output is just the name.
+            return [
+                'name' => $scenario->getName(),
+                'description' => null,
+            ];
+        }
+
+        // It was parsed in legacy mode and has a multi-line name/title. For consistency with previous Behat versions,
+        // we trim and join all the lines together to produce a one-line "name".
+        return [
+            'name' => implode(' ', array_map(trim(...), explode("\n", $scenario->getName() ?? ''))),
+            'description' => null,
+        ];
     }
 }

--- a/src/Behat/Behat/Output/Node/Printer/JSON/JSONScenarioPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/JSON/JSONScenarioPrinter.php
@@ -85,6 +85,8 @@ final class JSONScenarioPrinter implements ScenarioPrinter
      */
     private function getNameAndDescription(NamedScenarioInterface $scenario): array
     {
+        $scenarioName = $scenario->getName() ?? '';
+
         if ($scenario instanceof DescribableNodeInterface && $scenario->getDescription()) {
             // All ScenarioLikeInterface defined by behat/gherkin are also DescribableNodeInterface
             // but we can't guarantee that's true if the node has come from third-party code.
@@ -95,16 +97,16 @@ final class JSONScenarioPrinter implements ScenarioPrinter
             // Remove any internal padding from the description as this may not always be consistent and is of no real
             // use to the user.
             return [
-                'name' => $scenario->getName(),
+                'name' => $scenarioName,
                 'description' => implode("\n", array_map(trim(...), explode("\n", $scenario->getDescription()))),
             ];
         }
 
-        if (!str_contains((string) $scenario->getName(), "\n")) {
+        if (!str_contains($scenarioName, "\n")) {
             // It was parsed in gherkin-32 mode with no description, or in legacy mode with a single-line name/title
             // Either way the output is just the name.
             return [
-                'name' => $scenario->getName(),
+                'name' => $scenarioName,
                 'description' => null,
             ];
         }
@@ -112,7 +114,7 @@ final class JSONScenarioPrinter implements ScenarioPrinter
         // It was parsed in legacy mode and has a multi-line name/title. For consistency with previous Behat versions,
         // we trim and join all the lines together to produce a one-line "name".
         return [
-            'name' => implode(' ', array_map(trim(...), explode("\n", $scenario->getName() ?? ''))),
+            'name' => implode(' ', array_map(trim(...), explode("\n", $scenarioName))),
             'description' => null,
         ];
     }


### PR DESCRIPTION
As with other formatters, the main difference is in the way scenario names and descriptions are parsed.

Unlike the junit formatter, there may be a broader range of usecases for the JSON output (and we control our own schema). Therefore it makes sense to publish the `description` when we have one, and to keep it in a separate property rather than merging into the name. That gives end-users the most flexibility to decide how to present / use it.

I have made `description` an optional property in the schema:

* In LEGACY parsing mode, the JSON output is identical to previous Behat versions ("multiline title" merged together into a one-line "name").
* In GHERKIN_32 parsing mode, "name" is the title / first line as expected, and ""description" will only be present if it has content.

When rendering a GHERKIN_32 description, I think it will be more consistent / useful if we remove any indentation on the second & subsequent lines. That makes it easy for the user to add consistent indentation to their output if required to suit their usecase.

Fixes #1844