### PR TITLE
test: Run features in `gherkin-32` and `legacy` compatibility modes

### DIFF
--- a/behat.dist.php
+++ b/behat.dist.php
@@ -1,17 +1,41 @@
 <?php
 
 use Behat\Config\Config;
+use Behat\Config\Filter\TagFilter;
 use Behat\Config\GherkinOptions;
 use Behat\Config\Profile;
+use Behat\Config\Suite;
 use Behat\Config\TesterOptions;
 use Behat\Gherkin\GherkinCompatibilityMode;
 
+/*
+ * Scenarios that specify a gherkin mode in their own config (or specify that they should use Behat's
+ * own default) should be tagged '@gherkin-mode:has-explicit'. They will only run in this suite.
+ */
+$explicitGherkinSuite = (new Suite('explicit-gherkin-mode'))
+    ->addContext(FeatureContext::class, ['gherkinCompatibilityMode' => null])
+    ->withFilter(new TagFilter('@gherkin-mode:has-explicit'));
+
+/*
+ * Scenarios that do not have the `@gherkin-mode:has-explict` tag will run twice - once with the default forced to
+ * `gherkin-32`, and once with the default forced to `legacy`. This ensures that Behat's behaviour is the same in both
+ * parsing modes (unless we specify otherwise).
+ */
+$createGherkinModeSuite = fn (string $name, GherkinCompatibilityMode $mode): Suite => (new Suite($name))
+    ->addContext(FeatureContext::class, ['gherkinCompatibilityMode' => $mode])
+    ->withFilter(new TagFilter('~@gherkin-mode:has-explicit'));
+
 return (new Config())
-    ->withProfile((new Profile('default'))
+    ->withProfile(
+        (new Profile('default'))
+            ->withSuite($explicitGherkinSuite)
+            ->withSuite($createGherkinModeSuite('gherkin-32', GherkinCompatibilityMode::GHERKIN_32))
+            ->withSuite($createGherkinModeSuite('gherkin-legacy', GherkinCompatibilityMode::LEGACY))
             ->withGherkinOptions((new GherkinOptions())
-                    ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32),
+                // Our outer runner will always be in gherkin-32 mode, regardless of the mode it runs Behat in
+                ->withCompatibilityMode(GherkinCompatibilityMode::GHERKIN_32),
             )
-        ->withTesterOptions((new TesterOptions())
-            ->withFailOnBehatDeprecations()
-        )
+            ->withTesterOptions((new TesterOptions())
+                ->withFailOnBehatDeprecations(),
+            ),
     );

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -48,9 +48,8 @@ class FeatureContext implements Context
 
     private ?int $errorLevel = null;
 
-    private ?GherkinCompatibilityMode $gherkinCompatibilityMode = GherkinCompatibilityMode::GHERKIN_32;
-
     public function __construct(
+        private ?GherkinCompatibilityMode $gherkinCompatibilityMode,
         private readonly Filesystem $filesystem = new Filesystem(),
     ) {
     }
@@ -298,7 +297,7 @@ EOL;
      */
     private function applyDefaultGherkinCompatibilityMode(array $env): array
     {
-        if ($this->gherkinCompatibilityMode === null) {
+        if (!$this->gherkinCompatibilityMode instanceof GherkinCompatibilityMode) {
             // Don't override for this execution, the scenario has explicitly cleared the default
             return $env;
         }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -10,6 +10,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Output\Printer\Formatter\ConsoleFormatter;
 use Behat\Behat\Util\StrictRegex;
+use Behat\Gherkin\GherkinCompatibilityMode;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Hook\AfterSuite;
@@ -46,6 +47,8 @@ class FeatureContext implements Context
     private ?string $answerString = null;
 
     private ?int $errorLevel = null;
+
+    private ?GherkinCompatibilityMode $gherkinCompatibilityMode = GherkinCompatibilityMode::GHERKIN_32;
 
     public function __construct(
         private readonly Filesystem $filesystem = new Filesystem(),
@@ -263,7 +266,7 @@ EOL;
 
         // Prepare the process parameters.
         $this->process->setTimeout(20);
-        $this->process->setEnv($this->env);
+        $this->process->setEnv($this->applyDefaultGherkinCompatibilityMode($this->env));
         $this->process->setWorkingDirectory($this->workingDir);
 
         if ($this->answerString !== null) {
@@ -278,6 +281,47 @@ EOL;
         }
 
         $this->process->run();
+    }
+
+    /**
+     * Applies a default gherkin compatibility mode for the current execution.
+     *
+     * I am applying this as an environment variable as the easiest way to ensure it applies in all our scenarios
+     * regardless of the values we specify for CLI flags etc.
+     *
+     * When Behat loads config, environment variables are read *before* any other config. Therefore if a scenario is
+     * configuring an explicit gherkin mode (e.g. in a behat.php profile) that will take precedence.
+     *
+     * @param array<string,string> $env
+     *
+     * @return array<string,string>
+     */
+    private function applyDefaultGherkinCompatibilityMode(array $env): array
+    {
+        if ($this->gherkinCompatibilityMode === null) {
+            // Don't override for this execution, the scenario has explicitly cleared the default
+            return $env;
+        }
+
+        // Merge the default gherkin compatibility into the env vars
+        $behatParams = json_decode($env['BEHAT_PARAMS'] ?? '{}', true);
+        if (isset($behatParams['gherkin']['compatibility'])) {
+            // The scenario has explicitly customised this in the $env already, don't override it
+            return $env;
+        }
+
+        $behatParams['gherkin']['compatibility'] = $this->gherkinCompatibilityMode->value;
+
+        return [
+            ...$env,
+            'BEHAT_PARAMS' => json_encode($behatParams),
+        ];
+    }
+
+    #[Given('the test runner does not configure a default gherkin compatibility mode')]
+    public function clearDefaultGherkinCompatibilityMode(): void
+    {
+        $this->gherkinCompatibilityMode = null;
     }
 
     /**

--- a/features/gherkin_compatibility_mode.feature
+++ b/features/gherkin_compatibility_mode.feature
@@ -10,6 +10,7 @@ Feature: Gherkin compatibility mode
       | --no-colors |          |
       | --format    | progress |
 
+  @gherkin-mode:has-explicit
   Scenario: Legacy parsing by default (ignores invalid language)
     Given the test runner does not configure a default gherkin compatibility mode
     When I run behat with the following additional options:
@@ -23,6 +24,7 @@ Feature: Gherkin compatibility mode
       3 steps (3 undefined)
       """
 
+  @gherkin-mode:has-explicit
   Scenario: Opt in to cucumber-compatible parsing
     When I run behat with the following additional options:
       | option    | value      |

--- a/features/gherkin_compatibility_mode.feature
+++ b/features/gherkin_compatibility_mode.feature
@@ -11,6 +11,7 @@ Feature: Gherkin compatibility mode
       | --format    | progress |
 
   Scenario: Legacy parsing by default (ignores invalid language)
+    Given the test runner does not configure a default gherkin compatibility mode
     When I run behat with the following additional options:
       | option    | value   |
       | --profile | default |

--- a/features/json_format.feature
+++ b/features/json_format.feature
@@ -229,6 +229,7 @@ Feature: JSON Formatter
       """
     And the file "multiple_features.json" should be a valid document according to the json schema "schema.json"
 
+  @gherkin-mode:has-explicit
   Scenario: Confirm multiline scenario titles are printed correctly in legacy parsing mode
     When I run behat with the following additional options:
       | option    | value                  |
@@ -288,6 +289,7 @@ Feature: JSON Formatter
       """
     And the file "multiline_titles.json" should be a valid document according to the json schema "schema.json"
 
+  @gherkin-mode:has-explicit
   Scenario: Confirm multiline scenario titles are printed correctly in gherkin-32 parsing mode
     When I run behat with the following additional options:
       | option    | value                 |

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -76,6 +76,7 @@ Feature: JUnit Formatter
       """
     And the file "logs/multiple_features.xml" should be a valid document according to "junit.xsd"
 
+  @gherkin-mode:has-explicit
   Scenario: Confirm multiline scenario titles are printed correctly in legacy gherkin mode
     When I run behat with the following additional options:
       | option    | value                  |
@@ -94,6 +95,7 @@ Feature: JUnit Formatter
       """
     And the file "logs/multiline_titles.xml" should be a valid document according to "junit.xsd"
 
+  @gherkin-mode:has-explicit
   Scenario: Confirm multiline scenario titles do NOT include the description in gherkin-32 parsing mode
     # Our test examples are slightly contrived compared to a likely title / description in an actual feature
     When I run behat with the following additional options:

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -239,10 +239,11 @@ Feature: Pretty Formatter
       8 steps (6 passed, 2 failed)
       """
 
+  @gherkin-mode:has-explicit
   Scenario Outline: Consistent output between Gherkin parser compatibility modes
       When I run behat with the following additional options:
-        | option       | value |
-        | --profile       | gherkin-parity-<compatibility_mode> |
+        | option        | value                               |
+        | --profile     | gherkin-parity-<compatibility_mode> |
         | --no-snippets |                                     |
 
       Then it should fail with:


### PR DESCRIPTION
Prove that our gherkin-32 mode is now compatible with legacy mode by running all scenarios in both `gherkin-32` **and** `legacy` mode unless they specify otherwise.

The most reliable way I could find to do this without interfering with the CLI options or environment variables set by other steps is to merge the default into the environment variables immediately before we run Behat.

If any scenarios are specifying the mode in their config file, that will automatically take precedence over the environment variable.

We now run the features in three suites:
* `explicit-gherkin-mode` runs only those scenarios tagged `@gherkin-mode:has-explicit`, they only run once and we do not force a default gherkin mode.
* `gherkin-legacy` and `gherkin-32` run all other scenarios, forcing the default gherkin mode accordingly. These scenarios therefore run twice and are expected to behave the same in both cases.