### PR TITLE
fix: Handle empty argument lists when converting Context config to PHP

### DIFF
--- a/src/Behat/Config/Suite.php
+++ b/src/Behat/Config/Suite.php
@@ -114,6 +114,8 @@ final class Suite implements ConfigConverterInterface
         unset($this->settings[self::CONTEXTS_SETTING]);
 
         // Contexts can be configured with or without constructor arguments.
+        // Contexts with no arguments can be represented in different ways, so first normalise them.
+        $contexts = array_map($this->normaliseContextWithNoArgs(...), $contexts);
         $hasAnyWithArguments = (bool) array_filter($contexts, is_array(...));
 
         if (!$hasAnyWithArguments) {
@@ -137,6 +139,27 @@ final class Suite implements ConfigConverterInterface
             }
             $expr = ConfigConverterTools::addMethodCall(self::class, self::ADD_CONTEXT_FUNCTION, $args, $expr);
         }
+    }
+
+    /**
+     * Normalise configuring a context with no constructor arguments as a simple string.
+     *
+     * A context with no constructor arguments will usually be in the YAML as a simple string e.g. `- MyContext`.
+     *
+     * However, the YAML would also be valid with an empty list, or even just a trailing `:` (e.g. `- MyContext:`).
+     * Those will have been parsed as `['MyContext' => null]` or `['MyContext' => []]` depending on the YAML. We can
+     * normalise those to the `MyContext` string before converting to PHP config.
+     */
+    private function normaliseContextWithNoArgs(mixed $context): mixed
+    {
+        if (is_array($context) && count($context) === 1) {
+            $contextClass = array_key_first($context);
+            if (empty($context[$contextClass])) {
+                return $contextClass;
+            }
+        }
+
+        return $context;
     }
 
     private function addPathsToExpr(Expr &$expr): void

--- a/tests/Fixtures/ConvertConfig/suite_contexts.yaml
+++ b/tests/Fixtures/ConvertConfig/suite_contexts.yaml
@@ -3,4 +3,4 @@ default:
         my_suite:
             contexts:
                 - MyContext
-                - AnotherContext
+                - AnotherContext:

--- a/tests/Fixtures/ConvertConfig/suite_contexts_with_args.yaml
+++ b/tests/Fixtures/ConvertConfig/suite_contexts_with_args.yaml
@@ -9,4 +9,4 @@ default:
                 - AContextWithNamedArgs:
                       param1: Something
                       param2: Else
-                - AnotherContext
+                - AnotherContext: []


### PR DESCRIPTION
There are (valid) edge cases in YAML config where a Context definition can be parsed as an array even though it has no arguments. For example, if the Context class name has a trailing `:` e.g.

```yaml
# suite etc config
   contexts:
     - MyContext:
```

The config conversion was incorrectly treating these as having arguments, and assuming the structure would always be `[$contextClass => [$arg1,...]]`.

In this case we actually get `[$contextClass => null]` meaning the converter generates a statement like `->addContext('MyContext', null)` which causes a `TypeError` because that method does not accept `null`.

Fix this by normalising contexts with no arguments back to a simple string before the rest of the processing.

Fixes an issue reported by @phil-davis in the comments of #1846 

Fixes #1851