### PR TITLE
fix: Unexpected uses / creation of `RuntimeCallee` callables

### DIFF
--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -38,7 +38,7 @@ abstract class RuntimeFeatureHook extends RuntimeFilterableHook
     {
         parent::__construct($scopeName, $filterString, $callable, $description);
 
-        $this->throwIfInstanceMethod($callable, 'Feature');
+        $this->throwIfCallableIsInstanceMethod('Feature');
     }
 
     public function filterMatches(HookScope $scope)

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -41,6 +41,9 @@ class RuntimeCallee implements Callee
         private readonly ?string $description = null,
     ) {
         if (is_array($callable)) {
+            if (!$this->isCallableOrBehatContextCallable($callable)) {
+                DeprecationCollector::trigger('Creating '.static::class.' with a non-callable array other than a Behat context method reference is deprecated');
+            }
             $this->reflection = new ReflectionMethod($callable[0], $callable[1]);
             $this->path = $callable[0] . '::' . $callable[1] . '()';
         } else {
@@ -49,6 +52,18 @@ class RuntimeCallee implements Callee
         }
 
         $this->callable = $callable;
+    }
+
+    private function isCallableOrBehatContextCallable(array $callable): bool
+    {
+        if (is_callable($callable)) {
+            return true;
+        }
+
+        return count($callable) === 2
+            && is_string($callable[0])
+            && is_string($callable[1])
+            && is_a($callable[0], Context::class, true);
     }
 
     /**

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -12,6 +12,7 @@ namespace Behat\Testwork\Call;
 
 use Behat\Behat\Context\Context;
 use Behat\Testwork\Call\Exception\BadCallbackException;
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use ReflectionFunction;
 use ReflectionFunctionAbstract;
 use ReflectionMethod;
@@ -113,25 +114,29 @@ class RuntimeCallee implements Callee
 
     /**
      * @param callable|array{class-string, string} $callable
+     *
+     * @deprecated see throwIfCallableIsInstanceMethod()
      */
     protected function throwIfInstanceMethod(callable|array $callable, string $hookType): void
     {
-        if ($this->isAnInstanceMethod()) {
-            if (is_array($callable)) {
-                $className = $callable[0];
-                $methodName = $callable[1];
-            } else {
-                $reflection = new ReflectionMethod($callable);
-                $className = $reflection->getDeclaringClass()->getShortName();
-                $methodName = $reflection->getName();
-            }
+        DeprecationCollector::trigger('throwIfInstanceMethod() is deprecated and will be removed in 4.0 - use throwIfCallableIsInstanceMethod');
+        if ($callable !== $this->callable) {
+            // They have passed a different callable to the one we were initialised with.
+            // Wrap it in a new RuntimeCallee so that we can check it.
+            (new RuntimeCallee($callable))->throwIfCallableIsInstanceMethod($hookType);
+        } else {
+            $this->throwIfCallableIsInstanceMethod($hookType);
+        }
+    }
 
+    final protected function throwIfCallableIsInstanceMethod(string $hookType): void
+    {
+        if ($this->isAnInstanceMethod()) {
             throw new BadCallbackException(sprintf(
-                '%s hook callback: %s::%s() must be a static method',
+                '%s hook callback: %s must be a static method',
                 $hookType,
-                $className,
-                $methodName
-            ), $callable);
+                $this->getPath(),
+            ), $this->getCallable());
         }
     }
 }

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -35,7 +35,7 @@ abstract class RuntimeSuiteHook extends RuntimeFilterableHook
     {
         parent::__construct($scopeName, $filterString, $callable, $description);
 
-        $this->throwIfInstanceMethod($callable, 'Suite');
+        $this->throwIfCallableIsInstanceMethod('Suite');
     }
 
     public function filterMatches(HookScope $scope)


### PR DESCRIPTION
RuntimeCallee::throwIfInstanceMethod is used by our Feature and Suite hook classes to check that the hook is a static method.

It accepts a `callable` argument, but did not actually check the type of that callable. Instead, it checks the type of the `$this->callable` (through `$this->reflection`). The callable passed into the method is only used for rendering the exception. So in theory the method could false-positive and/or fail with an exception message that refers to the wrong callable.

I have fixed this, but also deprecated that usage - I don't think there's any need to support arbitrary callables in this method, and it is unlikely end-users are calling it or extending it.

Also deprecates creating a `RuntimeCallee` with a non-callable array that is not a Behat `Context` class method reference. 
The codebase assumes that a non-callable array will be an array of `[$contextClass, $contextMethod]`, which will later be resolved by `InitializedContextEnvironment`. However, this is never checked.

In practice, creating with other types of array would likely cause a runtime error somewhere in the chain, but we should deprecate it closer to source ahead of tightening the type-safety in 4.0.

Works towards #1519