### PR TITLE
[4.0] fix: Explicit Context callable types and SimpleArgumentTransformation constructor

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -261,5 +261,8 @@
 
         <!-- Formalised Context class method callback references -->
         <ignored-regex>#CHANGED: The parameter \$callable of .+ changed from callable|array to callable#</ignored-regex>
+
+        <!-- Required consistent constructor for SimpleArgumentTransformation -->
+        <ignored-regex>#ADDED: Method __construct\(\) was added to interface Behat\\Behat\\Transformation\\SimpleArgumentTransformation#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -255,5 +255,8 @@
         <ignored-regex>#REMOVED: These ancestors of .+ have been removed: \["Behat\\\\Behat\\\\EventDispatcher\\\\Event\\\\ScenarioLikeTested"\]#</ignored-regex>
         <ignored-regex>#REMOVED: Class Behat\\Behat\\EventDispatcher\\Event\\ScenarioLikeTested has been deleted#</ignored-regex>
         <ignored-regex>#REMOVED: Method Behat\\Behat\\EventDispatcher\\Event\\(Before|After)Background.+?\#getScenario\(\) was removed#</ignored-regex>
+
+        <!-- Deprecated RuntimeCallee::throwIfInstanceMethod() removed in favour of RuntimeCallee::throwIfCallableIsInstanceMethod() -->
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\Call\\RuntimeCallee\#throwIfInstanceMethod\(\) was removed#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -258,5 +258,8 @@
 
         <!-- Deprecated RuntimeCallee::throwIfInstanceMethod() removed in favour of RuntimeCallee::throwIfCallableIsInstanceMethod() -->
         <ignored-regex>#REMOVED: Method Behat\\Testwork\\Call\\RuntimeCallee\#throwIfInstanceMethod\(\) was removed#</ignored-regex>
+
+        <!-- Formalised Context class method callback references -->
+        <ignored-regex>#CHANGED: The parameter \$callable of .+ changed from callable|array to callable#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -8,8 +8,4 @@ parameters:
             paths:
                 - src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
         -
-            identifier: constructor.unusedParameter
-            paths:
-                - src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
-        -
             identifier: missingType.iterableValue

--- a/src/Behat/Behat/Context/ContextMethodCallableFactory.php
+++ b/src/Behat/Behat/Context/ContextMethodCallableFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Behat\Behat\Context;
+
+use ReflectionMethod;
+
+final class ContextMethodCallableFactory
+{
+    /**
+     * @param class-string<Context> $contextClass
+     */
+    public static function makeCallable(string $contextClass, ReflectionMethod $method): callable
+    {
+        if ($method->isStatic()) {
+            return [$contextClass, $method->getName()];
+        }
+
+        // NB that we create the instance with an explicit $contextClass and $methodName string, rather than passing
+        // in the ReflectionMethod. This is because the method might be declared in a parent class, but we need to
+        // reference it by the contextClass that will actually be instantiated / registered in the Behat process.
+        return new LateBoundContextMethodCallable($contextClass, $method->getName());
+    }
+}

--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -13,11 +13,11 @@ namespace Behat\Behat\Context\Environment;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler;
 use Behat\Behat\Context\Exception\ContextNotFoundException;
+use Behat\Behat\Context\LateBoundContextMethodCallable;
 use Behat\Behat\HelperContainer\Environment\ServiceContainerEnvironment;
 use Behat\Testwork\Call\Callee;
 use Behat\Testwork\Suite\Suite;
 use Psr\Container\ContainerInterface;
-use UnexpectedValueException;
 
 /**
  * Context environment based on a list of instantiated context objects.
@@ -120,18 +120,8 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
     {
         $callable = $callee->getCallable();
 
-        if ($callee->isAnInstanceMethod() && is_array($callable) && count($callable) === 2 && is_string($callable[0])) {
-            $contextClass = $callable[0];
-            if (!is_a($contextClass, Context::class, true)) {
-                throw new UnexpectedValueException(
-                    sprintf(
-                        'Expected a native callable or a reference to a `Context` method (got reference to `%s`).',
-                        $contextClass
-                    )
-                );
-            }
-
-            return [$this->getContext($contextClass), $callable[1]];
+        if ($callable instanceof LateBoundContextMethodCallable) {
+            return $callable->bindTo($this->getContext($callable->contextClass));
         }
 
         return $callable;

--- a/src/Behat/Behat/Context/LateBoundContextMethodCallable.php
+++ b/src/Behat/Behat/Context/LateBoundContextMethodCallable.php
@@ -21,7 +21,6 @@ final class LateBoundContextMethodCallable implements LateBoundInstanceCallable
 {
     private readonly ReflectionMethod $reflection;
     private readonly string $path;
-    private Context $contextInstance;
 
     /**
      * @param class-string<Context> $contextClass
@@ -47,7 +46,7 @@ final class LateBoundContextMethodCallable implements LateBoundInstanceCallable
     /**
      * Returns a new instance bound to a specific Context class.
      */
-    public function bindTo(Context $context): LateBoundContextMethodCallable
+    public function bindTo(Context $context): callable
     {
         if (!$context instanceof $this->contextClass) {
             throw new InvalidArgumentException(sprintf(
@@ -56,20 +55,13 @@ final class LateBoundContextMethodCallable implements LateBoundInstanceCallable
             ));
         }
 
-        $i = new LateBoundContextMethodCallable($this->contextClass, $this->methodName);
-        $i->contextInstance = $context;
-
-        return $i;
+        return $this->reflection->getClosure($context);
     }
 
     public function __invoke(mixed ...$args): mixed
     {
-        if (!isset($this->contextInstance)) {
-            throw new LogicException(
-                sprintf('Cannot directly invoke %s - it has not been bound to a Context', $this->path)
-            );
-        }
-
-        return $this->reflection->invokeArgs($this->contextInstance, $args);
+        throw new LogicException(
+            sprintf('Cannot directly invoke %s - it has not been bound to a Context', $this->path)
+        );
     }
 }

--- a/src/Behat/Behat/Context/LateBoundContextMethodCallable.php
+++ b/src/Behat/Behat/Context/LateBoundContextMethodCallable.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Behat\Behat\Context;
+
+use Behat\Testwork\Call\LateBoundInstanceCallable;
+use InvalidArgumentException;
+use LogicException;
+use ReflectionMethod;
+
+/**
+ * Represents a `Context` method that will be called on the current instance of that Context.
+ *
+ * These are collected when analysing contexts for Step / Hook / Transformation definitions,
+ * when we do not yet have instances of the Context classes (because those are created fresh
+ * for each Scenario).
+ *
+ * The `InitializedContextEnvironment` will then bind this to the current Context instance
+ * before it is called.
+ */
+final class LateBoundContextMethodCallable implements LateBoundInstanceCallable
+{
+    private readonly ReflectionMethod $reflection;
+    private readonly string $path;
+    private Context $contextInstance;
+
+    /**
+     * @param class-string<Context> $contextClass
+     */
+    public function __construct(
+        public readonly string $contextClass,
+        public readonly string $methodName,
+    ) {
+        $this->reflection = new ReflectionMethod($this->contextClass, $this->methodName);
+        $this->path = $this->contextClass.'::'.$this->methodName.'()';
+    }
+
+    public function getReflection(): ReflectionMethod
+    {
+        return $this->reflection;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Returns a new instance bound to a specific Context class.
+     */
+    public function bindTo(Context $context): LateBoundContextMethodCallable
+    {
+        if (!$context instanceof $this->contextClass) {
+            throw new InvalidArgumentException(sprintf(
+                'Cannot bind %s to an instance of %s',
+                $this->path, $context::class
+            ));
+        }
+
+        $i = new LateBoundContextMethodCallable($this->contextClass, $this->methodName);
+        $i->contextInstance = $context;
+
+        return $i;
+    }
+
+    public function __invoke(mixed ...$args): mixed
+    {
+        if (!isset($this->contextInstance)) {
+            throw new LogicException(
+                sprintf('Cannot directly invoke %s - it has not been bound to a Context', $this->path)
+            );
+        }
+
+        return $this->reflection->invokeArgs($this->contextInstance, $args);
+    }
+}

--- a/src/Behat/Behat/Definition/Call/Given.php
+++ b/src/Behat/Behat/Definition/Call/Given.php
@@ -10,14 +10,10 @@
 
 namespace Behat\Behat\Definition\Call;
 
-use Behat\Testwork\Call\RuntimeCallee;
-
 /**
  * Given steps definition.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class Given extends RuntimeDefinition
 {
@@ -25,10 +21,8 @@ final class Given extends RuntimeDefinition
 
     /**
      * Initializes definition.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(string $pattern, callable|array $callable, ?string $description = null)
+    public function __construct(string $pattern, callable $callable, ?string $description = null)
     {
         parent::__construct(self::KEYWORD, $pattern, $callable, $description);
     }

--- a/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
+++ b/src/Behat/Behat/Definition/Call/RuntimeDefinition.php
@@ -18,8 +18,6 @@ use Stringable;
  * Represents a step definition created and executed in the runtime.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 abstract class RuntimeDefinition extends RuntimeCallee implements Stringable, Definition
 {
@@ -27,13 +25,11 @@ abstract class RuntimeDefinition extends RuntimeCallee implements Stringable, De
 
     /**
      * Initializes definition.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         private readonly string $type,
         private readonly string $pattern,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($callable, $description);

--- a/src/Behat/Behat/Definition/Call/Then.php
+++ b/src/Behat/Behat/Definition/Call/Then.php
@@ -10,14 +10,10 @@
 
 namespace Behat\Behat\Definition\Call;
 
-use Behat\Testwork\Call\RuntimeCallee;
-
 /**
  * Then steps definition.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class Then extends RuntimeDefinition
 {
@@ -25,10 +21,8 @@ final class Then extends RuntimeDefinition
 
     /**
      * Initializes definition.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(string $pattern, callable|array $callable, ?string $description = null)
+    public function __construct(string $pattern, callable $callable, ?string $description = null)
     {
         parent::__construct(self::KEYWORD, $pattern, $callable, $description);
     }

--- a/src/Behat/Behat/Definition/Call/When.php
+++ b/src/Behat/Behat/Definition/Call/When.php
@@ -10,14 +10,10 @@
 
 namespace Behat\Behat\Definition\Call;
 
-use Behat\Testwork\Call\RuntimeCallee;
-
 /**
  * When steps definition.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class When extends RuntimeDefinition
 {
@@ -25,10 +21,8 @@ final class When extends RuntimeDefinition
 
     /**
      * Initializes definition.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(string $pattern, callable|array $callable, ?string $description = null)
+    public function __construct(string $pattern, callable $callable, ?string $description = null)
     {
         parent::__construct(self::KEYWORD, $pattern, $callable, $description);
     }

--- a/src/Behat/Behat/Definition/Context/Attribute/DefinitionAttributeReader.php
+++ b/src/Behat/Behat/Definition/Context/Attribute/DefinitionAttributeReader.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Definition\Context\Attribute;
 
 use Behat\Behat\Context\Annotation\DocBlockHelper;
 use Behat\Behat\Context\Attribute\AttributeReader;
+use Behat\Behat\Context\ContextMethodCallableFactory;
 use Behat\Behat\Definition\Call;
 use Behat\Behat\Definition\Call\Given;
 use Behat\Behat\Definition\Call\Then;
@@ -54,7 +55,7 @@ final class DefinitionAttributeReader implements AttributeReader
         $callees = [];
         foreach ($attributes as $attribute) {
             $class = self::$attributeToCallMap[$attribute->getName()];
-            $callable = [$contextClass, $method->getName()];
+            $callable = ContextMethodCallableFactory::makeCallable($contextClass, $method);
             $description = null;
             if ($docBlock = $method->getDocComment()) {
                 $description = $this->docBlockHelper->extractDescription($docBlock);

--- a/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
+++ b/src/Behat/Behat/Definition/Translator/TranslatedDefinition.php
@@ -77,7 +77,7 @@ final class TranslatedDefinition implements Stringable, Definition
         return $this->definition->isAnInstanceMethod();
     }
 
-    public function getCallable(): callable|array
+    public function getCallable(): callable
     {
         return $this->definition->getCallable();
     }

--- a/src/Behat/Behat/Hook/Call/AfterFeature.php
+++ b/src/Behat/Behat/Hook/Call/AfterFeature.php
@@ -11,23 +11,18 @@
 namespace Behat\Behat\Hook\Call;
 
 use Behat\Behat\Hook\Scope\FeatureScope;
-use Behat\Testwork\Call\RuntimeCallee;
 
 /**
  * Represents an AfterFeature hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class AfterFeature extends RuntimeFeatureHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct(FeatureScope::AFTER, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/AfterScenario.php
+++ b/src/Behat/Behat/Hook/Call/AfterScenario.php
@@ -11,23 +11,18 @@
 namespace Behat\Behat\Hook\Call;
 
 use Behat\Behat\Hook\Scope\ScenarioScope;
-use Behat\Testwork\Call\RuntimeCallee;
 
 /**
  * Represents an AfterScenario hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class AfterScenario extends RuntimeScenarioHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct(ScenarioScope::AFTER, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/AfterStep.php
+++ b/src/Behat/Behat/Hook/Call/AfterStep.php
@@ -11,23 +11,18 @@
 namespace Behat\Behat\Hook\Call;
 
 use Behat\Behat\Hook\Scope\StepScope;
-use Behat\Testwork\Call\RuntimeCallee;
 
 /**
  * Represents an AfterStep hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class AfterStep extends RuntimeStepHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct(StepScope::AFTER, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/BeforeFeature.php
+++ b/src/Behat/Behat/Hook/Call/BeforeFeature.php
@@ -11,23 +11,18 @@
 namespace Behat\Behat\Hook\Call;
 
 use Behat\Behat\Hook\Scope\FeatureScope;
-use Behat\Testwork\Call\RuntimeCallee;
 
 /**
  * Represents a BeforeFeature hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class BeforeFeature extends RuntimeFeatureHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct(FeatureScope::BEFORE, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/BeforeScenario.php
+++ b/src/Behat/Behat/Hook/Call/BeforeScenario.php
@@ -11,23 +11,18 @@
 namespace Behat\Behat\Hook\Call;
 
 use Behat\Behat\Hook\Scope\ScenarioScope;
-use Behat\Testwork\Call\RuntimeCallee;
 
 /**
  * Represents a BeforeScenario hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class BeforeScenario extends RuntimeScenarioHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct(ScenarioScope::BEFORE, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/BeforeStep.php
+++ b/src/Behat/Behat/Hook/Call/BeforeStep.php
@@ -11,23 +11,18 @@
 namespace Behat\Behat\Hook\Call;
 
 use Behat\Behat\Hook\Scope\StepScope;
-use Behat\Testwork\Call\RuntimeCallee;
 
 /**
  * Represents a BeforeStep hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class BeforeStep extends RuntimeStepHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct(StepScope::BEFORE, $filterString, $callable, $description);
     }

--- a/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
+++ b/src/Behat/Behat/Hook/Call/RuntimeFeatureHook.php
@@ -15,7 +15,6 @@ use Behat\Gherkin\Filter\NameFilter;
 use Behat\Gherkin\Filter\TagFilter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Call\Exception\BadCallbackException;
-use Behat\Testwork\Call\RuntimeCallee;
 use Behat\Testwork\Hook\Call\RuntimeFilterableHook;
 use Behat\Testwork\Hook\Scope\HookScope;
 
@@ -23,19 +22,15 @@ use Behat\Testwork\Hook\Scope\HookScope;
  * Represents a feature hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 abstract class RuntimeFeatureHook extends RuntimeFilterableHook
 {
     /**
      * Initializes hook.
      *
-     * @phpstan-param TBehatCallable $callable
-     *
      * @throws BadCallbackException If callback is method, but not a static one
      */
-    public function __construct(string $scopeName, ?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(string $scopeName, ?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct($scopeName, $filterString, $callable, $description);
 

--- a/src/Behat/Behat/Hook/Context/Attribute/HookAttributeReader.php
+++ b/src/Behat/Behat/Hook/Context/Attribute/HookAttributeReader.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Hook\Context\Attribute;
 
 use Behat\Behat\Context\Annotation\DocBlockHelper;
 use Behat\Behat\Context\Attribute\AttributeReader;
+use Behat\Behat\Context\ContextMethodCallableFactory;
 use Behat\Hook\AfterFeature;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\AfterStep;
@@ -59,7 +60,7 @@ final class HookAttributeReader implements AttributeReader
         $callees = [];
         foreach ($attributes as $attribute) {
             $class = self::KNOWN_ATTRIBUTES[$attribute->getName()];
-            $callable = [$contextClass, $method->getName()];
+            $callable = ContextMethodCallableFactory::makeCallable($contextClass, $method);
             $description = null;
             if ($docBlock = $method->getDocComment()) {
                 $description = $this->docBlockHelper->extractDescription($docBlock);

--- a/src/Behat/Behat/Transformation/Context/Factory/TransformationCalleeFactory.php
+++ b/src/Behat/Behat/Transformation/Context/Factory/TransformationCalleeFactory.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Transformation\Context\Factory;
 
+use Behat\Behat\Context\ContextMethodCallableFactory;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Behat\Transformation\Transformation;
 use Behat\Behat\Transformation\Transformation\ColumnBasedTableTransformation;
@@ -33,7 +34,7 @@ final class TransformationCalleeFactory
 {
     public static function create(string $contextClass, ReflectionMethod $method, string $pattern, ?string $description): Transformation
     {
-        $callable = [$contextClass, $method->getName()];
+        $callable = ContextMethodCallableFactory::makeCallable($contextClass, $method);
 
         foreach (self::simpleTransformations() as $transformation) {
             if ($transformation::supportsPatternAndMethod($pattern, $method)) {

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -23,6 +23,8 @@ use ReflectionMethod;
  */
 interface SimpleArgumentTransformation extends Transformation
 {
+    public function __construct(string $pattern, callable $callable, ?string $description = null);
+
     /**
      * Checks if transformation supports given pattern.
      */

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -23,8 +23,6 @@ use Stringable;
  * Column-based table transformation.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class ColumnBasedTableTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
@@ -37,12 +35,10 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
 
     /**
      * Initializes transformation.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         private readonly string $pattern,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($callable, $description);

--- a/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
@@ -24,19 +24,15 @@ use UnexpectedValueException;
  * Pattern-based transformation.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class PatternTransformation extends RuntimeCallee implements Stringable, Transformation
 {
     /**
      * Initializes transformation.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         private readonly string $pattern,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($callable, $description);

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -28,8 +28,6 @@ use Stringable;
  * By-type object transformation.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class ReturnTypeTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
@@ -46,10 +44,8 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
 
     /**
      * Initializes transformation.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(string $pattern, callable|array $callable, ?string $description = null)
+    public function __construct(string $pattern, callable $callable, ?string $description = null)
     {
         parent::__construct($callable, $description);
     }

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -24,8 +24,6 @@ use Stringable;
  * Row-based table transformation.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class RowBasedTableTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
@@ -38,12 +36,10 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
 
     /**
      * Initializes transformation.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         private readonly string $pattern,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($callable, $description);

--- a/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
@@ -20,9 +20,6 @@ use InvalidArgumentException;
 use ReflectionMethod;
 use Stringable;
 
-/**
- * @phpstan-import-type TBehatCallable from RuntimeCallee
- */
 final class TableColumnTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
     public const PATTERN_REGEX = '/^column\:[[:print:]]+$/u';
@@ -32,12 +29,9 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
         return 1 === preg_match(self::PATTERN_REGEX, (string) $pattern);
     }
 
-    /**
-     * @phpstan-param TBehatCallable $callable
-     */
     public function __construct(
         private readonly string $pattern,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($callable, $description);

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -23,8 +23,6 @@ use Stringable;
  * Table row transformation.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class TableRowTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
@@ -37,12 +35,10 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
 
     /**
      * Initializes transformation.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         private readonly string $pattern,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($callable, $description);

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
@@ -22,8 +22,6 @@ use Stringable;
  * Name and return type object transformation.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
@@ -38,10 +36,8 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
 
     /**
      * Initializes transformation.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(string $pattern, callable|array $callable, ?string $description = null)
+    public function __construct(string $pattern, callable $callable, ?string $description = null)
     {
         $this->tokenTransformation = new TokenNameTransformation($pattern, $callable, $description);
         $this->returnTransformation = new ReturnTypeTransformation('', $callable, $description);

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -22,8 +22,6 @@ use Stringable;
  * Token name based transformation.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class TokenNameTransformation extends RuntimeCallee implements Stringable, SimpleArgumentTransformation
 {
@@ -36,12 +34,10 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
 
     /**
      * Initializes transformation.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         private readonly string $pattern,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($callable, $description);

--- a/src/Behat/Testwork/Call/Callee.php
+++ b/src/Behat/Testwork/Call/Callee.php
@@ -18,8 +18,6 @@ use ReflectionFunctionAbstract;
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * @api
- *
- * @phpstan-type TBehatCallable callable|array{class-string, string}
  */
 interface Callee
 {
@@ -45,10 +43,8 @@ interface Callee
 
     /**
      * Returns callable.
-     *
-     * @phpstan-return TBehatCallable
      */
-    public function getCallable(): callable|array;
+    public function getCallable(): callable;
 
     /**
      * Returns callable reflection.

--- a/src/Behat/Testwork/Call/LateBoundInstanceCallable.php
+++ b/src/Behat/Testwork/Call/LateBoundInstanceCallable.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Behat\Testwork\Call;
+
+use ReflectionMethod;
+
+/**
+ * Represents a "callable" method that will be bound to an object instance later in execution.
+ *
+ * For example, Behat implements this interface when reading step definitions, hooks, and transformations
+ * that will be bound to a new instance of the declaring `Context` for each scenario.
+ */
+interface LateBoundInstanceCallable
+{
+    /**
+     * The Reflection for the method that will ultimately be called.
+     */
+    public function getReflection(): ReflectionMethod;
+
+    /**
+     * A path for the method e.g. to display in error messages, logs and output.
+     */
+    public function getPath(): string;
+
+    /**
+     * Invokes the method. This may throw if the method has not yet been bound to an instance.
+     */
+    public function __invoke(mixed ...$args): mixed;
+}

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -10,9 +10,7 @@
 
 namespace Behat\Testwork\Call;
 
-use Behat\Behat\Context\Context;
 use Behat\Testwork\Call\Exception\BadCallbackException;
-use Behat\Testwork\Deprecation\DeprecationCollector;
 use ReflectionFunction;
 use ReflectionFunctionAbstract;
 use ReflectionMethod;
@@ -21,13 +19,11 @@ use ReflectionMethod;
  * Represents callee created and executed in the runtime.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-type TBehatCallable callable|array{class-string<Context>, string}
  */
 class RuntimeCallee implements Callee
 {
     /**
-     * @var TBehatCallable
+     * @var callable
      */
     private $callable;
     private ReflectionMethod|ReflectionFunction $reflection;
@@ -35,37 +31,24 @@ class RuntimeCallee implements Callee
 
     /**
      * Initializes callee.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
-        callable|array $callable,
+        callable $callable,
         private readonly ?string $description = null,
     ) {
-        if (is_array($callable)) {
-            if (!$this->isCallableOrBehatContextCallable($callable)) {
-                DeprecationCollector::trigger('Creating '.static::class.' with a non-callable array other than a Behat context method reference is deprecated');
-            }
+        if ($callable instanceof LateBoundInstanceCallable) {
+            $this->reflection = $callable->getReflection();
+            $this->path = $callable->getPath();
+        } elseif (is_array($callable)) {
+            // An array `callable` will always have 2 elements, [className-or-object, methodName]
             $this->reflection = new ReflectionMethod($callable[0], $callable[1]);
-            $this->path = $callable[0] . '::' . $callable[1] . '()';
+            $this->path = $callable[0].'::'.$callable[1].'()';
         } else {
             $this->reflection = new ReflectionFunction($callable);
             $this->path = $this->reflection->getFileName() . ':' . $this->reflection->getStartLine();
         }
 
         $this->callable = $callable;
-    }
-
-    private function isCallableOrBehatContextCallable(array $callable): bool
-    {
-        if (is_callable($callable)) {
-            return true;
-        }
-
-        return count($callable) === 2
-            && is_string($callable[0])
-            && is_string($callable[1])
-            && is_a($callable[0], Context::class, true);
     }
 
     /**
@@ -86,10 +69,8 @@ class RuntimeCallee implements Callee
 
     /**
      * Returns callable.
-     *
-     * @return TBehatCallable
      */
-    public function getCallable(): callable|array
+    public function getCallable(): callable
     {
         return $this->callable;
     }

--- a/src/Behat/Testwork/Call/RuntimeCallee.php
+++ b/src/Behat/Testwork/Call/RuntimeCallee.php
@@ -119,23 +119,6 @@ class RuntimeCallee implements Callee
             && !$this->reflection->isStatic();
     }
 
-    /**
-     * @param callable|array{class-string, string} $callable
-     *
-     * @deprecated see throwIfCallableIsInstanceMethod()
-     */
-    protected function throwIfInstanceMethod(callable|array $callable, string $hookType): void
-    {
-        DeprecationCollector::trigger('throwIfInstanceMethod() is deprecated and will be removed in 4.0 - use throwIfCallableIsInstanceMethod');
-        if ($callable !== $this->callable) {
-            // They have passed a different callable to the one we were initialised with.
-            // Wrap it in a new RuntimeCallee so that we can check it.
-            (new RuntimeCallee($callable))->throwIfCallableIsInstanceMethod($hookType);
-        } else {
-            $this->throwIfCallableIsInstanceMethod($hookType);
-        }
-    }
-
     final protected function throwIfCallableIsInstanceMethod(string $hookType): void
     {
         if ($this->isAnInstanceMethod()) {

--- a/src/Behat/Testwork/Hook/Call/AfterSuite.php
+++ b/src/Behat/Testwork/Hook/Call/AfterSuite.php
@@ -10,24 +10,19 @@
 
 namespace Behat\Testwork\Hook\Call;
 
-use Behat\Testwork\Call\RuntimeCallee;
 use Behat\Testwork\Hook\Scope\SuiteScope;
 
 /**
  * Represents AfterSuite hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class AfterSuite extends RuntimeSuiteHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct(SuiteScope::AFTER, $filterString, $callable, $description);
     }

--- a/src/Behat/Testwork/Hook/Call/BeforeSuite.php
+++ b/src/Behat/Testwork/Hook/Call/BeforeSuite.php
@@ -10,24 +10,19 @@
 
 namespace Behat\Testwork\Hook\Call;
 
-use Behat\Testwork\Call\RuntimeCallee;
 use Behat\Testwork\Hook\Scope\SuiteScope;
 
 /**
  * Represents BeforeSuite hook.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 final class BeforeSuite extends RuntimeSuiteHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
-    public function __construct(?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct(SuiteScope::BEFORE, $filterString, $callable, $description);
     }

--- a/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeFilterableHook.php
@@ -10,7 +10,6 @@
 
 namespace Behat\Testwork\Hook\Call;
 
-use Behat\Testwork\Call\RuntimeCallee;
 use Behat\Testwork\Hook\FilterableHook;
 use Stringable;
 
@@ -18,20 +17,16 @@ use Stringable;
  * Represents runtime hook, filterable by filter string.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 abstract class RuntimeFilterableHook extends RuntimeHook implements Stringable, FilterableHook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         string $scopeName,
         private readonly ?string $filterString,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($scopeName, $callable, $description);

--- a/src/Behat/Testwork/Hook/Call/RuntimeHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeHook.php
@@ -18,19 +18,15 @@ use Stringable;
  * Represents a hook executed during the execution runtime.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 abstract class RuntimeHook extends RuntimeCallee implements Stringable, Hook
 {
     /**
      * Initializes hook.
-     *
-     * @phpstan-param TBehatCallable $callable
      */
     public function __construct(
         private readonly string $scopeName,
-        callable|array $callable,
+        callable $callable,
         ?string $description = null,
     ) {
         parent::__construct($callable, $description);

--- a/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
+++ b/src/Behat/Testwork/Hook/Call/RuntimeSuiteHook.php
@@ -11,7 +11,6 @@
 namespace Behat\Testwork\Hook\Call;
 
 use Behat\Testwork\Call\Exception\BadCallbackException;
-use Behat\Testwork\Call\RuntimeCallee;
 use Behat\Testwork\Hook\Scope\HookScope;
 use Behat\Testwork\Hook\Scope\SuiteScope;
 use Behat\Testwork\Suite\Suite;
@@ -20,19 +19,15 @@ use Behat\Testwork\Suite\Suite;
  * Represents suite hook executed in the runtime.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-import-type TBehatCallable from RuntimeCallee
  */
 abstract class RuntimeSuiteHook extends RuntimeFilterableHook
 {
     /**
      * Initializes hook.
      *
-     * @phpstan-param TBehatCallable $callable
-     *
      * @throws BadCallbackException If callback is method, but not a static one
      */
-    public function __construct(string $scopeName, ?string $filterString, callable|array $callable, ?string $description = null)
+    public function __construct(string $scopeName, ?string $filterString, callable $callable, ?string $description = null)
     {
         parent::__construct($scopeName, $filterString, $callable, $description);
 


### PR DESCRIPTION
This resolves the last BC breaks for 4.0-alpha1:

* It simplifies / tightens our typehints for the `callable`s passed around as step / hook / transformation callbacks (as discussed in https://github.com/Behat/Behat/pull/1694#discussion_r2554023051). The code is now explicit about callables that are expected to be bound to a Context instance before invoking, meaning we no longer need to support and type-check arbitrary `non-callable-array` types.
* It adds a constructor signature for `SimpleArgumentTransformation` - which fixes #1519

There are more details in the individual commit messages.