### PR TITLE
feat: Add 'inline_failures' option to progress formatter

### DIFF
--- a/features/progress_inline_failures.feature
+++ b/features/progress_inline_failures.feature
@@ -1,0 +1,55 @@
+Feature: Progress formatter inline failures
+  In order to diagnose problems during long progress-formatter runs
+  As a developer
+  I need the option to print failing, pending and undefined steps inline as they happen
+
+  Background:
+    Given I initialise the working directory from the "PrintInlineFailures" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option      | value |
+      | --no-colors |       |
+
+  Scenario: Step problems are only listed in the summary by default
+    When I run "behat --format=progress features/inline.feature"
+    Then it should fail with:
+      """
+      .FPU
+
+      --- Failed steps:
+      """
+
+  Scenario: Problems are printed inline when enabled via format settings
+    When I run "behat --format=progress --format-settings='{\"inline_failures\": true}' features/inline.feature"
+    Then it should fail with:
+      """
+      .
+      --- FAILED ---
+          And a failing step # features/inline.feature:5
+            step failed as supposed (RuntimeException)
+      ------------
+      --- PENDING ---
+          Given a pending step # features/inline.feature:8
+            TODO: write pending definition
+      ------------
+      --- UNDEFINED ---
+          Given an undefined step # features/inline.feature:11
+      ------------
+      """
+
+  Scenario: Inline failures can be enabled in the configuration file
+    When I run "behat --profile=inline --format=progress features/inline.feature"
+    Then it should fail with:
+      """
+      .
+      --- FAILED ---
+          And a failing step # features/inline.feature:5
+            step failed as supposed (RuntimeException)
+      ------------
+      --- PENDING ---
+          Given a pending step # features/inline.feature:8
+            TODO: write pending definition
+      ------------
+      --- UNDEFINED ---
+          Given an undefined step # features/inline.feature:11
+      ------------
+      """

--- a/src/Behat/Behat/Output/Node/EventListener/AST/CurrentFeatureListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/CurrentFeatureListener.php
@@ -10,8 +10,8 @@
 
 namespace Behat\Behat\Output\Node\EventListener\AST;
 
+use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
 use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
-use Behat\Behat\EventDispatcher\Event\FeatureTested;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Testwork\Event\Event;
 use Behat\Testwork\Output\Formatter;
@@ -34,7 +34,7 @@ final class CurrentFeatureListener implements EventListener
             $this->currentFeature = $event->getFeature();
         }
 
-        if ($eventName === FeatureTested::AFTER) {
+        if ($event instanceof AfterFeatureTested) {
             $this->currentFeature = null;
         }
     }

--- a/src/Behat/Behat/Output/Node/EventListener/AST/CurrentFeatureListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/AST/CurrentFeatureListener.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Output\Node\EventListener\AST;
+
+use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
+use Behat\Behat\EventDispatcher\Event\FeatureTested;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Testwork\Event\Event;
+use Behat\Testwork\Output\Formatter;
+use Behat\Testwork\Output\Node\EventListener\EventListener;
+
+/**
+ * Keeps the feature currently being tested available for the whole feature run.
+ *
+ * Step results do not all carry a reference back to their feature - an undefined
+ * step, for example, has no call result to read it from - so the feature node is
+ * captured here once per feature and exposed for the duration of that feature.
+ */
+final class CurrentFeatureListener implements EventListener
+{
+    private ?FeatureNode $currentFeature = null;
+
+    public function listenEvent(Formatter $formatter, Event $event, $eventName): void
+    {
+        if ($event instanceof BeforeFeatureTested) {
+            $this->currentFeature = $event->getFeature();
+        }
+
+        if ($eventName === FeatureTested::AFTER) {
+            $this->currentFeature = null;
+        }
+    }
+
+    public function getCurrentFeature(): ?FeatureNode
+    {
+        return $this->currentFeature;
+    }
+}

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
@@ -10,15 +10,20 @@
 
 namespace Behat\Behat\Output\Node\Printer\Progress;
 
+use Behat\Behat\Output\Node\EventListener\AST\CurrentFeatureListener;
 use Behat\Behat\Output\Node\Printer\Helper\ResultToStringConverter;
 use Behat\Behat\Output\Node\Printer\StepPrinter;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Behat\Tester\Result\StepResult;
+use Behat\Config\Formatter\ProgressFormatter;
 use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Gherkin\Node\ScenarioLikeInterface as Scenario;
 use Behat\Gherkin\Node\StepNode;
+use Behat\Testwork\Exception\ExceptionPresenter;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\OutputPrinter;
+use Behat\Testwork\PathOptions\Printer\ConfigurablePathPrinter;
+use Behat\Testwork\Tester\Result\ExceptionResult;
 use Behat\Testwork\Tester\Result\TestResult;
 
 /**
@@ -28,15 +33,25 @@ use Behat\Testwork\Tester\Result\TestResult;
  */
 final class ProgressStepPrinter implements StepPrinter
 {
+    /**
+     * Step result codes that carry a problem worth reporting inline.
+     */
+    private const INLINE_RESULT_CODES = [TestResult::FAILED, TestResult::PENDING, TestResult::UNDEFINED];
+
     private int $stepsPrinted = 0;
 
     private bool $hasPrintedOutput = false;
+
+    private bool $midLine = false;
 
     /**
      * Initializes printer.
      */
     public function __construct(
         private readonly ResultToStringConverter $resultConverter,
+        private readonly ?ExceptionPresenter $exceptionPresenter = null,
+        private readonly ?ConfigurablePathPrinter $configurablePathPrinter = null,
+        private readonly ?CurrentFeatureListener $currentFeatureListener = null,
     ) {
     }
 
@@ -50,24 +65,31 @@ final class ProgressStepPrinter implements StepPrinter
         if ($this->hasPrintedOutput) {
             $printer->writeln('');
             $this->hasPrintedOutput = false;
+            $this->midLine = false;
         }
 
-        switch ($result->getResultCode()) {
-            case TestResult::PASSED:
-                $printer->write("{+$style}.{-$style}");
-                break;
-            case TestResult::SKIPPED:
-                $printer->write("{+$style}-{-$style}");
-                break;
-            case TestResult::PENDING:
-                $printer->write("{+$style}P{-$style}");
-                break;
-            case TestResult::UNDEFINED:
-                $printer->write("{+$style}U{-$style}");
-                break;
-            case TestResult::FAILED:
-                $printer->write("{+$style}F{-$style}");
-                break;
+        if ($this->shouldPrintInline($formatter, $result)) {
+            $this->printInlineProblem($printer, $step, $result, $style);
+        } else {
+            switch ($result->getResultCode()) {
+                case TestResult::PASSED:
+                    $printer->write("{+$style}.{-$style}");
+                    break;
+                case TestResult::SKIPPED:
+                    $printer->write("{+$style}-{-$style}");
+                    break;
+                case TestResult::PENDING:
+                    $printer->write("{+$style}P{-$style}");
+                    break;
+                case TestResult::UNDEFINED:
+                    $printer->write("{+$style}U{-$style}");
+                    break;
+                case TestResult::FAILED:
+                    $printer->write("{+$style}F{-$style}");
+                    break;
+            }
+
+            $this->midLine = true;
         }
 
         $showOutput = $formatter->getParameter(ShowOutputOption::OPTION_NAME);
@@ -78,7 +100,96 @@ final class ProgressStepPrinter implements StepPrinter
 
         if (++$this->stepsPrinted % 70 === 0) {
             $printer->writeln(' ' . $this->stepsPrinted);
+            $this->midLine = false;
         }
+    }
+
+    /**
+     * Whether the failure/pending/undefined detail of this step should be printed
+     * inline rather than waiting for the end-of-run summary.
+     */
+    private function shouldPrintInline(Formatter $formatter, StepResult $result): bool
+    {
+        if (!$formatter->getParameter(ProgressFormatter::INLINE_FAILURES_SETTING)) {
+            return false;
+        }
+
+        if (!$this->configurablePathPrinter instanceof ConfigurablePathPrinter) {
+            return false;
+        }
+
+        return in_array($result->getResultCode(), self::INLINE_RESULT_CODES, true);
+    }
+
+    /**
+     * Prints the detail of a failed, pending or undefined step inline, in place
+     * of the single-character marker.
+     */
+    private function printInlineProblem(OutputPrinter $printer, StepNode $step, StepResult $result, string $style): void
+    {
+        $label = strtoupper($style);
+
+        // Break out of the line of progress markers before printing the block,
+        // but only when something has already been written on the current line.
+        if ($this->midLine) {
+            $printer->writeln('');
+            $this->midLine = false;
+        }
+
+        $printer->writeln(sprintf('{+%s}--- %s ---{-%s}', $style, $label, $style));
+        $printer->writeln(sprintf(
+            '    {+%s}%s{-%s} {+comment}# %s{-comment}',
+            $style,
+            $step->getFullText(),
+            $style,
+            $this->resolveStepPath($step)
+        ));
+
+        $this->printException($printer, $result, $style);
+
+        $printer->writeln(sprintf('{+%s}------------{-%s}', $style, $style));
+    }
+
+    /**
+     * Prints the presented exception of a step (if it carries one).
+     */
+    private function printException(OutputPrinter $printer, StepResult $result, string $style): void
+    {
+        if (!$this->exceptionPresenter instanceof ExceptionPresenter) {
+            return;
+        }
+
+        if (!$result instanceof ExceptionResult || !$result->hasException()) {
+            return;
+        }
+
+        $exception = $result->getException();
+        if ($exception === null) {
+            return;
+        }
+
+        $pad = static fn (string $line): string => '      ' . $line;
+        $text = $this->exceptionPresenter->presentException($exception);
+        $indented = implode("\n", array_map($pad, explode("\n", $text)));
+
+        $printer->writeln(sprintf('{+%s}%s{-%s}', $style, $indented, $style));
+    }
+
+    /**
+     * Builds the "feature_file:line" reference for a step, honouring the path
+     * options (relative/absolute, editor URL) when a printer is available.
+     */
+    private function resolveStepPath(StepNode $step): string
+    {
+        $feature = $this->currentFeatureListener?->getCurrentFeature();
+        $file = $feature?->getFile();
+        $path = $file !== null ? sprintf('%s:%d', $file, $step->getLine()) : (string) $step->getLine();
+
+        if (!$this->configurablePathPrinter instanceof ConfigurablePathPrinter) {
+            return $path;
+        }
+
+        return $this->configurablePathPrinter->processPathsInText($path);
     }
 
     /**

--- a/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
+++ b/src/Behat/Behat/Output/ServiceContainer/Formatter/ProgressFormatterFactory.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Output\ServiceContainer\Formatter;
 
+use Behat\Behat\Output\Node\EventListener\AST\CurrentFeatureListener;
 use Behat\Behat\Output\Node\EventListener\AST\StepListener;
 use Behat\Behat\Output\Node\EventListener\Statistics\HookStatsListener;
 use Behat\Behat\Output\Node\EventListener\Statistics\ScenarioStatsListener;
@@ -49,6 +50,7 @@ class ProgressFormatterFactory implements FormatterFactory
      * Available services
      */
     public const ROOT_LISTENER_ID = 'output.node.listener.progress';
+    public const CURRENT_FEATURE_LISTENER_ID = 'output.node.listener.progress.current_feature';
     public const RESULT_TO_STRING_CONVERTER_ID = 'output.node.printer.result_to_string';
 
     /*
@@ -108,8 +110,14 @@ class ProgressFormatterFactory implements FormatterFactory
         ]);
         $container->setDefinition('output.node.printer.list', $definition);
 
+        $definition = new Definition(CurrentFeatureListener::class);
+        $container->setDefinition(self::CURRENT_FEATURE_LISTENER_ID, $definition);
+
         $definition = new Definition(ProgressStepPrinter::class, [
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
+            new Reference(ExceptionExtension::PRESENTER_ID),
+            new Reference(PathOptionsExtension::CONFIGURABLE_PATH_PRINTER_ID),
+            new Reference(self::CURRENT_FEATURE_LISTENER_ID),
         ]);
         $container->setDefinition('output.node.printer.progress.step', $definition);
 
@@ -146,6 +154,7 @@ class ProgressFormatterFactory implements FormatterFactory
                 ChainEventListener::class,
                 [
                     [
+                        new Reference(self::CURRENT_FEATURE_LISTENER_ID),
                         new Reference(self::ROOT_LISTENER_ID),
                         new Definition(StatisticsListener::class, [
                             new Reference('output.progress.statistics'),

--- a/src/Behat/Config/Formatter/Formatter.php
+++ b/src/Behat/Config/Formatter/Formatter.php
@@ -127,6 +127,9 @@ class Formatter implements FormatterConfigInterface, ConfigConverterInterface
             if ($name === self::SHORT_SUMMARY_SETTING) {
                 $name = self::SHORT_SUMMARY_PARAMETER_NAME;
             }
+            if ($name === ProgressFormatter::INLINE_FAILURES_SETTING) {
+                $name = ProgressFormatter::INLINE_FAILURES_PARAMETER_NAME;
+            }
             if ($name === PrettyFormatter::PRINT_SKIPPED_STEPS_SETTING) {
                 $name = PrettyFormatter::PRINT_SKIPPED_STEPS_PARAMETER_NAME;
             }

--- a/src/Behat/Config/Formatter/ProgressFormatter.php
+++ b/src/Behat/Config/Formatter/ProgressFormatter.php
@@ -13,6 +13,9 @@ final class ProgressFormatter extends Formatter
 {
     public const NAME = 'progress';
 
+    public const INLINE_FAILURES_SETTING = 'inline_failures';
+    public const INLINE_FAILURES_PARAMETER_NAME = 'inlineFailures';
+
     private const TIMER_SETTING = 'timer';
     private const SHORT_SUMMARY_SETTING = 'short_summary';
 
@@ -24,17 +27,21 @@ final class ProgressFormatter extends Formatter
      *                                     formatter output (yes, no, on-fail, in-summary)
      * @param bool $shortSummary if we should print the short summary which just lists scenarios
      *                            or the long summary which lists steps
+     * @param bool $inlineFailures print the detail of each failed, pending or undefined step
+     *                             inline as it happens, instead of only in the end-of-run summary
      */
     public function __construct(
         bool $timer = true,
         ShowOutputOption $showOutput = ShowOutputOption::InSummary,
         bool $shortSummary = false,
+        bool $inlineFailures = false,
         ...$baseOptions,
     ) {
         $settings = [
             self::TIMER_SETTING => $timer,
             ShowOutputOption::OPTION_NAME => $showOutput->value,
             self::SHORT_SUMMARY_SETTING => $shortSummary,
+            self::INLINE_FAILURES_SETTING => $inlineFailures,
         ];
         $settings = [...$settings, ...$baseOptions];
         parent::__construct(name: self::NAME, settings: $settings);

--- a/tests/Behat/Tests/Config/ProfileTest.php
+++ b/tests/Behat/Tests/Config/ProfileTest.php
@@ -153,6 +153,7 @@ final class ProfileTest extends TestCase
                     'timer' => false,
                     'show_output' => 'in-summary',
                     'short_summary' => false,
+                    'inline_failures' => false,
                 ],
                 'junit' => [
                     'timer' => true,
@@ -193,6 +194,7 @@ final class ProfileTest extends TestCase
                     'timer' => true,
                     'show_output' => 'yes',
                     'short_summary' => false,
+                    'inline_failures' => false,
                 ],
                 'junit' => false,
             ],

--- a/tests/Fixtures/PrintInlineFailures/behat.php
+++ b/tests/Fixtures/PrintInlineFailures/behat.php
@@ -1,0 +1,26 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Formatter\ProgressFormatter;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+$defaultProfile = (new Profile('default'))
+    ->withSuite(
+        (new Suite('default'))
+            ->withContexts('FeatureContext')
+    )
+;
+
+$inlineProfile = (new Profile('inline'))
+    ->withSuite(
+        (new Suite('default'))
+            ->withContexts('FeatureContext')
+    )
+    ->withFormatter(new ProgressFormatter(inlineFailures: true))
+;
+
+return (new Config())
+    ->withProfile($defaultProfile)
+    ->withProfile($inlineProfile)
+;

--- a/tests/Fixtures/PrintInlineFailures/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/PrintInlineFailures/features/bootstrap/FeatureContext.php
@@ -1,0 +1,25 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Step\Given;
+
+class FeatureContext implements Context
+{
+    #[Given('a passing step')]
+    public function aPassingStep(): void
+    {
+    }
+
+    #[Given('a failing step')]
+    public function aFailingStep(): void
+    {
+        throw new RuntimeException('step failed as supposed');
+    }
+
+    #[Given('a pending step')]
+    public function aPendingStep(): void
+    {
+        throw new PendingException();
+    }
+}

--- a/tests/Fixtures/PrintInlineFailures/features/inline.feature
+++ b/tests/Fixtures/PrintInlineFailures/features/inline.feature
@@ -1,0 +1,11 @@
+Feature: Inline failures
+
+  Scenario: Passing then failing
+    Given a passing step
+    And a failing step
+
+  Scenario: Pending
+    Given a pending step
+
+  Scenario: Undefined
+    Given an undefined step


### PR DESCRIPTION
Closes #1860

## Summary

Adds an opt-in `inline_failures` option to the existing `progress` formatter that prints each failed, pending, or undefined step's detail (step text, `feature:line`, exception) inline as it happens, instead of only in the end-of-run summary. The option defaults to `false`, so all existing output is unchanged. This implements the format proposed in the issue body, using Behat-native `ExceptionPresenter` for verbosity-aware exception rendering and `ConfigurablePathPrinter` for path resolution (honouring `--print-absolute-paths` and editor URL settings).

## Changes

- **`ProgressFormatter`** - new `bool $inlineFailures = false` constructor parameter and `inline_failures` setting constant; defaults off for full backwards compatibility.
- **`Formatter` (YAML-to-PHP converter)** - added `inline_failures` → `inlineFailures` mapping so the option round-trips through `convert_config`.
- **`CurrentFeatureListener`** - new lightweight event listener that captures the current `FeatureNode` on `BeforeFeatureTested` and exposes it for the duration of that feature; required because undefined steps carry no call result from which to read the feature file.
- **`ProgressStepPrinter`** - new `shouldPrintInline()` / `printInlineProblem()` / `printException()` / `resolveStepPath()` methods; when the option is on and the result is failed/pending/undefined, the inline block is printed instead of the single-character marker (`F`/`P`/`U`); existing newline and 70-step line-wrap coordination is preserved.
- **`ProgressFormatterFactory`** - registers `CurrentFeatureListener` as a service, injects it (plus `ExceptionPresenter` and `ConfigurablePathPrinter`) into `ProgressStepPrinter`, and prepends it to the `ChainEventListener` so it fires before the root listener.
- **`features/progress_inline_failures.feature`** - new integration test covering: default (no inline output), `--format-settings` JSON activation, and PHP-config-profile activation.
- **`tests/Fixtures/PrintInlineFailures/`** - new fixture with a `behat.php` config (default + `inline` profiles), a `FeatureContext` with passing/failing/pending steps, and an `inline.feature` with three scenarios (passing-then-failing, pending, undefined).
- **`tests/Behat/Tests/Config/ProfileTest.php`** - added `inline_failures: false` to the expected defaults in two assertions that enumerate progress-formatter settings.

## Configuration

Enable via PHP config:

```php
new ProgressFormatter(inlineFailures: true)
```

Enable via YAML config:

```yaml
formatters:
  progress:
    inline_failures: true
```

Enable via CLI:

```
behat --format=progress --format-settings='{"inline_failures": true}'
```

The formatter name stays `progress` - this is not a new format name.

## Scope note

This PR implements the format from the **issue body**: an additive `inline_failures` option on the **existing** `progress` formatter. It deliberately does not implement the per-scenario layout floated in [acoulton's comment](https://github.com/Behat/Behat/issues/1860#issuecomment-4804492245) (a `feature:line` prefix before each scenario, one line per scenario), because that is a fundamentally different rendering model. That approach would require a **new formatter**: a scenario-aware renderer that prints a path prefix per scenario, emits one line per scenario, and replaces the 70-step line wrapping - a separate, larger piece of work. The two are complementary and can coexist: this option enriches the classic progress stream, while a future dedicated formatter could offer the per-scenario view as an opt-in choice. The reusable inline failure-block rendering introduced here would support that future formatter.

## Screenshots

N/A (CLI output formatter; example output is below).

## Before / After

**Before** (default, `inline_failures` not set or `false`):

```
.FPU

--- Failed steps:

001 Scenario: Passing then failing   # features/inline.feature:3
      And a failing step             # features/inline.feature:5
        step failed as supposed (RuntimeException)
...
```

**After** (`inline_failures: true`):

```
.
--- FAILED ---
    And a failing step # features/inline.feature:5
      step failed as supposed (RuntimeException)
------------
--- PENDING ---
    Given a pending step # features/inline.feature:8
      TODO: write pending definition
------------
--- UNDEFINED ---
    Given an undefined step # features/inline.feature:11
------------

--- Failed steps:

001 Scenario: Passing then failing   # features/inline.feature:3
      And a failing step             # features/inline.feature:5
        step failed as supposed (RuntimeException)
...
```

The end-of-run summary is still printed in both cases - the inline output is additive.
