### PR TITLE
feat: Add support for Cucumber tag expressions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.2",
         "behat/gherkin": "^4.17.0",
+        "cucumber/tag-expressions": "^11.0",
         "composer/xdebug-handler": "^1.4 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.19.2 || ^5.2",
         "psr/container": "^1.0 || ^2.0",

--- a/features/tag_expression_filters.feature
+++ b/features/tag_expression_filters.feature
@@ -48,11 +48,66 @@ Feature: Tag expressions
     Then it should pass
     And the output should contain:
       """
+      Feature: Feature N2
+
+        Background:
+          Given Some normal step N21
+
+        @fast
+        Scenario:
+          Given Some fast step N24
+          And Some fast step N25
+      """
+    And the output should contain:
+      """
+      Feature: Feature N3
+
+        Background:
+          Given Some normal step N21
+
+        @normal
+        Scenario:
+          Given Some normal step N38
+
+        @fast
+        Scenario Outline:
+          Given Some fast step N<num>
+
+          Examples:
+            | num |
+            | 33  |
+            | 34  |
+
+        @normal @fast
+        Scenario Outline:
+          Given Some normal step N<num>
+          And Some fast step N37
+
+          Examples:
+            | num |
+            | 35  |
+            | 36  |
+      """
+    And the output should contain:
+      """
+      Feature: Feature N4
+
+        @normal
+        Scenario:
+          Given Some normal step N41
+          And Some fast step N42
+
+        @fast
+        Scenario:
+          Given Some slow step N43
+      """
+    And the output should contain:
+      """
       8 scenarios (8 passed)
       18 steps (18 passed)
       """
 
-  Scenario: Outline examples are filtered by the expression
+  Scenario: Outlines are filtered by the expression
     When I run "behat --tag-expression '@normal and @fast'"
     Then it should pass
     And the output should contain:
@@ -78,9 +133,77 @@ Feature: Tag expressions
       6 steps (6 passed)
       """
 
+  Scenario: Outline examples are filtered by the expression
+    When I initialise the working directory from the "TagExpressionExamples" fixtures folder
+    And I run "behat features/outline_examples.feature --tag-expression '@quick'"
+    Then it should pass
+    And the output should contain:
+      """
+      Feature: Feature N5
+
+        Scenario Outline:
+          Given Some normal step N<num>
+
+          Examples:
+            | num |
+            | 51  |
+            | 52  |
+      """
+    And the output should contain:
+      """
+      2 scenarios (2 passed)
+      2 steps (2 passed)
+      """
+
   Scenario: Tag expression suite filter in the config file
     When I run "behat --config=behat-with-tag-expression-filter.php"
     Then it should pass
+    And the output should contain:
+      """
+      Feature: Feature N2
+
+        Background:
+          Given Some normal step N21
+
+        @fast
+        Scenario:
+          Given Some fast step N24
+          And Some fast step N25
+      """
+    And the output should contain:
+      """
+      Feature: Feature N3
+
+        Background:
+          Given Some normal step N21
+
+        @fast
+        Scenario Outline:
+          Given Some fast step N<num>
+
+          Examples:
+            | num |
+            | 33  |
+            | 34  |
+
+        @normal @fast
+        Scenario Outline:
+          Given Some normal step N<num>
+          And Some fast step N37
+
+          Examples:
+            | num |
+            | 35  |
+            | 36  |
+      """
+    And the output should contain:
+      """
+      Feature: Feature N4
+
+        @fast
+        Scenario:
+          Given Some slow step N43
+      """
     And the output should contain:
       """
       6 scenarios (6 passed)

--- a/features/tag_expression_filters.feature
+++ b/features/tag_expression_filters.feature
@@ -1,0 +1,96 @@
+Feature: Tag expressions
+  In order to run only needed features
+  As a Behat user
+  I need Behat to support Cucumber tag expressions
+
+  Background:
+    Given I initialise the working directory from the "TagFilters" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option            | value              |
+      | --no-colors       |                    |
+      | --format-settings | '{"paths": false}' |
+
+  Scenario: And expression
+    When I run "behat --tag-expression '@slow and @fast'"
+    Then it should pass
+    And the output should contain:
+      """
+      @slow
+      Feature: Feature N1
+
+        Background:
+          Given Some slow step N11
+
+        @fast
+        Scenario:
+          Given Some fast step N14
+      """
+    And the output should contain:
+      """
+      Feature: Feature N2
+
+        Background:
+          Given Some normal step N21
+
+        @slow @fast
+        Scenario:
+          Given Some slow step N22
+          And Some fast step N23
+      """
+    And the output should contain:
+      """
+      2 scenarios (2 passed)
+      5 steps (5 passed)
+      """
+
+  Scenario: Not expression
+    When I run "behat --tag-expression 'not @slow'"
+    Then it should pass
+    And the output should contain:
+      """
+      8 scenarios (8 passed)
+      18 steps (18 passed)
+      """
+
+  Scenario: Outline examples are filtered by the expression
+    When I run "behat --tag-expression '@normal and @fast'"
+    Then it should pass
+    And the output should contain:
+      """
+      Feature: Feature N3
+
+        Background:
+          Given Some normal step N21
+
+        @normal @fast
+        Scenario Outline:
+          Given Some normal step N<num>
+          And Some fast step N37
+
+          Examples:
+            | num |
+            | 35  |
+            | 36  |
+      """
+    And the output should contain:
+      """
+      2 scenarios (2 passed)
+      6 steps (6 passed)
+      """
+
+  Scenario: Tag expression suite filter in the config file
+    When I run "behat --config=behat-with-tag-expression-filter.php"
+    Then it should pass
+    And the output should contain:
+      """
+      6 scenarios (6 passed)
+      14 steps (14 passed)
+      """
+
+  Scenario: Invalid tag expression
+    When I run "behat --tag-expression '@a and ('"
+    Then it should fail
+    And the output should contain:
+      """
+      Tag expression "@a and (" could not be parsed because of syntax error: Unmatched (.
+      """

--- a/src/Behat/Behat/Gherkin/Cli/FilterController.php
+++ b/src/Behat/Behat/Gherkin/Cli/FilterController.php
@@ -60,7 +60,7 @@ final class FilterController implements Controller
             ->addOption(
                 '--tag-expression',
                 null,
-                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                InputOption::VALUE_REQUIRED,
                 'Only execute the features or scenarios with tags' . PHP_EOL .
                 'matching the given Cucumber tag expression,' . PHP_EOL .
                 'e.g. "@smoke and not @slow".'
@@ -94,7 +94,7 @@ final class FilterController implements Controller
             $filters[] = new TagFilter($tags);
         }
 
-        foreach ($input->getOption('tag-expression') as $tagExpression) {
+        if ($tagExpression = $input->getOption('tag-expression')) {
             $filters[] = new TagExpressionFilter($tagExpression);
         }
 

--- a/src/Behat/Behat/Gherkin/Cli/FilterController.php
+++ b/src/Behat/Behat/Gherkin/Cli/FilterController.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Gherkin\Cli;
 
+use Behat\Behat\Gherkin\Filter\TagExpressionFilter;
 use Behat\Gherkin\Filter\NameFilter;
 use Behat\Gherkin\Filter\NarrativeFilter;
 use Behat\Gherkin\Filter\RoleFilter;
@@ -57,6 +58,14 @@ final class FilterController implements Controller
                 'matching tag filter expression.'
             )
             ->addOption(
+                '--tag-expression',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Only execute the features or scenarios with tags' . PHP_EOL .
+                'matching the given Cucumber tag expression,' . PHP_EOL .
+                'e.g. "@smoke and not @slow".'
+            )
+            ->addOption(
                 '--role',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -83,6 +92,10 @@ final class FilterController implements Controller
 
         foreach ($input->getOption('tags') as $tags) {
             $filters[] = new TagFilter($tags);
+        }
+
+        foreach ($input->getOption('tag-expression') as $tagExpression) {
+            $filters[] = new TagExpressionFilter($tagExpression);
         }
 
         if ($role = $input->getOption('role')) {

--- a/src/Behat/Behat/Gherkin/Filter/TagExpressionFilter.php
+++ b/src/Behat/Behat/Gherkin/Filter/TagExpressionFilter.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Gherkin\Filter;
+
+use Behat\Gherkin\Filter\ComplexFilter;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\OutlineNode;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Cucumber\TagExpressions\Expression;
+use Cucumber\TagExpressions\TagExpressionException;
+use Cucumber\TagExpressions\TagExpressionParser;
+
+/**
+ * Filters scenarios by feature/scenario tag using a Cucumber tag expression.
+ *
+ * @see https://cucumber.io/docs/cucumber/api/#tag-expressions
+ */
+final class TagExpressionFilter extends ComplexFilter
+{
+    private readonly Expression $expression;
+
+    /**
+     * @throws TagExpressionException When the expression cannot be parsed
+     */
+    public function __construct(string $expressionString)
+    {
+        $this->expression = TagExpressionParser::parse($expressionString);
+    }
+
+    public function filterFeature(FeatureNode $feature): FeatureNode
+    {
+        $scenarios = [];
+        foreach ($feature->getScenarios() as $scenario) {
+            if (!$this->isScenarioMatch($feature, $scenario)) {
+                continue;
+            }
+
+            if ($scenario instanceof OutlineNode && $scenario->hasExamples()) {
+                $exampleTables = [];
+
+                foreach ($scenario->getExampleTables() as $exampleTable) {
+                    if ($this->evaluateTags(array_merge($feature->getTags(), $scenario->getTags(), $exampleTable->getTags()))) {
+                        $exampleTables[] = $exampleTable;
+                    }
+                }
+
+                $scenario = $scenario->withTables($exampleTables);
+            }
+
+            $scenarios[] = $scenario;
+        }
+
+        return $feature->withScenarios($scenarios);
+    }
+
+    public function isFeatureMatch(FeatureNode $feature): bool
+    {
+        return $this->evaluateTags($feature->getTags());
+    }
+
+    public function isScenarioMatch(FeatureNode $feature, ScenarioInterface $scenario): bool
+    {
+        if ($scenario instanceof OutlineNode && $scenario->hasExamples()) {
+            foreach ($scenario->getExampleTables() as $example) {
+                if ($this->evaluateTags(array_merge($feature->getTags(), $scenario->getTags(), $example->getTags()))) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $this->evaluateTags(array_merge($feature->getTags(), $scenario->getTags()));
+    }
+
+    /**
+     * @param array<array-key, string> $tags
+     */
+    private function evaluateTags(array $tags): bool
+    {
+        // tag expressions reference tags with their `@` prefix, but the legacy
+        // parsing mode strips the prefix from the parsed nodes: add it back
+        $tags = array_map(
+            static fn (string $tag) => str_starts_with($tag, '@') ? $tag : '@' . $tag,
+            $tags
+        );
+
+        return $this->expression->evaluate($tags);
+    }
+}

--- a/src/Behat/Behat/Gherkin/Filter/TagExpressionFilter.php
+++ b/src/Behat/Behat/Gherkin/Filter/TagExpressionFilter.php
@@ -82,7 +82,7 @@ final class TagExpressionFilter extends ComplexFilter
     }
 
     /**
-     * @param array<array-key, string> $tags
+     * @param list<string> $tags
      */
     private function evaluateTags(array $tags): bool
     {

--- a/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
+++ b/src/Behat/Behat/Gherkin/ServiceContainer/GherkinExtension.php
@@ -12,6 +12,7 @@ namespace Behat\Behat\Gherkin\ServiceContainer;
 
 use Behat\Behat\Gherkin\Cli\FilterController;
 use Behat\Behat\Gherkin\Cli\SyntaxController;
+use Behat\Behat\Gherkin\Filter\TagExpressionFilter;
 use Behat\Behat\Gherkin\Specification\Locator\FilesystemFeatureLocator;
 use Behat\Behat\Gherkin\Specification\Locator\FilesystemRerunScenariosListLocator;
 use Behat\Behat\Gherkin\Specification\Locator\FilesystemScenariosListLocator;
@@ -336,6 +337,10 @@ final class GherkinExtension implements Extension
             return new Definition(TagFilter::class, [$filterString]);
         }
 
+        if ('tag_expression' === $type) {
+            return new Definition(TagExpressionFilter::class, [$filterString]);
+        }
+
         if ('narrative' === $type) {
             return new Definition(NarrativeFilter::class, [$filterString]);
         }
@@ -343,7 +348,7 @@ final class GherkinExtension implements Extension
         throw new ExtensionException(sprintf(
             '`%s` filter is not supported by the `filters` option of gherkin extension. Supported types are `%s`.',
             $type,
-            implode('`, `', ['narrative', 'role', 'name', 'tags'])
+            implode('`, `', ['narrative', 'role', 'name', 'tags', 'tag_expression'])
         ), 'gherkin');
     }
 }

--- a/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
+++ b/src/Behat/Behat/Gherkin/Specification/LazyFeatureIterator.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Behat\Gherkin\Specification;
 
+use Behat\Behat\Gherkin\Filter\TagExpressionFilter;
 use Behat\Gherkin\Filter\FeatureFilterInterface;
 use Behat\Gherkin\Filter\NameFilter;
 use Behat\Gherkin\Filter\NarrativeFilter;
@@ -132,6 +133,10 @@ final class LazyFeatureIterator implements SpecificationIterator
             return new TagFilter($filterString);
         }
 
+        if ('tag_expression' === $type) {
+            return new TagExpressionFilter($filterString);
+        }
+
         if ('narrative' === $type) {
             return new NarrativeFilter($filterString);
         }
@@ -140,7 +145,7 @@ final class LazyFeatureIterator implements SpecificationIterator
             '`%s` filter is not supported by the `%s` suite. Supported types are `%s`.',
             $type,
             $suite->getName(),
-            implode('`, `', ['narrative', 'role', 'name', 'tags'])
+            implode('`, `', ['narrative', 'role', 'name', 'tags', 'tag_expression'])
         ), $suite->getName());
     }
 

--- a/src/Behat/Config/Filter/TagExpressionFilter.php
+++ b/src/Behat/Config/Filter/TagExpressionFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Config\Filter;
+
+/**
+ * @api
+ */
+final class TagExpressionFilter extends Filter
+{
+    public const NAME = 'tag_expression';
+
+    /**
+     * @api
+     */
+    public function __construct(
+        string $value,
+    ) {
+        parent::__construct(self::NAME, $value);
+    }
+}

--- a/src/Behat/Config/Suite.php
+++ b/src/Behat/Config/Suite.php
@@ -9,6 +9,7 @@ use Behat\Config\Filter\FilterInterface;
 use Behat\Config\Filter\NameFilter;
 use Behat\Config\Filter\NarrativeFilter;
 use Behat\Config\Filter\RoleFilter;
+use Behat\Config\Filter\TagExpressionFilter;
 use Behat\Config\Filter\TagFilter;
 use Behat\Testwork\ServiceContainer\Exception\ConfigurationLoadingException;
 use PhpParser\Node\Expr;
@@ -184,6 +185,7 @@ final class Suite implements ConfigConverterInterface
                     NarrativeFilter::NAME => new NarrativeFilter($filterValue),
                     RoleFilter::NAME => new RoleFilter($filterValue),
                     TagFilter::NAME => new TagFilter($filterValue),
+                    TagExpressionFilter::NAME => new TagExpressionFilter($filterValue),
                     default => null,
                 };
                 if ($filter !== null) {

--- a/tests/Behat/Tests/Gherkin/Filter/TagExpressionFilterTest.php
+++ b/tests/Behat/Tests/Gherkin/Filter/TagExpressionFilterTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Tests\Gherkin\Filter;
+
+use Behat\Behat\Gherkin\Filter\TagExpressionFilter;
+use Behat\Gherkin\Node\ExampleTableNode;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\OutlineNode;
+use Behat\Gherkin\Node\ScenarioNode;
+use Cucumber\TagExpressions\TagExpressionException;
+use PHPUnit\Framework\TestCase;
+
+final class TagExpressionFilterTest extends TestCase
+{
+    public function testItThrowsOnInvalidExpression(): void
+    {
+        $this->expectException(TagExpressionException::class);
+
+        new TagExpressionFilter('@a and (');
+    }
+
+    public function testItMatchesFeaturesByTag(): void
+    {
+        $filter = new TagExpressionFilter('@wip and not @slow');
+
+        $this->assertTrue($filter->isFeatureMatch($this->createFeature(['wip'])));
+        $this->assertFalse($filter->isFeatureMatch($this->createFeature(['wip', 'slow'])));
+        $this->assertFalse($filter->isFeatureMatch($this->createFeature([])));
+    }
+
+    public function testScenariosInheritFeatureTags(): void
+    {
+        $filter = new TagExpressionFilter('@wip and @fast');
+
+        $scenario = new ScenarioNode(null, ['fast'], [], 'Scenario', 2);
+        $feature = $this->createFeature(['wip'], [$scenario]);
+
+        $this->assertTrue($filter->isScenarioMatch($feature, $scenario));
+        $this->assertFalse($filter->isScenarioMatch($this->createFeature([], [$scenario]), $scenario));
+    }
+
+    public function testItFiltersOutlineExampleTables(): void
+    {
+        $filter = new TagExpressionFilter('@fast or @quick');
+
+        $matchingTable = new ExampleTableNode([10 => ['num'], 11 => ['1']], 'Examples', ['fast']);
+        $otherTable = new ExampleTableNode([12 => ['num'], 13 => ['2']], 'Examples', ['slow']);
+        $outline = new OutlineNode(null, [], [], [$matchingTable, $otherTable], 'Scenario Outline', 2);
+        $feature = $this->createFeature([], [$outline]);
+
+        $this->assertTrue($filter->isScenarioMatch($feature, $outline));
+
+        $filteredFeature = $filter->filterFeature($feature);
+        $filteredOutline = $filteredFeature->getScenarios()[0];
+
+        $this->assertInstanceOf(OutlineNode::class, $filteredOutline);
+        $this->assertSame([$matchingTable], $filteredOutline->getExampleTables());
+    }
+
+    public function testItAcceptsTagsWithExplicitAtPrefix(): void
+    {
+        $filter = new TagExpressionFilter('@wip');
+
+        // tags are stored without the `@` prefix in legacy parsing mode, and with it in gherkin-32 mode
+        $this->assertTrue($filter->isFeatureMatch($this->createFeature(['wip'])));
+        $this->assertTrue($filter->isFeatureMatch($this->createFeature(['@wip'])));
+    }
+
+    /**
+     * @param list<string> $tags
+     * @param list<ScenarioNode|OutlineNode> $scenarios
+     */
+    private function createFeature(array $tags, array $scenarios = []): FeatureNode
+    {
+        return new FeatureNode(null, null, $tags, null, $scenarios, 'Feature', 'en', null, 1);
+    }
+}

--- a/tests/Fixtures/TagExpressionExamples/features/outline_examples.feature
+++ b/tests/Fixtures/TagExpressionExamples/features/outline_examples.feature
@@ -1,0 +1,15 @@
+Feature: Feature N5
+
+  Scenario Outline:
+    Given Some normal step N<num>
+
+    @quick
+    Examples:
+      | num |
+      | 51  |
+      | 52  |
+
+    @lazy
+    Examples:
+      | num |
+      | 53  |

--- a/tests/Fixtures/TagFilters/behat-with-tag-expression-filter.php
+++ b/tests/Fixtures/TagFilters/behat-with-tag-expression-filter.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Config\Config;
+use Behat\Config\Filter\TagExpressionFilter;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+$profile = (new Profile('default'))
+    ->withSuite(
+        (new Suite('default'))
+            ->withFilter(new TagExpressionFilter('@fast and not @slow'))
+    )
+;
+
+return (new Config())->withProfile($profile);


### PR DESCRIPTION
Fixes #1642

Adds support for [Cucumber Tag Expressions](https://github.com/cucumber/tag-expressions) through the official `cucumber/tag-expressions` PHP port (published from cucumber/tag-expressions#194).

As suggested in the issue, the existing `--tags` syntax is untouched and the expressions get their own entry points, so there is no ambiguity between the two syntaxes:

- a new `--tag-expression` CLI option (repeatable, like `--tags`);
- a new `tag_expression` filter type for the profile and suite `filters` settings;
- a new `Behat\Config\Filter\TagExpressionFilter` class for the PHP config API.

The filter matches the `TagFilter` semantics: scenarios inherit feature tags, and outline example tables are filtered individually by their own tags. Tags are normalised to their `@`-prefixed form before evaluation, so both parsing modes (legacy and gherkin-32) behave the same, which the new `features/tag_expression_filters.feature` exercises in both modes. An invalid expression fails with the parser's message, e.g. `Tag expression "@a and (" could not be parsed because of syntax error: Unmatched (.`

I can send a follow-up to the docs repository once the shape is validated.