### PR TITLE
feat: Add DataTable and DocString step argument types

### DIFF
--- a/features/arguments.feature
+++ b/features/arguments.feature
@@ -64,10 +64,10 @@ Feature: Step Arguments
       | features/datatable.feature |       |
     Then it should pass with:
       """
-      ....
+      .....
 
       2 scenarios (2 passed)
-      4 steps (4 passed)
+      5 steps (5 passed)
       """
 
   Scenario: DocString
@@ -76,10 +76,10 @@ Feature: Step Arguments
       | features/docstring.feature |       |
     Then it should pass with:
       """
-      ..
+      .....
 
-      1 scenario (1 passed)
-      2 steps (2 passed)
+      2 scenarios (2 passed)
+      5 steps (5 passed)
       """
 
   Scenario: given TableNode argument that is not defined in context

--- a/features/arguments.feature
+++ b/features/arguments.feature
@@ -58,6 +58,30 @@ Feature: Step Arguments
       2 steps (2 passed)
       """
 
+  Scenario: DataTable
+    When I run behat with the following additional options:
+      | option                     | value |
+      | features/datatable.feature |       |
+    Then it should pass with:
+      """
+      ....
+
+      2 scenarios (2 passed)
+      4 steps (4 passed)
+      """
+
+  Scenario: DocString
+    When I run behat with the following additional options:
+      | option                     | value |
+      | features/docstring.feature |       |
+    Then it should pass with:
+      """
+      ..
+
+      1 scenario (1 passed)
+      2 steps (2 passed)
+      """
+
   Scenario: given TableNode argument that is not defined in context
     When I run behat with the following additional options:
       | option                                      | value |

--- a/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
@@ -176,9 +176,10 @@ final class RepositorySearchEngine implements SearchEngine
      * Wraps multiline arguments into their dedicated Behat representation
      * when the definition asks for it.
      *
-     * The raw Gherkin node always wins: an argument is only wrapped when no
-     * parameter of the definition accepts the node itself, and some parameter
-     * accepts the wrapper.
+     * A step cannot mix both representations of the same multiline argument, so
+     * asking for the wrapper anywhere in the signature is enough to wrap. When no
+     * parameter accepts it, the raw Gherkin node is passed through unchanged and
+     * existing definitions keep working.
      *
      * @param list<ArgumentInterface> $multiline
      *
@@ -189,14 +190,12 @@ final class RepositorySearchEngine implements SearchEngine
         return array_map(
             function (ArgumentInterface $argument) use ($function) {
                 if ($argument instanceof TableNode
-                    && !$this->someParameterAccepts($function, $argument::class)
                     && $this->someParameterAccepts($function, DataTable::class)
                 ) {
                     return new DataTable($argument);
                 }
 
                 if ($argument instanceof PyStringNode
-                    && !$this->someParameterAccepts($function, $argument::class)
                     && $this->someParameterAccepts($function, DocString::class)
                 ) {
                     return new DocString($argument);

--- a/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
@@ -18,11 +18,19 @@ use Behat\Behat\Definition\SearchResult;
 use Behat\Behat\Definition\Translator\DefinitionTranslator;
 use Behat\Gherkin\Node\ArgumentInterface;
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Step\DataTable;
+use Behat\Step\DocString;
 use Behat\Testwork\Argument\ArgumentOrganiser;
 use Behat\Testwork\Argument\Exception\UnexpectedMultilineArgumentException;
 use Behat\Testwork\Deprecation\DeprecationCollector;
 use Behat\Testwork\Environment\Environment;
+use ReflectionFunctionAbstract;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionUnionType;
 
 /**
  * Searches for a step definition using definition repository.
@@ -95,7 +103,7 @@ final class RepositorySearchEngine implements SearchEngine
         }
 
         $function = $definition->getReflection();
-        $match = array_merge($match, array_values($multiline));
+        $match = array_merge($match, $this->wrapMultilineArguments($function, array_values($multiline)));
 
         try {
             $arguments = $this->argumentOrganiser->organiseArguments($function, $match);
@@ -162,5 +170,68 @@ final class RepositorySearchEngine implements SearchEngine
         $namedGroups = count(array_filter(array_keys($match), is_string(...)));
 
         return count($match) - 1 - $namedGroups;
+    }
+
+    /**
+     * Wraps multiline arguments into their dedicated Behat representation
+     * when the definition asks for it.
+     *
+     * The raw Gherkin node always wins: an argument is only wrapped when no
+     * parameter of the definition accepts the node itself, and some parameter
+     * accepts the wrapper.
+     *
+     * @param list<ArgumentInterface> $multiline
+     *
+     * @return list<ArgumentInterface|DataTable|DocString>
+     */
+    private function wrapMultilineArguments(ReflectionFunctionAbstract $function, array $multiline): array
+    {
+        return array_map(
+            function (ArgumentInterface $argument) use ($function) {
+                if ($argument instanceof TableNode
+                    && !$this->someParameterAccepts($function, $argument::class)
+                    && $this->someParameterAccepts($function, DataTable::class)
+                ) {
+                    return new DataTable($argument);
+                }
+
+                if ($argument instanceof PyStringNode
+                    && !$this->someParameterAccepts($function, $argument::class)
+                    && $this->someParameterAccepts($function, DocString::class)
+                ) {
+                    return new DocString($argument);
+                }
+
+                return $argument;
+            },
+            $multiline,
+        );
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function someParameterAccepts(ReflectionFunctionAbstract $function, string $class): bool
+    {
+        foreach ($function->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            $namedTypes = match (true) {
+                $type instanceof ReflectionNamedType => [$type],
+                $type instanceof ReflectionUnionType,
+                $type instanceof ReflectionIntersectionType => array_filter(
+                    $type->getTypes(),
+                    static fn ($member) => $member instanceof ReflectionNamedType,
+                ),
+                default => [],
+            };
+
+            foreach ($namedTypes as $namedType) {
+                if (!$namedType->isBuiltin() && is_a($class, $namedType->getName(), true)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Behat/Step/DataTable.php
+++ b/src/Behat/Step/DataTable.php
@@ -10,8 +10,9 @@
 
 namespace Behat\Step;
 
-use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\TableNode;
+use InvalidArgumentException;
+use OutOfBoundsException;
 use Stringable;
 
 /**
@@ -25,9 +26,6 @@ use Stringable;
  */
 final class DataTable implements Stringable
 {
-    /**
-     * @internal instances are created by Behat, from the Gherkin node of the step
-     */
     public function __construct(
         private readonly TableNode $tableNode,
     ) {
@@ -59,27 +57,43 @@ final class DataTable implements Stringable
      * Returns a two-column table as an associative array, mapping the cells
      * of the first column to the cells of the second column.
      *
-     * A row that has more than two cells maps to the list of its remaining
-     * cells, and a single-column row maps to an empty list.
+     * Every row of a single-column table maps to null.
      *
-     * @return array<string, string|list<string>>
+     * @return array<string, string|null>
+     *
+     * @throws InvalidArgumentException when the table has more than two columns
      */
     public function asMap(): array
     {
-        return $this->tableNode->getRowsHash();
+        $width = $this->width();
+
+        if ($width > 2) {
+            throw new InvalidArgumentException(sprintf(
+                'A table with %d columns cannot be converted to a map, it must have at most two columns.',
+                $width,
+            ));
+        }
+
+        $map = [];
+
+        foreach ($this->asLists() as $row) {
+            $map[$row[0]] = $row[1] ?? null;
+        }
+
+        return $map;
     }
 
     /**
      * Returns the value of a single cell by zero-based row and column indexes.
      *
-     * @throws NodeException when the row or the column does not exist
+     * @throws OutOfBoundsException when the row or the column does not exist
      */
     public function cell(int $row, int $column): string
     {
         $cells = $this->row($row);
 
         if (!array_key_exists($column, $cells)) {
-            throw new NodeException(sprintf('Column #%s does not exist in table.', $column));
+            throw new OutOfBoundsException($this->columnIsOutOfBounds($column));
         }
 
         return $cells[$column];
@@ -89,20 +103,38 @@ final class DataTable implements Stringable
      * Returns a row as a list of cell values, by zero-based index.
      *
      * @return list<string>
+     *
+     * @throws OutOfBoundsException when the row does not exist
      */
     public function row(int $index): array
     {
-        return $this->tableNode->getRow($index);
+        $rows = $this->asLists();
+
+        if (!array_key_exists($index, $rows)) {
+            throw new OutOfBoundsException(sprintf(
+                'Row #%d does not exist in this table, which has %d rows.',
+                $index,
+                count($rows),
+            ));
+        }
+
+        return $rows[$index];
     }
 
     /**
      * Returns a column as a list of cell values, by zero-based index.
      *
      * @return list<string>
+     *
+     * @throws OutOfBoundsException when the column does not exist
      */
     public function column(int $index): array
     {
-        return $this->tableNode->getColumn($index);
+        if ($index < 0 || $index >= $this->width()) {
+            throw new OutOfBoundsException($this->columnIsOutOfBounds($index));
+        }
+
+        return array_column($this->asLists(), $index);
     }
 
     /**
@@ -148,5 +180,14 @@ final class DataTable implements Stringable
     public function __toString(): string
     {
         return $this->tableNode->getTableAsString();
+    }
+
+    private function columnIsOutOfBounds(int $index): string
+    {
+        return sprintf(
+            'Column #%d does not exist in this table, which has %d columns.',
+            $index,
+            $this->width(),
+        );
     }
 }

--- a/src/Behat/Step/DataTable.php
+++ b/src/Behat/Step/DataTable.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Step;
+
+use Behat\Gherkin\Node\TableNode;
+use Stringable;
+
+/**
+ * Represents a Gherkin data table passed to a step definition.
+ *
+ * Use this type instead of {@see TableNode} in step definition parameters to
+ * keep them decoupled from the Gherkin AST. The API is modelled on the
+ * cucumber DataTable classes.
+ *
+ * @api
+ */
+final class DataTable implements Stringable
+{
+    /**
+     * @api
+     */
+    public function __construct(
+        private readonly TableNode $tableNode,
+    ) {
+    }
+
+    /**
+     * Returns the whole table, including the header row if any, as a list of
+     * rows, each row being a list of cell values.
+     *
+     * @return list<list<string>>
+     *
+     * @api
+     */
+    public function asLists(): array
+    {
+        return array_values(array_map(array_values(...), $this->tableNode->getTable()));
+    }
+
+    /**
+     * Returns the table as a list of associative arrays, using the first row
+     * as keys for the values of every following row.
+     *
+     * @return list<array<string, string>>
+     *
+     * @api
+     */
+    public function asMaps(): array
+    {
+        return $this->tableNode->getHash();
+    }
+
+    /**
+     * Returns a two-column table as an associative array, mapping the cells
+     * of the first column to the cells of the second column.
+     *
+     * @return array<string, string>
+     *
+     * @api
+     */
+    public function asMap(): array
+    {
+        return $this->tableNode->getRowsHash();
+    }
+
+    /**
+     * Returns the value of a single cell by zero-based row and column indexes.
+     *
+     * @api
+     */
+    public function cell(int $row, int $column): string
+    {
+        return $this->row($row)[$column];
+    }
+
+    /**
+     * Returns a row as a list of cell values, by zero-based index.
+     *
+     * @return list<string>
+     *
+     * @api
+     */
+    public function row(int $index): array
+    {
+        return $this->tableNode->getRow($index);
+    }
+
+    /**
+     * Returns a column as a list of cell values, by zero-based index.
+     *
+     * @return list<string>
+     *
+     * @api
+     */
+    public function column(int $index): array
+    {
+        return $this->tableNode->getColumn($index);
+    }
+
+    /**
+     * Returns the number of rows.
+     *
+     * @api
+     */
+    public function height(): int
+    {
+        return count($this->tableNode->getRows());
+    }
+
+    /**
+     * Returns the number of columns.
+     *
+     * @api
+     */
+    public function width(): int
+    {
+        return count($this->tableNode->getRows()[0] ?? []);
+    }
+
+    /**
+     * Returns whether the table has no rows at all.
+     *
+     * @api
+     */
+    public function isEmpty(): bool
+    {
+        return $this->tableNode->getRows() === [];
+    }
+
+    /**
+     * Returns a new table with rows and columns swapped.
+     *
+     * @api
+     */
+    public function transpose(): self
+    {
+        $rows = array_values(array_map(array_values(...), $this->tableNode->getTable()));
+        $transposed = [];
+        foreach ($rows as $rowIndex => $row) {
+            foreach ($row as $columnIndex => $cell) {
+                $transposed[$columnIndex][$rowIndex] = $cell;
+            }
+        }
+
+        return new self(new TableNode($transposed));
+    }
+
+    /**
+     * @api
+     */
+    public function __toString(): string
+    {
+        return $this->tableNode->getTableAsString();
+    }
+}

--- a/src/Behat/Step/DataTable.php
+++ b/src/Behat/Step/DataTable.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Step;
 
+use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\TableNode;
 use Stringable;
 
@@ -25,7 +26,7 @@ use Stringable;
 final class DataTable implements Stringable
 {
     /**
-     * @api
+     * @internal instances are created by Behat, from the Gherkin node of the step
      */
     public function __construct(
         private readonly TableNode $tableNode,
@@ -37,8 +38,6 @@ final class DataTable implements Stringable
      * rows, each row being a list of cell values.
      *
      * @return list<list<string>>
-     *
-     * @api
      */
     public function asLists(): array
     {
@@ -50,8 +49,6 @@ final class DataTable implements Stringable
      * as keys for the values of every following row.
      *
      * @return list<array<string, string>>
-     *
-     * @api
      */
     public function asMaps(): array
     {
@@ -62,9 +59,10 @@ final class DataTable implements Stringable
      * Returns a two-column table as an associative array, mapping the cells
      * of the first column to the cells of the second column.
      *
-     * @return array<string, string>
+     * A row that has more than two cells maps to the list of its remaining
+     * cells, and a single-column row maps to an empty list.
      *
-     * @api
+     * @return array<string, string|list<string>>
      */
     public function asMap(): array
     {
@@ -74,19 +72,23 @@ final class DataTable implements Stringable
     /**
      * Returns the value of a single cell by zero-based row and column indexes.
      *
-     * @api
+     * @throws NodeException when the row or the column does not exist
      */
     public function cell(int $row, int $column): string
     {
-        return $this->row($row)[$column];
+        $cells = $this->row($row);
+
+        if (!array_key_exists($column, $cells)) {
+            throw new NodeException(sprintf('Column #%s does not exist in table.', $column));
+        }
+
+        return $cells[$column];
     }
 
     /**
      * Returns a row as a list of cell values, by zero-based index.
      *
      * @return list<string>
-     *
-     * @api
      */
     public function row(int $index): array
     {
@@ -97,8 +99,6 @@ final class DataTable implements Stringable
      * Returns a column as a list of cell values, by zero-based index.
      *
      * @return list<string>
-     *
-     * @api
      */
     public function column(int $index): array
     {
@@ -107,8 +107,6 @@ final class DataTable implements Stringable
 
     /**
      * Returns the number of rows.
-     *
-     * @api
      */
     public function height(): int
     {
@@ -117,8 +115,6 @@ final class DataTable implements Stringable
 
     /**
      * Returns the number of columns.
-     *
-     * @api
      */
     public function width(): int
     {
@@ -127,8 +123,6 @@ final class DataTable implements Stringable
 
     /**
      * Returns whether the table has no rows at all.
-     *
-     * @api
      */
     public function isEmpty(): bool
     {
@@ -137,8 +131,6 @@ final class DataTable implements Stringable
 
     /**
      * Returns a new table with rows and columns swapped.
-     *
-     * @api
      */
     public function transpose(): self
     {
@@ -153,9 +145,6 @@ final class DataTable implements Stringable
         return new self(new TableNode($transposed));
     }
 
-    /**
-     * @api
-     */
     public function __toString(): string
     {
         return $this->tableNode->getTableAsString();

--- a/src/Behat/Step/DocString.php
+++ b/src/Behat/Step/DocString.php
@@ -24,7 +24,7 @@ use Stringable;
 final class DocString implements Stringable
 {
     /**
-     * @api
+     * @internal instances are created by Behat, from the Gherkin node of the step
      */
     public function __construct(
         private readonly PyStringNode $pyStringNode,
@@ -33,17 +33,12 @@ final class DocString implements Stringable
 
     /**
      * Returns the text of the doc string.
-     *
-     * @api
      */
     public function getContent(): string
     {
         return $this->pyStringNode->getRaw();
     }
 
-    /**
-     * @api
-     */
     public function __toString(): string
     {
         return $this->pyStringNode->getRaw();

--- a/src/Behat/Step/DocString.php
+++ b/src/Behat/Step/DocString.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Step;
+
+use Behat\Gherkin\Node\PyStringNode;
+use Stringable;
+
+/**
+ * Represents a Gherkin doc string passed to a step definition.
+ *
+ * Use this type instead of {@see PyStringNode} in step definition parameters
+ * to keep them decoupled from the Gherkin AST.
+ *
+ * @api
+ */
+final class DocString implements Stringable
+{
+    /**
+     * @api
+     */
+    public function __construct(
+        private readonly PyStringNode $pyStringNode,
+    ) {
+    }
+
+    /**
+     * Returns the text of the doc string.
+     *
+     * @api
+     */
+    public function getContent(): string
+    {
+        return $this->pyStringNode->getRaw();
+    }
+
+    /**
+     * @api
+     */
+    public function __toString(): string
+    {
+        return $this->pyStringNode->getRaw();
+    }
+}

--- a/src/Behat/Step/DocString.php
+++ b/src/Behat/Step/DocString.php
@@ -23,9 +23,6 @@ use Stringable;
  */
 final class DocString implements Stringable
 {
-    /**
-     * @internal instances are created by Behat, from the Gherkin node of the step
-     */
     public function __construct(
         private readonly PyStringNode $pyStringNode,
     ) {

--- a/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
+++ b/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php
@@ -12,6 +12,8 @@ namespace Behat\Testwork\Argument;
 
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Step\DataTable;
+use Behat\Step\DocString;
 use Behat\Testwork\Argument\Exception\UnexpectedMultilineArgumentException;
 use Closure;
 use ReflectionClass;
@@ -88,7 +90,9 @@ final class MixedArgumentOrganiser implements ArgumentOrganiser
     private function hasMultilineArgument(array $arguments): bool
     {
         foreach ($arguments as $argument) {
-            if ($argument instanceof TableNode || $argument instanceof PyStringNode) {
+            if ($argument instanceof TableNode || $argument instanceof PyStringNode
+                || $argument instanceof DataTable || $argument instanceof DocString
+            ) {
                 return true;
             }
         }

--- a/tests/Behat/Tests/Step/DataTableTest.php
+++ b/tests/Behat/Tests/Step/DataTableTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Behat\Tests\Step;
+
+use Behat\Gherkin\Node\TableNode;
+use Behat\Step\DataTable;
+use PHPUnit\Framework\TestCase;
+
+final class DataTableTest extends TestCase
+{
+    private DataTable $table;
+
+    protected function setUp(): void
+    {
+        $this->table = new DataTable(new TableNode([
+            10 => ['name', 'colour'],
+            11 => ['apple', 'green'],
+            12 => ['plum', 'purple'],
+        ]));
+    }
+
+    public function testAsListsReturnsAllRowsAsLists(): void
+    {
+        $this->assertSame([
+            ['name', 'colour'],
+            ['apple', 'green'],
+            ['plum', 'purple'],
+        ], $this->table->asLists());
+    }
+
+    public function testAsMapsUsesTheFirstRowAsKeys(): void
+    {
+        $this->assertSame([
+            ['name' => 'apple', 'colour' => 'green'],
+            ['name' => 'plum', 'colour' => 'purple'],
+        ], $this->table->asMaps());
+    }
+
+    public function testAsMapMapsTheFirstColumnToTheSecondOne(): void
+    {
+        $this->assertSame([
+            'name' => 'colour',
+            'apple' => 'green',
+            'plum' => 'purple',
+        ], $this->table->asMap());
+    }
+
+    public function testCellIsAccessedByZeroBasedRowAndColumn(): void
+    {
+        $this->assertSame('name', $this->table->cell(0, 0));
+        $this->assertSame('purple', $this->table->cell(2, 1));
+    }
+
+    public function testRowIsAccessedByZeroBasedIndex(): void
+    {
+        $this->assertSame(['apple', 'green'], $this->table->row(1));
+    }
+
+    public function testColumnIsAccessedByZeroBasedIndex(): void
+    {
+        $this->assertSame(['colour', 'green', 'purple'], $this->table->column(1));
+    }
+
+    public function testHeightCountsAllRows(): void
+    {
+        $this->assertSame(3, $this->table->height());
+    }
+
+    public function testWidthCountsTheColumns(): void
+    {
+        $this->assertSame(2, $this->table->width());
+    }
+
+    public function testAnEmptyTableHasNoDimensions(): void
+    {
+        $table = new DataTable(new TableNode([]));
+
+        $this->assertTrue($table->isEmpty());
+        $this->assertSame(0, $table->height());
+        $this->assertSame(0, $table->width());
+        $this->assertSame([], $table->asLists());
+    }
+
+    public function testANonEmptyTableIsNotEmpty(): void
+    {
+        $this->assertFalse($this->table->isEmpty());
+    }
+
+    public function testTransposeSwapsRowsAndColumns(): void
+    {
+        $this->assertSame([
+            ['name', 'apple', 'plum'],
+            ['colour', 'green', 'purple'],
+        ], $this->table->transpose()->asLists());
+    }
+
+    public function testItStringifiesAsAPaddedTable(): void
+    {
+        $this->assertSame(
+            "| name  | colour |\n| apple | green  |\n| plum  | purple |",
+            (string) $this->table,
+        );
+    }
+}

--- a/tests/Behat/Tests/Step/DataTableTest.php
+++ b/tests/Behat/Tests/Step/DataTableTest.php
@@ -2,9 +2,10 @@
 
 namespace Behat\Tests\Step;
 
-use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Step\DataTable;
+use InvalidArgumentException;
+use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
 final class DataTableTest extends TestCase
@@ -29,80 +30,81 @@ final class DataTableTest extends TestCase
         ], $this->table->asLists());
     }
 
-    public function testAsMapsUsesTheFirstRowAsKeys(): void
+    /**
+     * @return array<string, array{array<int, list<string>>, list<array<string, string>>}>
+     */
+    public static function providerAsMaps(): array
     {
-        $this->assertSame([
-            ['name' => 'apple', 'colour' => 'green'],
-            ['name' => 'plum', 'colour' => 'purple'],
-        ], $this->table->asMaps());
+        return [
+            'header row and value rows' => [
+                [['name', 'colour'], ['apple', 'green']],
+                [['name' => 'apple', 'colour' => 'green']],
+            ],
+            'header row only' => [
+                [['name', 'colour']],
+                [],
+            ],
+            'empty table' => [
+                [],
+                [],
+            ],
+        ];
     }
 
-    public function testAsMapMapsTheFirstColumnToTheSecondOne(): void
+    /**
+     * @dataProvider providerAsMaps
+     *
+     * @param array<int, list<string>> $rows
+     * @param list<array<string, string>> $expect
+     */
+    public function testAsMapsUsesTheFirstRowAsKeys(array $rows, array $expect): void
     {
-        $this->assertSame([
-            'name' => 'colour',
-            'apple' => 'green',
-            'plum' => 'purple',
-        ], $this->table->asMap());
+        $this->assertSame($expect, (new DataTable(new TableNode($rows)))->asMaps());
     }
 
-    public function testAsMapsIsEmptyWhenTheTableOnlyHasItsHeaderRow(): void
+    /**
+     * @return array<string, array{array<int, list<string>>, array<string, string|null>}>
+     */
+    public static function providerAsMap(): array
     {
-        $table = new DataTable(new TableNode([['name', 'colour']]));
-
-        $this->assertSame([], $table->asMaps());
+        return [
+            'two columns' => [
+                [['name', 'colour'], ['apple', 'green'], ['plum', 'purple']],
+                ['name' => 'colour', 'apple' => 'green', 'plum' => 'purple'],
+            ],
+            'single column' => [
+                [['name'], ['apple']],
+                ['name' => null, 'apple' => null],
+            ],
+            'empty table' => [
+                [],
+                [],
+            ],
+        ];
     }
 
-    public function testAsMapOnASingleColumnTableMapsEveryRowToAnEmptyList(): void
+    /**
+     * @dataProvider providerAsMap
+     *
+     * @param array<int, list<string>> $rows
+     * @param array<string, string|null> $expect
+     */
+    public function testAsMapMapsTheFirstColumnToTheSecondOne(array $rows, array $expect): void
     {
-        $table = new DataTable(new TableNode([['name'], ['apple']]));
-
-        $this->assertSame(['name' => [], 'apple' => []], $table->asMap());
+        $this->assertSame($expect, (new DataTable(new TableNode($rows)))->asMap());
     }
 
-    public function testAsMapOnAWiderTableMapsTheFirstCellToTheRemainingOnes(): void
+    public function testAsMapRejectsATableWithMoreThanTwoColumns(): void
     {
         $table = new DataTable(new TableNode([
             ['name', 'colour', 'size'],
             ['apple', 'green', 'small'],
         ]));
 
-        $this->assertSame([
-            'name' => ['colour', 'size'],
-            'apple' => ['green', 'small'],
-        ], $table->asMap());
-    }
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A table with 3 columns cannot be converted to a map, it must have at most two columns.');
 
-    public function testAccessingARowThatDoesNotExistThrows(): void
-    {
-        $this->expectException(NodeException::class);
-        $this->expectExceptionMessage('Rows #9 does not exist in table.');
-
-        $this->table->row(9);
-    }
-
-    public function testAccessingAColumnThatDoesNotExistThrows(): void
-    {
-        $this->expectException(NodeException::class);
-        $this->expectExceptionMessage('Column #9 does not exist in table.');
-
-        $this->table->column(9);
-    }
-
-    public function testAccessingACellOutsideTheRowsThrows(): void
-    {
-        $this->expectException(NodeException::class);
-        $this->expectExceptionMessage('Rows #9 does not exist in table.');
-
-        $this->table->cell(9, 0);
-    }
-
-    public function testAccessingACellOutsideTheColumnsThrows(): void
-    {
-        $this->expectException(NodeException::class);
-        $this->expectExceptionMessage('Column #9 does not exist in table.');
-
-        $this->table->cell(0, 9);
+        $table->asMap();
     }
 
     public function testCellIsAccessedByZeroBasedRowAndColumn(): void
@@ -121,6 +123,52 @@ final class DataTableTest extends TestCase
         $this->assertSame(['colour', 'green', 'purple'], $this->table->column(1));
     }
 
+    /**
+     * @return array<string, array{callable(DataTable): mixed, string}>
+     */
+    public static function providerOutOfBoundsAccess(): array
+    {
+        return [
+            'row just past the last one' => [
+                static fn (DataTable $table) => $table->row(3),
+                'Row #3 does not exist in this table, which has 3 rows.',
+            ],
+            'negative row' => [
+                static fn (DataTable $table) => $table->row(-1),
+                'Row #-1 does not exist in this table, which has 3 rows.',
+            ],
+            'column just past the last one' => [
+                static fn (DataTable $table) => $table->column(2),
+                'Column #2 does not exist in this table, which has 2 columns.',
+            ],
+            'negative column' => [
+                static fn (DataTable $table) => $table->column(-1),
+                'Column #-1 does not exist in this table, which has 2 columns.',
+            ],
+            'cell in a row just past the last one' => [
+                static fn (DataTable $table) => $table->cell(3, 0),
+                'Row #3 does not exist in this table, which has 3 rows.',
+            ],
+            'cell in a column just past the last one' => [
+                static fn (DataTable $table) => $table->cell(0, 2),
+                'Column #2 does not exist in this table, which has 2 columns.',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerOutOfBoundsAccess
+     *
+     * @param callable(DataTable): mixed $access
+     */
+    public function testAccessingARowColumnOrCellThatDoesNotExistThrows(callable $access, string $expect): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage($expect);
+
+        $access($this->table);
+    }
+
     public function testHeightCountsAllRows(): void
     {
         $this->assertSame(3, $this->table->height());
@@ -131,6 +179,11 @@ final class DataTableTest extends TestCase
         $this->assertSame(2, $this->table->width());
     }
 
+    public function testANonEmptyTableIsNotEmpty(): void
+    {
+        $this->assertFalse($this->table->isEmpty());
+    }
+
     public function testAnEmptyTableHasNoDimensions(): void
     {
         $table = new DataTable(new TableNode([]));
@@ -139,11 +192,6 @@ final class DataTableTest extends TestCase
         $this->assertSame(0, $table->height());
         $this->assertSame(0, $table->width());
         $this->assertSame([], $table->asLists());
-    }
-
-    public function testANonEmptyTableIsNotEmpty(): void
-    {
-        $this->assertFalse($this->table->isEmpty());
     }
 
     public function testTransposeSwapsRowsAndColumns(): void

--- a/tests/Behat/Tests/Step/DataTableTest.php
+++ b/tests/Behat/Tests/Step/DataTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Behat\Tests\Step;
 
+use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Step\DataTable;
 use PHPUnit\Framework\TestCase;
@@ -43,6 +44,65 @@ final class DataTableTest extends TestCase
             'apple' => 'green',
             'plum' => 'purple',
         ], $this->table->asMap());
+    }
+
+    public function testAsMapsIsEmptyWhenTheTableOnlyHasItsHeaderRow(): void
+    {
+        $table = new DataTable(new TableNode([['name', 'colour']]));
+
+        $this->assertSame([], $table->asMaps());
+    }
+
+    public function testAsMapOnASingleColumnTableMapsEveryRowToAnEmptyList(): void
+    {
+        $table = new DataTable(new TableNode([['name'], ['apple']]));
+
+        $this->assertSame(['name' => [], 'apple' => []], $table->asMap());
+    }
+
+    public function testAsMapOnAWiderTableMapsTheFirstCellToTheRemainingOnes(): void
+    {
+        $table = new DataTable(new TableNode([
+            ['name', 'colour', 'size'],
+            ['apple', 'green', 'small'],
+        ]));
+
+        $this->assertSame([
+            'name' => ['colour', 'size'],
+            'apple' => ['green', 'small'],
+        ], $table->asMap());
+    }
+
+    public function testAccessingARowThatDoesNotExistThrows(): void
+    {
+        $this->expectException(NodeException::class);
+        $this->expectExceptionMessage('Rows #9 does not exist in table.');
+
+        $this->table->row(9);
+    }
+
+    public function testAccessingAColumnThatDoesNotExistThrows(): void
+    {
+        $this->expectException(NodeException::class);
+        $this->expectExceptionMessage('Column #9 does not exist in table.');
+
+        $this->table->column(9);
+    }
+
+    public function testAccessingACellOutsideTheRowsThrows(): void
+    {
+        $this->expectException(NodeException::class);
+        $this->expectExceptionMessage('Rows #9 does not exist in table.');
+
+        $this->table->cell(9, 0);
+    }
+
+    public function testAccessingACellOutsideTheColumnsThrows(): void
+    {
+        $this->expectException(NodeException::class);
+        $this->expectExceptionMessage('Column #9 does not exist in table.');
+
+        $this->table->cell(0, 9);
     }
 
     public function testCellIsAccessedByZeroBasedRowAndColumn(): void

--- a/tests/Behat/Tests/Step/DocStringTest.php
+++ b/tests/Behat/Tests/Step/DocStringTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Behat\Tests\Step;
+
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Step\DocString;
+use PHPUnit\Framework\TestCase;
+
+final class DocStringTest extends TestCase
+{
+    public function testItExposesItsContent(): void
+    {
+        $docString = new DocString(new PyStringNode(['hello', 'world'], 12));
+
+        $this->assertSame("hello\nworld", $docString->getContent());
+    }
+
+    public function testItStringifiesToItsContent(): void
+    {
+        $docString = new DocString(new PyStringNode(['hello', 'world'], 12));
+
+        $this->assertSame("hello\nworld", (string) $docString);
+    }
+}

--- a/tests/Fixtures/Arguments/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Arguments/features/bootstrap/FeatureContext.php
@@ -12,6 +12,7 @@ use Behat\Tests\Fixtures\Assert;
 class FeatureContext implements Context
 {
     private $input;
+    private $text;
     private $strings = [];
     private $tables = [];
 
@@ -81,8 +82,8 @@ class FeatureContext implements Context
     #[Then('/^the data table must be equals to table (\d+)$/')]
     public function theDataTableMustBeEqualsToTable($number)
     {
-        PHPUnit\Framework\Assert::assertInstanceOf(DataTable::class, $this->input);
-        PHPUnit\Framework\Assert::assertEquals($this->tables[intval($number)], $this->input->asMaps());
+        Assert::assertSame(DataTable::class, $this->input::class);
+        Assert::assertEquals($this->tables[intval($number)], $this->input->asMaps());
     }
 
     #[Given('/^a doc string:$/')]
@@ -94,19 +95,33 @@ class FeatureContext implements Context
     #[Then('/^the doc string must be equals to string (\d+)$/')]
     public function theDocStringMustBeEqualsToString($number)
     {
-        PHPUnit\Framework\Assert::assertInstanceOf(DocString::class, $this->input);
-        PHPUnit\Framework\Assert::assertEquals($this->strings[intval($number)], $this->input->getContent());
+        Assert::assertSame(DocString::class, $this->input::class);
+        Assert::assertEquals($this->strings[intval($number)], $this->input->getContent());
     }
 
-    #[Given('/^a table that could be wrapped or not:$/')]
-    public function aTableThatCouldBeWrappedOrNot(TableNode|DataTable $table)
+    #[Given('/^an untyped step that takes "([^"]*)" and these values:$/')]
+    public function anUntypedStepThatTakesAndTheseValues($text, $table)
     {
         $this->input = $table;
+        $this->text = $text;
     }
 
-    #[Then('/^the argument must be a raw TableNode$/')]
-    public function theArgumentMustBeARawTableNode()
+    #[Given('/^an untyped step that takes "([^"]*)" and this text:$/')]
+    public function anUntypedStepThatTakesAndThisText($text, $string)
     {
-        PHPUnit\Framework\Assert::assertInstanceOf(TableNode::class, $this->input);
+        $this->input = $string;
+        $this->text = $text;
+    }
+
+    #[Then('/^the argument must be a raw (TableNode|PyStringNode)$/')]
+    public function theArgumentMustBeARawGherkinNode($class)
+    {
+        Assert::assertSame('Behat\\Gherkin\\Node\\' . $class, $this->input::class);
+    }
+
+    #[Then('/^the other argument must be "([^"]*)"$/')]
+    public function theOtherArgumentMustBe($expected)
+    {
+        Assert::assertSame($expected, $this->text);
     }
 }

--- a/tests/Fixtures/Arguments/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Arguments/features/bootstrap/FeatureContext.php
@@ -3,6 +3,8 @@
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Step\DataTable;
+use Behat\Step\DocString;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Tests\Fixtures\Assert;
@@ -68,5 +70,43 @@ class FeatureContext implements Context
     #[Given('/^a step with no argument$/')]
     public function aStepWithNoArgument(): void
     {
+    }
+
+    #[Given('/^a data table:$/')]
+    public function aDataTable(DataTable $table)
+    {
+        $this->input = $table;
+    }
+
+    #[Then('/^the data table must be equals to table (\d+)$/')]
+    public function theDataTableMustBeEqualsToTable($number)
+    {
+        PHPUnit\Framework\Assert::assertInstanceOf(DataTable::class, $this->input);
+        PHPUnit\Framework\Assert::assertEquals($this->tables[intval($number)], $this->input->asMaps());
+    }
+
+    #[Given('/^a doc string:$/')]
+    public function aDocString(DocString $string)
+    {
+        $this->input = $string;
+    }
+
+    #[Then('/^the doc string must be equals to string (\d+)$/')]
+    public function theDocStringMustBeEqualsToString($number)
+    {
+        PHPUnit\Framework\Assert::assertInstanceOf(DocString::class, $this->input);
+        PHPUnit\Framework\Assert::assertEquals($this->strings[intval($number)], $this->input->getContent());
+    }
+
+    #[Given('/^a table that could be wrapped or not:$/')]
+    public function aTableThatCouldBeWrappedOrNot(TableNode|DataTable $table)
+    {
+        $this->input = $table;
+    }
+
+    #[Then('/^the argument must be a raw TableNode$/')]
+    public function theArgumentMustBeARawTableNode()
+    {
+        PHPUnit\Framework\Assert::assertInstanceOf(TableNode::class, $this->input);
     }
 }

--- a/tests/Fixtures/Arguments/features/datatable.feature
+++ b/tests/Fixtures/Arguments/features/datatable.feature
@@ -1,0 +1,13 @@
+Feature: Data tables
+  Scenario:
+    Given a data table:
+      | item1 | item2 | item3 |
+      | super | mega  | extra |
+      | hyper | mini  | XXL   |
+    Then the data table must be equals to table 1
+
+  Scenario:
+    Given a table that could be wrapped or not:
+      | item1 | item2 | item3 |
+      | super | mega  | extra |
+    Then the argument must be a raw TableNode

--- a/tests/Fixtures/Arguments/features/datatable.feature
+++ b/tests/Fixtures/Arguments/features/datatable.feature
@@ -6,8 +6,9 @@ Feature: Data tables
       | hyper | mini  | XXL   |
     Then the data table must be equals to table 1
 
-  Scenario:
-    Given a table that could be wrapped or not:
+  Scenario: A step with no declared types still receives the raw Gherkin node
+    Given an untyped step that takes "hello" and these values:
       | item1 | item2 | item3 |
       | super | mega  | extra |
     Then the argument must be a raw TableNode
+    And the other argument must be "hello"

--- a/tests/Fixtures/Arguments/features/docstring.feature
+++ b/tests/Fixtures/Arguments/features/docstring.feature
@@ -1,0 +1,12 @@
+Feature: Doc strings
+  Scenario:
+    Given a doc string:
+      """
+      hello,
+        w
+         o
+      r
+      l
+         d
+      """
+    Then the doc string must be equals to string 1

--- a/tests/Fixtures/Arguments/features/docstring.feature
+++ b/tests/Fixtures/Arguments/features/docstring.feature
@@ -10,3 +10,16 @@ Feature: Doc strings
          d
       """
     Then the doc string must be equals to string 1
+
+  Scenario: A step with no declared types still receives the raw Gherkin node
+    Given an untyped step that takes "hello" and this text:
+      """
+      hello,
+        w
+         o
+      r
+      l
+         d
+      """
+    Then the argument must be a raw PyStringNode
+    And the other argument must be "hello"


### PR DESCRIPTION
Closes #1639.

This adds the dedicated Behat representation of multiline step arguments discussed in the issue:

- `Behat\Step\DataTable` wraps `TableNode` (it never extends it) and exposes an API modelled on the cucumber DataTable classes: `asLists()`, `asMaps()`, `asMap()`, `cell()`, `row()`, `column()`, `width()`, `height()`, `isEmpty()`, `transpose()`, plus `Stringable`. Nothing from behat/gherkin leaks into the public API besides the constructor, so it can later wrap a `PickleTable` without breaking step definitions.
- `Behat\Step\DocString` is the almost-empty `Stringable` DTO suggested by @acoulton: `getContent()` and `__toString()`. Chosen over passing a raw `string` so the #1614 checks keep working unchanged.

Wrapping happens during definition matching, and only when no parameter accepts the raw Gherkin node while one accepts the wrapper: every existing step definition keeps receiving exactly what it received before (covered by a test where a `TableNode|DataTable` parameter gets the raw node). The #1614 unused-argument check recognizes the wrappers too.

Bikeshedding welcome on names and namespace; I went with `Behat\Step` since that's where the user-facing step definition API already lives. Follow-ups not included here: snippet generation still proposes `TableNode`/`PyStringNode`, and a docs PR on Behat/docs once the API settles.
