### PR TITLE
feat: Show the suite name in failure summaries when several suites ran

### DIFF
--- a/features/multiple_suites_summary.feature
+++ b/features/multiple_suites_summary.feature
@@ -1,0 +1,106 @@
+Feature: Suite names in the summary lists
+  In order to identify the suite a scenario failed in when several suites share feature files
+  As a feature developer
+  I need the failure summaries to name the suite when more than one suite was executed
+
+  Background:
+    Given I initialise the working directory from the "Rerun" fixtures folder
+    And I provide the following options for all behat invocations:
+      | option      | value |
+      | --no-colors |       |
+
+  Scenario: Failed steps are annotated with the suite name when several suites run
+    When I run "behat --format progress"
+    Then it should fail with:
+      """
+      ..F.............F......F.............F......F.............F....
+
+      --- Failed steps:
+
+      001 Scenario: I'm little hungry   # features/apples.feature:9 (default)
+            Then I should have 3 apples # features/apples.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29 (default)
+            Then I should have 8 apples     # features/apples.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      003 Scenario: I'm little hungry    # features/bananas.feature:9 (default)
+            Then I should have 3 bananas # features/bananas.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      004 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (default)
+            Then I should have 8 bananas    # features/bananas.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      005 Scenario: I'm little hungry    # features/bananas.feature:9 (suite2)
+            Then I should have 3 bananas # features/bananas.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      006 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (suite2)
+            Then I should have 8 bananas    # features/bananas.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      18 scenarios (12 passed, 6 failed)
+      63 steps (57 passed, 6 failed)
+      """
+
+  Scenario: Failed scenarios are annotated with the suite name when several suites run
+    When I run behat with the following additional options:
+      | option            | value                     |
+      | --format          | progress                  |
+      | --format-settings | '{"short_summary": true}' |
+    Then it should fail with:
+      """
+      ..F.............F......F.............F......F.............F....
+
+      --- Failed scenarios:
+
+          features/apples.feature:9 (default) (on line 11)
+          features/apples.feature:29 (default) (on line 24)
+          features/bananas.feature:9 (default) (on line 11)
+          features/bananas.feature:29 (default) (on line 24)
+          features/bananas.feature:9 (suite2) (on line 11)
+          features/bananas.feature:29 (suite2) (on line 24)
+
+      18 scenarios (12 passed, 6 failed)
+      63 steps (57 passed, 6 failed)
+      """
+
+  Scenario: The pretty formatter annotates the failed scenarios too
+    When I run "behat --format pretty"
+    Then it should fail
+    And the output should contain:
+      """
+      --- Failed scenarios:
+
+          features/apples.feature:9 (default) (on line 11)
+          features/apples.feature:29 (default) (on line 24)
+          features/bananas.feature:9 (default) (on line 11)
+          features/bananas.feature:29 (default) (on line 24)
+          features/bananas.feature:9 (suite2) (on line 11)
+          features/bananas.feature:29 (suite2) (on line 24)
+
+      18 scenarios (12 passed, 6 failed)
+      63 steps (57 passed, 6 failed)
+      """
+
+  Scenario: Suite names are omitted when a single suite runs
+    When I run "behat --format progress --suite suite2"
+    Then it should fail with:
+      """
+      ..F.............F....
+
+      --- Failed steps:
+
+      001 Scenario: I'm little hungry    # features/bananas.feature:9
+            Then I should have 3 bananas # features/bananas.feature:11
+              Failed asserting that 2 matches expected 3.
+
+      002 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+            Then I should have 8 bananas    # features/bananas.feature:24
+              Failed asserting that 7 matches expected 8.
+
+      6 scenarios (4 passed, 2 failed)
+      21 steps (19 passed, 2 failed)
+      """

--- a/features/multiple_suites_summary.feature
+++ b/features/multiple_suites_summary.feature
@@ -19,19 +19,19 @@ Feature: Suite names in the summary lists
 
       001 Scenario: I'm little hungry   # features/apples.feature:9 (default)
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 1   | 8      |     # features/apples.feature:24 (default)
             Then I should have 8 apples # features/apples.feature:19
-              Failed asserting that 2 matches expected 8.
+              Failed asserting that 2 matches expected 8. (Exception)
 
       003 Scenario: I'm little hungry    # features/bananas.feature:9 (default)
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       004 Scenario: I'm little hungry    # features/bananas.feature:9 (suite2)
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       6 scenarios (2 passed, 4 failed)
       18 steps (14 passed, 4 failed)
@@ -83,7 +83,7 @@ Feature: Suite names in the summary lists
 
       001 Scenario: I'm little hungry    # features/bananas.feature:9
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       1 scenario (1 failed)
       3 steps (2 passed, 1 failed)

--- a/features/multiple_suites_summary.feature
+++ b/features/multiple_suites_summary.feature
@@ -4,7 +4,7 @@ Feature: Suite names in the summary lists
   I need the failure summaries to name the suite when more than one suite was executed
 
   Background:
-    Given I initialise the working directory from the "Rerun" fixtures folder
+    Given I initialise the working directory from the "MultipleSuitesSummary" fixtures folder
     And I provide the following options for all behat invocations:
       | option      | value |
       | --no-colors |       |
@@ -13,7 +13,7 @@ Feature: Suite names in the summary lists
     When I run "behat --format progress"
     Then it should fail with:
       """
-      ..F.............F......F.............F......F.............F....
+      ..F........F..F..F
 
       --- Failed steps:
 
@@ -21,28 +21,20 @@ Feature: Suite names in the summary lists
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-      002 Example: | 0   | 4     | 8      | # features/apples.feature:29 (default)
-            Then I should have 8 apples     # features/apples.feature:24
-              Failed asserting that 7 matches expected 8.
+      002 Example: | 1   | 8      |     # features/apples.feature:24 (default)
+            Then I should have 8 apples # features/apples.feature:19
+              Failed asserting that 2 matches expected 8.
 
       003 Scenario: I'm little hungry    # features/bananas.feature:9 (default)
             Then I should have 3 bananas # features/bananas.feature:11
               Failed asserting that 2 matches expected 3.
 
-      004 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (default)
-            Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
-
-      005 Scenario: I'm little hungry    # features/bananas.feature:9 (suite2)
+      004 Scenario: I'm little hungry    # features/bananas.feature:9 (suite2)
             Then I should have 3 bananas # features/bananas.feature:11
               Failed asserting that 2 matches expected 3.
 
-      006 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (suite2)
-            Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
-
-      18 scenarios (12 passed, 6 failed)
-      63 steps (57 passed, 6 failed)
+      6 scenarios (2 passed, 4 failed)
+      18 steps (14 passed, 4 failed)
       """
 
   Scenario: Failed scenarios are annotated with the suite name when several suites run
@@ -52,19 +44,17 @@ Feature: Suite names in the summary lists
       | --format-settings | '{"short_summary": true}' |
     Then it should fail with:
       """
-      ..F.............F......F.............F......F.............F....
+      ..F........F..F..F
 
       --- Failed scenarios:
 
           features/apples.feature:9 (default) (on line 11)
-          features/apples.feature:29 (default) (on line 24)
+          features/apples.feature:24 (default) (on line 19)
           features/bananas.feature:9 (default) (on line 11)
-          features/bananas.feature:29 (default) (on line 24)
           features/bananas.feature:9 (suite2) (on line 11)
-          features/bananas.feature:29 (suite2) (on line 24)
 
-      18 scenarios (12 passed, 6 failed)
-      63 steps (57 passed, 6 failed)
+      6 scenarios (2 passed, 4 failed)
+      18 steps (14 passed, 4 failed)
       """
 
   Scenario: The pretty formatter annotates the failed scenarios too
@@ -75,21 +65,19 @@ Feature: Suite names in the summary lists
       --- Failed scenarios:
 
           features/apples.feature:9 (default) (on line 11)
-          features/apples.feature:29 (default) (on line 24)
+          features/apples.feature:24 (default) (on line 19)
           features/bananas.feature:9 (default) (on line 11)
-          features/bananas.feature:29 (default) (on line 24)
           features/bananas.feature:9 (suite2) (on line 11)
-          features/bananas.feature:29 (suite2) (on line 24)
 
-      18 scenarios (12 passed, 6 failed)
-      63 steps (57 passed, 6 failed)
+      6 scenarios (2 passed, 4 failed)
+      18 steps (14 passed, 4 failed)
       """
 
   Scenario: Suite names are omitted when a single suite runs
     When I run "behat --format progress --suite suite2"
     Then it should fail with:
       """
-      ..F.............F....
+      ..F
 
       --- Failed steps:
 
@@ -97,10 +85,6 @@ Feature: Suite names in the summary lists
             Then I should have 3 bananas # features/bananas.feature:11
               Failed asserting that 2 matches expected 3.
 
-      002 Example: | 0   | 4     | 8      | # features/bananas.feature:29
-            Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
-
-      6 scenarios (4 passed, 2 failed)
-      21 steps (19 passed, 2 failed)
+      1 scenario (1 failed)
+      3 steps (2 passed, 1 failed)
       """

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -18,27 +18,27 @@ Feature: Rerun with multiple suite
 
       --- Failed steps:
 
-      001 Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9 (default)
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-      002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29 (default)
             Then I should have 8 apples     # features/apples.feature:24
               Failed asserting that 7 matches expected 8.
 
-      003 Scenario: I'm little hungry    # features/bananas.feature:9
+      003 Scenario: I'm little hungry    # features/bananas.feature:9 (default)
             Then I should have 3 bananas # features/bananas.feature:11
               Failed asserting that 2 matches expected 3.
 
-      004 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+      004 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (default)
             Then I should have 8 bananas    # features/bananas.feature:24
               Failed asserting that 7 matches expected 8.
 
-      005 Scenario: I'm little hungry    # features/bananas.feature:9
+      005 Scenario: I'm little hungry    # features/bananas.feature:9 (suite2)
             Then I should have 3 bananas # features/bananas.feature:11
               Failed asserting that 2 matches expected 3.
 
-      006 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+      006 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (suite2)
             Then I should have 8 bananas    # features/bananas.feature:24
               Failed asserting that 7 matches expected 8.
 
@@ -52,27 +52,27 @@ Feature: Rerun with multiple suite
 
     --- Failed steps:
 
-    001 Scenario: I'm little hungry   # features/apples.feature:9
+    001 Scenario: I'm little hungry   # features/apples.feature:9 (default)
           Then I should have 3 apples # features/apples.feature:11
             Failed asserting that 2 matches expected 3.
 
-    002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+    002 Example: | 0   | 4     | 8      | # features/apples.feature:29 (default)
           Then I should have 8 apples     # features/apples.feature:24
             Failed asserting that 7 matches expected 8.
 
-    003 Scenario: I'm little hungry    # features/bananas.feature:9
+    003 Scenario: I'm little hungry    # features/bananas.feature:9 (default)
           Then I should have 3 bananas # features/bananas.feature:11
             Failed asserting that 2 matches expected 3.
 
-    004 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+    004 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (default)
           Then I should have 8 bananas    # features/bananas.feature:24
             Failed asserting that 7 matches expected 8.
 
-    005 Scenario: I'm little hungry    # features/bananas.feature:9
+    005 Scenario: I'm little hungry    # features/bananas.feature:9 (suite2)
           Then I should have 3 bananas # features/bananas.feature:11
             Failed asserting that 2 matches expected 3.
 
-    006 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+    006 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (suite2)
           Then I should have 8 bananas    # features/bananas.feature:24
             Failed asserting that 7 matches expected 8.
 
@@ -88,27 +88,27 @@ Feature: Rerun with multiple suite
 
       --- Failed steps:
 
-      001 Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9 (default)
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-      002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29 (default)
             Then I should have 8 apples     # features/apples.feature:24
               Failed asserting that 7 matches expected 8.
 
-      003 Scenario: I'm little hungry    # features/bananas.feature:9
+      003 Scenario: I'm little hungry    # features/bananas.feature:9 (default)
             Then I should have 3 bananas # features/bananas.feature:11
               Failed asserting that 2 matches expected 3.
 
-      004 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+      004 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (default)
             Then I should have 8 bananas    # features/bananas.feature:24
               Failed asserting that 7 matches expected 8.
 
-      005 Scenario: I'm little hungry    # features/bananas.feature:9
+      005 Scenario: I'm little hungry    # features/bananas.feature:9 (suite2)
             Then I should have 3 bananas # features/bananas.feature:11
               Failed asserting that 2 matches expected 3.
 
-      006 Example: | 0   | 4     | 8      | # features/bananas.feature:29
+      006 Example: | 0   | 4     | 8      | # features/bananas.feature:29 (suite2)
             Then I should have 8 bananas    # features/bananas.feature:24
               Failed asserting that 7 matches expected 8.
 
@@ -123,11 +123,11 @@ Feature: Rerun with multiple suite
 
       --- Failed steps:
 
-      001 Scenario: I'm little hungry   # features/apples.feature:9
+      001 Scenario: I'm little hungry   # features/apples.feature:9 (default)
             Then I should have 3 apples # features/apples.feature:11
               Failed asserting that 2 matches expected 3.
 
-      002 Example: | 0   | 4     | 8      | # features/apples.feature:29
+      002 Example: | 0   | 4     | 8      | # features/apples.feature:29 (default)
             Then I should have 8 apples     # features/apples.feature:24
               Failed asserting that 7 matches expected 8.
 

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/ScenarioStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/ScenarioStatsListener.php
@@ -16,6 +16,8 @@ use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
 use Behat\Behat\Output\Statistics\ScenarioStat;
 use Behat\Behat\Output\Statistics\Statistics;
 use Behat\Testwork\Event\Event;
+use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
+use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTested;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Node\EventListener\EventListener;
 
@@ -26,6 +28,7 @@ use Behat\Testwork\Output\Node\EventListener\EventListener;
  */
 final class ScenarioStatsListener implements EventListener
 {
+    private ?string $currentSuiteName = null;
     private ?string $currentFeaturePath = null;
 
     public function __construct(
@@ -35,9 +38,29 @@ final class ScenarioStatsListener implements EventListener
 
     public function listenEvent(Formatter $formatter, Event $event, $eventName): void
     {
+        $this->captureCurrentSuiteNameOnBeforeSuiteEvent($event);
+        $this->forgetCurrentSuiteNameOnAfterSuiteEvent($event);
         $this->captureCurrentFeaturePathOnBeforeFeatureEvent($event);
         $this->forgetCurrentFeaturePathOnAfterFeatureEvent($event);
         $this->captureScenarioOrExampleStatsOnAfterEvent($event);
+    }
+
+    private function captureCurrentSuiteNameOnBeforeSuiteEvent(Event $event): void
+    {
+        if (!$event instanceof BeforeSuiteTested) {
+            return;
+        }
+
+        $this->currentSuiteName = $event->getSuite()->getName();
+    }
+
+    private function forgetCurrentSuiteNameOnAfterSuiteEvent(Event $event): void
+    {
+        if (!$event instanceof AfterSuiteTested) {
+            return;
+        }
+
+        $this->currentSuiteName = null;
     }
 
     /**
@@ -78,7 +101,7 @@ final class ScenarioStatsListener implements EventListener
         $path = sprintf('%s:%d', $this->currentFeaturePath, $scenario->getLine());
         $resultCode = $event->getTestResult()->getResultCode();
 
-        $stat = new ScenarioStat($title, $path, $resultCode);
+        $stat = new ScenarioStat($title, $path, $resultCode, $this->currentSuiteName);
         $this->statistics->registerScenarioStat($stat);
     }
 }

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
@@ -22,6 +22,8 @@ use Behat\Behat\Tester\Result\DefinedStepResult;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
 use Behat\Behat\Tester\Result\StepResult;
 use Behat\Testwork\Event\Event;
+use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
+use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTested;
 use Behat\Testwork\Exception\ExceptionPresenter;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Node\EventListener\EventListener;
@@ -35,6 +37,7 @@ use Throwable;
  */
 final class StepStatsListener implements EventListener
 {
+    private ?string $currentSuiteName = null;
     private ?string $currentFeaturePath = null;
 
     private ?string $scenarioTitle = null;
@@ -49,11 +52,31 @@ final class StepStatsListener implements EventListener
 
     public function listenEvent(Formatter $formatter, Event $event, $eventName): void
     {
+        $this->captureCurrentSuiteNameOnBeforeSuiteEvent($event);
+        $this->forgetCurrentSuiteNameOnAfterSuiteEvent($event);
         $this->captureCurrentFeaturePathOnBeforeFeatureEvent($event);
         $this->forgetCurrentFeaturePathOnAfterFeatureEvent($eventName);
         $this->captureScenarioOnBeforeFeatureEvent($event);
         $this->forgetScenarioOnAfterFeatureEvent($eventName);
         $this->captureStepStatsOnAfterEvent($event);
+    }
+
+    private function captureCurrentSuiteNameOnBeforeSuiteEvent(Event $event): void
+    {
+        if (!$event instanceof BeforeSuiteTested) {
+            return;
+        }
+
+        $this->currentSuiteName = $event->getSuite()->getName();
+    }
+
+    private function forgetCurrentSuiteNameOnAfterSuiteEvent(Event $event): void
+    {
+        if (!$event instanceof AfterSuiteTested) {
+            return;
+        }
+
+        $this->currentSuiteName = null;
     }
 
     /**
@@ -123,7 +146,7 @@ final class StepStatsListener implements EventListener
         $stdOut = $result instanceof ExecutedStepResult ? $result->getCallResult()->getStdOut() : null;
 
         $resultCode = $result->getResultCode();
-        $stat = new StepStatV2($this->scenarioTitle, $this->scenarioPath, $text, $path, $resultCode, $error, $stdOut);
+        $stat = new StepStatV2($this->scenarioTitle, $this->scenarioPath, $text, $path, $resultCode, $error, $stdOut, $this->currentSuiteName);
 
         $this->statistics->registerStepStat($stat);
     }

--- a/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/ListPrinter.php
@@ -61,7 +61,7 @@ final class ListPrinter
      * @param ScenarioStat[] $scenarioStats
      * @param StepStat[]     $stepStats
      */
-    public function printScenariosList(OutputPrinter $printer, $intro, $resultCode, array $scenarioStats, ?array $stepStats = null): void
+    public function printScenariosList(OutputPrinter $printer, $intro, $resultCode, array $scenarioStats, ?array $stepStats = null, bool $printSuiteNames = false): void
     {
         if (!count($scenarioStats)) {
             return;
@@ -73,7 +73,7 @@ final class ListPrinter
         $printer->writeln(sprintf('--- {+%s}%s{-%s}' . PHP_EOL, $style, $intro, $style));
         foreach ($scenarioStats as $stat) {
             $path = $this->configurablePathPrinter->processPathsInText((string) $stat);
-
+            $path = $this->appendSuiteName($path, $printSuiteNames ? $stat->getSuiteName() : null);
             $path = $this->appendFailingStepText($stepStats, $path, $stat);
 
             $printer->writeln(sprintf('    {+%s}%s{-%s}', $style, $path, $style));
@@ -95,6 +95,7 @@ final class ListPrinter
         $resultCode,
         array $stepStats,
         ?ShowOutputOption $showOutput = ShowOutputOption::InSummary,
+        bool $printSuiteNames = false,
     ): void {
         if (!count($stepStats)) {
             return;
@@ -107,7 +108,7 @@ final class ListPrinter
 
         foreach ($stepStats as $num => $stepStat) {
             if ($stepStat instanceof StepStatV2) {
-                $this->printStepStat($printer, $num + 1, $stepStat, $style, $showOutput);
+                $this->printStepStat($printer, $num + 1, $stepStat, $style, $showOutput, $printSuiteNames);
             } elseif ($stepStat instanceof StepStat) {
                 $this->printStat(
                     $printer,
@@ -224,6 +225,7 @@ final class ListPrinter
         StepStatV2 $stat,
         string $style,
         ?ShowOutputOption $showOutput,
+        bool $printSuiteName = false,
     ): void {
         $maxLength = max(mb_strlen($stat->getScenarioText(), 'utf8'), mb_strlen($stat->getStepText(), 'utf8') + 2) + 1;
 
@@ -235,7 +237,10 @@ final class ListPrinter
                 $stat->getScenarioText(),
                 $style,
                 str_pad(' ', $maxLength - mb_strlen($stat->getScenarioText(), 'utf8')),
-                $this->configurablePathPrinter->processPathsInText($stat->getScenarioPath())
+                $this->appendSuiteName(
+                    $this->configurablePathPrinter->processPathsInText($stat->getScenarioPath()),
+                    $printSuiteName ? $stat->getSuiteName() : null
+                )
             )
         );
 
@@ -281,7 +286,11 @@ final class ListPrinter
             // > although Statistics::getFailedSteps() is typed as returning StepStat[] for BC reasons,
             // > in practice we only ever create / register instances of StepStatV2. And that has a
             // > getScenarioPath() which I think should always match the getPath() of ScenarioStat.
-            if ($stepStat instanceof StepStatV2 && $stepStat->getScenarioPath() === $scenarioStat->getPath()) {
+            if (
+                $stepStat instanceof StepStatV2
+                && $stepStat->getScenarioPath() === $scenarioStat->getPath()
+                && $stepStat->getSuiteName() === $scenarioStat->getSuiteName()
+            ) {
                 $foundStepStat = $stepStat;
                 break;
             }
@@ -301,6 +310,15 @@ final class ListPrinter
         }
 
         return $path . $lineHelper;
+    }
+
+    private function appendSuiteName(string $path, ?string $suiteName): string
+    {
+        if (null === $suiteName) {
+            return $path;
+        }
+
+        return sprintf('%s (%s)', $path, $suiteName);
     }
 
     private function extractLineNumber(string $path): ?string

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStatisticsPrinter.php
@@ -14,6 +14,7 @@ use Behat\Behat\Output\Node\Printer\CounterPrinter;
 use Behat\Behat\Output\Node\Printer\ListPrinter;
 use Behat\Behat\Output\Node\Printer\StatisticsPrinter;
 use Behat\Behat\Output\Statistics\Statistics;
+use Behat\Behat\Output\Statistics\TotalStatistics;
 use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Tester\Result\TestResult;
@@ -39,23 +40,25 @@ final class PrettyStatisticsPrinter implements StatisticsPrinter
         $printer = $formatter->getOutputPrinter();
 
         $hookStats = $statistics->getFailedHookStats();
+        // Suite names only disambiguate the lists when scenarios ran in more than one suite
+        $printSuiteNames = $statistics instanceof TotalStatistics && count($statistics->getSuiteNames()) > 1;
         $this->listPrinter->printFailedHooksList($printer, 'failed_hooks_title', $hookStats, true);
 
         $shortSummary = $formatter->getParameter('short_summary');
         if ($shortSummary) {
             $scenarioStats = $statistics->getSkippedScenarios();
-            $this->listPrinter->printScenariosList($printer, 'skipped_scenarios_title', TestResult::SKIPPED, $scenarioStats);
+            $this->listPrinter->printScenariosList($printer, 'skipped_scenarios_title', TestResult::SKIPPED, $scenarioStats, null, $printSuiteNames);
 
             $scenarioStats = $statistics->getFailedScenarios();
             $failedStepStats = $statistics->getFailedSteps();
-            $this->listPrinter->printScenariosList($printer, 'failed_scenarios_title', TestResult::FAILED, $scenarioStats, $failedStepStats);
+            $this->listPrinter->printScenariosList($printer, 'failed_scenarios_title', TestResult::FAILED, $scenarioStats, $failedStepStats, $printSuiteNames);
         } else {
             $showOutput = $formatter->getParameter(ShowOutputOption::OPTION_NAME);
             $stepStats = $statistics->getFailedSteps();
-            $this->listPrinter->printStepList($printer, 'failed_steps_title', TestResult::FAILED, $stepStats, $showOutput);
+            $this->listPrinter->printStepList($printer, 'failed_steps_title', TestResult::FAILED, $stepStats, $showOutput, $printSuiteNames);
 
             $stepStats = $statistics->getPendingSteps();
-            $this->listPrinter->printStepList($printer, 'pending_steps_title', TestResult::PENDING, $stepStats, $showOutput);
+            $this->listPrinter->printStepList($printer, 'pending_steps_title', TestResult::PENDING, $stepStats, $showOutput, $printSuiteNames);
         }
 
         $this->counterPrinter->printCounters($printer, 'scenarios_count', $statistics->getScenarioStatCounts());

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStatisticsPrinter.php
@@ -14,6 +14,7 @@ use Behat\Behat\Output\Node\Printer\CounterPrinter;
 use Behat\Behat\Output\Node\Printer\ListPrinter;
 use Behat\Behat\Output\Node\Printer\StatisticsPrinter;
 use Behat\Behat\Output\Statistics\Statistics;
+use Behat\Behat\Output\Statistics\TotalStatistics;
 use Behat\Config\Formatter\ShowOutputOption;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Tester\Result\TestResult;
@@ -42,23 +43,25 @@ final class ProgressStatisticsPrinter implements StatisticsPrinter
         $printer->writeln();
 
         $hookStats = $statistics->getFailedHookStats();
+        // Suite names only disambiguate the lists when scenarios ran in more than one suite
+        $printSuiteNames = $statistics instanceof TotalStatistics && count($statistics->getSuiteNames()) > 1;
         $this->listPrinter->printFailedHooksList($printer, 'failed_hooks_title', $hookStats);
 
         $shortSummary = $formatter->getParameter('short_summary');
         if ($shortSummary) {
             $scenarioStats = $statistics->getSkippedScenarios();
-            $this->listPrinter->printScenariosList($printer, 'skipped_scenarios_title', TestResult::SKIPPED, $scenarioStats);
+            $this->listPrinter->printScenariosList($printer, 'skipped_scenarios_title', TestResult::SKIPPED, $scenarioStats, null, $printSuiteNames);
 
             $scenarioStats = $statistics->getFailedScenarios();
             $failedStepStats = $statistics->getFailedSteps();
-            $this->listPrinter->printScenariosList($printer, 'failed_scenarios_title', TestResult::FAILED, $scenarioStats, $failedStepStats);
+            $this->listPrinter->printScenariosList($printer, 'failed_scenarios_title', TestResult::FAILED, $scenarioStats, $failedStepStats, $printSuiteNames);
         } else {
             $showOutput = $formatter->getParameter(ShowOutputOption::OPTION_NAME);
             $stepStats = $statistics->getFailedSteps();
-            $this->listPrinter->printStepList($printer, 'failed_steps_title', TestResult::FAILED, $stepStats, $showOutput);
+            $this->listPrinter->printStepList($printer, 'failed_steps_title', TestResult::FAILED, $stepStats, $showOutput, $printSuiteNames);
 
             $stepStats = $statistics->getPendingSteps();
-            $this->listPrinter->printStepList($printer, 'pending_steps_title', TestResult::PENDING, $stepStats, $showOutput);
+            $this->listPrinter->printStepList($printer, 'pending_steps_title', TestResult::PENDING, $stepStats, $showOutput, $printSuiteNames);
         }
 
         $this->counterPrinter->printCounters($printer, 'scenarios_count', $statistics->getScenarioStatCounts());

--- a/src/Behat/Behat/Output/Statistics/PhaseStatistics.php
+++ b/src/Behat/Behat/Output/Statistics/PhaseStatistics.php
@@ -99,6 +99,16 @@ final class PhaseStatistics implements Statistics
     }
 
     /**
+     * Returns the names of the suites that executed at least one scenario.
+     *
+     * @return string[]
+     */
+    public function getSuiteNames(): array
+    {
+        return $this->statistics->getSuiteNames();
+    }
+
+    /**
      * Returns counters for different scenario result codes.
      *
      * @return array<TestResult::*, int>

--- a/src/Behat/Behat/Output/Statistics/ScenarioStat.php
+++ b/src/Behat/Behat/Output/Statistics/ScenarioStat.php
@@ -30,6 +30,7 @@ final class ScenarioStat implements Stringable
         private ?string $title,
         private readonly string $path,
         private readonly int $resultCode,
+        private readonly ?string $suiteName = null,
     ) {
         $this->title = null;
     }
@@ -58,6 +59,14 @@ final class ScenarioStat implements Stringable
     public function getResultCode(): int
     {
         return $this->resultCode;
+    }
+
+    /**
+     * Returns the name of the suite the scenario was executed in, if known.
+     */
+    public function getSuiteName(): ?string
+    {
+        return $this->suiteName;
     }
 
     /**

--- a/src/Behat/Behat/Output/Statistics/StepStatV2.php
+++ b/src/Behat/Behat/Output/Statistics/StepStatV2.php
@@ -33,6 +33,7 @@ final class StepStatV2 extends StepStat implements Stringable
         private readonly int $resultCode,
         private readonly ?string $error = null,
         private readonly ?string $stdOut = null,
+        private readonly ?string $suiteName = null,
     ) {
     }
 
@@ -108,6 +109,14 @@ final class StepStatV2 extends StepStat implements Stringable
     public function getStdOut(): ?string
     {
         return $this->stdOut;
+    }
+
+    /**
+     * Returns the name of the suite the step was executed in, if known.
+     */
+    public function getSuiteName(): ?string
+    {
+        return $this->suiteName;
     }
 
     /**

--- a/src/Behat/Behat/Output/Statistics/TotalStatistics.php
+++ b/src/Behat/Behat/Output/Statistics/TotalStatistics.php
@@ -55,6 +55,10 @@ final class TotalStatistics implements Statistics
      * @var list<HookStat>
      */
     private array $failedHookStats = [];
+    /**
+     * @var array<string, true>
+     */
+    private array $suiteNames = [];
 
     /**
      * Initializes statistics.
@@ -121,6 +125,10 @@ final class TotalStatistics implements Statistics
 
         ++$this->scenarioCounters[$stat->getResultCode()];
 
+        if (null !== $stat->getSuiteName()) {
+            $this->suiteNames[$stat->getSuiteName()] = true;
+        }
+
         if (TestResult::FAILED === $stat->getResultCode()) {
             $this->failedScenarioStats[] = $stat;
         }
@@ -156,6 +164,16 @@ final class TotalStatistics implements Statistics
         }
 
         $this->failedHookStats[] = $stat;
+    }
+
+    /**
+     * Returns the names of the suites that executed at least one scenario.
+     *
+     * @return string[]
+     */
+    public function getSuiteNames(): array
+    {
+        return array_keys($this->suiteNames);
     }
 
     /**

--- a/tests/Fixtures/MultipleSuitesSummary/behat.php
+++ b/tests/Fixtures/MultipleSuitesSummary/behat.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+return (new Config())
+    ->withProfile(
+        (new Profile('default'))
+            ->withSuite(
+                (new Suite('default'))
+                    ->withPaths('features/apples.feature', 'features/bananas.feature')
+                    ->withContexts('FeatureContext')
+            )
+            ->withSuite(
+                (new Suite('suite2'))
+                    ->withPaths('features/bananas.feature')
+                    ->withContexts('FeatureContext')
+            )
+    )
+;

--- a/tests/Fixtures/MultipleSuitesSummary/features/apples.feature
+++ b/tests/Fixtures/MultipleSuitesSummary/features/apples.feature
@@ -1,0 +1,24 @@
+Feature: Apples story
+  In order to eat apples
+  As a little kid
+  I need to have apples in my pocket
+
+  Background:
+    Given I have 3 apples
+
+  Scenario: I'm little hungry
+    When I ate 1 apples
+    Then I should have 3 apples
+
+  Scenario: Found more apples
+    When I found 5 apples
+    Then I should have 8 apples
+
+  Scenario Outline: Other situations
+    When I ate <ate> apples
+    Then I should have <result> apples
+
+    Examples:
+      | ate | result |
+      | 1   | 2      |
+      | 1   | 8      |

--- a/tests/Fixtures/MultipleSuitesSummary/features/bananas.feature
+++ b/tests/Fixtures/MultipleSuitesSummary/features/bananas.feature
@@ -1,0 +1,11 @@
+Feature: Bananas story
+  In order to eat bananas
+  As a little kid
+  I need to have bananas in my pocket
+
+  Background:
+    Given I have 3 bananas
+
+  Scenario: I'm little hungry
+    When I ate 1 bananas
+    Then I should have 3 bananas

--- a/tests/Fixtures/MultipleSuitesSummary/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/MultipleSuitesSummary/features/bootstrap/FeatureContext.php
@@ -6,7 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {

--- a/tests/Fixtures/MultipleSuitesSummary/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/MultipleSuitesSummary/features/bootstrap/FeatureContext.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Behat\Context\Context;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+use PHPUnit\Framework\Assert;
+
+class FeatureContext implements Context
+{
+    private int $apples = 0;
+    private int $bananas = 0;
+
+    #[Given('/^I have (\d+) (apples|bananas)$/')]
+    public function iHaveFruit(string $count, string $fruit): void
+    {
+        $this->{$fruit} = (int) $count;
+    }
+
+    #[When('/^I ate (\d+) (apples|bananas)$/')]
+    public function iAteFruit(string $count, string $fruit): void
+    {
+        $this->{$fruit} -= (int) $count;
+    }
+
+    #[When('/^I found (\d+) (apples|bananas)$/')]
+    public function iFoundFruit(string $count, string $fruit): void
+    {
+        $this->{$fruit} += (int) $count;
+    }
+
+    #[Then('/^I should have (\d+) (apples|bananas)$/')]
+    public function iShouldHaveFruit(string $count, string $fruit): void
+    {
+        Assert::assertEquals((int) $count, $this->{$fruit});
+    }
+}


### PR DESCRIPTION
Fixes #1772

When several suites share feature files, the failure summaries printed by the `progress` and `pretty` formatters only showed `features/apples.feature:9`, with no way to tell which suite the failure came from. This PR appends the suite name to those lists, following the format suggested in the issue:

```
--- Failed steps:

001 Scenario: I'm little hungry    # features/bananas.feature:9 (default)
      Then I should have 3 bananas # features/bananas.feature:11
        Failed asserting that 2 matches expected 3.

002 Scenario: I'm little hungry    # features/bananas.feature:9 (suite2)
      Then I should have 3 bananas # features/bananas.feature:11
        Failed asserting that 2 matches expected 3.
```

and, with `short_summary` enabled (or in the pretty formatter):

```
--- Failed scenarios:

    features/bananas.feature:9 (default) (on line 11)
    features/bananas.feature:9 (suite2) (on line 11)
```

### How it works

- `ScenarioStat` and `StepStatV2` get an optional `suiteName` (new trailing constructor argument and getter, so no BC break), captured by the existing stats listeners on `BeforeSuiteTested` / `AfterSuiteTested`.
- `TotalStatistics::getSuiteNames()` returns the suites that executed at least one scenario. `PhaseStatistics` delegates to it. The `Statistics` interface is `@api`, so it is left untouched; the two statistics printers check for `TotalStatistics`, which is what they are always wired with.
- `ListPrinter` prints the suite name when asked to, and now also matches the failing step to its scenario by suite (two suites can produce the same scenario path).
- The annotation is only printed when more than one suite ran scenarios, so single-suite runs are unchanged.

### One note on "more than one suite was executed"

I went with "more than one suite executed at least one scenario" rather than counting `BeforeSuiteTested` events. The reason is that running `behat features/apples.feature` dispatches `BeforeSuiteTested` for every configured suite, including the ones that end up with zero matching scenarios. Counting those would add the annotation for anyone with two suites who runs a single file, which is exactly the noise the issue wanted to avoid. If a suite ran scenarios, it is counted, so the "only one scenario fails, which suite was it in?" case from the discussion is covered. Happy to adjust if you would rather have the stricter interpretation.

### Tests

- `features/rerun_with_multiple_suite.feature` updated (both suites run there, the `--suite suite2` and the final `--rerun` with only one suite left stay unannotated).
- New `features/multiple_suites_summary.feature` covering the failed steps list, the short summary list, the pretty formatter and the single-suite case.
