### PR TITLE
Throw deprecation if definition and function number of parameters do not match

### DIFF
--- a/features/print_deprecations.feature
+++ b/features/print_deprecations.feature
@@ -75,6 +75,18 @@ Feature: Print deprecations
       2 steps (2 passed)
       """
 
+  Scenario: Patterns providing more arguments than the definition accepts are deprecated
+    When I run behat with the following additional options:
+      | option   | value                        |
+      | --config | behat-unused-arguments.php   |
+    Then it should pass with:
+      """
+      2 deprecations triggered (1 unique):
+
+        ⚠ The pattern "/^(Alice|Bob) presses the (?P<button>red|green) button$/" provides 2 arguments but FeatureContext::pressesTheButton() only accepts 1. Silently discarding the extra argument is deprecated and will be an error in Behat 4.0: either add the missing parameters or use non-capturing groups "(?:...)" in the pattern. (2x)
+          → features/bootstrap/FeatureContext.php:XX
+      """
+
   Scenario: Fail on deprecations passes when no deprecations exist
     When I run behat with the following additional options:
       | option   | value                           |

--- a/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
+++ b/src/Behat/Behat/Definition/Search/RepositorySearchEngine.php
@@ -21,6 +21,7 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\Argument\ArgumentOrganiser;
 use Behat\Testwork\Argument\Exception\UnexpectedMultilineArgumentException;
+use Behat\Testwork\Deprecation\DeprecationCollector;
 use Behat\Testwork\Environment\Environment;
 
 /**
@@ -110,6 +111,56 @@ final class RepositorySearchEngine implements SearchEngine
             );
         }
 
+        $this->checkForUnusedArguments($definition, $match);
+
         return new SearchResult($definition, $stepText, $arguments);
+    }
+
+    /**
+     * Reports a deprecation if the pattern provides more arguments than the definition can accept.
+     *
+     * @param array<int|string, mixed> $match the pattern match, with any multiline arguments appended
+     */
+    private function checkForUnusedArguments(Definition $definition, array $match): void
+    {
+        $function = $definition->getReflection();
+
+        if ($function->isVariadic()) {
+            return;
+        }
+
+        $providedCount = $this->countProvidedArguments($match);
+        $parameterCount = $function->getNumberOfParameters();
+
+        if ($providedCount <= $parameterCount) {
+            return;
+        }
+
+        DeprecationCollector::trigger(sprintf(
+            'The pattern "%s" provides %d argument%s but %s only accepts %d. '
+            . 'Silently discarding the extra argument%s is deprecated and will be an error in Behat 4.0: '
+            . 'either add the missing parameters or use non-capturing groups "(?:...)" in the pattern.',
+            $definition->getPattern(),
+            $providedCount,
+            $providedCount === 1 ? '' : 's',
+            $definition->getPath(),
+            $parameterCount,
+            $providedCount - $parameterCount === 1 ? '' : 's',
+        ), $function->getFileName() ?: null, $function->getStartLine() ?: null);
+    }
+
+    /**
+     * Counts the arguments a pattern match will provide to the definition.
+     *
+     * The first element of a `preg_match` result is the full match rather than an argument, and every
+     * named capturing group is represented twice - once under its name and once under its number.
+     *
+     * @param array<int|string, mixed> $match
+     */
+    private function countProvidedArguments(array $match): int
+    {
+        $namedGroups = count(array_filter(array_keys($match), is_string(...)));
+
+        return count($match) - 1 - $namedGroups;
     }
 }

--- a/src/Behat/Testwork/Deprecation/DeprecationCollector.php
+++ b/src/Behat/Testwork/Deprecation/DeprecationCollector.php
@@ -41,17 +41,25 @@ final class DeprecationCollector
         return self::$instance;
     }
 
-    public static function trigger(string $message): void
+    /**
+     * Records a deprecation.
+     *
+     * By default the deprecation is reported against the caller. Pass $file and $line to report it against
+     * the code that is responsible for the deprecated usage instead, e.g. a user's step definition.
+     */
+    public static function trigger(string $message, ?string $file = null, ?int $line = null): void
     {
         $instance = self::getInstance();
 
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
-        $caller = $backtrace[0];
+        if ($file === null) {
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+            $caller = $backtrace[0];
 
-        $file = $caller['file'] ?? 'unknown';
-        $line = $caller['line'] ?? 0;
+            $file = $caller['file'] ?? 'unknown';
+            $line = $caller['line'] ?? 0;
+        }
 
-        $instance->recordDeprecation($message, $file, $line);
+        $instance->recordDeprecation($message, $file, $line ?? 0);
     }
 
     /**

--- a/tests/Fixtures/Deprecations/behat-unused-arguments.php
+++ b/tests/Fixtures/Deprecations/behat-unused-arguments.php
@@ -1,0 +1,18 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+use Behat\Config\TesterOptions;
+
+return (new Config())
+    ->withProfile(
+        (new Profile('default'))
+            ->withTesterOptions(
+                (new TesterOptions())->withPrintBehatDeprecations()
+            )
+            ->withSuite(
+                (new Suite('default'))
+                    ->withPaths('features/unused_arguments.feature')
+            )
+    );

--- a/tests/Fixtures/Deprecations/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Deprecations/features/bootstrap/FeatureContext.php
@@ -31,6 +31,16 @@ class FeatureContext implements Context
         trigger_error('Deprecation triggered in step definition', E_USER_DEPRECATED);
     }
 
+    #[Given('/^(Alice|Bob) presses the (?P<button>red|green) button$/')]
+    public function pressesTheButton(string $button): void
+    {
+    }
+
+    #[Given('/^(?:Alice|Bob) pushes the (?P<button>red|green) button$/')]
+    public function pushesTheButton(string $button): void
+    {
+    }
+
     #[Then('the step should pass')]
     public function theStepShouldPass(): void
     {

--- a/tests/Fixtures/Deprecations/features/unused_arguments.feature
+++ b/tests/Fixtures/Deprecations/features/unused_arguments.feature
@@ -1,0 +1,9 @@
+Feature: Patterns capturing more arguments than the definition accepts
+
+  Scenario: A capturing group that the definition does not accept
+    Given Alice presses the red button
+    And Bob presses the green button
+
+  Scenario: The same pattern using a non-capturing group
+    Given Alice pushes the red button
+    And Bob pushes the green button


### PR DESCRIPTION
When a step pattern captures more arguments than the definition method has parameters, Behat silently discards the extras, so a stray capturing group goes unnoticed. This reports a deprecation via `DeprecationCollector`, anchored to the definition's own file and line, naming the pattern, the method and both counts, and pointing at non-capturing groups `(?:...)` as the fix for patterns that intentionally capture more than they use. Variadic definitions are skipped so `FriendsOfBehat/VariadicExtension` is unaffected; the missing-value direction already throws via `Argument\Validator`. The `4.x` branch will turn this into an error.

`DeprecationCollector::trigger()` gained optional `$file/$line`. Existing deprecations describe Behat's own APIs, so the backtraced call site suits them; this one describes user code, and without it the printed location was `RepositorySearchEngine.php:139`.

Implements the first part of the fix for https://github.com/Behat/Behat/issues/1691