### PR TITLE
Exclude internal-only methods from the public API

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -288,5 +288,13 @@
         <ignored-regex>#CHANGED: .+ Behat\\Behat\\Output\\Node\\Printer\\Pretty\\PrettyOutlineTablePrinter\#__construct\(\)#</ignored-regex>
         <ignored-regex>#CHANGED: .+ Behat\\Behat\\Output\\Node\\EventListener\\AST\\OutlineListener\#__construct\(\)#</ignored-regex>
         <ignored-regex>#CHANGED: .+ Behat\\Behat\\Output\\Node\\EventListener\\AST\\OutlineTableListener\#__construct\(\)#</ignored-regex>
+
+        <!--
+        Methods marked "@internal" are no longer part of our public API, even though their declaring class is marked
+        "@api". These are only called by Behat itself. ExecutedStepResult::getCallResult() is replaced for end-users by
+        the new hasStdOut() / getStdOut() methods on the same class.
+        -->
+        <ignored-regex>#Behat\\Behat\\Tester\\Result\\ExecutedStepResult\#getCallResult\(\) was (removed|marked "@internal")#</ignored-regex>
+        <ignored-regex>#Behat\\Testwork\\ServiceContainer\\ExtensionManager\#(setExtensionsPath|activateExtension|initializeExtensions|debugInformation)\(\) was (removed|marked "@internal")#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
@@ -50,6 +50,8 @@ final class ExecutedStepResult implements StepResult, DefinedStepResult, Excepti
      * Returns definition call result or null if no call were made.
      *
      * @return CallResult<DefinitionCall>
+     *
+     * @internal use hasStdOut()/getStdOut() for step output, or getException() for failures
      */
     public function getCallResult(): CallResult
     {

--- a/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
+++ b/src/Behat/Testwork/ServiceContainer/ExtensionManager.php
@@ -53,6 +53,8 @@ final class ExtensionManager
 
     /**
      * Sets path to directory in which manager will try to find extension files.
+     *
+     * @internal behat sets this up before extensions are initialized
      */
     public function setExtensionsPath(?string $path): void
     {
@@ -63,6 +65,8 @@ final class ExtensionManager
      * Activate extension by its locator.
      *
      * @param string $locator phar file name, php file name, class name
+     *
+     * @internal behat activates extensions from the loaded configuration
      */
     public function activateExtension(string $locator): Extension
     {
@@ -103,6 +107,8 @@ final class ExtensionManager
 
     /**
      * Initializes all activated and predefined extensions.
+     *
+     * @internal called once by Behat; this is what triggers Extension::initialize()
      */
     public function initializeExtensions(): void
     {
@@ -115,6 +121,8 @@ final class ExtensionManager
      * Returns array with extensions debug information.
      *
      * @return array{extensions_list: list<string>}
+     *
+     * @internal
      */
     public function debugInformation(): array
     {


### PR DESCRIPTION
Marking a class `@api` promises every public method on it, including methods that only exist for Behat's own use. This introduces the convention that `@internal` on a member excludes it from the public API even when its declaring class is `@api`, and applies it to the methods on ExtensionManager and ExecutedStepResult that extension authors have no reason to call. Part of #1237.

Callers of getCallResult() should use hasStdOut() / getStdOut() instead, added in #1874. This needs a merge-up from 3.x to make sense on 4.x.