### PR TITLE
Give transformations a public API of their own

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -264,5 +264,16 @@
 
         <!-- Required consistent constructor for SimpleArgumentTransformation -->
         <ignored-regex>#ADDED: Method __construct\(\) was added to interface Behat\\Behat\\Transformation\\SimpleArgumentTransformation#</ignored-regex>
+
+        <!--
+        Transformations now receive a TransformationScope instead of a DefinitionCall and a CallCenter. This changes
+        the signature of supportsDefinitionAndArgument() and transformArgument() on the ArgumentTransformer and
+        SimpleArgumentTransformation interfaces and on every implementation we ship, and drops the CallCenter
+        parameter from RepositoryArgumentTransformer::__construct().
+        -->
+        <ignored-regex>#CHANGED: The parameter .+? of Behat\\Behat\\Transformation\\Transformer\\RepositoryArgumentTransformer\#__construct\(\)#</ignored-regex>
+        <ignored-regex>#CHANGED: The parameter .+? of Behat\\Behat\\Transformation\\.+?\#(supportsDefinitionAndArgument|transformArgument)\(\)#</ignored-regex>
+        <ignored-regex>#CHANGED: Parameter \d+ of Behat\\Behat\\Transformation\\.+?\#(supportsDefinitionAndArgument|transformArgument)\(\) changed name#</ignored-regex>
+        <ignored-regex>#ADDED: Parameter \w+ was added to Method (supportsDefinitionAndArgument|transformArgument)\(\) of class Behat\\Behat\\Transformation\\#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -33,6 +33,23 @@ Feature: Extensions
       `inexistent_extension` extension file or class could not be located.
       """
 
+  Scenario: Extension can register an argument transformer using only public API
+    When I run behat with the following additional options:
+      | option                               | value                            |
+      | --config                             | behat-argument-transformer.php   |
+      | features/argument_transformer.feature |                                 |
+    Then it should pass with:
+      """
+      Feature:
+
+        Scenario:                      # features/argument_transformer.feature:2
+          Then the argument is "world" # ArgumentTransformerContext::theArgumentIs()
+            │ world [suite=default language=en line=3 pattern=the argument is :value]
+
+      1 scenario (1 passed)
+      1 step (1 passed)
+      """
+
   Scenario: Exception handlers extension
     When I run behat with the following additional options:
       | option                              | value                         |

--- a/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
+++ b/src/Behat/Behat/Transformation/Call/Filter/DefinitionArgumentsTransformer.php
@@ -12,8 +12,10 @@ namespace Behat\Behat\Transformation\Call\Filter;
 
 use Behat\Behat\Definition\Call\DefinitionCall;
 use Behat\Behat\Transformation\Exception\UnsupportedCallException;
+use Behat\Behat\Transformation\Scope\RuntimeTransformationScope;
 use Behat\Behat\Transformation\Transformer\ArgumentTransformer;
 use Behat\Testwork\Call\Call;
+use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\Filter\CallFilter;
 
 /**
@@ -27,6 +29,11 @@ final class DefinitionArgumentsTransformer implements CallFilter
      * @var list<ArgumentTransformer>
      */
     private array $argumentTransformers = [];
+
+    public function __construct(
+        private readonly CallCenter $callCenter,
+    ) {
+    }
 
     /**
      * Registers new argument transformer.
@@ -81,12 +88,14 @@ final class DefinitionArgumentsTransformer implements CallFilter
      */
     private function transformArgument(DefinitionCall $definitionCall, int|string $index, mixed $value): mixed
     {
+        $scope = new RuntimeTransformationScope($definitionCall, $this->callCenter);
+
         foreach ($this->argumentTransformers as $transformer) {
-            if (!$transformer->supportsDefinitionAndArgument($definitionCall, $index, $value)) {
+            if (!$transformer->supportsDefinitionAndArgument($scope, $index, $value)) {
                 continue;
             }
 
-            return $transformer->transformArgument($definitionCall, $index, $value);
+            return $transformer->transformArgument($scope, $index, $value);
         }
 
         return $value;

--- a/src/Behat/Behat/Transformation/Scope/RuntimeTransformationScope.php
+++ b/src/Behat/Behat/Transformation/Scope/RuntimeTransformationScope.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Transformation\Scope;
+
+use Behat\Behat\Definition\Call\DefinitionCall;
+use Behat\Behat\Definition\Definition;
+use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Behat\Transformation\Transformation;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Testwork\Call\CallCenter;
+use Behat\Testwork\Environment\Environment;
+
+/**
+ * Exposes a definition call to transformations, and runs them against Behat's call center.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+final class RuntimeTransformationScope implements TransformationScope
+{
+    /**
+     * @param DefinitionCall $definitionCall the call whose arguments are being transformed
+     */
+    public function __construct(
+        private readonly DefinitionCall $definitionCall,
+        private readonly CallCenter $callCenter,
+    ) {
+    }
+
+    public function call(Transformation $transformation, array $arguments): mixed
+    {
+        $result = $this->callCenter->makeCall(new TransformationCall(
+            $this->definitionCall->getEnvironment(),
+            $this->definitionCall->getCallee(),
+            $transformation,
+            $arguments
+        ));
+
+        if ($result->hasException()) {
+            throw $result->getException();
+        }
+
+        return $result->getReturn();
+    }
+
+    public function getEnvironment(): Environment
+    {
+        return $this->definitionCall->getEnvironment();
+    }
+
+    public function getFeature(): FeatureNode
+    {
+        return $this->definitionCall->getFeature();
+    }
+
+    public function getStep(): StepNode
+    {
+        return $this->definitionCall->getStep();
+    }
+
+    public function getDefinition(): Definition
+    {
+        return $this->definitionCall->getCallee();
+    }
+}

--- a/src/Behat/Behat/Transformation/Scope/TransformationScope.php
+++ b/src/Behat/Behat/Transformation/Scope/TransformationScope.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\Transformation\Scope;
+
+use Behat\Behat\Definition\Definition;
+use Behat\Behat\Transformation\Transformation;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Testwork\Environment\Environment;
+use Throwable;
+
+/**
+ * Represents the step definition call whose arguments are being transformed.
+ *
+ * Transformations receive this rather than the definition call itself, so that they can
+ * inspect the call being made and run their own callable without depending on internals
+ * of Behat's call pipeline.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @api
+ */
+interface TransformationScope
+{
+    /**
+     * Runs the given transformation with the provided arguments and returns its return value.
+     *
+     * The transformation is invoked through the same call pipeline as any other Behat callable,
+     * so error handling and output capturing apply as usual. Any exception thrown by the
+     * transformation itself is rethrown to the caller.
+     *
+     * @param mixed[] $arguments
+     *
+     * @throws Throwable if the transformation throws
+     */
+    public function call(Transformation $transformation, array $arguments): mixed;
+
+    /**
+     * Returns the environment that the step is being run in.
+     */
+    public function getEnvironment(): Environment;
+
+    /**
+     * Returns the feature that the step belongs to.
+     */
+    public function getFeature(): FeatureNode;
+
+    /**
+     * Returns the step being called.
+     */
+    public function getStep(): StepNode;
+
+    /**
+     * Returns the step definition that matched the step, whose arguments are being transformed.
+     */
+    public function getDefinition(): Definition;
+}

--- a/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
+++ b/src/Behat/Behat/Transformation/ServiceContainer/TransformationExtension.php
@@ -87,7 +87,9 @@ final class TransformationExtension implements Extension
      */
     private function loadDefinitionArgumentsTransformer(ContainerBuilder $container): void
     {
-        $definition = new Definition(DefinitionArgumentsTransformer::class);
+        $definition = new Definition(DefinitionArgumentsTransformer::class, [
+            new Reference(CallExtension::CALL_CENTER_ID),
+        ]);
         $definition->addTag(CallExtension::CALL_FILTER_TAG, ['priority' => 200]);
         $container->setDefinition(self::DEFINITION_ARGUMENT_TRANSFORMER_ID, $definition);
     }
@@ -99,7 +101,6 @@ final class TransformationExtension implements Extension
     {
         $definition = new Definition(RepositoryArgumentTransformer::class, [
             new Reference(self::REPOSITORY_ID),
-            new Reference(CallExtension::CALL_CENTER_ID),
             new Reference(DefinitionExtension::PATTERN_TRANSFORMER_ID),
             new Reference(TranslatorExtension::TRANSLATOR_ID),
         ]);

--- a/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
+++ b/src/Behat/Behat/Transformation/SimpleArgumentTransformation.php
@@ -10,8 +10,7 @@
 
 namespace Behat\Behat\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Testwork\Call\CallCenter;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use ReflectionMethod;
 
 /**
@@ -38,10 +37,10 @@ interface SimpleArgumentTransformation extends Transformation
     /**
      * Checks if transformation supports argument.
      */
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool;
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentArgumentValue): bool;
 
     /**
      * Transforms argument value using transformation and returns a new one.
      */
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed;
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): mixed;
 }

--- a/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ColumnBasedTableTransformation.php
@@ -10,11 +10,9 @@
 
 namespace Behat\Behat\Transformation\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use ReflectionMethod;
 use Stringable;
@@ -44,7 +42,7 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -54,22 +52,9 @@ final class ColumnBasedTableTransformation extends RuntimeCallee implements Stri
             || $this->pattern === 'table:*';
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): mixed
     {
-        $call = new TransformationCall(
-            $definitionCall->getEnvironment(),
-            $definitionCall->getCallee(),
-            $this,
-            [$argumentValue]
-        );
-
-        $result = $callCenter->makeCall($call);
-
-        if ($result->hasException()) {
-            throw $result->getException();
-        }
-
-        return $result->getReturn();
+        return $scope->call($this, [$argumentValue]);
     }
 
     public function getPriority(): int

--- a/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/PatternTransformation.php
@@ -10,11 +10,9 @@
 
 namespace Behat\Behat\Transformation\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Behat\Transformation\Call\TransformationCall;
 use Behat\Behat\Transformation\RegexGenerator;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\Transformation;
-use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use Exception;
 use Stringable;
@@ -43,13 +41,13 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
      */
     public function supportsDefinitionAndArgument(
         RegexGenerator $regexGenerator,
-        DefinitionCall $definitionCall,
+        TransformationScope $scope,
         mixed $argumentValue,
     ): bool {
         $regex = $regexGenerator->generateRegex(
-            $definitionCall->getEnvironment()->getSuite()->getName(),
+            $scope->getEnvironment()->getSuite()->getName(),
             $this->pattern,
-            $definitionCall->getFeature()->getLanguage()
+            $scope->getFeature()->getLanguage()
         );
 
         return $this->match($regex, $argumentValue) !== false;
@@ -62,14 +60,13 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
      */
     public function transformArgument(
         RegexGenerator $regexGenerator,
-        CallCenter $callCenter,
-        DefinitionCall $definitionCall,
+        TransformationScope $scope,
         mixed $argumentValue,
     ): mixed {
         $regex = $regexGenerator->generateRegex(
-            $definitionCall->getEnvironment()->getSuite()->getName(),
+            $scope->getEnvironment()->getSuite()->getName(),
             $this->pattern,
-            $definitionCall->getFeature()->getLanguage()
+            $scope->getFeature()->getLanguage()
         );
 
         $arguments = $this->match($regex, $argumentValue);
@@ -82,20 +79,7 @@ final class PatternTransformation extends RuntimeCallee implements Stringable, T
             );
         }
 
-        $call = new TransformationCall(
-            $definitionCall->getEnvironment(),
-            $definitionCall->getCallee(),
-            $this,
-            $arguments
-        );
-
-        $result = $callCenter->makeCall($call);
-
-        if ($result->hasException()) {
-            throw $result->getException();
-        }
-
-        return $result->getReturn();
+        return $scope->call($this, $arguments);
     }
 
     public function __toString(): string

--- a/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/ReturnTypeTransformation.php
@@ -10,10 +10,8 @@
 
 namespace Behat\Behat\Transformation\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
-use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use Closure;
 use ReflectionClass;
@@ -50,7 +48,7 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         $returnClass = self::getReturnClass($this->getReflection());
 
@@ -58,27 +56,14 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
             return false;
         }
 
-        $parameterClass = $this->getParameterClassNameByIndex($definitionCall, $argumentIndex);
+        $parameterClass = $this->getParameterClassNameByIndex($scope, $argumentIndex);
 
         return $parameterClass === $returnClass;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): mixed
     {
-        $call = new TransformationCall(
-            $definitionCall->getEnvironment(),
-            $definitionCall->getCallee(),
-            $this,
-            [$argumentValue]
-        );
-
-        $result = $callCenter->makeCall($call);
-
-        if ($result->hasException()) {
-            throw $result->getException();
-        }
-
-        return $result->getReturn();
+        return $scope->call($this, [$argumentValue]);
     }
 
     public function getPriority(): int
@@ -109,11 +94,11 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
     /**
      * Attempts to get definition parameter using its index (parameter position or name).
      */
-    private function getParameterClassNameByIndex(DefinitionCall $definitionCall, int|string $argumentIndex): ?string
+    private function getParameterClassNameByIndex(TransformationScope $scope, int|string $argumentIndex): ?string
     {
         $parameters = array_filter(
             array_filter(
-                $this->getCallParameters($definitionCall),
+                $this->getCallParameters($scope),
                 $this->hasIndex($argumentIndex)
             ),
             $this->getClassReflection()
@@ -131,9 +116,9 @@ final class ReturnTypeTransformation extends RuntimeCallee implements Stringable
      *
      * @return list<ReflectionParameter>
      */
-    private function getCallParameters(DefinitionCall $definitionCall): array
+    private function getCallParameters(TransformationScope $scope): array
     {
-        return $definitionCall->getCallee()->getReflection()->getParameters();
+        return $scope->getDefinition()->getReflection()->getParameters();
     }
 
     /**

--- a/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/RowBasedTableTransformation.php
@@ -10,12 +10,10 @@
 
 namespace Behat\Behat\Transformation\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use ReflectionMethod;
 use Stringable;
@@ -45,7 +43,7 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -70,22 +68,9 @@ final class RowBasedTableTransformation extends RuntimeCallee implements Stringa
         return false;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): mixed
     {
-        $call = new TransformationCall(
-            $definitionCall->getEnvironment(),
-            $definitionCall->getCallee(),
-            $this,
-            [$argumentValue]
-        );
-
-        $result = $callCenter->makeCall($call);
-
-        if ($result->hasException()) {
-            throw $result->getException();
-        }
-
-        return $result->getReturn();
+        return $scope->call($this, [$argumentValue]);
     }
 
     public function getPriority(): int

--- a/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableColumnTransformation.php
@@ -10,11 +10,9 @@
 
 namespace Behat\Behat\Transformation\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use InvalidArgumentException;
 use ReflectionMethod;
@@ -38,7 +36,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
     }
 
     public function supportsDefinitionAndArgument(
-        DefinitionCall $definitionCall,
+        TransformationScope $scope,
         int|string $argumentIndex,
         mixed $argumentArgumentValue,
     ): bool {
@@ -83,8 +81,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
      * @return list<mixed[]>
      */
     public function transformArgument(
-        CallCenter $callCenter,
-        DefinitionCall $definitionCall,
+        TransformationScope $scope,
         int|string $argumentIndex,
         mixed $argumentValue,
     ): array {
@@ -100,20 +97,7 @@ final class TableColumnTransformation extends RuntimeCallee implements Stringabl
         foreach ($argumentValue as $row) {
             foreach ($columnNames as $columnName) {
                 if (isset($row[$columnName])) {
-                    $call = new TransformationCall(
-                        $definitionCall->getEnvironment(),
-                        $definitionCall->getCallee(),
-                        $this,
-                        [$row[$columnName]]
-                    );
-
-                    $result = $callCenter->makeCall($call);
-
-                    if ($result->hasException()) {
-                        throw $result->getException();
-                    }
-
-                    $row[$columnName] = $result->getReturn();
+                    $row[$columnName] = $scope->call($this, [$row[$columnName]]);
                 }
             }
             $rows[] = $row;

--- a/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TableRowTransformation.php
@@ -10,11 +10,9 @@
 
 namespace Behat\Behat\Transformation\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use ReflectionMethod;
 use Stringable;
@@ -44,7 +42,7 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         if (!$argumentArgumentValue instanceof TableNode) {
             return false;
@@ -56,24 +54,11 @@ final class TableRowTransformation extends RuntimeCallee implements Stringable, 
     /**
      * @return list<mixed>
      */
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): array
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): array
     {
         $rows = [];
         foreach ($argumentValue as $row) {
-            $call = new TransformationCall(
-                $definitionCall->getEnvironment(),
-                $definitionCall->getCallee(),
-                $this,
-                [$row]
-            );
-
-            $result = $callCenter->makeCall($call);
-
-            if ($result->hasException()) {
-                throw $result->getException();
-            }
-
-            $rows[] = $result->getReturn();
+            $rows[] = $scope->call($this, [$row]);
         }
 
         return $rows;

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameAndReturnTypeTransformation.php
@@ -10,10 +10,8 @@
 
 namespace Behat\Behat\Transformation\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
-use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use ReflectionMethod;
 use Stringable;
@@ -45,28 +43,15 @@ final class TokenNameAndReturnTypeTransformation extends RuntimeCallee implement
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
-        return $this->tokenTransformation->supportsDefinitionAndArgument($definitionCall, $argumentIndex, $argumentArgumentValue)
-            && $this->returnTransformation->supportsDefinitionAndArgument($definitionCall, $argumentIndex, $argumentArgumentValue);
+        return $this->tokenTransformation->supportsDefinitionAndArgument($scope, $argumentIndex, $argumentArgumentValue)
+            && $this->returnTransformation->supportsDefinitionAndArgument($scope, $argumentIndex, $argumentArgumentValue);
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): mixed
     {
-        $call = new TransformationCall(
-            $definitionCall->getEnvironment(),
-            $definitionCall->getCallee(),
-            $this,
-            [$argumentValue]
-        );
-
-        $result = $callCenter->makeCall($call);
-
-        if ($result->hasException()) {
-            throw $result->getException();
-        }
-
-        return $result->getReturn();
+        return $scope->call($this, [$argumentValue]);
     }
 
     public function getPriority(): int

--- a/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
+++ b/src/Behat/Behat/Transformation/Transformation/TokenNameTransformation.php
@@ -10,10 +10,8 @@
 
 namespace Behat\Behat\Transformation\Transformation;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
-use Behat\Behat\Transformation\Call\TransformationCall;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
-use Behat\Testwork\Call\CallCenter;
 use Behat\Testwork\Call\RuntimeCallee;
 use ReflectionMethod;
 use Stringable;
@@ -43,27 +41,14 @@ final class TokenNameTransformation extends RuntimeCallee implements Stringable,
         parent::__construct($callable, $description);
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentArgumentValue): bool
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentArgumentValue): bool
     {
         return ':' . $argumentIndex === $this->pattern;
     }
 
-    public function transformArgument(CallCenter $callCenter, DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): mixed
     {
-        $call = new TransformationCall(
-            $definitionCall->getEnvironment(),
-            $definitionCall->getCallee(),
-            $this,
-            [$argumentValue]
-        );
-
-        $result = $callCenter->makeCall($call);
-
-        if ($result->hasException()) {
-            throw $result->getException();
-        }
-
-        return $result->getReturn();
+        return $scope->call($this, [$argumentValue]);
     }
 
     public function getPriority(): int

--- a/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php
@@ -10,7 +10,7 @@
 
 namespace Behat\Behat\Transformation\Transformer;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 
 /**
  * Transforms a single argument value.
@@ -24,10 +24,10 @@ interface ArgumentTransformer
     /**
      * Checks if transformer supports argument.
      */
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): bool;
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): bool;
 
     /**
      * Transforms argument value using transformation and returns a new one.
      */
-    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed;
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): mixed;
 }

--- a/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
+++ b/src/Behat/Behat/Transformation/Transformer/RepositoryArgumentTransformer.php
@@ -10,16 +10,15 @@
 
 namespace Behat\Behat\Transformation\Transformer;
 
-use Behat\Behat\Definition\Call\DefinitionCall;
 use Behat\Behat\Definition\Pattern\PatternTransformer;
 use Behat\Behat\Definition\Translator\TranslatorInterface;
 use Behat\Behat\Transformation\RegexGenerator;
+use Behat\Behat\Transformation\Scope\TransformationScope;
 use Behat\Behat\Transformation\SimpleArgumentTransformation;
 use Behat\Behat\Transformation\Transformation;
 use Behat\Behat\Transformation\Transformation\PatternTransformation;
 use Behat\Behat\Transformation\TransformationRepository;
 use Behat\Gherkin\Node\ArgumentInterface;
-use Behat\Testwork\Call\CallCenter;
 
 /**
  * Argument transformer based on transformations repository.
@@ -33,26 +32,25 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      */
     public function __construct(
         private readonly TransformationRepository $repository,
-        private readonly CallCenter $callCenter,
         private readonly PatternTransformer $patternTransformer,
         private readonly TranslatorInterface $translator,
     ) {
     }
 
-    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): bool
+    public function supportsDefinitionAndArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): bool
     {
-        return count($this->repository->getEnvironmentTransformations($definitionCall->getEnvironment())) > 0;
+        return count($this->repository->getEnvironmentTransformations($scope->getEnvironment())) > 0;
     }
 
-    public function transformArgument(DefinitionCall $definitionCall, int|string $argumentIndex, mixed $argumentValue): mixed
+    public function transformArgument(TransformationScope $scope, int|string $argumentIndex, mixed $argumentValue): mixed
     {
-        $environment = $definitionCall->getEnvironment();
+        $environment = $scope->getEnvironment();
         [$simpleTransformations, $normalTransformations] = $this->splitSimpleAndNormalTransformations(
             $this->repository->getEnvironmentTransformations($environment)
         );
 
-        $newValue = $this->applySimpleTransformations($simpleTransformations, $definitionCall, $argumentIndex, $argumentValue);
-        $newValue = $this->applyNormalTransformations($normalTransformations, $definitionCall, $argumentIndex, $newValue);
+        $newValue = $this->applySimpleTransformations($simpleTransformations, $scope, $argumentIndex, $argumentValue);
+        $newValue = $this->applyNormalTransformations($normalTransformations, $scope, $argumentIndex, $newValue);
 
         return $newValue;
     }
@@ -72,13 +70,13 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      *
      * @param SimpleArgumentTransformation[] $transformations
      */
-    private function applySimpleTransformations(array $transformations, DefinitionCall $definitionCall, int|string $index, mixed $value): mixed
+    private function applySimpleTransformations(array $transformations, TransformationScope $scope, int|string $index, mixed $value): mixed
     {
         usort($transformations, fn (SimpleArgumentTransformation $t1, SimpleArgumentTransformation $t2): int => $t2->getPriority() <=> $t1->getPriority());
 
         $newValue = $value;
         foreach ($transformations as $transformation) {
-            $newValue = $this->transform($definitionCall, $transformation, $index, $newValue);
+            $newValue = $this->transform($scope, $transformation, $index, $newValue);
         }
 
         return $newValue;
@@ -89,11 +87,11 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
      *
      * @param Transformation[] $transformations
      */
-    private function applyNormalTransformations(array $transformations, DefinitionCall $definitionCall, int|string $index, mixed $value): mixed
+    private function applyNormalTransformations(array $transformations, TransformationScope $scope, int|string $index, mixed $value): mixed
     {
         $newValue = $value;
         foreach ($transformations as $transformation) {
-            $newValue = $this->transform($definitionCall, $transformation, $index, $newValue);
+            $newValue = $this->transform($scope, $transformation, $index, $newValue);
         }
 
         return $newValue;
@@ -102,20 +100,20 @@ final class RepositoryArgumentTransformer implements ArgumentTransformer, RegexG
     /**
      * Transforms argument value using registered transformers.
      */
-    private function transform(DefinitionCall $definitionCall, Transformation $transformation, int|string $index, mixed $value): mixed
+    private function transform(TransformationScope $scope, Transformation $transformation, int|string $index, mixed $value): mixed
     {
         if (is_object($value) && !$value instanceof ArgumentInterface) {
             return $value;
         }
 
         if ($transformation instanceof SimpleArgumentTransformation
-            && $transformation->supportsDefinitionAndArgument($definitionCall, $index, $value)) {
-            return $transformation->transformArgument($this->callCenter, $definitionCall, $index, $value);
+            && $transformation->supportsDefinitionAndArgument($scope, $index, $value)) {
+            return $transformation->transformArgument($scope, $index, $value);
         }
 
         if ($transformation instanceof PatternTransformation
-            && $transformation->supportsDefinitionAndArgument($this, $definitionCall, $value)) {
-            return $transformation->transformArgument($this, $this->callCenter, $definitionCall, $value);
+            && $transformation->supportsDefinitionAndArgument($this, $scope, $value)) {
+            return $transformation->transformArgument($this, $scope, $value);
         }
 
         return $value;

--- a/tests/Fixtures/Extensions/behat-argument-transformer.php
+++ b/tests/Fixtures/Extensions/behat-argument-transformer.php
@@ -1,0 +1,16 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Extension;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+return (new Config())
+    ->withProfile(
+        (new Profile('default'))
+            ->withExtension(new Extension('custom_transformer_extension.php'))
+            ->withSuite(
+                (new Suite('default'))
+                    ->withContexts('ArgumentTransformerContext')
+            )
+    );

--- a/tests/Fixtures/Extensions/custom_transformer_extension.php
+++ b/tests/Fixtures/Extensions/custom_transformer_extension.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Behat\Transformation\Scope\TransformationScope;
+use Behat\Behat\Transformation\ServiceContainer\TransformationExtension;
+use Behat\Behat\Transformation\Transformer\ArgumentTransformer;
+use Behat\Testwork\ServiceContainer\Extension;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * A third-party argument transformer, written against nothing but Behat's public API.
+ *
+ * It rewrites every string argument to include details read back off the
+ * TransformationScope, so that the scenario can prove each accessor works.
+ */
+class ContextReportingTransformer implements ArgumentTransformer
+{
+    public function supportsDefinitionAndArgument(
+        TransformationScope $scope,
+        int|string $argumentIndex,
+        mixed $argumentValue,
+    ): bool {
+        return is_string($argumentValue);
+    }
+
+    public function transformArgument(
+        TransformationScope $scope,
+        int|string $argumentIndex,
+        mixed $argumentValue,
+    ): mixed {
+        return sprintf(
+            '%s [suite=%s language=%s line=%d pattern=%s]',
+            $argumentValue,
+            $scope->getEnvironment()->getSuite()->getName(),
+            $scope->getFeature()->getLanguage(),
+            $scope->getStep()->getLine(),
+            $scope->getDefinition()->getPattern(),
+        );
+    }
+}
+
+class CustomTransformer implements Extension
+{
+    public function getConfigKey(): string
+    {
+        return 'custom_transformer';
+    }
+
+    public function configure(ArrayNodeDefinition $builder): void
+    {
+    }
+
+    public function initialize(ExtensionManager $extensionManager): void
+    {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+    }
+
+    public function load(ContainerBuilder $container, array $config): void
+    {
+        $definition = new Definition('ContextReportingTransformer', []);
+        $definition->addTag(TransformationExtension::ARGUMENT_TRANSFORMER_TAG, ['priority' => 100]);
+        $container->setDefinition(
+            TransformationExtension::ARGUMENT_TRANSFORMER_TAG . '.context_reporting',
+            $definition
+        );
+    }
+}
+
+return new CustomTransformer();

--- a/tests/Fixtures/Extensions/features/argument_transformer.feature
+++ b/tests/Fixtures/Extensions/features/argument_transformer.feature
@@ -1,0 +1,3 @@
+Feature:
+  Scenario:
+    Then the argument is "world"

--- a/tests/Fixtures/Extensions/features/bootstrap/ArgumentTransformerContext.php
+++ b/tests/Fixtures/Extensions/features/bootstrap/ArgumentTransformerContext.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Behat\Context\Context;
+use Behat\Step\Then;
+
+class ArgumentTransformerContext implements Context
+{
+    #[Then('the argument is :value')]
+    public function theArgumentIs(string $value): void
+    {
+        echo $value;
+    }
+}


### PR DESCRIPTION
`ArgumentTransformer` and `SimpleArgumentTransformation` are marked `@api` and are the documented way to add a custom transformation, but implementing either one meant accepting a `DefinitionCall` and a `CallCenter`, neither of which is part of our public API — so a conforming custom transformation could not actually be written without reaching into Behat's internals. Every transformation we ship turned out to want the same small things from those objects, and all of them ended with an identical block that built a call, ran it through the call center and unwrapped the result. This replaces both parameters with a single `TransformationScope`, which exposes what a transformation actually needs and runs the transformation for it, so the whole call pipeline stays internal and the shared block collapses to one line. Part of #1237.
