### PR TITLE
Turn the event base classes into interfaces

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -264,5 +264,17 @@
 
         <!-- Required consistent constructor for SimpleArgumentTransformation -->
         <ignored-regex>#ADDED: Method __construct\(\) was added to interface Behat\\Behat\\Transformation\\SimpleArgumentTransformation#</ignored-regex>
+
+        <!--
+        The event base classes are now interfaces, with their shared implementation moved into internal Runtime*
+        classes. Existing type hints, instanceof checks and event name constants such as ScenarioTested::BEFORE are
+        unaffected; only extending these base classes is no longer possible, which was never intended. As a result
+        the interfaces no longer inherit from Behat's and Symfony's Event classes.
+        -->
+        <ignored-regex>#CHANGED: Class Behat\\(Behat|Testwork)\\EventDispatcher\\Event\\\w+ became an interface#</ignored-regex>
+        <ignored-regex>#REMOVED: These ancestors of Behat\\(Behat|Testwork)\\EventDispatcher\\Event\\\w+ have been removed#</ignored-regex>
+        <ignored-regex>#CHANGED: Method (getNode|getSuite|getEnvironment)\(\) of class Behat\\(Behat|Testwork)\\EventDispatcher\\Event\\\w+ changed from concrete to abstract#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Behat\\Testwork\\EventDispatcher\\Event\\LifecycleEvent\#__construct\(\) was removed#</ignored-regex>
+        <ignored-regex>#REMOVED: Method Symfony\\Contracts\\EventDispatcher\\Event\#(isPropagationStopped|stopPropagation)\(\) was removed#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundSetup.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Setup\Setup;
  *
  * @api
  */
-final class AfterBackgroundSetup extends BackgroundTested implements AfterSetup
+final class AfterBackgroundSetup extends RuntimeBackgroundTested implements BackgroundTested, AfterSetup
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterBackgroundTested.php
@@ -24,7 +24,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  *
  * @api
  */
-final class AfterBackgroundTested extends BackgroundTested implements AfterTested
+final class AfterBackgroundTested extends RuntimeBackgroundTested implements BackgroundTested, AfterTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterFeatureSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterFeatureSetup.php
@@ -22,7 +22,7 @@ use Behat\Testwork\Tester\Setup\Setup;
  *
  * @api
  */
-final class AfterFeatureSetup extends FeatureTested implements AfterSetup
+final class AfterFeatureSetup extends RuntimeFeatureTested implements FeatureTested, AfterSetup
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterFeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterFeatureTested.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  *
  * @api
  */
-final class AfterFeatureTested extends FeatureTested implements AfterTested
+final class AfterFeatureTested extends RuntimeFeatureTested implements FeatureTested, AfterTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterOutlineSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterOutlineSetup.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Setup\Setup;
  *
  * @api
  */
-final class AfterOutlineSetup extends OutlineTested implements AfterSetup
+final class AfterOutlineSetup extends RuntimeOutlineTested implements OutlineTested, AfterSetup
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterOutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterOutlineTested.php
@@ -24,7 +24,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  *
  * @api
  */
-final class AfterOutlineTested extends OutlineTested implements AfterTested
+final class AfterOutlineTested extends RuntimeOutlineTested implements OutlineTested, AfterTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterScenarioSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterScenarioSetup.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Setup\Setup;
  *
  * @api
  */
-final class AfterScenarioSetup extends ScenarioTested implements AfterSetup
+final class AfterScenarioSetup extends RuntimeScenarioTested implements ScenarioTested, AfterSetup
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterScenarioTested.php
@@ -24,7 +24,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  *
  * @api
  */
-final class AfterScenarioTested extends ScenarioTested implements AfterTested
+final class AfterScenarioTested extends RuntimeScenarioTested implements ScenarioTested, AfterTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepSetup.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Setup\Setup;
  *
  * @api
  */
-final class AfterStepSetup extends StepTested implements AfterSetup
+final class AfterStepSetup extends RuntimeStepTested implements StepTested, AfterSetup
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
@@ -26,7 +26,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  *
  * @api
  */
-final class AfterStepTested extends StepTested implements AfterTested
+final class AfterStepTested extends RuntimeStepTested implements StepTested, AfterTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BackgroundTested.php
@@ -12,7 +12,6 @@ namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\NodeInterface;
 use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
 
 /**
@@ -22,7 +21,7 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  *
  * @api
  */
-abstract class BackgroundTested extends LifecycleEvent implements GherkinNodeTested
+interface BackgroundTested extends LifecycleEvent, GherkinNodeTested
 {
     public const BEFORE = 'tester.background_tested.before';
     public const AFTER_SETUP = 'tester.background_tested.after_setup';
@@ -30,20 +29,12 @@ abstract class BackgroundTested extends LifecycleEvent implements GherkinNodeTes
     public const AFTER = 'tester.background_tested.after';
 
     /**
-     * Returns feature node.
+     * Returns feature.
      */
-    abstract public function getFeature(): FeatureNode;
+    public function getFeature(): FeatureNode;
 
     /**
      * Returns background node.
      */
-    abstract public function getBackground(): BackgroundNode;
-
-    /**
-     * Returns node.
-     */
-    final public function getNode(): NodeInterface
-    {
-        return $this->getBackground();
-    }
+    public function getBackground(): BackgroundNode;
 }

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTeardown.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  *
  * @api
  */
-final class BeforeBackgroundTeardown extends BackgroundTested implements BeforeTeardown
+final class BeforeBackgroundTeardown extends RuntimeBackgroundTested implements BackgroundTested, BeforeTeardown
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeBackgroundTested.php
@@ -22,7 +22,7 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  *
  * @api
  */
-final class BeforeBackgroundTested extends BackgroundTested implements BeforeTested
+final class BeforeBackgroundTested extends RuntimeBackgroundTested implements BackgroundTested, BeforeTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTeardown.php
@@ -22,7 +22,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  *
  * @api
  */
-final class BeforeFeatureTeardown extends FeatureTested implements BeforeTeardown
+final class BeforeFeatureTeardown extends RuntimeFeatureTested implements FeatureTested, BeforeTeardown
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeFeatureTested.php
@@ -21,7 +21,7 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  *
  * @api
  */
-final class BeforeFeatureTested extends FeatureTested implements BeforeTested
+final class BeforeFeatureTested extends RuntimeFeatureTested implements FeatureTested, BeforeTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTeardown.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  *
  * @api
  */
-final class BeforeOutlineTeardown extends OutlineTested implements BeforeTeardown
+final class BeforeOutlineTeardown extends RuntimeOutlineTested implements OutlineTested, BeforeTeardown
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeOutlineTested.php
@@ -22,7 +22,7 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  *
  * @api
  */
-final class BeforeOutlineTested extends OutlineTested implements BeforeTested
+final class BeforeOutlineTested extends RuntimeOutlineTested implements OutlineTested, BeforeTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTeardown.php
@@ -23,7 +23,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  *
  * @api
  */
-final class BeforeScenarioTeardown extends ScenarioTested implements BeforeTeardown
+final class BeforeScenarioTeardown extends RuntimeScenarioTested implements ScenarioTested, BeforeTeardown
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeScenarioTested.php
@@ -22,7 +22,7 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  *
  * @api
  */
-final class BeforeScenarioTested extends ScenarioTested implements BeforeTested
+final class BeforeScenarioTested extends RuntimeScenarioTested implements ScenarioTested, BeforeTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
@@ -26,7 +26,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  *
  * @api
  */
-final class BeforeStepTeardown extends StepTested implements BeforeTeardown
+final class BeforeStepTeardown extends RuntimeStepTested implements StepTested, BeforeTeardown
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTested.php
@@ -22,7 +22,7 @@ use Behat\Testwork\EventDispatcher\Event\BeforeTested;
  *
  * @api
  */
-final class BeforeStepTested extends StepTested implements BeforeTested
+final class BeforeStepTested extends RuntimeStepTested implements StepTested, BeforeTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/FeatureTested.php
@@ -11,7 +11,6 @@
 namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\NodeInterface;
 use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
 
 /**
@@ -21,7 +20,7 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  *
  * @api
  */
-abstract class FeatureTested extends LifecycleEvent implements GherkinNodeTested
+interface FeatureTested extends LifecycleEvent, GherkinNodeTested
 {
     public const BEFORE = 'tester.feature_tested.before';
     public const AFTER_SETUP = 'tester.feature_tested.after_setup';
@@ -31,13 +30,5 @@ abstract class FeatureTested extends LifecycleEvent implements GherkinNodeTested
     /**
      * Returns feature.
      */
-    abstract public function getFeature(): FeatureNode;
-
-    /**
-     * Returns node.
-     */
-    final public function getNode(): NodeInterface
-    {
-        return $this->getFeature();
-    }
+    public function getFeature(): FeatureNode;
 }

--- a/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/OutlineTested.php
@@ -11,18 +11,17 @@
 namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\NodeInterface;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
 
 /**
- * Represents an outline event.
+ * Represents a outline event.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * @api
  */
-abstract class OutlineTested extends LifecycleEvent implements GherkinNodeTested
+interface OutlineTested extends LifecycleEvent, GherkinNodeTested
 {
     public const BEFORE = 'tester.outline_tested.before';
     public const AFTER_SETUP = 'tester.outline_tested.after_setup';
@@ -32,18 +31,10 @@ abstract class OutlineTested extends LifecycleEvent implements GherkinNodeTested
     /**
      * Returns feature.
      */
-    abstract public function getFeature(): FeatureNode;
+    public function getFeature(): FeatureNode;
 
     /**
      * Returns outline node.
      */
-    abstract public function getOutline(): OutlineNode;
-
-    /**
-     * Returns node.
-     */
-    final public function getNode(): NodeInterface
-    {
-        return $this->getOutline();
-    }
+    public function getOutline(): OutlineNode;
 }

--- a/src/Behat/Behat/EventDispatcher/Event/RuntimeBackgroundTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/RuntimeBackgroundTested.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\EventDispatcher\Event;
+
+use Behat\Gherkin\Node\NodeInterface;
+use Behat\Testwork\EventDispatcher\Event\RuntimeLifecycleEvent;
+
+/**
+ * Base implementation for background events.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @internal Behat's own events extend this. Third parties should implement {@see BackgroundTested}.
+ */
+abstract class RuntimeBackgroundTested extends RuntimeLifecycleEvent implements BackgroundTested
+{
+    final public function getNode(): NodeInterface
+    {
+        return $this->getBackground();
+    }
+}

--- a/src/Behat/Behat/EventDispatcher/Event/RuntimeFeatureTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/RuntimeFeatureTested.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\EventDispatcher\Event;
+
+use Behat\Gherkin\Node\NodeInterface;
+use Behat\Testwork\EventDispatcher\Event\RuntimeLifecycleEvent;
+
+/**
+ * Base implementation for feature events.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @internal Behat's own events extend this. Third parties should implement {@see FeatureTested}.
+ */
+abstract class RuntimeFeatureTested extends RuntimeLifecycleEvent implements FeatureTested
+{
+    final public function getNode(): NodeInterface
+    {
+        return $this->getFeature();
+    }
+}

--- a/src/Behat/Behat/EventDispatcher/Event/RuntimeOutlineTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/RuntimeOutlineTested.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\EventDispatcher\Event;
+
+use Behat\Gherkin\Node\NodeInterface;
+use Behat\Testwork\EventDispatcher\Event\RuntimeLifecycleEvent;
+
+/**
+ * Base implementation for outline events.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @internal Behat's own events extend this. Third parties should implement {@see OutlineTested}.
+ */
+abstract class RuntimeOutlineTested extends RuntimeLifecycleEvent implements OutlineTested
+{
+    final public function getNode(): NodeInterface
+    {
+        return $this->getOutline();
+    }
+}

--- a/src/Behat/Behat/EventDispatcher/Event/RuntimeScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/RuntimeScenarioTested.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\EventDispatcher\Event;
+
+use Behat\Gherkin\Node\NodeInterface;
+use Behat\Testwork\EventDispatcher\Event\RuntimeLifecycleEvent;
+
+/**
+ * Base implementation for scenario events.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @internal Behat's own events extend this. Third parties should implement {@see ScenarioTested}.
+ */
+abstract class RuntimeScenarioTested extends RuntimeLifecycleEvent implements ScenarioTested
+{
+    final public function getNode(): NodeInterface
+    {
+        return $this->getScenario();
+    }
+}

--- a/src/Behat/Behat/EventDispatcher/Event/RuntimeStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/RuntimeStepTested.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Behat\EventDispatcher\Event;
+
+use Behat\Gherkin\Node\NodeInterface;
+use Behat\Testwork\EventDispatcher\Event\RuntimeLifecycleEvent;
+
+/**
+ * Base implementation for step events.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @internal Behat's own events extend this. Third parties should implement {@see StepTested}.
+ */
+abstract class RuntimeStepTested extends RuntimeLifecycleEvent implements StepTested
+{
+    final public function getNode(): NodeInterface
+    {
+        return $this->getStep();
+    }
+}

--- a/src/Behat/Behat/EventDispatcher/Event/ScenarioTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/ScenarioTested.php
@@ -11,7 +11,6 @@
 namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\NodeInterface;
 use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
 
@@ -22,7 +21,7 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  *
  * @api
  */
-abstract class ScenarioTested extends LifecycleEvent implements GherkinNodeTested
+interface ScenarioTested extends LifecycleEvent, GherkinNodeTested
 {
     public const BEFORE = 'tester.scenario_tested.before';
     public const AFTER_SETUP = 'tester.scenario_tested.after_setup';
@@ -30,17 +29,12 @@ abstract class ScenarioTested extends LifecycleEvent implements GherkinNodeTeste
     public const AFTER = 'tester.scenario_tested.after';
 
     /**
-     * Returns feature node.
+     * Returns feature.
      */
-    abstract public function getFeature(): FeatureNode;
+    public function getFeature(): FeatureNode;
 
     /**
      * Returns scenario node.
      */
-    abstract public function getScenario(): ScenarioLikeInterface;
-
-    final public function getNode(): NodeInterface
-    {
-        return $this->getScenario();
-    }
+    public function getScenario(): ScenarioLikeInterface;
 }

--- a/src/Behat/Behat/EventDispatcher/Event/StepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/StepTested.php
@@ -11,7 +11,6 @@
 namespace Behat\Behat\EventDispatcher\Event;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\NodeInterface;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
 
@@ -22,7 +21,7 @@ use Behat\Testwork\EventDispatcher\Event\LifecycleEvent;
  *
  * @api
  */
-abstract class StepTested extends LifecycleEvent implements GherkinNodeTested
+interface StepTested extends LifecycleEvent, GherkinNodeTested
 {
     public const BEFORE = 'tester.step_tested.before';
     public const AFTER_SETUP = 'tester.step_tested.after_setup';
@@ -32,15 +31,10 @@ abstract class StepTested extends LifecycleEvent implements GherkinNodeTested
     /**
      * Returns feature.
      */
-    abstract public function getFeature(): FeatureNode;
+    public function getFeature(): FeatureNode;
 
     /**
      * Returns step node.
      */
-    abstract public function getStep(): StepNode;
-
-    final public function getNode(): NodeInterface
-    {
-        return $this->getStep();
-    }
+    public function getStep(): StepNode;
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseAborted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseAborted.php
@@ -10,6 +10,8 @@
 
 namespace Behat\Testwork\EventDispatcher\Event;
 
+use Behat\Testwork\Event\Event;
+
 /**
  * Represents an event in which exercise was aborted.
  *
@@ -17,7 +19,7 @@ namespace Behat\Testwork\EventDispatcher\Event;
  *
  * @api
  */
-final class AfterExerciseAborted extends ExerciseCompleted
+final class AfterExerciseAborted extends Event implements ExerciseCompleted
 {
     public function getSpecificationIterators(): array
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseCompleted.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\EventDispatcher\Event;
 
+use Behat\Testwork\Event\Event;
 use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Result\TestResult;
 use Behat\Testwork\Tester\Setup\Teardown;
@@ -21,7 +22,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  *
  * @api
  */
-final class AfterExerciseCompleted extends ExerciseCompleted implements AfterTested
+final class AfterExerciseCompleted extends Event implements ExerciseCompleted, AfterTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterExerciseSetup.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\EventDispatcher\Event;
 
+use Behat\Testwork\Event\Event;
 use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Setup\Setup;
 
@@ -20,7 +21,7 @@ use Behat\Testwork\Tester\Setup\Setup;
  *
  * @api
  */
-final class AfterExerciseSetup extends ExerciseCompleted implements AfterSetup
+final class AfterExerciseSetup extends Event implements ExerciseCompleted, AfterSetup
 {
     /**
      * Initializes event.

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteAborted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteAborted.php
@@ -20,7 +20,7 @@ use Behat\Testwork\Specification\SpecificationIterator;
  *
  * @api
  */
-final class AfterSuiteAborted extends SuiteTested
+final class AfterSuiteAborted extends RuntimeLifecycleEvent implements SuiteTested
 {
     public function getSpecificationIterator(): SpecificationIterator
     {

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteSetup.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteSetup.php
@@ -21,7 +21,7 @@ use Behat\Testwork\Tester\Setup\Setup;
  *
  * @api
  */
-final class AfterSuiteSetup extends SuiteTested implements AfterSetup
+final class AfterSuiteSetup extends RuntimeLifecycleEvent implements SuiteTested, AfterSetup
 {
     /**
      * Initializes event.

--- a/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/AfterSuiteTested.php
@@ -22,7 +22,7 @@ use Behat\Testwork\Tester\Setup\Teardown;
  *
  * @api
  */
-final class AfterSuiteTested extends SuiteTested implements AfterTested
+final class AfterSuiteTested extends RuntimeLifecycleEvent implements SuiteTested, AfterTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseCompleted.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\EventDispatcher\Event;
 
+use Behat\Testwork\Event\Event;
 use Behat\Testwork\Specification\SpecificationIterator;
 
 /**
@@ -19,7 +20,7 @@ use Behat\Testwork\Specification\SpecificationIterator;
  *
  * @api
  */
-final class BeforeExerciseCompleted extends ExerciseCompleted implements BeforeTested
+final class BeforeExerciseCompleted extends Event implements ExerciseCompleted, BeforeTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeExerciseTeardown.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Testwork\EventDispatcher\Event;
 
+use Behat\Testwork\Event\Event;
 use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Result\TestResult;
 
@@ -20,7 +21,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  *
  * @api
  */
-final class BeforeExerciseTeardown extends ExerciseCompleted implements BeforeTeardown
+final class BeforeExerciseTeardown extends Event implements ExerciseCompleted, BeforeTeardown
 {
     /**
      * Initializes event.

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTeardown.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTeardown.php
@@ -21,7 +21,7 @@ use Behat\Testwork\Tester\Result\TestResult;
  *
  * @api
  */
-final class BeforeSuiteTeardown extends SuiteTested implements BeforeTeardown
+final class BeforeSuiteTeardown extends RuntimeLifecycleEvent implements SuiteTested, BeforeTeardown
 {
     /**
      * Initializes event.

--- a/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/BeforeSuiteTested.php
@@ -20,7 +20,7 @@ use Behat\Testwork\Specification\SpecificationIterator;
  *
  * @api
  */
-final class BeforeSuiteTested extends SuiteTested implements BeforeTested
+final class BeforeSuiteTested extends RuntimeLifecycleEvent implements SuiteTested, BeforeTested
 {
     /**
      * Initializes event.

--- a/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/ExerciseCompleted.php
@@ -10,7 +10,6 @@
 
 namespace Behat\Testwork\EventDispatcher\Event;
 
-use Behat\Testwork\Event\Event;
 use Behat\Testwork\Specification\SpecificationIterator;
 
 /**
@@ -20,7 +19,7 @@ use Behat\Testwork\Specification\SpecificationIterator;
  *
  * @api
  */
-abstract class ExerciseCompleted extends Event
+interface ExerciseCompleted
 {
     public const BEFORE = 'tester.exercise_completed.before';
     public const AFTER_SETUP = 'tester.exercise_completed.after_setup';
@@ -32,5 +31,5 @@ abstract class ExerciseCompleted extends Event
      *
      * @return SpecificationIterator<mixed>[]
      */
-    abstract public function getSpecificationIterators(): array;
+    public function getSpecificationIterators(): array;
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/LifecycleEvent.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/LifecycleEvent.php
@@ -11,7 +11,6 @@
 namespace Behat\Testwork\EventDispatcher\Event;
 
 use Behat\Testwork\Environment\Environment;
-use Behat\Testwork\Event\Event;
 use Behat\Testwork\Suite\Suite;
 
 /**
@@ -21,29 +20,15 @@ use Behat\Testwork\Suite\Suite;
  *
  * @api
  */
-abstract class LifecycleEvent extends Event
+interface LifecycleEvent
 {
-    /**
-     * Initializes scenario event.
-     */
-    public function __construct(
-        private readonly Environment $environment,
-    ) {
-    }
-
     /**
      * Returns suite in which this event was fired.
      */
-    public function getSuite(): Suite
-    {
-        return $this->environment->getSuite();
-    }
+    public function getSuite(): Suite;
 
     /**
      * Returns environment in which this event was fired.
      */
-    public function getEnvironment(): Environment
-    {
-        return $this->environment;
-    }
+    public function getEnvironment(): Environment;
 }

--- a/src/Behat/Testwork/EventDispatcher/Event/RuntimeLifecycleEvent.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/RuntimeLifecycleEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Behat Testwork.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Testwork\EventDispatcher\Event;
+
+use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\Event\Event;
+use Behat\Testwork\Suite\Suite;
+
+/**
+ * Base implementation for events which hold references to current suite and environment.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @internal Behat's own events extend this. Third parties should implement {@see LifecycleEvent}.
+ */
+abstract class RuntimeLifecycleEvent extends Event implements LifecycleEvent
+{
+    /**
+     * Initializes scenario event.
+     */
+    public function __construct(
+        private readonly Environment $environment,
+    ) {
+    }
+
+    public function getSuite(): Suite
+    {
+        return $this->environment->getSuite();
+    }
+
+    public function getEnvironment(): Environment
+    {
+        return $this->environment;
+    }
+}

--- a/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
+++ b/src/Behat/Testwork/EventDispatcher/Event/SuiteTested.php
@@ -19,7 +19,7 @@ use Behat\Testwork\Specification\SpecificationIterator;
  *
  * @api
  */
-abstract class SuiteTested extends LifecycleEvent
+interface SuiteTested extends LifecycleEvent
 {
     public const BEFORE = 'tester.suite_tested.before';
     public const AFTER_SETUP = 'tester.suite_tested.after_setup';
@@ -31,5 +31,5 @@ abstract class SuiteTested extends LifecycleEvent
      *
      * @return SpecificationIterator<mixed>
      */
-    abstract public function getSpecificationIterator(): SpecificationIterator;
+    public function getSpecificationIterator(): SpecificationIterator;
 }


### PR DESCRIPTION
Our event base classes are marked `@api` and so, under the 4.0 rules, third parties may extend them — but that was never the intent. They are marked only because they are the sole place where accessors like `getSuite()`, `getEnvironment()` and `getFeature()` are declared, so a listener that wants to handle any event carrying a suite has no interface to type against and has to reach for the abstract class instead. This PR converts each of those base classes into an interface of the same name and moves the shared implementation into internal `Runtime*` base classes, following the existing `ExampleTested` interface which already carries its event name constants this way. Existing type hints, `instanceof` checks and constant references such as `ScenarioTested::BEFORE` all keep working; only extending the base classes stops, which is the promise we did not mean to make. Part of #1237.
