### PR TITLE
test: Don't use PHPUnit assertions in Behat's own test suite

### DIFF
--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -19,6 +19,7 @@ Feature: Append snippets option
       use Behat\Step\Given;
       use Behat\Step\Then;
       use Behat\Step\When;
+      use Behat\Tests\Fixtures\Assert;
 
       class FeatureContext implements Context
       {
@@ -51,20 +52,20 @@ Feature: Append snippets option
           #[Then('/^I should have (\\d+) apples$/')]
           public function iShouldHaveApples($count)
           {
-              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
+              Assert::assertEquals(intval($count), $this->apples);
           }
 
           #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]
           public function contextParameterShouldBeEqualTo($key, $val)
           {
-              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
+              Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           #[Given('/^context parameter "([^"]*)" should be array with (\\d+) elements$/')]
           public function contextParameterShouldBeArrayWithElements($key, $count)
           {
-              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
-              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
+              Assert::assertIsArray($this->parameters[$key]);
+              Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith()
@@ -125,6 +126,7 @@ Feature: Append snippets option
       use Behat\Step\Given;
       use Behat\Step\Then;
       use Behat\Step\When;
+      use Behat\Tests\Fixtures\Assert;
 
       class FeatureContextNoPendingException implements Context
       {
@@ -157,20 +159,20 @@ Feature: Append snippets option
           #[Then('/^I should have (\\d+) apples$/')]
           public function iShouldHaveApples($count)
           {
-              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
+              Assert::assertEquals(intval($count), $this->apples);
           }
 
           #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]
           public function contextParameterShouldBeEqualTo($key, $val)
           {
-              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
+              Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           #[Given('/^context parameter "([^"]*)" should be array with (\\d+) elements$/')]
           public function contextParameterShouldBeArrayWithElements($key, $count)
           {
-              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
-              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
+              Assert::assertIsArray($this->parameters[$key]);
+              Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith()
@@ -230,6 +232,7 @@ Feature: Append snippets option
       use Behat\Step\Given;
       use Behat\Step\Then;
       use Behat\Step\When;
+      use Behat\Tests\Fixtures\Assert;
 
       class FeatureContextMinimalImports implements Context
       {
@@ -262,20 +265,20 @@ Feature: Append snippets option
           #[Then('/^I should have (\\d+) apples$/')]
           public function iShouldHaveApples($count)
           {
-              PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
+              Assert::assertEquals(intval($count), $this->apples);
           }
 
           #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]
           public function contextParameterShouldBeEqualTo($key, $val)
           {
-              PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
+              Assert::assertEquals($val, $this->parameters[$key]);
           }
 
           #[Given('/^context parameter "([^"]*)" should be array with (\\d+) elements$/')]
           public function contextParameterShouldBeArrayWithElements($key, $count)
           {
-              PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
-              PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
+              Assert::assertIsArray($this->parameters[$key]);
+              Assert::assertEquals(2, count($this->parameters[$key]));
           }
 
           private function doSomethingUndefinedWith()

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -20,7 +20,6 @@ use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
 use Opis\JsonSchema\Validator;
-use PHPUnit\Framework\Assert;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 use Symfony\Component\Filesystem\Filesystem;
@@ -178,7 +177,7 @@ EOL;
     #[Given('/^file "([^"]*)" should exist$/')]
     public function fileShouldExist(string $path): void
     {
-        Assert::assertFileExists($this->workingDir . DIRECTORY_SEPARATOR . $path);
+        $this->assertFileExists($this->workingDir . DIRECTORY_SEPARATOR . $path);
     }
 
     #[Given('I clear the default behat options')]
@@ -389,7 +388,11 @@ EOL;
     #[Then('/^it should (fail|pass) with no output$/')]
     public function itShouldPassOrFailWithNoOutput(string $success): void
     {
-        Assert::assertEmpty($this->getOutput());
+        $this->assertStringIsEmpty(
+            $this->getOutput(),
+            'Expected the command to produce no output, but got:'
+        );
+
         $this->itShouldPassOrFail($success);
     }
 
@@ -403,7 +406,7 @@ EOL;
     public function fileShouldContain(string $path, PyStringNode $text): void
     {
         $path = $this->workingDir . '/' . $path;
-        Assert::assertFileExists($path);
+        $this->assertFileExists($path);
 
         $fileContent = trim(file_get_contents($path));
         // Normalize the line endings in the output
@@ -411,14 +414,18 @@ EOL;
             $fileContent = str_replace(PHP_EOL, "\n", $fileContent);
         }
 
-        Assert::assertEquals($this->getExpectedOutput($text), $fileContent);
+        $this->assertStringsMatch(
+            $this->getExpectedOutput($text),
+            $fileContent,
+            sprintf('The contents of file "%s" do not match the expected text.', $path)
+        );
     }
 
     #[Then(':path file should contain exactly:')]
     public function fileShouldContainExactly(string $path, PyStringNode $text): void
     {
         $path = $this->workingDir.'/'.$path;
-        Assert::assertFileExists($path);
+        $this->assertFileExists($path);
 
         $fileContent = trim(file_get_contents($path));
         // Normalize the line endings in the output
@@ -426,14 +433,18 @@ EOL;
             $fileContent = str_replace(PHP_EOL, "\n", $fileContent);
         }
 
-        Assert::assertEquals($text, $fileContent);
+        $this->assertStringsMatch(
+            (string) $text,
+            $fileContent,
+            sprintf('The contents of file "%s" do not match the expected text exactly.', $path)
+        );
     }
 
     #[Then(':path file should contain text:')]
     public function fileShouldContainText(string $path, PyStringNode $text): void
     {
         $path = $this->workingDir.'/'.$path;
-        Assert::assertFileExists($path);
+        $this->assertFileExists($path);
 
         $fileContent = file_get_contents($path);
         $expectedText = (string) $this->getExpectedOutput($text);
@@ -475,7 +486,7 @@ EOL;
     public function fileShouldHaveBeenRemoved(string $file): void
     {
         $path = $this->workingDir . '/' . $file;
-        Assert::assertFileDoesNotExist($path);
+        $this->assertFileDoesNotExist($path);
     }
 
     /**
@@ -557,7 +568,7 @@ EOL;
 
     private function checkXmlFileContents(string $path, PyStringNode $text): void
     {
-        Assert::assertFileExists($path);
+        $this->assertFileExists($path);
 
         $fileContent = trim(file_get_contents($path));
 
@@ -574,18 +585,26 @@ EOL;
         $dom->loadXML($text);
         $dom->formatOutput = true;
 
-        Assert::assertEquals(trim($dom->saveXML(null, LIBXML_NOEMPTYTAG)), $fileContent);
+        $this->assertStringsMatch(
+            trim((string) $dom->saveXML(null, LIBXML_NOEMPTYTAG)),
+            $fileContent,
+            sprintf('The XML in file "%s" does not match the expected document.', $path)
+        );
     }
 
     private function checkJSONFileContents(string $path, PyStringNode $text): void
     {
-        Assert::assertFileExists($path);
+        $this->assertFileExists($path);
 
         $fileContent = trim(file_get_contents($path));
 
         $data = json_decode($fileContent, true, JSON_THROW_ON_ERROR);
 
-        Assert::assertIsArray($data);
+        if (!is_array($data)) {
+            throw new UnexpectedValueException(
+                sprintf('Expected the JSON in file "%s" to decode to an array, but got %s.', $path, get_debug_type($data))
+            );
+        }
 
         $fileContent = preg_replace('/"time": [\d.]+/', '"time": -IGNORE-VALUE-', $fileContent);
 
@@ -604,7 +623,11 @@ EOL;
             $text
         );
 
-        Assert::assertEquals($text, $fileContent);
+        $this->assertStringsMatch(
+            $text,
+            $fileContent,
+            sprintf('The JSON in file "%s" does not match the expected document.', $path)
+        );
     }
 
     private function getExpectedOutput(PyStringNode $expectedText): string
@@ -737,9 +760,52 @@ EOL;
 
     private function getOutputDiff(PyStringNode $expectedText): string
     {
+        return $this->diff($this->getExpectedOutput($expectedText), $this->getOutput());
+    }
+
+    private function diff(string $expected, string $actual): string
+    {
         $differ = new Differ(new DiffOnlyOutputBuilder());
 
-        return $differ->diff($this->getExpectedOutput($expectedText), $this->getOutput());
+        return $differ->diff($expected, $actual);
+    }
+
+    /**
+     * Behat's own test suite deliberately does not depend on an assertion library.
+     *
+     * Steps throw an exception carrying all the detail we want to report, so that the failure is fully described by
+     * its message alone. See https://github.com/Behat/Behat/issues/1746 for background.
+     */
+    private function assertFileExists(string $path): void
+    {
+        if (!file_exists($path)) {
+            throw new UnexpectedValueException(sprintf('Expected file "%s" to exist, but it does not.', $path));
+        }
+    }
+
+    private function assertFileDoesNotExist(string $path): void
+    {
+        if (file_exists($path)) {
+            throw new UnexpectedValueException(sprintf('Expected file "%s" not to exist, but it does.', $path));
+        }
+    }
+
+    private function assertStringsMatch(string $expected, string $actual, string $message): void
+    {
+        if ($expected === $actual) {
+            return;
+        }
+
+        throw new UnexpectedValueException($message . PHP_EOL . PHP_EOL . $this->diff($expected, $actual));
+    }
+
+    private function assertStringIsEmpty(string $actual, string $message): void
+    {
+        if ($actual === '') {
+            return;
+        }
+
+        throw new UnexpectedValueException($message . PHP_EOL . PHP_EOL . $actual);
     }
 
     private function addBehatOptions(TableNode $table): void

--- a/features/context_consistency.feature
+++ b/features/context_consistency.feature
@@ -29,19 +29,19 @@ Feature: Context Consistency
 
       001 Scenario: I'm little hungry   # features/apples-false.feature:9
             Then I should have 5 apples # features/apples-false.feature:11
-              Failed asserting that 2 matches expected 5.
+              Failed asserting that 2 matches expected 5. (Exception)
 
       002 Scenario: Found more apples    # features/apples-false.feature:13
             Then I should have 10 apples # features/apples-false.feature:15
-              Failed asserting that 13 matches expected 10.
+              Failed asserting that 13 matches expected 10. (Exception)
 
       003 Example: | 3   | 1     | 3      | # features/apples-false.feature:24
             Then I should have 3 apples     # features/apples-false.feature:20
-              Failed asserting that 1 matches expected 3.
+              Failed asserting that 1 matches expected 3. (Exception)
 
       004 Example: | 2   | 2     | 4      | # features/apples-false.feature:26
             Then I should have 4 apples     # features/apples-false.feature:20
-              Failed asserting that 3 matches expected 4.
+              Failed asserting that 3 matches expected 4. (Exception)
 
       5 scenarios (1 passed, 4 failed)
       18 steps (14 passed, 4 failed)

--- a/features/format_options.feature
+++ b/features/format_options.feature
@@ -24,7 +24,7 @@ Feature: Format options
         Scenario: I'm little hungry   # features/apples.feature:9
           When I ate 1 apple          # FeatureContext::iAteApples()
           Then I should have 3 apples # FeatureContext::iShouldHaveApples()
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
         Scenario: Found more apples   # features/apples.feature:13
           When I found 5 apples       # FeatureContext::iFoundApples()
@@ -45,7 +45,7 @@ Feature: Format options
             | 3   | 1     | 1      |
             | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
             | 2   | 2     | 3      |
 
         Scenario: Multilines # features/apples.feature:33
@@ -101,7 +101,7 @@ Feature: Format options
         Scenario: I'm little hungry
           When I ate 1 apple
           Then I should have 3 apples
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
         Scenario: Found more apples
           When I found 5 apples
@@ -122,7 +122,7 @@ Feature: Format options
             | 3   | 1     | 1      |
             | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
             | 2   | 2     | 3      |
 
         Scenario: Multilines
@@ -178,7 +178,7 @@ Feature: Format options
         Scenario: I'm little hungry   # features/apples.feature:9
           When I ate 1 apple          # FeatureContext::iAteApples()
           Then I should have 3 apples # FeatureContext::iShouldHaveApples()
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
         Scenario: Found more apples   # features/apples.feature:13
           When I found 5 apples       # FeatureContext::iFoundApples()
@@ -199,7 +199,7 @@ Feature: Format options
             | 3   | 1     | 1      |
             | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
             | 2   | 2     | 3      |
 
         Scenario: Multilines # features/apples.feature:33
@@ -235,7 +235,7 @@ Feature: Format options
         Scenario: I'm little hungry   # features/apples.feature:9
           When I ate 1 apple          # FeatureContext::iAteApples()
           Then I should have 3 apples # FeatureContext::iShouldHaveApples()
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
         Scenario: Found more apples   # features/apples.feature:13
           When I found 5 apples       # FeatureContext::iFoundApples()
@@ -261,7 +261,7 @@ Feature: Format options
               When I ate 0 apples         # FeatureContext::iAteApples()
               And I found 4 apples        # FeatureContext::iFoundApples()
               Then I should have 8 apples # FeatureContext::iShouldHaveApples()
-                Failed asserting that 7 matches expected 8.
+                Failed asserting that 7 matches expected 8. (Exception)
             | 2   | 2     | 3      |      # features/apples.feature:31
               When I ate 2 apples         # FeatureContext::iAteApples()
               And I found 2 apples        # FeatureContext::iFoundApples()
@@ -320,7 +320,7 @@ Feature: Format options
         Scenario: I'm little hungry   # features/apples.feature:9
           When I ate 1 apple          # FeatureContext::iAteApples()
           Then I should have 3 apples # FeatureContext::iShouldHaveApples()
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
         Scenario: Found more apples   # features/apples.feature:13
           When I found 5 apples       # FeatureContext::iFoundApples()
@@ -341,7 +341,7 @@ Feature: Format options
             | 3   | 1     | 1      |
             | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
             | 2   | 2     | 3      |
 
         Scenario: Multilines # features/apples.feature:33

--- a/features/json_format.feature
+++ b/features/json_format.feature
@@ -98,7 +98,7 @@ Feature: JSON Formatter
                                   "line": 25,
                                   "failures": [
                                       {
-                                          "message": "Then I must have 13: Failed asserting that 14 matches expected '13'.",
+                                          "message": "Then I must have 13: Failed asserting that 14 matches expected '13'. (Exception)",
                                           "type": "failed"
                                       }
                                   ]
@@ -111,7 +111,7 @@ Feature: JSON Formatter
                                   "line": 29,
                                   "failures": [
                                       {
-                                          "message": "Then I must have 16: Failed asserting that 15 matches expected '16'.",
+                                          "message": "Then I must have 16: Failed asserting that 15 matches expected '16'. (Exception)",
                                           "type": "failed"
                                       }
                                   ]
@@ -131,7 +131,7 @@ Feature: JSON Formatter
                                   "line": 29,
                                   "failures": [
                                       {
-                                          "message": "Then I must have 32: Failed asserting that 33 matches expected '32'.",
+                                          "message": "Then I must have 32: Failed asserting that 33 matches expected '32'. (Exception)",
                                           "type": "failed"
                                       }
                                   ]
@@ -424,7 +424,7 @@ Feature: JSON Formatter
                                   "line": 11,
                                   "failures": [
                                       {
-                                          "message": "Then I must have 477: Failed asserting that 378 matches expected '477'.",
+                                          "message": "Then I must have 477: Failed asserting that 378 matches expected '477'. (Exception)",
                                           "type": "failed"
                                       }
                                   ]
@@ -551,7 +551,7 @@ Feature: JSON Formatter
                                   "line": 11,
                                   "failures": [
                                       {
-                                          "message": "Then I must have 13: Failed asserting that 14 matches expected '13'.",
+                                          "message": "Then I must have 13: Failed asserting that 14 matches expected '13'. (Exception)",
                                           "type": "failed"
                                       }
                                   ]

--- a/features/junit_format.feature
+++ b/features/junit_format.feature
@@ -41,14 +41,14 @@ Feature: JUnit Formatter
             <error message="And Something not done yet: TODO: write pending definition" type="pending"/>
           </testcase>
           <testcase name="Failed" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="25">
-            <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
+            <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'. (Exception)"/>
           </testcase>
           <testcase name="Passed &amp; Failed with value=5 #1" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29">
-            <failure message="Then I must have 16: Failed asserting that 15 matches expected '16'."/>
+            <failure message="Then I must have 16: Failed asserting that 15 matches expected '16'. (Exception)"/>
           </testcase>
           <testcase name="Passed &amp; Failed with value=10 #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29"/>
           <testcase name="Passed &amp; Failed with value=23 #3" classname="Adding numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="29">
-            <failure message="Then I must have 32: Failed asserting that 33 matches expected '32'."/>
+            <failure message="Then I must have 32: Failed asserting that 33 matches expected '32'. (Exception)"/>
           </testcase>
           <testcase name="Another Outline (5 = 15) #1" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="39"/>
           <testcase name="Another Outline (10 = 20) #2" classname="Adding numbers" status="passed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-single_feature.feature" line="39"/>
@@ -136,7 +136,7 @@ Feature: JUnit Formatter
       <testsuites name="old_man">
         <testsuite name="Adding difficult numbers" file="features-DIRECTORY-SEPARATOR-multiple_suites_2.feature" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
           <testcase name="Difficult sum" classname="Adding difficult numbers" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-multiple_suites_2.feature" line="11">
-            <failure message="Then I must have 477: Failed asserting that 378 matches expected '477'."/>
+            <failure message="Then I must have 477: Failed asserting that 378 matches expected '477'. (Exception)"/>
           </testcase>
         </testsuite>
       </testsuites>
@@ -175,7 +175,7 @@ Feature: JUnit Formatter
       <testsuites name="stop_on_failure">
         <testsuite name="Stop on failure" file="features-DIRECTORY-SEPARATOR-stop_on_failure.feature" tests="1" skipped="0" failures="1" errors="0" time="-IGNORE-VALUE-">
           <testcase name="Failed" classname="Stop on failure" status="failed" time="-IGNORE-VALUE-" file="features-DIRECTORY-SEPARATOR-stop_on_failure.feature" line="11">
-            <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'."/>
+            <failure message="Then I must have 13: Failed asserting that 14 matches expected '13'. (Exception)"/>
           </testcase>
         </testsuite>
       </testsuites>

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -26,7 +26,7 @@ Feature: Multiple formats
         Scenario: I'm little hungry   # features/apples.feature:9
           When I ate 1 apple          # FeatureContext::iAteApples()
       .    Then I should have 3 apples # FeatureContext::iShouldHaveApples()
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
       F
         Scenario: Found more apples   # features/apples.feature:13
       .    When I found 5 apples       # FeatureContext::iFoundApples()
@@ -47,7 +47,7 @@ Feature: Multiple formats
             | 3   | 1     | 1      |
       ...F      | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
       ....      | 2   | 2     | 3      |
 
         Scenario: Multilines # features/apples.feature:33
@@ -69,11 +69,11 @@ Feature: Multiple formats
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)
@@ -114,7 +114,7 @@ Feature: Multiple formats
         Scenario: I'm little hungry   # features/apples.feature:9
           When I ate 1 apple          # FeatureContext::iAteApples()
       .    Then I should have 3 apples # FeatureContext::iShouldHaveApples()
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
       F
         Scenario: Found more apples   # features/apples.feature:13
       .    When I found 5 apples       # FeatureContext::iFoundApples()
@@ -135,7 +135,7 @@ Feature: Multiple formats
             | 3   | 1     | 1      |
       ...F      | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
       ....      | 2   | 2     | 3      |
 
         Scenario: Multilines # features/apples.feature:33
@@ -157,11 +157,11 @@ Feature: Multiple formats
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)
@@ -197,11 +197,11 @@ Feature: Multiple formats
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)
@@ -239,7 +239,7 @@ Feature: Multiple formats
         Scenario: I'm little hungry
           When I ate 1 apple
           Then I should have 3 apples
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
         Scenario: Found more apples
           When I found 5 apples
@@ -260,7 +260,7 @@ Feature: Multiple formats
             | 3   | 1     | 1      |
             | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
             | 2   | 2     | 3      |
 
         Scenario: Multilines
@@ -293,7 +293,7 @@ Feature: Multiple formats
         Scenario: I'm little hungry
           When I ate 1 apple
           Then I should have 3 apples
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
         Scenario: Found more apples
           When I found 5 apples
@@ -314,7 +314,7 @@ Feature: Multiple formats
             | 3   | 1     | 1      |
             | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
             | 2   | 2     | 3      |
 
         Scenario: Multilines
@@ -359,11 +359,11 @@ Feature: Multiple formats
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)
@@ -406,7 +406,7 @@ Feature: Multiple formats
         Scenario: I'm little hungry
           When I ate 1 apple
           Then I should have 3 apples
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
         Scenario: Found more apples
           When I found 5 apples
@@ -427,7 +427,7 @@ Feature: Multiple formats
             | 3   | 1     | 1      |
             | 0   | 4     | 8      |
               Failed step: Then I should have 8 apples
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
             | 2   | 2     | 3      |
 
         Scenario: Multilines
@@ -452,11 +452,11 @@ Feature: Multiple formats
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:30
             Then I should have 8 apples     # features/apples.feature:25
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       7 scenarios (3 passed, 2 failed, 2 undefined)
       25 steps (20 passed, 2 failed, 3 undefined)

--- a/features/outlines.feature
+++ b/features/outlines.feature
@@ -40,19 +40,19 @@ Feature: Scenario Outlines
 
       001 Example: | 5       | 4       | 15     | # features/math-failing.feature:14
             Then The result should be 15          # features/math-failing.feature:9
-              Failed asserting that 20 matches expected 15.
+              Failed asserting that 20 matches expected 15. (Exception)
 
       002 Scenario:                     # features/math-failing.feature:16
             Then The result should be 7 # features/math-failing.feature:20
-              Failed asserting that 6 matches expected 7.
+              Failed asserting that 6 matches expected 7. (Exception)
 
       003 Example: | 50      | 10      | 2      | # features/math-failing.feature:31
             Then The result should be 2           # features/math-failing.feature:26
-              Failed asserting that 5 matches expected 2.
+              Failed asserting that 5 matches expected 2. (Exception)
 
       004 Example: | 50      | 10      | 4      | # features/math-failing.feature:32
             Then The result should be 4           # features/math-failing.feature:26
-              Failed asserting that 5 matches expected 4.
+              Failed asserting that 5 matches expected 4. (Exception)
 
       6 scenarios (2 passed, 4 failed)
       30 steps (26 passed, 4 failed)
@@ -68,11 +68,11 @@ Feature: Scenario Outlines
 
       001 Example: | 5       | 4       | 10     | # features/math-multiple-examples.feature:14
             Then The result should be 10          # features/math-multiple-examples.feature:9
-              Failed asserting that 20 matches expected 10.
+              Failed asserting that 20 matches expected 10. (Exception)
 
       002 Example: | 139     | 201     | 99     | # features/math-multiple-examples.feature:19
             Then The result should be 99          # features/math-multiple-examples.feature:9
-              Failed asserting that 27939 matches expected 99.
+              Failed asserting that 27939 matches expected 99. (Exception)
 
       5 scenarios (3 passed, 2 failed)
       25 steps (23 passed, 2 failed)

--- a/features/pretty_format.feature
+++ b/features/pretty_format.feature
@@ -35,7 +35,7 @@ Feature: Pretty Formatter
         Scenario: Failed      # features/World.feature:19
           When I add 4        # FeatureContext::iAdd()
           Then I must have 13 # FeatureContext::iMustHave()
-            Failed asserting that 14 matches expected '13'.
+            Failed asserting that 14 matches expected '13'. (Exception)
 
         Scenario Outline: Passed & Failed # features/World.feature:23
           Given I must have 10            # FeatureContext::iMustHave()
@@ -46,11 +46,11 @@ Feature: Pretty Formatter
             | value | result |
             | 5     | 16     |
               Failed step: Then I must have 16
-              Failed asserting that 15 matches expected '16'.
+              Failed asserting that 15 matches expected '16'. (Exception)
             | 10    | 20     |
             | 23    | 32     |
               Failed step: Then I must have 32
-              Failed asserting that 33 matches expected '32'.
+              Failed asserting that 33 matches expected '32'. (Exception)
 
       --- Failed scenarios:
 
@@ -268,7 +268,7 @@ Feature: Pretty Formatter
           Scenario: Simple failing scenario # features/gherkin-parity.feature:20
             When I add 3                    # FeatureContext::iAdd()
             Then I must have 30             # FeatureContext::iMustHave()
-              Failed asserting that 28 matches expected '30'.
+              Failed asserting that 28 matches expected '30'. (Exception)
 
           @wip @new
           Scenario: With unknown step # features/gherkin-parity.feature:25

--- a/features/rerun-only.feature
+++ b/features/rerun-only.feature
@@ -20,11 +20,11 @@ Feature: Rerun
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:29
             Then I should have 8 apples     # features/apples.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       6 scenarios (4 passed, 2 failed)
       21 steps (19 passed, 2 failed)
@@ -38,11 +38,11 @@ Feature: Rerun
 
     001 Scenario: I'm little hungry   # features/apples.feature:9
           Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
     002 Example: | 0   | 4     | 8      | # features/apples.feature:29
           Then I should have 8 apples     # features/apples.feature:24
-            Failed asserting that 7 matches expected 8.
+            Failed asserting that 7 matches expected 8. (Exception)
 
     2 scenarios (2 failed)
     7 steps (5 passed, 2 failed)

--- a/features/rerun.feature
+++ b/features/rerun.feature
@@ -18,11 +18,11 @@ Feature: Rerun
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:29
             Then I should have 8 apples     # features/apples.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       6 scenarios (4 passed, 2 failed)
       21 steps (19 passed, 2 failed)
@@ -38,11 +38,11 @@ Feature: Rerun
 
     001 Scenario: I'm little hungry   # features/apples.feature:9
           Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
     002 Example: | 0   | 4     | 8      | # features/apples.feature:29
           Then I should have 8 apples     # features/apples.feature:24
-            Failed asserting that 7 matches expected 8.
+            Failed asserting that 7 matches expected 8. (Exception)
 
     2 scenarios (2 failed)
     7 steps (5 passed, 2 failed)
@@ -59,7 +59,7 @@ Feature: Rerun
 
     001 Scenario: I'm little hungry   # features/apples.feature:9
           Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
     2 scenarios (1 passed, 1 failed)
     7 steps (6 passed, 1 failed)
@@ -73,7 +73,7 @@ Feature: Rerun
 
     001 Scenario: I'm little hungry   # features/apples.feature:9
           Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
     1 scenario (1 failed)
     3 steps (2 passed, 1 failed)

--- a/features/rerun_with_multiple_suite.feature
+++ b/features/rerun_with_multiple_suite.feature
@@ -20,27 +20,27 @@ Feature: Rerun with multiple suite
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:29
             Then I should have 8 apples     # features/apples.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       003 Scenario: I'm little hungry    # features/bananas.feature:9
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       004 Example: | 0   | 4     | 8      | # features/bananas.feature:29
             Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       005 Scenario: I'm little hungry    # features/bananas.feature:9
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       006 Example: | 0   | 4     | 8      | # features/bananas.feature:29
             Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       18 scenarios (12 passed, 6 failed)
       63 steps (57 passed, 6 failed)
@@ -54,27 +54,27 @@ Feature: Rerun with multiple suite
 
     001 Scenario: I'm little hungry   # features/apples.feature:9
           Then I should have 3 apples # features/apples.feature:11
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
     002 Example: | 0   | 4     | 8      | # features/apples.feature:29
           Then I should have 8 apples     # features/apples.feature:24
-            Failed asserting that 7 matches expected 8.
+            Failed asserting that 7 matches expected 8. (Exception)
 
     003 Scenario: I'm little hungry    # features/bananas.feature:9
           Then I should have 3 bananas # features/bananas.feature:11
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
     004 Example: | 0   | 4     | 8      | # features/bananas.feature:29
           Then I should have 8 bananas    # features/bananas.feature:24
-            Failed asserting that 7 matches expected 8.
+            Failed asserting that 7 matches expected 8. (Exception)
 
     005 Scenario: I'm little hungry    # features/bananas.feature:9
           Then I should have 3 bananas # features/bananas.feature:11
-            Failed asserting that 2 matches expected 3.
+            Failed asserting that 2 matches expected 3. (Exception)
 
     006 Example: | 0   | 4     | 8      | # features/bananas.feature:29
           Then I should have 8 bananas    # features/bananas.feature:24
-            Failed asserting that 7 matches expected 8.
+            Failed asserting that 7 matches expected 8. (Exception)
 
     6 scenarios (6 failed)
     21 steps (15 passed, 6 failed)
@@ -90,27 +90,27 @@ Feature: Rerun with multiple suite
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:29
             Then I should have 8 apples     # features/apples.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       003 Scenario: I'm little hungry    # features/bananas.feature:9
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       004 Example: | 0   | 4     | 8      | # features/bananas.feature:29
             Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       005 Scenario: I'm little hungry    # features/bananas.feature:9
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       006 Example: | 0   | 4     | 8      | # features/bananas.feature:29
             Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       18 scenarios (12 passed, 6 failed)
       63 steps (57 passed, 6 failed)
@@ -125,11 +125,11 @@ Feature: Rerun with multiple suite
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:29
             Then I should have 8 apples     # features/apples.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       18 scenarios (16 passed, 2 failed)
       63 steps (61 passed, 2 failed)
@@ -143,11 +143,11 @@ Feature: Rerun with multiple suite
 
       001 Scenario: I'm little hungry   # features/apples.feature:9
             Then I should have 3 apples # features/apples.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/apples.feature:29
             Then I should have 8 apples     # features/apples.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       2 scenarios (2 failed)
     7 steps (5 passed, 2 failed)
@@ -163,11 +163,11 @@ Feature: Rerun with multiple suite
       
       001 Scenario: I'm little hungry    # features/bananas.feature:9
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
       
       002 Example: | 0   | 4     | 8      | # features/bananas.feature:29
             Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
       
       6 scenarios (4 passed, 2 failed)
       21 steps (19 passed, 2 failed)
@@ -181,11 +181,11 @@ Feature: Rerun with multiple suite
 
       001 Scenario: I'm little hungry    # features/bananas.feature:9
             Then I should have 3 bananas # features/bananas.feature:11
-              Failed asserting that 2 matches expected 3.
+              Failed asserting that 2 matches expected 3. (Exception)
 
       002 Example: | 0   | 4     | 8      | # features/bananas.feature:29
             Then I should have 8 bananas    # features/bananas.feature:24
-              Failed asserting that 7 matches expected 8.
+              Failed asserting that 7 matches expected 8. (Exception)
 
       2 scenarios (2 failed)
       7 steps (5 passed, 2 failed)

--- a/features/result_types.feature
+++ b/features/result_types.feature
@@ -143,11 +143,11 @@ Feature: Different result types
 
       001 Scenario: Check thrown amount         # features/failed.feature:9
             Then I should see 12$ on the screen # features/failed.feature:10
-              Failed asserting that 10 matches expected '12'.
+              Failed asserting that 10 matches expected '12'. (Exception)
 
       002 Scenario: Additional throws           # features/failed.feature:12
             Then I should see 31$ on the screen # features/failed.feature:14
-              Failed asserting that 30 matches expected '31'.
+              Failed asserting that 30 matches expected '31'. (Exception)
 
       2 scenarios (2 failed)
       6 steps (3 passed, 2 failed, 1 skipped)

--- a/tests/Behat/Tests/Fixtures/Assert.php
+++ b/tests/Behat/Tests/Fixtures/Assert.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Tests\Fixtures;
+
+use Exception;
+
+/**
+ * Minimal assertions for the context classes under tests/Fixtures.
+ *
+ * Behat's own test suite deliberately does not depend on an assertion library, so that we do not couple our runtime
+ * code to PHPUnit. Each assertion throws a plain exception whose message carries everything we want to report, which
+ * is what the fixtures' expected output asserts on.
+ *
+ * See https://github.com/Behat/Behat/issues/1746 for background.
+ */
+final class Assert
+{
+    /**
+     * Asserts that two values are equal, comparing loosely as the fixtures rely on comparing step arguments
+     * (which are always strings) against typed context state.
+     */
+    public static function assertEquals(mixed $expected, mixed $actual): void
+    {
+        if ($expected == $actual) {
+            return;
+        }
+
+        throw new Exception(sprintf(
+            'Failed asserting that %s matches expected %s.',
+            self::describe($actual),
+            self::describe($expected),
+        ));
+    }
+
+    public static function assertSame(mixed $expected, mixed $actual): void
+    {
+        if ($expected === $actual) {
+            return;
+        }
+
+        throw new Exception(sprintf(
+            'Failed asserting that %s is identical to %s.',
+            self::describe($actual),
+            self::describe($expected),
+        ));
+    }
+
+    public static function assertNull(mixed $actual): void
+    {
+        if ($actual === null) {
+            return;
+        }
+
+        throw new Exception(sprintf('Failed asserting that %s is null.', self::describe($actual)));
+    }
+
+    public static function assertIsArray(mixed $actual): void
+    {
+        if (is_array($actual)) {
+            return;
+        }
+
+        throw new Exception(sprintf('Failed asserting that %s is of type array.', self::describe($actual)));
+    }
+
+    public static function assertIsString(mixed $actual): void
+    {
+        if (is_string($actual)) {
+            return;
+        }
+
+        throw new Exception(sprintf('Failed asserting that %s is of type string.', self::describe($actual)));
+    }
+
+    /**
+     * @param array<mixed> $haystack
+     */
+    public static function assertContains(mixed $needle, array $haystack): void
+    {
+        if (in_array($needle, $haystack, true)) {
+            return;
+        }
+
+        throw new Exception(sprintf(
+            'Failed asserting that %s contains %s.',
+            self::describe($haystack),
+            self::describe($needle),
+        ));
+    }
+
+    /**
+     * @param array<mixed> $haystack
+     */
+    public static function assertNotContains(mixed $needle, array $haystack): void
+    {
+        if (!in_array($needle, $haystack, true)) {
+            return;
+        }
+
+        throw new Exception(sprintf(
+            'Failed asserting that %s does not contain %s.',
+            self::describe($haystack),
+            self::describe($needle),
+        ));
+    }
+
+    /**
+     * Renders a value the way the expected output of our features describes it.
+     */
+    private static function describe(mixed $value): string
+    {
+        return match (true) {
+            $value === null => 'null',
+            is_bool($value) => $value ? 'true' : 'false',
+            is_string($value) => "'" . $value . "'",
+            is_scalar($value) => (string) $value,
+            default => (string) json_encode($value),
+        };
+    }
+}

--- a/tests/Fixtures/AppendSnippets/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/AppendSnippets/features/bootstrap/FeatureContext.php
@@ -7,6 +7,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {
@@ -39,20 +40,20 @@ class FeatureContext implements Context
     #[Then('/^I should have (\\d+) apples$/')]
     public function iShouldHaveApples($count)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
+        Assert::assertEquals(intval($count), $this->apples);
     }
 
     #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]
     public function contextParameterShouldBeEqualTo($key, $val)
     {
-        PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
+        Assert::assertEquals($val, $this->parameters[$key]);
     }
 
     #[Given('/^context parameter "([^"]*)" should be array with (\\d+) elements$/')]
     public function contextParameterShouldBeArrayWithElements($key, $count)
     {
-        PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
-        PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
+        Assert::assertIsArray($this->parameters[$key]);
+        Assert::assertEquals(2, count($this->parameters[$key]));
     }
 
     private function doSomethingUndefinedWith()

--- a/tests/Fixtures/AppendSnippets/features/bootstrap/FeatureContextMinimalImports.php
+++ b/tests/Fixtures/AppendSnippets/features/bootstrap/FeatureContextMinimalImports.php
@@ -4,6 +4,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContextMinimalImports implements Context
 {
@@ -36,20 +37,20 @@ class FeatureContextMinimalImports implements Context
     #[Then('/^I should have (\\d+) apples$/')]
     public function iShouldHaveApples($count)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
+        Assert::assertEquals(intval($count), $this->apples);
     }
 
     #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]
     public function contextParameterShouldBeEqualTo($key, $val)
     {
-        PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
+        Assert::assertEquals($val, $this->parameters[$key]);
     }
 
     #[Given('/^context parameter "([^"]*)" should be array with (\\d+) elements$/')]
     public function contextParameterShouldBeArrayWithElements($key, $count)
     {
-        PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
-        PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
+        Assert::assertIsArray($this->parameters[$key]);
+        Assert::assertEquals(2, count($this->parameters[$key]));
     }
 
     private function doSomethingUndefinedWith()

--- a/tests/Fixtures/AppendSnippets/features/bootstrap/FeatureContextNoPendingException.php
+++ b/tests/Fixtures/AppendSnippets/features/bootstrap/FeatureContextNoPendingException.php
@@ -6,6 +6,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContextNoPendingException implements Context
 {
@@ -38,20 +39,20 @@ class FeatureContextNoPendingException implements Context
     #[Then('/^I should have (\\d+) apples$/')]
     public function iShouldHaveApples($count)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($count), $this->apples);
+        Assert::assertEquals(intval($count), $this->apples);
     }
 
     #[Then('/^context parameter "([^"]*)" should be equal to "([^"]*)"$/')]
     public function contextParameterShouldBeEqualTo($key, $val)
     {
-        PHPUnit\Framework\Assert::assertEquals($val, $this->parameters[$key]);
+        Assert::assertEquals($val, $this->parameters[$key]);
     }
 
     #[Given('/^context parameter "([^"]*)" should be array with (\\d+) elements$/')]
     public function contextParameterShouldBeArrayWithElements($key, $count)
     {
-        PHPUnit\Framework\Assert::assertIsArray($this->parameters[$key]);
-        PHPUnit\Framework\Assert::assertEquals(2, count($this->parameters[$key]));
+        Assert::assertIsArray($this->parameters[$key]);
+        Assert::assertEquals(2, count($this->parameters[$key]));
     }
 
     private function doSomethingUndefinedWith()

--- a/tests/Fixtures/Arguments/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Arguments/features/bootstrap/FeatureContext.php
@@ -5,6 +5,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {
@@ -48,20 +49,20 @@ class FeatureContext implements Context
     #[Then('/^it must be equals to string (\d+)$/')]
     public function itMustBeEqualsToString($number)
     {
-        PHPUnit\Framework\Assert::assertEquals($this->strings[intval($number)], (string) $this->input);
+        Assert::assertEquals($this->strings[intval($number)], (string) $this->input);
     }
 
     #[Then('/^it must be equals to table (\d+)$/')]
     public function itMustBeEqualsToTable($number)
     {
-        PHPUnit\Framework\Assert::assertEquals($this->tables[intval($number)], $this->input->getHash());
+        Assert::assertEquals($this->tables[intval($number)], $this->input->getHash());
     }
 
     #[Given('/^I have number2 = (?P<number2>\d+) and number1 = (?P<number1>\d+)$/')]
     public function iHaveNumberAndNumber($number1, $number2)
     {
-        PHPUnit\Framework\Assert::assertEquals(13, intval($number1));
-        PHPUnit\Framework\Assert::assertEquals(243, intval($number2));
+        Assert::assertEquals(13, intval($number1));
+        Assert::assertEquals(243, intval($number2));
     }
 
     #[Given('/^a step with no argument$/')]

--- a/tests/Fixtures/Autowire/features/bootstrap/MixedConstructorArgsContext.php
+++ b/tests/Fixtures/Autowire/features/bootstrap/MixedConstructorArgsContext.php
@@ -2,12 +2,13 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
+use Behat\Tests\Fixtures\Assert;
 
 class MixedConstructorArgsContext implements Context
 {
     public function __construct(Service2 $s2, $name, Service1 $s1, Service3 $s3)
     {
-        PHPUnit\Framework\Assert::assertEquals('Konstantin', $name);
+        Assert::assertEquals('Konstantin', $name);
     }
 
     #[Given('a step')]

--- a/tests/Fixtures/Autowire/features/bootstrap/NullArgsContext.php
+++ b/tests/Fixtures/Autowire/features/bootstrap/NullArgsContext.php
@@ -2,12 +2,13 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
+use Behat\Tests\Fixtures\Assert;
 
 class NullArgsContext implements Context
 {
     public function __construct($name, Service1 $s1, Service2 $s2, Service3 $s3)
     {
-        PHPUnit\Framework\Assert::assertNull($name);
+        Assert::assertNull($name);
     }
 
     #[Given('a step')]

--- a/tests/Fixtures/Autowire/features/bootstrap/StepDefinitionArgsContext.php
+++ b/tests/Fixtures/Autowire/features/bootstrap/StepDefinitionArgsContext.php
@@ -3,6 +3,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class StepDefinitionArgsContext implements Context
 {
@@ -15,6 +16,6 @@ class StepDefinitionArgsContext implements Context
     #[Then('that state should be persisted as :value')]
     public function checkState($val, Service2 $s2)
     {
-        PHPUnit\Framework\Assert::assertEquals($val, $s2->state);
+        Assert::assertEquals($val, $s2->state);
     }
 }

--- a/tests/Fixtures/Autowire/features/bootstrap/TransformationArgsContext.php
+++ b/tests/Fixtures/Autowire/features/bootstrap/TransformationArgsContext.php
@@ -3,6 +3,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 use Behat\Transformation\Transform;
 
 class TransformationArgsContext implements Context
@@ -22,6 +23,6 @@ class TransformationArgsContext implements Context
     #[Then('the :flag flag should be persisted as :value')]
     public function checkState($flag, $value)
     {
-        PHPUnit\Framework\Assert::assertEquals($value, $flag);
+        Assert::assertEquals($value, $flag);
     }
 }

--- a/tests/Fixtures/ConfigInheritance/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/ConfigInheritance/features/bootstrap/FeatureContext.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {

--- a/tests/Fixtures/ContextConsistency/features/bootstrap/CoreContext.php
+++ b/tests/Fixtures/ContextConsistency/features/bootstrap/CoreContext.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class CoreContext
 {

--- a/tests/Fixtures/ContextConsistency/features/bootstrap/FirstContext.php
+++ b/tests/Fixtures/ContextConsistency/features/bootstrap/FirstContext.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FirstContext implements Context
 {

--- a/tests/Fixtures/DefinitionsPatterns/features/bootstrap/DecimalNumberAnnotations.php
+++ b/tests/Fixtures/DefinitionsPatterns/features/bootstrap/DecimalNumberAnnotations.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class DecimalNumberAnnotations implements Context
 {

--- a/tests/Fixtures/DefinitionsPatterns/features/bootstrap/DecimalNumberAttributes.php
+++ b/tests/Fixtures/DefinitionsPatterns/features/bootstrap/DecimalNumberAttributes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class DecimalNumberAttributes implements Context
 {

--- a/tests/Fixtures/DefinitionsPatterns/features/bootstrap/EmptyParameterAnnotations.php
+++ b/tests/Fixtures/DefinitionsPatterns/features/bootstrap/EmptyParameterAnnotations.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class EmptyParameterAnnotations implements Context
 {

--- a/tests/Fixtures/DefinitionsPatterns/features/bootstrap/EmptyParameterAttributes.php
+++ b/tests/Fixtures/DefinitionsPatterns/features/bootstrap/EmptyParameterAttributes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class EmptyParameterAttributes implements Context
 {

--- a/tests/Fixtures/DefinitionsPatterns/features/bootstrap/NegativeNumberAnnotations.php
+++ b/tests/Fixtures/DefinitionsPatterns/features/bootstrap/NegativeNumberAnnotations.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class NegativeNumberAnnotations implements Context
 {

--- a/tests/Fixtures/DefinitionsPatterns/features/bootstrap/NegativeNumberAttributes.php
+++ b/tests/Fixtures/DefinitionsPatterns/features/bootstrap/NegativeNumberAttributes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class NegativeNumberAttributes implements Context
 {

--- a/tests/Fixtures/DefinitionsPatterns/features/bootstrap/UnixPathAnnotations.php
+++ b/tests/Fixtures/DefinitionsPatterns/features/bootstrap/UnixPathAnnotations.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class UnixPathAnnotations implements Context
 {

--- a/tests/Fixtures/DefinitionsPatterns/features/bootstrap/UnixPathAttributes.php
+++ b/tests/Fixtures/DefinitionsPatterns/features/bootstrap/UnixPathAttributes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class UnixPathAttributes implements Context
 {

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/ArgumentsContextAnnotations.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/ArgumentsContextAnnotations.php
@@ -1,6 +1,7 @@
 <?php
 
 use Behat\Behat\Context\TranslatableContext;
+use Behat\Tests\Fixtures\Assert;
 
 class ArgumentsContextAnnotations implements TranslatableContext
 {
@@ -21,7 +22,7 @@ class ArgumentsContextAnnotations implements TranslatableContext
     /** @Then /^the index should be "([^"]*)"$/ */
     public function theIndexShouldBe($value)
     {
-        PHPUnit\Framework\Assert::assertSame($value, $this->index);
+        Assert::assertSame($value, $this->index);
     }
 
     public static function getTranslationResources()

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/ArgumentsContextAttributes.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/ArgumentsContextAttributes.php
@@ -3,6 +3,7 @@
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Behat\Tests\Fixtures\Assert;
 use Behat\Transformation\Transform;
 
 class ArgumentsContextAttributes implements TranslatableContext
@@ -24,7 +25,7 @@ class ArgumentsContextAttributes implements TranslatableContext
     #[Then('/^the index should be "([^"]*)"$/')]
     public function theIndexShouldBe($value)
     {
-        PHPUnit\Framework\Assert::assertSame($value, $this->index);
+        Assert::assertSame($value, $this->index);
     }
 
     public static function getTranslationResources()

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/FeatureContextAnnotations.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/FeatureContextAnnotations.php
@@ -1,6 +1,7 @@
 <?php
 
 use Behat\Behat\Context\TranslatableContext;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContextAnnotations implements TranslatableContext
 {
@@ -28,7 +29,7 @@ class FeatureContextAnnotations implements TranslatableContext
      */
     public function iShouldSeeOnTheScreen($result)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
+        Assert::assertEquals(intval($result), $this->result);
     }
 
     /** @Transform /"([^"]+)" user/ */
@@ -42,7 +43,7 @@ class FeatureContextAnnotations implements TranslatableContext
      */
     public function theUserUsername($user, $username)
     {
-        PHPUnit\Framework\Assert::assertEquals($username, $user->name);
+        Assert::assertEquals($username, $user->name);
     }
 
     public static function getTranslationResources()

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/FeatureContextAttributes.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/FeatureContextAttributes.php
@@ -3,6 +3,7 @@
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Behat\Tests\Fixtures\Assert;
 use Behat\Transformation\Transform;
 
 class FeatureContextAttributes implements TranslatableContext
@@ -25,7 +26,7 @@ class FeatureContextAttributes implements TranslatableContext
     #[Then('/^I should see (\d+) on the screen$/')]
     public function iShouldSeeOnTheScreen($result)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
+        Assert::assertEquals(intval($result), $this->result);
     }
 
     #[Transform('/"([^"]+)" user/')]
@@ -37,7 +38,7 @@ class FeatureContextAttributes implements TranslatableContext
     #[Then('/^the ("[^"]+" user) name should be "([^"]*)"$/')]
     public function theUserUsername($user, $username)
     {
-        PHPUnit\Framework\Assert::assertEquals($username, $user->name);
+        Assert::assertEquals($username, $user->name);
     }
 
     public static function getTranslationResources()

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/PhpContextAnnotations.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/PhpContextAnnotations.php
@@ -1,6 +1,7 @@
 <?php
 
 use Behat\Behat\Context\TranslatableContext;
+use Behat\Tests\Fixtures\Assert;
 
 class PhpContextAnnotations implements TranslatableContext
 {
@@ -28,7 +29,7 @@ class PhpContextAnnotations implements TranslatableContext
      */
     public function iShouldSeeOnTheScreen($result)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
+        Assert::assertEquals(intval($result), $this->result);
     }
 
     /** @Transform /"([^"]+)" user/ */
@@ -42,7 +43,7 @@ class PhpContextAnnotations implements TranslatableContext
      */
     public function theUserUsername($user, $username)
     {
-        PHPUnit\Framework\Assert::assertEquals($username, $user->name);
+        Assert::assertEquals($username, $user->name);
     }
 
     public static function getTranslationResources()

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/PhpContextAttributes.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/PhpContextAttributes.php
@@ -3,6 +3,7 @@
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Behat\Tests\Fixtures\Assert;
 use Behat\Transformation\Transform;
 
 class PhpContextAttributes implements TranslatableContext
@@ -25,7 +26,7 @@ class PhpContextAttributes implements TranslatableContext
     #[Then('/^I should see (\d+) on the screen$/')]
     public function iShouldSeeOnTheScreen($result)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
+        Assert::assertEquals(intval($result), $this->result);
     }
 
     #[Transform('/"([^"]+)" user/')]
@@ -37,7 +38,7 @@ class PhpContextAttributes implements TranslatableContext
     #[Then('/^the ("[^"]+" user) name should be "([^"]*)"$/')]
     public function theUserUsername($user, $username)
     {
-        PHPUnit\Framework\Assert::assertEquals($username, $user->name);
+        Assert::assertEquals($username, $user->name);
     }
 
     public static function getTranslationResources()

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/YamlContextAnnotations.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/YamlContextAnnotations.php
@@ -1,6 +1,7 @@
 <?php
 
 use Behat\Behat\Context\TranslatableContext;
+use Behat\Tests\Fixtures\Assert;
 
 class YamlContextAnnotations implements TranslatableContext
 {
@@ -28,7 +29,7 @@ class YamlContextAnnotations implements TranslatableContext
      */
     public function iShouldSeeOnTheScreen($result)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
+        Assert::assertEquals(intval($result), $this->result);
     }
 
     /** @Transform /"([^"]+)" user/ */
@@ -42,7 +43,7 @@ class YamlContextAnnotations implements TranslatableContext
      */
     public function theUserUsername($user, $username)
     {
-        PHPUnit\Framework\Assert::assertEquals($username, $user->name);
+        Assert::assertEquals($username, $user->name);
     }
 
     public static function getTranslationResources()

--- a/tests/Fixtures/DefinitionsTranslations/features/bootstrap/YamlContextAttributes.php
+++ b/tests/Fixtures/DefinitionsTranslations/features/bootstrap/YamlContextAttributes.php
@@ -3,6 +3,7 @@
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Behat\Tests\Fixtures\Assert;
 use Behat\Transformation\Transform;
 
 class YamlContextAttributes implements TranslatableContext
@@ -25,7 +26,7 @@ class YamlContextAttributes implements TranslatableContext
     #[Then('/^I should see (\d+) on the screen$/')]
     public function iShouldSeeOnTheScreen($result)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
+        Assert::assertEquals(intval($result), $this->result);
     }
 
     #[Transform('/"([^"]+)" user/')]
@@ -37,7 +38,7 @@ class YamlContextAttributes implements TranslatableContext
     #[Then('/^the ("[^"]+" user) name should be "([^"]*)"$/')]
     public function theUserUsername($user, $username)
     {
-        PHPUnit\Framework\Assert::assertEquals($username, $user->name);
+        Assert::assertEquals($username, $user->name);
     }
 
     public static function getTranslationResources()

--- a/tests/Fixtures/EnvVarPlaceholders/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/EnvVarPlaceholders/features/bootstrap/FeatureContext.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 final class FeatureContext implements Context
 {

--- a/tests/Fixtures/ErrorReporting/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/ErrorReporting/features/bootstrap/FeatureContext.php
@@ -4,6 +4,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {
@@ -26,7 +27,7 @@ class FeatureContext implements Context
     #[Then('/^I should get NULL$/')]
     public function iShouldGetNull()
     {
-        PHPUnit\Framework\Assert::assertNull($this->result);
+        Assert::assertNull($this->result);
     }
 
     #[When('/^I push "([^"]*)" to that array$/')]
@@ -38,7 +39,7 @@ class FeatureContext implements Context
     #[Then('/^I should get "([^"]*)"$/')]
     public function iShouldGet($arg1)
     {
-        PHPUnit\Framework\Assert::assertEquals($arg1, $this->result);
+        Assert::assertEquals($arg1, $this->result);
     }
 
     #[When('an exception is thrown')]

--- a/tests/Fixtures/ExtensionInheritance/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/ExtensionInheritance/features/bootstrap/FeatureContext.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 final class FeatureContext implements Context
 {

--- a/tests/Fixtures/Extensions/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Extensions/features/bootstrap/FeatureContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 final class FeatureContext implements Context
 {
@@ -23,6 +24,6 @@ final class FeatureContext implements Context
     #[Then('the extension should be loaded')]
     public function theExtensionLoaded(): void
     {
-        PHPUnit\Framework\Assert::assertEquals(['param1' => 'val1', 'param2' => 'val2'], $this->extension);
+        Assert::assertEquals(['param1' => 'val1', 'param2' => 'val2'], $this->extension);
     }
 }

--- a/tests/Fixtures/FormatOptions/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/FormatOptions/features/bootstrap/FeatureContext.php
@@ -6,7 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 final class FeatureContext implements Context
 {

--- a/tests/Fixtures/HelperContainers/features/bootstrap/FirstContext.php
+++ b/tests/Fixtures/HelperContainers/features/bootstrap/FirstContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 final class FirstContext implements Context
 {
@@ -18,7 +19,7 @@ final class FirstContext implements Context
     #[Given('service has no state')]
     public function noState(): void
     {
-        PHPUnit\Framework\Assert::assertNull($this->service->number);
+        Assert::assertNull($this->service->number);
     }
 
     #[When('service gets a state of :number in first context')]

--- a/tests/Fixtures/HelperContainers/features/bootstrap/SecondContext.php
+++ b/tests/Fixtures/HelperContainers/features/bootstrap/SecondContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
+use Behat\Tests\Fixtures\Assert;
 
 final class SecondContext implements Context
 {
@@ -17,6 +18,6 @@ final class SecondContext implements Context
     #[Then('service should have a state of :number in second context')]
     public function checkState(string $number): void
     {
-        PHPUnit\Framework\Assert::assertSame($number, $this->service->number);
+        Assert::assertSame($number, $this->service->number);
     }
 }

--- a/tests/Fixtures/Hooks/features/bootstrap/FeatureContextAnnotations.php
+++ b/tests/Fixtures/Hooks/features/bootstrap/FeatureContextAnnotations.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContextAnnotations implements Context
 {
@@ -104,7 +105,7 @@ class FeatureContextAnnotations implements Context
      */
     public function iMustHave($number)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($number), $this->number);
+        Assert::assertEquals(intval($number), $this->number);
     }
 
     /**
@@ -112,7 +113,7 @@ class FeatureContextAnnotations implements Context
      */
     public function iMustHaveScenarioFilter($filterValue)
     {
-        PHPUnit\Framework\Assert::assertEquals($filterValue, $this->scenarioFilter);
+        Assert::assertEquals($filterValue, $this->scenarioFilter);
     }
 
     /**

--- a/tests/Fixtures/Hooks/features/bootstrap/FeatureContextAttributes.php
+++ b/tests/Fixtures/Hooks/features/bootstrap/FeatureContextAttributes.php
@@ -11,6 +11,7 @@ use Behat\Hook\BeforeScenario;
 use Behat\Hook\BeforeStep;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContextAttributes implements Context
 {
@@ -88,13 +89,13 @@ class FeatureContextAttributes implements Context
     #[Then('/^I must have (\\d+)$/')]
     public function iMustHave($number)
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($number), $this->number);
+        Assert::assertEquals(intval($number), $this->number);
     }
 
     #[Then('I must have a scenario filter value of :value')]
     public function iMustHaveScenarioFilter($filterValue)
     {
-        PHPUnit\Framework\Assert::assertEquals($filterValue, $this->scenarioFilter);
+        Assert::assertEquals($filterValue, $this->scenarioFilter);
     }
 
     #[BeforeScenario]

--- a/tests/Fixtures/MultipleFormats/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/MultipleFormats/features/bootstrap/FeatureContext.php
@@ -6,7 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 final class FeatureContext implements Context
 {

--- a/tests/Fixtures/Outlines/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Outlines/features/bootstrap/FeatureContext.php
@@ -6,6 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {
@@ -67,6 +68,6 @@ class FeatureContext implements Context
     #[Then('/^The result should be (\d+)$/')]
     public function theResultShouldBe($result): void
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($result), $this->result);
+        Assert::assertEquals(intval($result), $this->result);
     }
 }

--- a/tests/Fixtures/Outlines/features/bootstrap/FeatureContextIsolation.php
+++ b/tests/Fixtures/Outlines/features/bootstrap/FeatureContextIsolation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContextIsolation implements Context
 {
@@ -19,6 +20,6 @@ class FeatureContextIsolation implements Context
     #[Then('the result should be :result')]
     public function theResultShouldBe($result): void
     {
-        PHPUnit\Framework\Assert::assertEquals(intval($result), $this->number);
+        Assert::assertEquals(intval($result), $this->number);
     }
 }

--- a/tests/Fixtures/Parameters/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Parameters/features/bootstrap/FeatureContext.php
@@ -6,6 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {
@@ -43,6 +44,6 @@ class FeatureContext implements Context
     #[Then('/The result should be (\d+)/')]
     public function theResultShouldBe($result): void
     {
-        PHPUnit\Framework\Assert::assertEquals($result, $this->result);
+        Assert::assertEquals($result, $this->result);
     }
 }

--- a/tests/Fixtures/PreferredProfile/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/PreferredProfile/features/bootstrap/FeatureContext.php
@@ -6,7 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {

--- a/tests/Fixtures/PrettyFormat/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/PrettyFormat/features/bootstrap/FeatureContext.php
@@ -7,7 +7,7 @@ use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {

--- a/tests/Fixtures/PrettyFormat/features/bootstrap/FeatureContextLs.php
+++ b/tests/Fixtures/PrettyFormat/features/bootstrap/FeatureContextLs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContextLs implements Context
 {
@@ -13,7 +14,7 @@ class FeatureContextLs implements Context
     #[Then('/I must have "([^"]+)"/')]
     public function iMustHave(string $num): void
     {
-        PHPUnit\Framework\Assert::assertEquals(intval(preg_replace('/[^\d]+/', '', $num)), $this->value);
+        Assert::assertEquals(intval(preg_replace('/[^\d]+/', '', $num)), $this->value);
     }
 
     #[When('/I add "([^"]+)"/')]

--- a/tests/Fixtures/PrettyFormat/features/bootstrap/FeatureContextMultiline.php
+++ b/tests/Fixtures/PrettyFormat/features/bootstrap/FeatureContextMultiline.php
@@ -6,7 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContextMultiline implements Context
 {

--- a/tests/Fixtures/Profiles/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Profiles/features/bootstrap/FeatureContext.php
@@ -6,7 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {

--- a/tests/Fixtures/Rerun/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/Rerun/features/bootstrap/FeatureContext.php
@@ -6,7 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {

--- a/tests/Fixtures/ResultTypes/features/bootstrap/FailedContext.php
+++ b/tests/Fixtures/ResultTypes/features/bootstrap/FailedContext.php
@@ -3,7 +3,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class FailedContext implements Context
 {

--- a/tests/Fixtures/ResultTypes/features/bootstrap/SkippedContext.php
+++ b/tests/Fixtures/ResultTypes/features/bootstrap/SkippedContext.php
@@ -4,7 +4,7 @@ use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class SkippedContext implements Context
 {

--- a/tests/Fixtures/TestReportFormat/features/bootstrap/FeatureContext.php
+++ b/tests/Fixtures/TestReportFormat/features/bootstrap/FeatureContext.php
@@ -6,6 +6,7 @@ use Behat\Hook\BeforeScenario;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Tests\Fixtures\Assert;
 
 class FeatureContext implements Context
 {
@@ -32,7 +33,7 @@ class FeatureContext implements Context
     #[Then('/I must have (\d+)/')]
     public function iMustHave($num)
     {
-        PHPUnit\Framework\Assert::assertEquals($num, $this->value);
+        Assert::assertEquals($num, $this->value);
     }
 
     #[BeforeScenario('@setup-error')]

--- a/tests/Fixtures/Traits/features/bootstrap/ApplesDefinitions.php
+++ b/tests/Fixtures/Traits/features/bootstrap/ApplesDefinitions.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 trait ApplesDefinitions
 {

--- a/tests/Fixtures/Transformations/features/bootstrap/OrdinalTransformationAnnotationsContext.php
+++ b/tests/Fixtures/Transformations/features/bootstrap/OrdinalTransformationAnnotationsContext.php
@@ -1,7 +1,7 @@
 <?php
 
 use Behat\Behat\Context\Context;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class OrdinalTransformationAnnotationsContext implements Context
 {

--- a/tests/Fixtures/Transformations/features/bootstrap/ScalarTypeAnnotationsContext.php
+++ b/tests/Fixtures/Transformations/features/bootstrap/ScalarTypeAnnotationsContext.php
@@ -1,7 +1,7 @@
 <?php
 
 use Behat\Behat\Context\Context;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class ScalarTypeAnnotationsContext implements Context
 {

--- a/tests/Fixtures/Transformations/features/bootstrap/UserContext.php
+++ b/tests/Fixtures/Transformations/features/bootstrap/UserContext.php
@@ -3,7 +3,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class UserContext implements Context
 {

--- a/tests/Fixtures/Transformations/features/bootstrap/WholeTableAnnotationsContext.php
+++ b/tests/Fixtures/Transformations/features/bootstrap/WholeTableAnnotationsContext.php
@@ -2,7 +2,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
-use PHPUnit\Framework\Assert;
+use Behat\Tests\Fixtures\Assert;
 
 class WholeTableAnnotationsContext implements Context
 {


### PR DESCRIPTION
First step towards #1746: neither our FeatureContext nor the fixture contexts use PHPUnit assertions any more, so that core can later drop PHPUnitExceptionStringer without breaking our tests. The fixtures now use a small `Behat\Tests\Fixtures\Assert` helper that keeps the existing message wording.

The failures on PHP 8.4 and 8.5 are unrelated to this change: #1873 needs to be merged and this branch rebased before all tests pass.