### PR TITLE
fix: Change how we assert on how PHP renders anonymous class names

### DIFF
--- a/tests/Behat/Tests/Config/Converter/ConfigConverterToolsTest.php
+++ b/tests/Behat/Tests/Config/Converter/ConfigConverterToolsTest.php
@@ -136,7 +136,8 @@ final class ConfigConverterToolsTest extends TestCase
                 $obj::class,
                 'withNothing',
                 [],
-                'Method class@anonymous::withNothing() does not exist',
+                // PHP renders the anonymous class name differently across versions, so only assert on the rest
+                '::withNothing() does not exist',
             ],
             'not enough params' => [
                 $obj::class,


### PR DESCRIPTION
PHP 8.4.25 and 8.5.10 changed the ReflectionException message for a missing method to include the full anonymous class name. ConfigConverterToolsTest asserted on the old rendering, so it now asserts only on the part of the message we care about.