### PR TITLE
feat: Add hasStdOut() and getStdOut() to ExecutedStepResult

### DIFF
--- a/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
+++ b/src/Behat/Behat/Tester/Result/ExecutedStepResult.php
@@ -51,6 +51,22 @@ final class ExecutedStepResult implements StepResult, DefinedStepResult, Excepti
         return $this->callResult;
     }
 
+    /**
+     * Checks if the step printed any output while it ran.
+     */
+    public function hasStdOut(): bool
+    {
+        return $this->callResult->hasStdOut();
+    }
+
+    /**
+     * Returns output printed by the step while it ran, if any.
+     */
+    public function getStdOut(): ?string
+    {
+        return $this->callResult->getStdOut();
+    }
+
     public function getStepDefinition(): ?Definition
     {
         return $this->searchResult->getMatchedDefinition();


### PR DESCRIPTION
Backports the two new methods from #1869 so that extensions supporting both 3.x and 4.x can read a step's output without going through getCallResult(), which is excluded from the public API in 4.x.