### PR TITLE
test: Enforce the @api boundary with custom phpstan rules

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -9,3 +9,27 @@ parameters:
                 - src/Behat/Testwork/Exception/Stringer/PHPUnitExceptionStringer.php
         -
             identifier: missingType.iterableValue
+
+services:
+    behatApiTags:
+        class: Behat\Tests\PHPStan\ApiTags
+        arguments:
+            apiNamespacePrefixes:
+                - 'Behat\Behat\'
+                - 'Behat\Config\'
+                - 'Behat\Testwork\'
+                - 'Behat\Step\'
+                - 'Behat\Hook\'
+                - 'Behat\Transformation\'
+    -
+        class: Behat\Tests\PHPStan\ApiBoundaryRule
+        arguments:
+            apiTags: @behatApiTags
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Behat\Tests\PHPStan\ApiSupertypeRule
+        arguments:
+            apiTags: @behatApiTags
+        tags:
+            - phpstan.rules.rule

--- a/tests/Behat/Tests/PHPStan/ApiBoundaryRule.php
+++ b/tests/Behat/Tests/PHPStan/ApiBoundaryRule.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Tests\PHPStan;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Keeps the public API self-contained.
+ *
+ * From 4.0 we only promise backwards compatibility for code marked `@api`. That promise is only meaningful if it is
+ * closed over itself: a method callers are told they may use must not hand them, or demand of them, a type that is
+ * outside the promise.
+ *
+ * This rule reports any public method of an `@api` class whose signature references a Behat type that is not itself
+ * `@api`. Because marking a type `@api` subjects its own methods to the same check, the transitive closure is
+ * enforced by induction - the rule never has to compute reachability itself.
+ *
+ * A member marked `@internal` is excluded from the promise even when its declaring class is `@api`, so it is not
+ * checked. Types outside Behat's own psr-4 roots (PHP built-ins, Symfony, behat/gherkin - a separate package with
+ * its own BC policy) are never expected to carry our tag and are ignored.
+ *
+ * @see ApiSupertypeRule for the same contract applied to a type's ancestry
+ *
+ * @implements Rule<InClassMethodNode>
+ *
+ * @see https://github.com/Behat/Behat/issues/1237
+ */
+final class ApiBoundaryRule implements Rule
+{
+    public function __construct(
+        private readonly ApiTags $apiTags,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return InClassMethodNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $class = $node->getClassReflection();
+        $method = $node->getMethodReflection();
+
+        // Only report against the class that declares the method, so an inherited method is not reported repeatedly.
+        if ($method->getDeclaringClass()->getName() !== $class->getName()) {
+            return [];
+        }
+
+        if (!$this->apiTags->isApiMethod($class, $method->getName()) || !$method->isPublic()) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($this->referencedTypes($method) as $referenced) {
+            if (!$this->apiTags->isOurs($referenced) || $this->apiTags->isClassMarkedApi($referenced)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Method %s::%s() is part of the public API but references %s, which is not marked @api.',
+                $class->getName(),
+                $method->getName(),
+                $referenced,
+            ))
+                ->identifier('behat.apiBoundary')
+                ->tip(sprintf('Mark %s as @api, or keep it out of this signature. If this member is not really part of the public API, mark it @internal.', $referenced))
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function referencedTypes(ExtendedMethodReflection $method): array
+    {
+        // Behat has no overloaded signatures, so the single variant is the whole signature.
+        $variant = $method->getVariants()[0];
+
+        $types = [$variant->getReturnType()];
+        foreach ($variant->getParameters() as $parameter) {
+            $types[] = $parameter->getType();
+        }
+
+        $referenced = [];
+        foreach ($types as $type) {
+            // getReferencedClasses() unwraps unions, nullables, arrays-of and generic type arguments for us.
+            foreach ($type->getReferencedClasses() as $class) {
+                $referenced[$class] = true;
+            }
+        }
+
+        return array_keys($referenced);
+    }
+}

--- a/tests/Behat/Tests/PHPStan/ApiBoundaryRule.php
+++ b/tests/Behat/Tests/PHPStan/ApiBoundaryRule.php
@@ -60,7 +60,7 @@ final class ApiBoundaryRule implements Rule
             return [];
         }
 
-        if (!$this->apiTags->isApiMethod($class, $method->getName()) || !$method->isPublic()) {
+        if ($method->isPrivate() || !$this->apiTags->isApiMethod($class, $method)) {
             return [];
         }
 
@@ -92,15 +92,11 @@ final class ApiBoundaryRule implements Rule
         // Behat has no overloaded signatures, so the single variant is the whole signature.
         $variant = $method->getVariants()[0];
 
-        $types = [$variant->getReturnType()];
-        foreach ($variant->getParameters() as $parameter) {
-            $types[] = $parameter->getType();
-        }
+        // getReferencedClasses() unwraps unions, nullables, arrays-of and generic type arguments for us.
+        $referenced = array_fill_keys($variant->getReturnType()->getReferencedClasses(), true);
 
-        $referenced = [];
-        foreach ($types as $type) {
-            // getReferencedClasses() unwraps unions, nullables, arrays-of and generic type arguments for us.
-            foreach ($type->getReferencedClasses() as $class) {
+        foreach ($variant->getParameters() as $parameter) {
+            foreach ($parameter->getType()->getReferencedClasses() as $class) {
                 $referenced[$class] = true;
             }
         }

--- a/tests/Behat/Tests/PHPStan/ApiSupertypeRule.php
+++ b/tests/Behat/Tests/PHPStan/ApiSupertypeRule.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Tests\PHPStan;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * Keeps the supertypes of an `@api` type inside the public API.
+ *
+ * A type is reachable through its own ancestry, not only through method signatures: callers of an `@api` interface
+ * may type against, catch, or implement anything it extends. `ContextException` is `@api` and extends
+ * `TestworkException`, so the promise leaks unless that parent is covered too.
+ *
+ * Supertypes that are themselves marked `@internal` are left alone - see the note in processNode().
+ *
+ * @implements Rule<InClassNode>
+ *
+ * @see ApiBoundaryRule for the same contract applied to method signatures
+ * @see https://github.com/Behat/Behat/issues/1237
+ */
+final class ApiSupertypeRule implements Rule
+{
+    public function __construct(
+        private readonly ApiTags $apiTags,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $class = $node->getClassReflection();
+
+        if (!$this->apiTags->isApiClass($class)) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($this->supertypes($class->getName()) as $supertype) {
+            if (!$this->apiTags->isOurs($supertype) || $this->apiTags->isClassMarkedApi($supertype)) {
+                continue;
+            }
+
+            // A supertype marked `@internal` is a decision that has already been taken, not an oversight. Inheriting
+            // one gives callers nothing they can reach: a marker interface behind a final attribute is never caught,
+            // never handed to them and never implemented by them. Only undecided supertypes are worth reporting.
+            if ($this->apiTags->isClassMarkedInternal($supertype)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                '%s is part of the public API but %s, which it extends, is not marked @api.',
+                $class->getName(),
+                $supertype,
+            ))
+                ->identifier('behat.apiSupertype')
+                ->tip(sprintf('Mark %s as @api, so that everything reachable through this type is covered by the promise.', $supertype))
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function supertypes(string $class): array
+    {
+        $native = $this->apiTagsReflection($class);
+
+        if ($native === null) {
+            return [];
+        }
+
+        $supertypes = $native->getInterfaceNames();
+
+        for ($parent = $native->getParentClass(); $parent !== false; $parent = $parent->getParentClass()) {
+            $supertypes[] = $parent->getName();
+        }
+
+        return array_values(array_unique($supertypes));
+    }
+
+    private function apiTagsReflection(string $class): ?ReflectionClass
+    {
+        try {
+            return new ReflectionClass($class);
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+}

--- a/tests/Behat/Tests/PHPStan/ApiSupertypeRule.php
+++ b/tests/Behat/Tests/PHPStan/ApiSupertypeRule.php
@@ -13,10 +13,9 @@ namespace Behat\Tests\PHPStan;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use ReflectionClass;
-use ReflectionException;
 
 /**
  * Keeps the supertypes of an `@api` type inside the public API.
@@ -53,7 +52,7 @@ final class ApiSupertypeRule implements Rule
         }
 
         $errors = [];
-        foreach ($this->supertypes($class->getName()) as $supertype) {
+        foreach ($this->supertypes($class) as $supertype) {
             if (!$this->apiTags->isOurs($supertype) || $this->apiTags->isClassMarkedApi($supertype)) {
                 continue;
             }
@@ -81,29 +80,18 @@ final class ApiSupertypeRule implements Rule
     /**
      * @return list<string>
      */
-    private function supertypes(string $class): array
+    private function supertypes(ClassReflection $class): array
     {
-        $native = $this->apiTagsReflection($class);
+        $supertypes = [];
 
-        if ($native === null) {
-            return [];
+        foreach ($class->getInterfaces() as $interface) {
+            $supertypes[$interface->getName()] = true;
         }
 
-        $supertypes = $native->getInterfaceNames();
-
-        for ($parent = $native->getParentClass(); $parent !== false; $parent = $parent->getParentClass()) {
-            $supertypes[] = $parent->getName();
+        for ($parent = $class->getParentClass(); $parent !== null; $parent = $parent->getParentClass()) {
+            $supertypes[$parent->getName()] = true;
         }
 
-        return array_values(array_unique($supertypes));
-    }
-
-    private function apiTagsReflection(string $class): ?ReflectionClass
-    {
-        try {
-            return new ReflectionClass($class);
-        } catch (ReflectionException) {
-            return null;
-        }
+        return array_keys($supertypes);
     }
 }

--- a/tests/Behat/Tests/PHPStan/ApiTags.php
+++ b/tests/Behat/Tests/PHPStan/ApiTags.php
@@ -16,8 +16,10 @@ use PHPStan\Reflection\ReflectionProvider;
 /**
  * Reads the `@api` / `@internal` tags that define our public API.
  *
- * PHPStan's reflection exposes `@internal` but not `@api`, so we read the raw docblocks ourselves and treat both
- * tags the same way for consistency.
+ * PHPStan's reflection exposes `@internal` but not `@api`, so we read the raw docblocks ourselves.
+ *
+ * Constructing a type is opted into separately from using one: `@api` on a class does not promise that callers may
+ * build an instance, so a constructor only counts when it carries the tag itself.
  */
 final class ApiTags
 {
@@ -79,13 +81,22 @@ final class ApiTags
     public function isApiMethod(ClassReflection $class, string $method): bool
     {
         $native = $class->getNativeReflection();
-        $doc = $native->hasMethod($method) ? $native->getMethod($method)->getDocComment() : false;
+        $reflection = $native->hasMethod($method) ? $native->getMethod($method) : null;
+        $doc = $reflection?->getDocComment() ?? false;
 
         if ($this->hasTag($doc, 'internal')) {
             return false;
         }
 
-        return $this->hasTag($doc, 'api') || $this->isApiClass($class);
+        if ($this->hasTag($doc, 'api')) {
+            return true;
+        }
+
+        if ($reflection?->isConstructor() === true) {
+            return false;
+        }
+
+        return $this->isApiClass($class);
     }
 
     private function hasTag(string|false|null $docComment, string $tag): bool

--- a/tests/Behat/Tests/PHPStan/ApiTags.php
+++ b/tests/Behat/Tests/PHPStan/ApiTags.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Behat.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Tests\PHPStan;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+
+/**
+ * Reads the `@api` / `@internal` tags that define our public API.
+ *
+ * PHPStan's reflection exposes `@internal` but not `@api`, so we read the raw docblocks ourselves and treat both
+ * tags the same way for consistency.
+ */
+final class ApiTags
+{
+    /**
+     * @param list<string> $apiNamespacePrefixes psr-4 roots of this package, from composer.json
+     */
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly array $apiNamespacePrefixes,
+    ) {
+    }
+
+    /**
+     * Is this a type of ours, and so one we expect to carry the tag?
+     *
+     * Anything else - PHP built-ins, Symfony, and behat/gherkin, which is a separate package with its own BC policy -
+     * is never expected to be marked and is not our business here.
+     */
+    public function isOurs(string $class): bool
+    {
+        foreach ($this->apiNamespacePrefixes as $prefix) {
+            if (str_starts_with($class, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function isClassMarkedApi(string $class): bool
+    {
+        if (!$this->reflectionProvider->hasClass($class)) {
+            return false;
+        }
+
+        return $this->hasTag($this->reflectionProvider->getClass($class)->getNativeReflection()->getDocComment(), 'api');
+    }
+
+    public function isClassMarkedInternal(string $class): bool
+    {
+        if (!$this->reflectionProvider->hasClass($class)) {
+            return false;
+        }
+
+        return $this->hasTag($this->reflectionProvider->getClass($class)->getNativeReflection()->getDocComment(), 'internal');
+    }
+
+    public function isApiClass(ClassReflection $class): bool
+    {
+        $doc = $class->getNativeReflection()->getDocComment();
+
+        return !$this->hasTag($doc, 'internal') && $this->hasTag($doc, 'api');
+    }
+
+    /**
+     * A member marked `@internal` is excluded from the promise even when its class is `@api`, and a member marked
+     * `@api` is included even when its class is not.
+     */
+    public function isApiMethod(ClassReflection $class, string $method): bool
+    {
+        $native = $class->getNativeReflection();
+        $doc = $native->hasMethod($method) ? $native->getMethod($method)->getDocComment() : false;
+
+        if ($this->hasTag($doc, 'internal')) {
+            return false;
+        }
+
+        return $this->hasTag($doc, 'api') || $this->isApiClass($class);
+    }
+
+    private function hasTag(string|false|null $docComment, string $tag): bool
+    {
+        return is_string($docComment)
+            && preg_match('/^\s*\*\s*@' . $tag . '\b/m', $docComment) === 1;
+    }
+}

--- a/tests/Behat/Tests/PHPStan/ApiTags.php
+++ b/tests/Behat/Tests/PHPStan/ApiTags.php
@@ -11,6 +11,7 @@
 namespace Behat\Tests\PHPStan;
 
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 
 /**
@@ -55,7 +56,7 @@ final class ApiTags
             return false;
         }
 
-        return $this->hasTag($this->reflectionProvider->getClass($class)->getNativeReflection()->getDocComment(), 'api');
+        return $this->hasTag($this->reflectionProvider->getClass($class)->getResolvedPhpDoc()?->getPhpDocString(), 'api');
     }
 
     public function isClassMarkedInternal(string $class): bool
@@ -64,31 +65,28 @@ final class ApiTags
             return false;
         }
 
-        return $this->hasTag($this->reflectionProvider->getClass($class)->getNativeReflection()->getDocComment(), 'internal');
+        return $this->reflectionProvider->getClass($class)->isInternal();
     }
 
     public function isApiClass(ClassReflection $class): bool
     {
-        $doc = $class->getNativeReflection()->getDocComment();
-
-        return !$this->hasTag($doc, 'internal') && $this->hasTag($doc, 'api');
+        return !$class->isInternal() && $this->hasTag($class->getResolvedPhpDoc()?->getPhpDocString(), 'api');
     }
 
     /**
      * A member marked `@internal` is excluded from the promise even when its class is `@api`, and a member marked
      * `@api` is included even when its class is not.
      */
-    public function isApiMethod(ClassReflection $class, string $method): bool
+    public function isApiMethod(ClassReflection $class, ExtendedMethodReflection $method): bool
     {
-        $native = $class->getNativeReflection();
-        $reflection = $native->hasMethod($method) ? $native->getMethod($method) : null;
-        $doc = $reflection?->getDocComment() ?? false;
-
-        if ($this->hasTag($doc, 'internal')) {
+        if ($method->isInternal()->yes()) {
             return false;
         }
 
-        if ($this->hasTag($doc, 'api')) {
+        $native = $class->getNativeReflection();
+        $reflection = $native->hasMethod($method->getName()) ? $native->getMethod($method->getName()) : null;
+
+        if ($this->hasTag($reflection?->getDocComment() ?? false, 'api')) {
             return true;
         }
 


### PR DESCRIPTION
A custom phpstan rule enforcing that a method in the public API does not reference types outside it. There are two rules, one over method signatures and one over a type's parents and interfaces, since a type is reachable through its ancestry as well.

This only goes green once #1868 and #1869 are both merged: on 4.x as it stands it reports 58 errors, #1868 takes that to 2, and #1869 to 0.