### PR TITLE
feat: Propose DataTable and DocString in generated snippets

### DIFF
--- a/features/append_snippets.feature
+++ b/features/append_snippets.feature
@@ -12,6 +12,8 @@ Feature: Append snippets option
       """
       <?php
 
+      use Behat\Step\DataTable;
+      use Behat\Step\DocString;
       use Behat\Behat\Context\Context;
       use Behat\Behat\Tester\Exception\PendingException;
       use Behat\Gherkin\Node\PyStringNode;
@@ -94,19 +96,19 @@ Feature: Append snippets option
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^pystring (\d+):$/')]
-          public function pystring2($arg1, PyStringNode $string): void
+          public function pystring2($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -119,6 +121,8 @@ Feature: Append snippets option
       """
       <?php
 
+      use Behat\Step\DataTable;
+      use Behat\Step\DocString;
       use Behat\Behat\Tester\Exception\PendingException;
       use Behat\Behat\Context\Context;
       use Behat\Gherkin\Node\PyStringNode;
@@ -200,19 +204,19 @@ Feature: Append snippets option
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^pystring (\d+):$/')]
-          public function pystring2($arg1, PyStringNode $string): void
+          public function pystring2($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -225,8 +229,8 @@ Feature: Append snippets option
       """
       <?php
 
-      use Behat\Gherkin\Node\TableNode;
-      use Behat\Gherkin\Node\PyStringNode;
+      use Behat\Step\DataTable;
+      use Behat\Step\DocString;
       use Behat\Behat\Tester\Exception\PendingException;
       use Behat\Behat\Context\Context;
       use Behat\Step\Given;
@@ -298,19 +302,19 @@ Feature: Append snippets option
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^pystring (\d+):$/')]
-          public function pystring2($arg1, PyStringNode $string): void
+          public function pystring2($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -363,8 +367,8 @@ Feature: Append snippets option
       """
       <?php
 
-      use Behat\Gherkin\Node\TableNode;
-      use Behat\Gherkin\Node\PyStringNode;
+      use Behat\Step\DataTable;
+      use Behat\Step\DocString;
       use Behat\Step\Then;
       use Behat\Step\When;
       use Behat\Step\Given;
@@ -417,19 +421,19 @@ Feature: Append snippets option
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^pystring (\d+):$/')]
-          public function pystring2($arg1, PyStringNode $string): void
+          public function pystring2($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }

--- a/features/format_options.feature
+++ b/features/format_options.feature
@@ -74,13 +74,13 @@ Feature: Format options
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -151,13 +151,13 @@ Feature: Format options
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -293,13 +293,13 @@ Feature: Format options
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -367,13 +367,13 @@ Feature: Format options
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }

--- a/features/legacy_snippets.feature
+++ b/features/legacy_snippets.feature
@@ -43,13 +43,13 @@ Feature: Legacy Snippets
           }
 
           #[Then('/^I should get a \'([^\']*)\':$/')]
-          public function iShouldGetA($arg1, PyStringNode $string): void
+          public function iShouldGetA($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Then('/^I should get a simple string:$/')]
-          public function iShouldGetASimpleString(PyStringNode $string): void
+          public function iShouldGetASimpleString(DocString $docString): void
           {
               throw new PendingException();
           }
@@ -73,7 +73,7 @@ Feature: Legacy Snippets
           }
 
           #[Then('/^I should get a "([^"]*)":$/')]
-          public function iShouldGetA2($arg1, PyStringNode $string): void
+          public function iShouldGetA2($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
@@ -84,7 +84,7 @@ Feature: Legacy Snippets
           use Behat\Step\Given;
           use Behat\Step\When;
           use Behat\Step\Then;
-          use Behat\Gherkin\Node\PyStringNode;
+          use Behat\Step\DocString;
       """
 
   Scenario: Regex snippets are working
@@ -148,13 +148,13 @@ Feature: Legacy Snippets
           }
 
           #[Then('I should get a :arg1:')]
-          public function iShouldGetA($arg1, PyStringNode $string): void
+          public function iShouldGetA($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Then('I should get a simple string:')]
-          public function iShouldGetASimpleString(PyStringNode $string): void
+          public function iShouldGetASimpleString(DocString $docString): void
           {
               throw new PendingException();
           }
@@ -171,7 +171,7 @@ Feature: Legacy Snippets
           use Behat\Step\Given;
           use Behat\Step\When;
           use Behat\Step\Then;
-          use Behat\Gherkin\Node\PyStringNode;
+          use Behat\Step\DocString;
       """
 
   Scenario: Turnip snippets are working

--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -87,13 +87,13 @@ Feature: Multiple formats
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -175,13 +175,13 @@ Feature: Multiple formats
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -215,13 +215,13 @@ Feature: Multiple formats
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -340,13 +340,13 @@ Feature: Multiple formats
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }
@@ -382,13 +382,13 @@ Feature: Multiple formats
           }
 
           #[Given('/^pystring:$/')]
-          public function pystring(PyStringNode $string): void
+          public function pystring(DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Given('/^table:$/')]
-          public function table(TableNode $table): void
+          public function table(DataTable $table): void
           {
               throw new PendingException();
           }

--- a/features/snippets.feature
+++ b/features/snippets.feature
@@ -40,13 +40,13 @@ Feature: Snippets generation and addition
           }
 
           #[Then('/^I should get a \'([^\']*)\':$/')]
-          public function iShouldGetA($arg1, PyStringNode $string): void
+          public function iShouldGetA($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Then('/^I should get a simple string:$/')]
-          public function iShouldGetASimpleString(PyStringNode $string): void
+          public function iShouldGetASimpleString(DocString $docString): void
           {
               throw new PendingException();
           }
@@ -70,7 +70,7 @@ Feature: Snippets generation and addition
           }
 
           #[Then('/^I should get a "([^"]*)":$/')]
-          public function iShouldGetA2($arg1, PyStringNode $string): void
+          public function iShouldGetA2($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
@@ -81,7 +81,7 @@ Feature: Snippets generation and addition
           use Behat\Step\Given;
           use Behat\Step\When;
           use Behat\Step\Then;
-          use Behat\Gherkin\Node\PyStringNode;
+          use Behat\Step\DocString;
       """
 
   Scenario: Appending regex snippets to a particular context
@@ -143,13 +143,13 @@ Feature: Snippets generation and addition
           }
 
           #[Then('I should get a :arg1:')]
-          public function iShouldGetA($arg1, PyStringNode $string): void
+          public function iShouldGetA($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Then('I should get a simple string:')]
-          public function iShouldGetASimpleString(PyStringNode $string): void
+          public function iShouldGetASimpleString(DocString $docString): void
           {
               throw new PendingException();
           }
@@ -166,7 +166,7 @@ Feature: Snippets generation and addition
           use Behat\Step\Given;
           use Behat\Step\When;
           use Behat\Step\Then;
-          use Behat\Gherkin\Node\PyStringNode;
+          use Behat\Step\DocString;
       """
 
   Scenario: Appending turnip snippets to a particular context
@@ -304,13 +304,13 @@ Feature: Snippets generation and addition
           }
 
           #[Then('I should get a :arg1:')]
-          public function iShouldGetA($arg1, PyStringNode $string): void
+          public function iShouldGetA($arg1, DocString $docString): void
           {
               throw new PendingException();
           }
 
           #[Then('I should get a simple string:')]
-          public function iShouldGetASimpleString(PyStringNode $string): void
+          public function iShouldGetASimpleString(DocString $docString): void
           {
               throw new PendingException();
           }
@@ -327,7 +327,7 @@ Feature: Snippets generation and addition
           use Behat\Step\Given;
           use Behat\Step\When;
           use Behat\Step\Then;
-          use Behat\Gherkin\Node\PyStringNode;
+          use Behat\Step\DocString;
       """
 
   Scenario: Generating snippets for steps with apostrophes

--- a/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
+++ b/src/Behat/Behat/Context/Snippet/Generator/ContextSnippetGenerator.php
@@ -24,6 +24,8 @@ use Behat\Gherkin\Node\ArgumentInterface;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Step\DataTable;
+use Behat\Step\DocString;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
@@ -173,7 +175,7 @@ TPL;
         };
 
         foreach ($step->getArguments() as $argument) {
-            $usedClasses[] = $argument::class;
+            $usedClasses[] = $this->getMethodArgumentClass($argument);
         }
 
         return $usedClasses;
@@ -284,9 +286,21 @@ TPL;
     private function getMethodArgument(ArgumentInterface $argument): string
     {
         return match (true) {
-            $argument instanceof PyStringNode => 'PyStringNode $string',
-            $argument instanceof TableNode => 'TableNode $table',
+            $argument instanceof PyStringNode => 'DocString $docString',
+            $argument instanceof TableNode => 'DataTable $table',
             default => '__unknown__',
+        };
+    }
+
+    /**
+     * @return class-string
+     */
+    private function getMethodArgumentClass(ArgumentInterface $argument): string
+    {
+        return match (true) {
+            $argument instanceof PyStringNode => DocString::class,
+            $argument instanceof TableNode => DataTable::class,
+            default => $argument::class,
         };
     }
 }


### PR DESCRIPTION
Follow-up to #1864, first half of what you asked for. The documentation side is next, in `Behat/docs`.

Generated snippets now propose the new types rather than the Gherkin AST ones:

```diff
-#[Given('/^table:$/')]
-public function table(TableNode $table): void
+#[Given('/^table:$/')]
+public function table(DataTable $table): void
```

Two places in `ContextSnippetGenerator`: the parameter type, and the import list, which used `$argument::class` and therefore named the AST class. The mapping is in one new private method so the two cannot disagree.

Since #1864 made both types resolvable by `MixedArgumentOrganiser`, a generated snippet still runs as soon as it is pasted, and someone starting from `--append-snippets` now lands on the decoupled API by default.

Expectations updated in five feature files: `snippets`, `legacy_snippets`, `append_snippets`, `format_options` and `multiple_formats`. Full suite green, 792 scenarios and 131 unit tests.

**One thing worth a separate look.** This makes visible a pre-existing quirk of `ContextSnippetAppender::importClass()`, which inserts every new import before the first existing `use`, unsorted:

```php
<?php

use Behat\Step\DataTable;
use Behat\Step\DocString;
use Behat\Behat\Context\Context;
```

It never showed until now because the argument classes were usually already imported by the context. It is not touched here, since sorting the imports would change the output for every appended class. Happy to send that as its own pull request if you want it fixed.
