### PR TITLE
refactor: use the new hasStdOut()/getStdOut() functions

### DIFF
--- a/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
+++ b/src/Behat/Behat/EventDispatcher/Event/AfterStepTested.php
@@ -110,6 +110,6 @@ final class AfterStepTested extends StepTested implements AfterTested
             return false;
         }
 
-        return $this->result->getCallResult()->hasStdOut() || $this->result->getCallResult()->hasException();
+        return $this->result->hasStdOut() || $this->result->hasException();
     }
 }

--- a/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
+++ b/src/Behat/Behat/EventDispatcher/Event/BeforeStepTeardown.php
@@ -91,6 +91,6 @@ final class BeforeStepTeardown extends StepTested implements BeforeTeardown
             return false;
         }
 
-        return $this->result->getCallResult()->hasStdOut() || $this->result->getCallResult()->hasException();
+        return $this->result->hasStdOut() || $this->result->hasException();
     }
 }

--- a/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
+++ b/src/Behat/Behat/Output/Node/EventListener/Statistics/StepStatsListener.php
@@ -143,7 +143,7 @@ final class StepStatsListener implements EventListener
 
         $path = $this->getStepPath($event, $exception);
         $error = $exception instanceof Throwable ? $this->exceptionPresenter->presentException($exception) : null;
-        $stdOut = $result instanceof ExecutedStepResult ? $result->getCallResult()->getStdOut() : null;
+        $stdOut = $result instanceof ExecutedStepResult ? $result->getStdOut() : null;
 
         $resultCode = $result->getResultCode();
         $stat = new StepStatV2($this->scenarioTitle, $this->scenarioPath, $text, $path, $resultCode, $error, $stdOut, $this->currentSuiteName);

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyExampleRowPrinter.php
@@ -140,11 +140,10 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
      */
     private function printStepStdOut(OutputPrinter $printer, StepResult $result): void
     {
-        if (!$result instanceof ExecutedStepResult || null === $result->getCallResult()->getStdOut()) {
+        if (!$result instanceof ExecutedStepResult || null === $result->getStdOut()) {
             return;
         }
 
-        $callResult = $result->getCallResult();
         $indentedText = $this->subIndentText;
 
         $pad = (fn ($line): string => sprintf(
@@ -153,7 +152,7 @@ final class PrettyExampleRowPrinter implements ExampleRowPrinter
             $line
         ));
 
-        $printer->writeln(implode("\n", array_map($pad, explode("\n", (string) $callResult->getStdOut()))));
+        $printer->writeln(implode("\n", array_map($pad, explode("\n", (string) $result->getStdOut()))));
     }
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Pretty/PrettyStepPrinter.php
@@ -128,11 +128,10 @@ final class PrettyStepPrinter implements StepPrinter
      */
     private function printStdOut(OutputPrinter $printer, StepResult $result): void
     {
-        if (!$result instanceof ExecutedStepResult || null === $result->getCallResult()->getStdOut()) {
+        if (!$result instanceof ExecutedStepResult || null === $result->getStdOut()) {
             return;
         }
 
-        $callResult = $result->getCallResult();
         $indentedText = $this->subIndentText;
 
         $pad = (fn ($line): string => sprintf(
@@ -141,7 +140,7 @@ final class PrettyStepPrinter implements StepPrinter
             $line
         ));
 
-        $printer->writeln(implode("\n", array_map($pad, explode("\n", (string) $callResult->getStdOut()))));
+        $printer->writeln(implode("\n", array_map($pad, explode("\n", (string) $result->getStdOut()))));
     }
 
     /**

--- a/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
+++ b/src/Behat/Behat/Output/Node/Printer/Progress/ProgressStepPrinter.php
@@ -197,18 +197,17 @@ final class ProgressStepPrinter implements StepPrinter
      */
     private function printStdOut(OutputPrinter $printer, StepResult $result): void
     {
-        if (!$result instanceof ExecutedStepResult || null === $result->getCallResult()->getStdOut()) {
+        if (!$result instanceof ExecutedStepResult || null === $result->getStdOut()) {
             return;
         }
 
         $printer->writeln("\n" . $result->getStepDefinition()->getPath() . ':');
-        $callResult = $result->getCallResult();
         $pad = (fn ($line): string => sprintf(
             '  | {+stdout}%s{-stdout}',
             $line
         ));
 
-        $printer->write(implode("\n", array_map($pad, explode("\n", (string) $callResult->getStdOut()))));
+        $printer->write(implode("\n", array_map($pad, explode("\n", (string) $result->getStdOut()))));
         $this->hasPrintedOutput = true;
     }
 }


### PR DESCRIPTION
Behat's own printers and events read a step's output through getCallResult()->getStdOut(). #1874 added hasStdOut()/getStdOut() on ExecutedStepResult, so they use those instead and no longer reach through the call result into a type that is not part of our public API.