### PR TITLE
fix: Handle aborted suites when printing unused definitions

### DIFF
--- a/features/stop_on_failure.feature
+++ b/features/stop_on_failure.feature
@@ -89,6 +89,26 @@ Feature: Stop on failure via config
       7 steps (5 passed, 1 failed, 1 skipped)
       """
 
+  Scenario: Print unused definitions while stopping on the first failure
+    When  I run behat with the following additional options:
+      | option                     | value |
+      | --stop-on-failure          |       |
+      | --print-unused-definitions |       |
+      | features/failing.feature   |       |
+    Then it should fail with:
+      """
+      --- Failed scenarios:
+
+          features/failing.feature:13 (on line 15)
+
+      2 scenarios (1 passed, 1 failed)
+      7 steps (5 passed, 1 failed, 1 skipped)
+      """
+    And the output should contain:
+      """
+      --- No unused definitions
+      """
+
   Scenario: Do not stop on undefined steps by default
     When  I run behat with the following additional options:
       | option                        | value           |

--- a/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
+++ b/src/Behat/Behat/Definition/Cli/UnusedDefinitionsController.php
@@ -68,8 +68,14 @@ final class UnusedDefinitionsController implements Controller
         return null;
     }
 
-    public function registerDefinitionUsages(AfterSuiteTested $event): void
+    public function registerDefinitionUsages(SuiteTested $event): void
     {
+        // A suite cut short by --stop-on-failure is dispatched under the same name as an
+        // AfterSuiteAborted, and has no further definition usage to register.
+        if (!$event instanceof AfterSuiteTested) {
+            return;
+        }
+
         $environmentDefinitions = $this->definitionRepository->getEnvironmentDefinitions($event->getEnvironment());
         foreach ($environmentDefinitions as $definition) {
             if ($definition instanceof RuntimeDefinition) {


### PR DESCRIPTION
Fixes #1881

`--stop-on-failure` combined with `--print-unused-definitions` ended the run with a PHP fatal error instead of the summary, and exited 255.

`SuiteTested::AFTER` carries two event classes. `EventDispatchingSuiteTester` dispatches an `AfterSuiteTested`, and `StopOnFailureHandler::exitOnFailure()` dispatches an `AfterSuiteAborted`, which extends `SuiteTested` but not `AfterSuiteTested`. `UnusedDefinitionsController` typed its listener on the class it expected, so PHP threw before the body ran. The listener now takes the base type and returns early on anything else.

**The aborted suite contributes nothing to the report.** That is deliberate, and it is the reason the guard is a `return` rather than a widened type: the body itself only needs `getEnvironment()`, so it would run happily on the aborted event, but it would then report every definition the run had not reached yet as unused. Since the option exists so people can delete unused code, reporting code as dead because the run stopped early is the wrong direction to be wrong in. It is also what the suites that never ran at all already do: they register nothing.

Covered by a scenario in `features/stop_on_failure.feature`, which fails on `3.x` with the fatal above.

`4.x` carries the same listener shape and should pick this up on the next merge up, but say the word if you would rather have it separately.

Tests: `composer all-tests` green.
