### PR TITLE
Explain the relationship between --format and --out

### DIFF
--- a/features/multiple_formats.feature
+++ b/features/multiple_formats.feature
@@ -278,6 +278,17 @@ Feature: Multiple formats
       25 steps (20 passed, 2 failed, 3 undefined)
       """
 
+  Scenario: a single output is applied to every format
+    When I run "behat -f pretty -f junit --out=apples-out"
+    Then it should fail with:
+      """
+      In ConsoleOutputFactory.php line XX:
+
+        A file name expected for the `output_path` option, but a directory was given.
+        Note that a single `--out` is applied to every `--format`.
+        Pass one `--out` per `--format`, in the same order, to send them to different places.
+      """
+
   Scenario: 2 formats, write second to file
     When I run "behat -f pretty -o std --format=progress --out=apples.progress --format-settings='{\"multiline\": false, \"paths\": false}'"
     Then it should fail with:

--- a/src/Behat/Testwork/Output/Cli/OutputController.php
+++ b/src/Behat/Testwork/Output/Cli/OutputController.php
@@ -42,15 +42,19 @@ class OutputController implements Controller
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'How to format tests output. <comment>pretty</comment> is default.' . PHP_EOL .
                 'Available formats are:' . PHP_EOL . $this->getFormatterDescriptions() .
-                'You can use multiple formats at the same time.'
+                'You can use multiple formats at the same time. See <comment>--out</comment>' . PHP_EOL .
+                'to send each of them to a different place.'
             )
             ->addOption(
                 '--out',
                 '-o',
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Write format output to a file/directory instead of' . PHP_EOL .
-                'STDOUT <comment>(output_path)</comment>. You can also provide different' . PHP_EOL .
-                'outputs to multiple formats. This option is mandatory for the junit formatter.'
+                'STDOUT <comment>(output_path)</comment>. A single <comment>--out</comment> is applied to every' . PHP_EOL .
+                '<comment>--format</comment>. To send formats to different places, pass one' . PHP_EOL .
+                '<comment>--out</comment> per <comment>--format</comment>, in the same order, using <comment>std</comment>' . PHP_EOL .
+                'for those that stay on STDOUT.' . PHP_EOL .
+                'This option is mandatory for the junit formatter.'
             )
             ->addOption(
                 '--format-settings',

--- a/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
+++ b/src/Behat/Testwork/Output/Printer/Factory/ConsoleOutputFactory.php
@@ -63,10 +63,12 @@ class ConsoleOutputFactory extends OutputFactory
         } elseif (!is_dir($this->getOutputPath())) {
             $stream = fopen($this->getOutputPath(), 'w');
         } else {
-            throw new BadOutputPathException(sprintf(
-                'Filename expected as `output_path` parameter, but got `%s`.',
+            throw new BadOutputPathException(
+                'A file name expected for the `output_path` option, but a directory was given.' . PHP_EOL
+                . 'Note that a single `--out` is applied to every `--format`.' . PHP_EOL
+                . 'Pass one `--out` per `--format`, in the same order, to send them to different places.',
                 $this->getOutputPath()
-            ), $this->getOutputPath());
+            );
         }
 
         return $stream;


### PR DESCRIPTION
Fixes #1409, scoped to the two points @acoulton reopened it for: the option help and the error message.

Reproducing it first turned up something the issue does not say. A single `--out` is not applied to the first formatter, it is applied to **every** one, through `setFormattersParameter()`. The index pairing only starts once there are two or more `--out`. So in the reported command the console formatter receives the directory meant for junit, and complains about a path the user never intended for it.

```
$ behat --format=pretty --format=junit --out=some/dir

  Filename expected as `output_path` parameter, but got `/app/some/dir`.
```

The message now says where that directory came from, and adopts the wording the two sibling factories already use:

```
  A file name expected for the `output_path` option, but a directory was given.
  Note that a single `--out` is applied to every `--format`.
  Pass one `--out` per `--format`, in the same order, to send them to different places.
```

It is split over three lines because the Symfony error box does not wrap: as a single sentence it rendered as a box 230 characters wide. The path is no longer interpolated, matching `FileOutputFactory` and `FilesystemOutputFactory`, and it is still on the exception through `getPath()`.

The help of `--out` now states the rule, and `--format` points at it, which is what @stof asked for:

```
  -f, --format=FORMAT   ...
                        You can use multiple formats at the same time. See --out
                        to send each of them to a different place.
  -o, --out=OUT         Write format output to a file/directory instead of
                        STDOUT (output_path). A single --out is applied to every
                        --format. To send formats to different places, pass one
                        --out per --format, in the same order, using std
                        for those that stay on STDOUT.
                        This option is mandatory for the junit formatter.
```

A scenario in `features/multiple_formats.feature` pins the message, using the reported command. Worth knowing for whoever reads it: `-f pretty -f progress --out=file` does *not* fail, because two console formatters both write to the file and the second simply overwrites the first. Only mixing a console formatter with junit trips it, since junit creates the directory that the console formatter then chokes on.

#### One thing I left alone

The symmetric case is worse and I did not touch it, since it is behaviour rather than wording:

```
$ behat --format=junit --format=pretty --out=report.xml
```

junit creates a **directory** named `report.xml` containing `default.xml`, and then pretty fails saying a file name was expected. The user gave a file name, so the message contradicts what they typed. Happy to open a separate issue if you think that deserves one.
